### PR TITLE
[Distributed] Allow nonsending remoteCall and distributed thunks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DataBenchmarks
     single-source/DeadArray
     single-source/DevirtualizeProtocolComposition
+    single-source/DistributedThunkHop
     single-source/DictOfArraysToArrayOfDicts
     single-source/DictTest
     single-source/DictTest2

--- a/benchmark/single-source/DistributedThunkHop.swift
+++ b/benchmark/single-source/DistributedThunkHop.swift
@@ -1,0 +1,284 @@
+//===--- DistributedThunkHop.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Cost of the executor hop a distributed thunk performs before entering `remoteCall`.
+//
+// Before adoption of nonisolated(nonsending) remote calls would pessimistically
+// have to hop off from the caller to the global pool, causing un-necessary hops.
+//
+// Since 6.5:
+// We allow opting into end-to-end nonisolated(nonsending), which avoids these hops.
+//
+// Reading the results: the harness reports time per unit of `n`, and every case
+// here performs `callsPerIteration` remote calls per unit. Divide the reported
+// figure by that constant to get the cost of a single call round trip. All six
+// cases use the same constant, so the raw numbers are directly comparable
+
+import TestsUtils
+
+#if canImport(Distributed)
+import Distributed
+#endif
+
+public let benchmarks: [BenchmarkInfo] = {
+#if canImport(Distributed)
+  guard #available(macOS 15, iOS 18, tvOS 18, watchOS 11, *) else { return [] }
+  return [
+    BenchmarkInfo(
+      name: "DistributedThunkHop.Actor.Hopping",
+      runFunction: { await runActorCallerHopping($0) },
+      tags: [.concurrency, .distributed]),
+    BenchmarkInfo(
+      name: "DistributedThunkHop.Actor.nonsending",
+      runFunction: { await runActorCallerNonsending($0) },
+      tags: [.concurrency, .distributed]),
+    BenchmarkInfo(
+      name: "DistributedThunkHop.MainActor.Hopping",
+      runFunction: { await runMainHopping($0) },
+      tags: [.concurrency, .distributed]),
+    BenchmarkInfo(
+      name: "DistributedThunkHop.MainActor.nonsending",
+      runFunction: { await runMainNonsending($0) },
+      tags: [.concurrency, .distributed]),
+    BenchmarkInfo(
+      name: "DistributedThunkHop.Concurrent.Hopping",
+      runFunction: { await runConcurrentHopping($0) },
+      tags: [.concurrency, .distributed]),
+    BenchmarkInfo(
+      name: "DistributedThunkHop.Concurrent.nonsending",
+      runFunction: { await runConcurrentNonsending($0) },
+      tags: [.concurrency, .distributed]),
+  ]
+#else
+  return []
+#endif
+}()
+
+#if canImport(Distributed)
+
+// ==== ------------------------------------------------------------------------
+// MARK: Systems
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+final class HoppingSystem: DistributedActorSystem, @unchecked Sendable {
+  typealias ActorID = String
+  typealias InvocationEncoder = NopEncoder
+  typealias InvocationDecoder = NopDecoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = NopResultHandler
+
+  func resolve<Act>(id: ActorID, as t: Act.Type) throws -> Act?
+    where Act: DistributedActor, Act.ID == ActorID { nil }
+  func assignID<Act>(_ t: Act.Type) -> ActorID
+    where Act: DistributedActor, Act.ID == ActorID { "id" }
+  func actorReady<Act>(_ a: Act) where Act: DistributedActor, Act.ID == ActorID {}
+  func resignID(_ id: ActorID) {}
+  func makeInvocationEncoder() -> InvocationEncoder { NopEncoder() }
+
+  func remoteCall<Act, Err, Res>(
+      on actor: Act, target: RemoteCallTarget,
+      invocation: inout InvocationEncoder,
+      throwing: Err.Type, returning: Res.Type) async throws -> Res
+    where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: Codable {
+    return 0 as! Res
+  }
+  func remoteCallVoid<Act, Err>(
+      on actor: Act, target: RemoteCallTarget,
+      invocation: inout InvocationEncoder, throwing: Err.Type) async throws
+    where Act: DistributedActor, Act.ID == ActorID, Err: Error {}
+}
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+final class NonsendingSystem: DistributedActorSystem, @unchecked Sendable {
+  typealias ActorID = String
+  typealias InvocationEncoder = NopEncoder
+  typealias InvocationDecoder = NopDecoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = NopResultHandler
+
+  func resolve<Act>(id: ActorID, as t: Act.Type) throws -> Act?
+    where Act: DistributedActor, Act.ID == ActorID { nil }
+  func assignID<Act>(_ t: Act.Type) -> ActorID
+    where Act: DistributedActor, Act.ID == ActorID { "id" }
+  func actorReady<Act>(_ a: Act) where Act: DistributedActor, Act.ID == ActorID {}
+  func resignID(_ id: ActorID) {}
+  func makeInvocationEncoder() -> InvocationEncoder { NopEncoder() }
+
+  nonisolated(nonsending)
+  func remoteCall<Act, Err, Res>(
+      on actor: Act, target: RemoteCallTarget,
+      invocation: inout InvocationEncoder,
+      throwing: Err.Type, returning: Res.Type) async throws -> Res
+    where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: Codable {
+    return 0 as! Res
+  }
+  nonisolated(nonsending)
+  func remoteCallVoid<Act, Err>(
+      on actor: Act, target: RemoteCallTarget,
+      invocation: inout InvocationEncoder, throwing: Err.Type) async throws
+    where Act: DistributedActor, Act.ID == ActorID, Err: Error {}
+}
+
+struct NopEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Codable
+  mutating func recordGenericSubstitution<T>(_ t: T.Type) throws {}
+  mutating func recordArgument<V: Codable>(_ a: RemoteCallArgument<V>) throws {}
+  mutating func recordReturnType<R: Codable>(_ t: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ t: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
+struct NopDecoder: DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable
+  mutating func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  mutating func decodeNextArgument<A: Codable>() throws -> A { fatalError() }
+  mutating func decodeReturnType() throws -> Any.Type? { nil }
+  mutating func decodeErrorType() throws -> Any.Type? { nil }
+}
+struct NopResultHandler: DistributedTargetInvocationResultHandler {
+  typealias SerializationRequirement = Codable
+  func onReturn<S: Codable>(value: S) async throws {}
+  func onReturnVoid() async throws {}
+  func onThrow<E: Error>(error: E) async throws {}
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: Targets
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+distributed actor Hopper {
+  typealias ActorSystem = HoppingSystem
+  distributed func poke() -> Int { 0 }
+}
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+distributed actor LessHopper {
+  typealias ActorSystem = NonsendingSystem
+  distributed func poke() -> Int { 0 }
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: Callers
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+actor ActorCaller {
+  func hopping(_ n: Int, _ a: Hopper) async {
+    var acc = 0
+    for _ in 0..<n { acc += (try? await a.poke()) ?? 1 }
+    check(acc == 0)
+  }
+  func nonsending(_ n: Int, _ a: LessHopper) async {
+    var acc = 0
+    for _ in 0..<n { acc += (try? await a.poke()) ?? 1 }
+    check(acc == 0)
+  }
+}
+
+@MainActor
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func mainHopping(_ n: Int, _ a: Hopper) async {
+  var acc = 0
+  for _ in 0..<n { acc += (try? await a.poke()) ?? 1 }
+  check(acc == 0)
+}
+
+@MainActor
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func mainNonsending(_ n: Int, _ a: LessHopper) async {
+  var acc = 0
+  for _ in 0..<n { acc += (try? await a.poke()) ?? 1 }
+  check(acc == 0)
+}
+
+// A `@concurrent` nonisolated caller already runs on the generic executor and
+// has no isolation to inherit, so neither thunk flavour performs a real
+// executor switch: the hopping thunk's `hop_to_executor` to the generic
+// executor resolves to a no-op, and the caller-isolated thunk is handed no
+// actor at all.
+//
+// The pair is therefore a control that isolates what remains once the *switch*
+// is free. Measured, that residue is still about 2x (roughly 6ns vs 3ns per
+// call): the hopping thunk must be a separate `@concurrent` async function, so
+// each call pays for its own async frame plus the `swift_task_switch` check
+// that decides the hop is unnecessary, whereas the caller-isolated thunk can
+// simply inline into the caller. Compare against the MainActor pair, where the
+// switch is a genuine cross-executor transition and dominates everything else
+
+@concurrent
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func concurrentHopping(_ n: Int, _ a: Hopper) async {
+  var acc = 0
+  for _ in 0..<n { acc += (try? await a.poke()) ?? 1 }
+  check(acc == 0)
+}
+
+@concurrent
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func concurrentNonsending(_ n: Int, _ a: LessHopper) async {
+  var acc = 0
+  for _ in 0..<n { acc += (try? await a.poke()) ?? 1 }
+  check(acc == 0)
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: Entry points
+
+// Remote calls performed per unit of `n`, identical for every case so that the
+// reported figures can be compared directly and divided by a single constant to
+// obtain per-call cost.
+//
+// The value has to be large enough that the fixed per-sample cost amortizes
+// away. Entering a `@MainActor` timed function costs one real executor hop, and
+// the harness divides each sample by `n`, so that hop shows up as an inflated
+// per-call figure at small scales: measured with 20 calls per unit, the cheapest
+// case read 0.340us at `--num-iters=50` but 0.064us at `--num-iters=4000`, all
+// of the difference being setup rather than call cost. It also has to stay small
+// enough that the most expensive case, hopping off the main actor at ~9us per
+// call, does not blow past the suite's ~1ms per workload guideline
+let callsPerIteration = 100
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func runActorCallerHopping(_ n: Int) async {
+  let a = try! Hopper.resolve(id: "x", using: HoppingSystem())
+  await ActorCaller().hopping(n * callsPerIteration, a)
+}
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func runActorCallerNonsending(_ n: Int) async {
+  let a = try! LessHopper.resolve(id: "x", using: NonsendingSystem())
+  await ActorCaller().nonsending(n * callsPerIteration, a)
+}
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func runMainHopping(_ n: Int) async {
+  let a = try! Hopper.resolve(id: "x", using: HoppingSystem())
+  await mainHopping(n * callsPerIteration, a)
+}
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func runMainNonsending(_ n: Int) async {
+  let a = try! LessHopper.resolve(id: "x", using: NonsendingSystem())
+  await mainNonsending(n * callsPerIteration, a)
+}
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func runConcurrentHopping(_ n: Int) async {
+  let a = try! Hopper.resolve(id: "x", using: HoppingSystem())
+  await concurrentHopping(n * callsPerIteration, a)
+}
+
+@available(macOS 15, iOS 18, tvOS 18, watchOS 11, *)
+func runConcurrentNonsending(_ n: Int) async {
+  let a = try! LessHopper.resolve(id: "x", using: NonsendingSystem())
+  await concurrentNonsending(n * callsPerIteration, a)
+}
+
+#endif // canImport(Distributed)

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -30,6 +30,9 @@ public enum BenchmarkCategory : String {
   case abstraction, safetychecks, exceptions, bridging, concurrency, existential, cxxInterop
   case exclusivity, differentiation
 
+  // Benchmarks of distributed actors and the distributed actor system.
+  distributed
+
   // Algorithms are "micro" that test some well-known algorithm in isolation:
   // sorting, searching, hashing, fibonacci, crypto, etc.
   case algorithm

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -67,6 +67,7 @@ import CxxStringConversion
 import DataBenchmarks
 import DeadArray
 import DevirtualizeProtocolComposition
+import DistributedThunkHop
 import DictOfArraysToArrayOfDicts
 import DictTest
 import DictTest2
@@ -281,6 +282,7 @@ register(CxxStringConversion.benchmarks)
 register(DataBenchmarks.benchmarks)
 register(DeadArray.benchmarks)
 register(DevirtualizeProtocolComposition.benchmarks)
+register(DistributedThunkHop.benchmarks)
 register(DictOfArraysToArrayOfDicts.benchmarks)
 register(DictTest.benchmarks)
 register(DictTest2.benchmarks)

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -3077,6 +3077,10 @@ public:
   enum {
     /// Whether this is a "distributed" actor function.
     Distributed = 0,
+    /// Whether the function this record points at is 'nonisolated(nonsending)'.
+    /// I.e. its lowered signature has a leading implicit `Builtin.ImplicitActor`
+    /// parameter.
+    NonisolatedNonsending = 1,
   };
 
   explicit AccessibleFunctionFlags(uint32_t bits) : FlagSet(bits) {}
@@ -3084,6 +3088,10 @@ public:
 
   /// Whether the this is a "distributed" actor function.
   FLAGSET_DEFINE_FLAG_ACCESSORS(Distributed, isDistributed, setDistributed)
+
+  /// Whether the target function is 'nonisolated(nonsending).
+  FLAGSET_DEFINE_FLAG_ACCESSORS(NonisolatedNonsending, isNonisolatedNonsending,
+                                setNonisolatedNonsending)
 };
 
 } // end namespace swift

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -185,6 +185,32 @@ AbstractFunctionDecl *
 getRemoteCallOnDistributedActorSystem(NominalTypeDecl *actorOrSystem,
                                       bool isVoidReturn);
 
+/// Determine whether the concrete `remoteCall` (or `remoteCallVoid`) witness
+/// on the given actor system is declared `nonisolated(nonsending)`.
+///
+/// When the witness is `nonisolated(nonsending)`,
+/// distributed thunks for actors using this system are emitted `nonisolated(nonsending)` too,
+/// so the caller's actor isolation is forwarded straight into `system.remoteCall`
+/// without ever hopping off the caller.
+///
+/// This optimization only works when the concrete actor system is known
+/// at time of emitting the distributed thunks.
+///
+/// ### Backwards compatibility
+/// When the witness is not `nonisolated(nonsending)`,
+/// distributed thunks use the default `@concurrent nonisolated` combination.
+///
+/// ### Generic actor systems
+/// When the `ActorSystem` is a generic parameter we don't know if the system's
+/// remoteCall is `nonisolated(nonsending)` so thunks use the old shape.
+/// This works because the isolation will be filled in as `nil` by a different
+/// adapter thunk.
+///
+/// \param isVoidReturn true for `remoteCallVoid`, false for `remoteCall`.
+/// \return true iff the witness is declared `nonisolated(nonsending)`.
+bool isDistributedActorSystemRemoteCallWitnessNonisolatedNonsending(
+    NominalTypeDecl *actorOrSystem, bool isVoidReturn);
+
 /// Retrieve the declaration of DistributedActorSystem.make().
 ///
 /// \param thunk the function from which we'll be invoking things on the

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessRequests.h"
 #include "swift/AST/AccessScope.h"
+#include "swift/AST/ActorIsolation.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -1529,6 +1530,17 @@ swift::getRemoteCallOnDistributedActorSystem(NominalTypeDecl *actorOrSystem,
                            GetDistributedActorSystemRemoteCallFunctionRequest{
                                mutableSystem, /*isVoidReturn=*/isVoidReturn},
                            nullptr);
+}
+
+bool swift::isDistributedActorSystemRemoteCallWitnessNonisolatedNonsending(
+    NominalTypeDecl *actorOrSystem, bool isVoidReturn) {
+  if (!actorOrSystem)
+    return false;
+  auto *witness =
+      getRemoteCallOnDistributedActorSystem(actorOrSystem, isVoidReturn);
+  if (!witness)
+    return false;
+  return getActorIsolation(witness).isNonisolatedNonsending();
 }
 
 /******************************************************************************/

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4864,6 +4864,7 @@ void IRGenModule::emitAccessibleFunction(StringRef sectionName,
   // -- Field: Flags
   AccessibleFunctionFlags flags;
   flags.setDistributed(func.isDistributed());
+  flags.setNonisolatedNonsending(func.isNonisolatedNonsending());
   fields.addInt32(flags.getOpaqueValue());
 
   // ---- End of 'TargetAccessibleFunctionRecord' fields

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -235,6 +235,19 @@ public:
 
   CanSILFunctionType getType() const { return Type; }
 
+  /// When the target 'nonisolated(nonsending)' the function needs
+  /// to be passed an implicitly added leading `Builtin.ImplicitActor` argument.
+  bool hasImplicitActorParameter() const {
+    auto isolated = Type->maybeGetIsolatedParameter();
+    return isolated && isolated->hasOption(SILParameterInfo::ImplicitLeading);
+  }
+
+  /// Number of leading parameters that are not part of the formal argument
+  /// list and therefore are never decoded from the invocation.
+  unsigned getNumImplicitLeadingParameters() const {
+    return hasImplicitActorParameter() ? 1 : 0;
+  }
+
   bool isGeneric() const {
     auto sig = Type->getInvocationGenericSignature();
     return sig && !sig->areAllParamsConcrete();
@@ -487,8 +500,12 @@ void DistributedAccessor::decodeArguments(const ArgumentDecoderInfo &decoder,
                                           Explosion &arguments) {
   auto fnType = Target.getType();
 
-  // Cover all of the arguments except to `self` of the actor.
-  auto parameters = fnType->getParameters().drop_back();
+  // Cover all of the arguments except:
+  auto parameters = fnType->getParameters()
+    // - the `self` of the actor:
+    .drop_back()
+    // -  the implicit leading isolation parameter, when the func is `nonisolated(nonsending)`:
+    .drop_front(Target.getNumImplicitLeadingParameters());
 
   // If there are no parameters to extract, we are done.
   if (parameters.empty())
@@ -889,9 +906,31 @@ void DistributedAccessor::emit() {
     arguments.add(typedResultBuffer);
   }
 
+  // It is invoked by `swift_distributed_execute_target` and has no caller whose isolation could
+  // be inherited, so pass a null actor. The thunk's entry hop then becomes a
+  // no-op and its local branch hops onto the target actor exactly as it does
+  // for a plain thunk.
+  if (Target.hasImplicitActorParameter()) {
+    // The thunk is nonisolated(nonsending) and needs to be passed
+    // an isolation `Builtin.ImplicitActor` as first parameter first.
+    auto implicitParamTy = targetConv.getSILType(
+        targetTy->getParameters().front(), expansionContext);
+    auto &implicitParamTI =
+        cast<LoadableTypeInfo>(IGM.getTypeInfo(implicitParamTy));
+    auto *pairTy = cast<llvm::StructType>(implicitParamTI.getStorageType());
+    assert(pairTy->getNumElements() == 2 &&
+           "Builtin.ImplicitActor is expected to be a scalar pair");
+
+    // We pass `(null, null)` as the isolation, it represents the global generic executor.
+    arguments.add(llvm::Constant::getNullValue(pairTy->getElementType(0)));
+    arguments.add(llvm::Constant::getNullValue(pairTy->getElementType(1)));
+  }
+
   // There is always at least one parameter associated with accessor - `self`
-  // of the distributed actor.
-  if (targetTy->getNumParameters() > 1) {
+  // of the distributed actor - plus any implicit leading parameters, none of
+  // which are encoded in the invocation.
+  if (targetTy->getNumParameters() >
+      1 + Target.getNumImplicitLeadingParameters()) {
     /// The argument decoder associated with the distributed actor
     /// this accessor belong to.
     ArgumentDecoderInfo decoder =

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -671,6 +671,12 @@ public:
 
   bool isDistributed() const { return IsDistributed; }
 
+  /// Whether the recorded function is 'nonisolated(nonsending)'.
+  bool isNonisolatedNonsending() const {
+    auto isolated = Type->maybeGetIsolatedParameter();
+    return isolated && isolated->hasOption(SILParameterInfo::ImplicitLeading);
+  }
+
   CanSILFunctionType getType() const { return Type; }
 
   llvm::Constant *getAddress() const { return Address; }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5370,6 +5370,11 @@ public:
     return (callee.kind == Callee::Kind::EnumElement);
   }
 
+  /// Is this call dispatched through a distributed thunk?
+  bool callsDistributedThunk() const {
+    return callee.getMethodName().isDistributedThunk();
+  }
+
   /// Sets a flag that indicates whether this call be treated as being 
   /// implicitly async, i.e., it requires a hop_to_executor prior to 
   /// invoking the sync callee, etc.
@@ -6113,7 +6118,17 @@ CallEmission CallEmission::forApplyExpr(SILGenFunction &SGF, ApplyExpr *e) {
 
     // For an implicitly-async call, record the target of the actor hop.
     if (auto target = call->isImplicitlyAsync()) {
-      emission.setImplicitlyAsync(target);
+      // ... unless the call is dispatched through a distributed thunk.
+      //
+      // The thunk is 'nonisolated' or 'nonisolated(nonsending)' and decides for
+      // itself whether to hop. It only hops onto 'self' in its local branch,
+      // and its remote branch never executes on the target actor at all.
+      //
+      // For a nonisolated(nonsending) thunk, it would even be incorrect to hop here,
+      // as it defeats the no-hops guarantee the thunk aims to provide.
+      if (!emission.callsDistributedThunk()) {
+        emission.setImplicitlyAsync(target);
+      }
     } else {
       // If we are emitting a call to an `async` variant of an ObjC completion
       // handler API, we need to hop at the call site because there is no
@@ -7887,7 +7902,10 @@ RValue SILGenFunction::emitGetAccessor(
   CanAnyFunctionType accessType = getter.getSubstFormalType();
 
   CallEmission emission(*this, std::move(getter), std::move(writebackScope));
-  if (implicitActorHopTarget)
+  // A distributed thunk accessor performs its own hop onto 'self' on the local
+  // branch, so hopping to the target actor here would be redundant. See the
+  // matching comment in CallEmission::forApplyExpr
+  if (implicitActorHopTarget && !get.isDistributedThunk())
     emission.setImplicitlyAsync(implicitActorHopTarget);
 
   // Self ->

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -592,6 +592,60 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   return {body, /*isTypeChecked=*/false};
 }
 
+/// Look up the concrete `remoteCall` (or `remoteCallVoid`) witness for
+/// \p func's enclosing distributed actor and report whether the witness is
+/// declared `nonisolated(nonsending)`. Because the actor's `ActorSystem`
+/// is statically known here, the synthesized distributed thunk can mirror
+/// the witness's isolation and, when both are `nonisolated(nonsending)`,
+/// forward the caller's isolation straight into `system.remoteCall`
+/// without hopping off the caller
+static bool distributedThunkShouldBeNonisolatedNonsending(FuncDecl *func) {
+  auto *DC = func->getDeclContext();
+  auto *actorNominal = DC->getSelfNominalTypeDecl();
+  if (!actorNominal)
+    return false;
+
+  auto systemTy = getConcreteReplacementForProtocolActorSystemType(actorNominal);
+  if (!systemTy)
+    return false;
+
+  auto *systemNominal = systemTy->getNominalOrBoundGenericNominal();
+  if (!systemNominal)
+    return false;
+
+  bool isVoidReturn = false;
+  if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
+    isVoidReturn = accessor->getStorage()
+                       ->getValueInterfaceType()
+                       ->isVoid();
+  } else {
+    isVoidReturn = func->getResultInterfaceType()->isVoid();
+  }
+
+  return isDistributedActorSystemRemoteCallWitnessNonisolatedNonsending(
+      systemNominal, isVoidReturn);
+}
+
+/// Attach the correct isolation attributes for a synthesized distributed thunk.
+///
+/// If the concrete system's `remoteCall` witness is `nonisolated(nonsending)`,
+/// emit the thunk as `nonisolated(nonsending)` so the caller's actor
+/// isolation is threaded into `system.remoteCall` without a hop.
+///
+/// Otherwise fall back to `nonisolated @concurrent`.
+static void addDistributedThunkIsolationAttributes(FuncDecl *thunk,
+                                                   FuncDecl *originalFunc) {
+  auto &C = thunk->getASTContext();
+
+  if (distributedThunkShouldBeNonisolatedNonsending(originalFunc)) {
+    thunk->addAttribute(
+        NonisolatedAttr::createImplicit(C, NonIsolatedModifier::NonSending));
+  } else {
+    thunk->addAttribute(NonisolatedAttr::createImplicit(C));
+    thunk->addAttribute(new (C) ConcurrentAttr(/*IsImplicit=*/true));
+  }
+}
+
 /// Create a new FuncDecl that has the same signature as the passed in func.
 /// This is used both to create stub witnesses as well as distributed thunks.
 ///
@@ -671,11 +725,7 @@ static FuncDecl *createSameSignatureDistributedThunkDecl(DeclContext *DC,
 
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
-  thunk->addAttribute(NonisolatedAttr::createImplicit(C));
-  // TODO(distributed): It would be nicer to make distributed thunks nonisolated(nonsending) instead;
-  //                    this way we would not hop off the caller when calling system.remoteCall;
-  //                    it'd need new ABI and the remoteCall also to become nonisolated(nonsending)
-  thunk->addAttribute(new (C) ConcurrentAttr(/*IsImplicit=*/true));
+  addDistributedThunkIsolationAttributes(thunk, func);
 
   return thunk;
 }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -257,7 +257,8 @@ static bool diagnoseMissingAdHocProtocolRequirement(ASTContext &C, Identifier id
   Printer << (decl->getFormalAccess() == AccessLevel::Public ? "public " : "");
 
   if (identifier == C.Id_remoteCall) {
-    Printer << "func remoteCall<Act, Err, Res>("
+    Printer << "nonisolated(nonsending) "
+               "func remoteCall<Act, Err, Res>("
                "on actor: Act, "
                "target: RemoteCallTarget, "
                "invocation: inout InvocationEncoder, "
@@ -269,7 +270,8 @@ static bool diagnoseMissingAdHocProtocolRequirement(ASTContext &C, Identifier id
                "Err: Error, "
                "Res: SerializationRequirement";
   } else if (identifier == C.Id_remoteCallVoid) {
-    Printer << "func remoteCallVoid<Act, Err>("
+    Printer << "nonisolated(nonsending) "
+               "func remoteCallVoid<Act, Err>("
                "on actor: Act, "
                "target: RemoteCallTarget, "
                "invocation: inout InvocationEncoder, "

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -331,9 +331,20 @@ public protocol DistributedActorSystem<SerializationRequirement>: Sendable {
   /// Implementations of this method must ensure that the `Argument` type parameter conforms
   /// to the types' `SerializationRequirement`.
   ///
+  /// ### Nonisolated nonsending witnesses
+  /// It is possible to witness this requirement using a `nonisolated(nonsending)` function.
+  /// Doing so will result much of the generated code supporting remote call to also adopt
+  /// `nonisolated(nonsending)` resulting in improved latency due to less actor isolation
+  /// changes on remote call paths.
+  ///
+  /// > Tip: When writing a new `DistributedActorSystem` it is recommended to witness the
+  /// >      `remoteCall` functions using `nonisolated(nonsending)` witnesses.
+  ///
   /// ## Errors
   /// This method is allowed to throw because of underlying transport or serialization errors,
   /// as well as by re-throwing the error received from the remote callee (if able to).
+  ///
+  /// - SeeAlso: ``remoteCallVoid(on:target:invocation:throwing:)``
   @available(SwiftStdlib 6.0, *)
   func remoteCall<Act, Err, Res>(
       on actor: Act,
@@ -354,9 +365,20 @@ public protocol DistributedActorSystem<SerializationRequirement>: Sendable {
   ///
   /// This method should perform the actual remote function call, and await for its response.
   ///
+  /// ### Nonisolated nonsending witnesses
+  /// It is possible to witness this requirement using a `nonisolated(nonsending)` function.
+  /// Doing so will result much of the generated code supporting remote call to also adopt
+  /// `nonisolated(nonsending)` resulting in improved latency due to less actor isolation
+  /// changes on remote call paths.
+  ///
+  /// > Tip: When writing a new `DistributedActorSystem` it is recommended to witness the
+  /// >      `remoteCall` functions using `nonisolated(nonsending)` witnesses.
+  ///
   /// ## Errors
   /// This method is allowed to throw because of underlying transport or serialization errors,
   /// as well as by re-throwing the error received from the remote callee (if able to).
+  ///
+  /// - SeeAlso: ``remoteCall(on:target:invocation:throwing:)``
   @available(SwiftStdlib 6.0, *)
   func remoteCallVoid<Act, Err>(
       on actor: Act,

--- a/test/Distributed/Inputs/FakeDistributedActorSystems.swift
+++ b/test/Distributed/Inputs/FakeDistributedActorSystems.swift
@@ -582,7 +582,7 @@ public struct FakeRoundtripResultHandler: DistributedTargetInvocationResultHandl
 
   let storeReturn: (any Any) -> Void
   let storeError: (any Error) -> Void
-  init(_ storeReturn: @escaping (Any) -> Void, onError storeError: @escaping (Error) -> Void) {
+  public init(_ storeReturn: @escaping (Any) -> Void, onError storeError: @escaping (Error) -> Void) {
     self.storeReturn = storeReturn
     self.storeError = storeError
   }

--- a/test/Distributed/Inputs/FakeNonsendingActorSystems.swift
+++ b/test/Distributed/Inputs/FakeNonsendingActorSystems.swift
@@ -1,0 +1,291 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// Actor systems whose ad-hoc `remoteCall` requirements are declared
+// 'nonisolated(nonsending)'. They live apart from `FakeDistributedActorSystems`
+// on purpose: driving the recipient side from a caller-isolated witness means
+// handing generic conformances to `executeDistributedTarget`, which is
+// `@concurrent`, and that draws isolated-conformance warnings. Those are
+// inherent to mixing the two isolation conventions rather than a defect here,
+// but tests that run with `-verify` should not have to tolerate them, and most
+// of them import `FakeDistributedActorSystems` without needing any of this.
+
+import Distributed
+import FakeDistributedActorSystems
+
+// ==== -----------------------------------------------------------------------
+// MARK: 'nonisolated(nonsending)' actor systems
+//
+// A system may declare its ad-hoc `remoteCall` requirements
+// 'nonisolated(nonsending)'. The concrete actor system is statically known when
+// a distributed thunk is synthesized, so the thunk then inherits that isolation
+// too: instead of hopping to the generic executor before calling `remoteCall`,
+// it forwards the caller's isolation straight through. The two systems below
+// mirror `FakeActorSystem` and `FakeRoundtripActorSystem` so that a test can
+// pair a hopping and a non-sending system in one process.
+
+/// Minimal 'nonisolated(nonsending)' system, mirroring `FakeActorSystem`.
+///
+/// Its `remoteCall` bodies throw, so it is meant for compile-time tests
+/// (SILGen, IRGen, type checking). Use `FakeNonsendingRoundtripActorSystem`
+/// when the call has to actually execute.
+@available(SwiftStdlib 6.0, *)
+public struct FakeNonsendingActorSystem: DistributedActorSystem, CustomStringConvertible {
+  public typealias ActorID = ActorAddress
+  public typealias InvocationDecoder = FakeInvocationDecoder
+  public typealias InvocationEncoder = FakeInvocationEncoder
+  public typealias SerializationRequirement = Codable
+  public typealias ResultHandler = FakeRoundtripResultHandler
+
+  public init() {}
+
+  public func resolve<Act>(id: ActorID, as actorType: Act.Type) throws -> Act?
+      where Act: DistributedActor,
+            Act.ID == ActorID {
+    nil
+  }
+
+  public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+      where Act: DistributedActor,
+            Act.ID == ActorID {
+    ActorAddress(parse: "xxx")
+  }
+
+  public func actorReady<Act>(_ actor: Act)
+      where Act: DistributedActor,
+            Act.ID == ActorID {
+  }
+
+  public func resignID(_ id: ActorID) {
+  }
+
+  public func makeInvocationEncoder() -> InvocationEncoder {
+    .init()
+  }
+
+  nonisolated(nonsending)
+  public func remoteCall<Act, Err, Res>(
+      on actor: Act,
+      target: RemoteCallTarget,
+      invocation invocationEncoder: inout InvocationEncoder,
+      throwing: Err.Type,
+      returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+
+  nonisolated(nonsending)
+  public func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
+
+  public nonisolated var description: Swift.String {
+    "\(Self.self)()"
+  }
+}
+
+/// Round-tripping 'nonisolated(nonsending)' system, mirroring
+/// `FakeRoundtripActorSystem`: `resolve` always reports remote, and
+/// `remoteCall` loops the invocation back into `executeDistributedTarget` on
+/// the local instance. That drives the recipient-side distributed accessor,
+/// which for a 'nonisolated(nonsending)' thunk has to supply the implicit
+/// leading actor parameter itself.
+@available(SwiftStdlib 6.0, *)
+public final class FakeNonsendingRoundtripActorSystem: DistributedActorSystem, @unchecked Sendable {
+  public typealias ActorID = ActorAddress
+  public typealias InvocationEncoder = FakeInvocationEncoder
+  public typealias InvocationDecoder = FakeInvocationDecoder
+  public typealias SerializationRequirement = Codable
+  public typealias ResultHandler = FakeRoundtripResultHandler
+
+  var activeActors: [ActorID: any DistributedActor] = [:]
+
+  /// Invoked synchronously at the top of `remoteCall` / `remoteCallVoid`,
+  /// before anything is awaited, passing the `#isolation` seen there. Because
+  /// these witnesses are 'nonisolated(nonsending)' that is the caller's
+  /// isolation, so a test can assert it was forwarded rather than hopped away
+  /// from. Assert on the executor as well as the value: checking `#isolation`
+  /// alone can pass while actually running on the target actor's executor
+  public var onRemoteCall: (@Sendable ((any Actor)?) -> Void)? = nil
+
+  /// When true, `resolve` hands back the locally registered instance instead of
+  /// reporting remote, which makes a distributed thunk take its *local* branch
+  public var resolveLocally: Bool = false
+
+  /// When set, `remoteCall` returns this value and `remoteCallVoid` simply
+  /// returns, in both cases *without* executing the target. That leaves only
+  /// the sending side of the call, so a test can assert which executor the
+  /// caller ends up on without a recipient-side hop confusing the picture
+  public var stubbedRemoteCallReply: Any? = nil
+
+  public init() {}
+
+  public func shutdown() {
+    self.activeActors = [:]
+  }
+
+  public func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    if resolveLocally, let active = activeActors[id] as? Act {
+      print("| resolve \(id) as local")
+      return active
+    }
+    print("| resolve \(id) as remote")
+    return nil
+  }
+
+  public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    let id = ActorAddress(parse: "<unique-id>")
+    print("| assign id: \(id) for \(actorType)")
+    return id
+  }
+
+  public func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+          Act.ID == ActorID {
+    print("| actor ready: \(actor)")
+    self.activeActors[actor.id] = actor
+  }
+
+  public func resignID(_ id: ActorID) {
+    print("X resign id: \(id)")
+  }
+
+  public func makeInvocationEncoder() -> InvocationEncoder {
+    .init()
+  }
+
+  private var remoteCallResult: Any? = nil
+  private var remoteCallError: Error? = nil
+
+  nonisolated(nonsending)
+  public func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing errorType: Err.Type,
+    returning returnType: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    onRemoteCall?(#isolation)
+    print("  >> remoteCall: on:\(actor), target:\(target), throwing:\(String(reflecting: errorType)), returning:\(String(reflecting: returnType))")
+    if let stubbedRemoteCallReply {
+      print("  << remoteCall stubbed reply: \(stubbedRemoteCallReply)")
+      return stubbedRemoteCallReply as! Res
+    }
+    guard let targetActor = activeActors[actor.id] else {
+      fatalError("Attempted to call mock 'roundtrip' on: \(actor.id) without active actor")
+    }
+
+    func doIt<A: DistributedActor>(active: A) async throws -> Res {
+      let resultHandler = FakeRoundtripResultHandler { value in
+        self.remoteCallResult = value
+        self.remoteCallError = nil
+      } onError: { error in
+        self.remoteCallResult = nil
+        self.remoteCallError = error
+      }
+
+      var decoder = invocation.makeDecoder()
+
+      print(" > execute distributed target: \(target)")
+      try await executeDistributedTarget(
+        on: active,
+        target: target,
+        invocationDecoder: &decoder,
+        handler: resultHandler
+      )
+
+      switch (remoteCallResult, remoteCallError) {
+      case (.some(let value), nil):
+        print("  << remoteCall return: \(value)")
+        return remoteCallResult! as! Res
+      case (nil, .some(let error)):
+        print("  << remoteCall throw: \(error)")
+        throw error
+      default:
+        fatalError("No reply!")
+      }
+    }
+    return try await _openExistential(targetActor, do: doIt)
+  }
+
+  nonisolated(nonsending)
+  public func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing errorType: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error {
+    onRemoteCall?(#isolation)
+    print("  >> remoteCallVoid: on:\(actor), target:\(target), throwing:\(String(reflecting: errorType))")
+    if stubbedRemoteCallReply != nil {
+      print("  << remoteCallVoid stubbed")
+      return
+    }
+    guard let targetActor = activeActors[actor.id] else {
+      fatalError("Attempted to call mock 'roundtrip' on: \(actor.id) without active actor")
+    }
+
+    func doIt<A: DistributedActor>(active: A) async throws {
+      let resultHandler = FakeRoundtripResultHandler { value in
+        self.remoteCallResult = value
+        self.remoteCallError = nil
+      } onError: { error in
+        self.remoteCallResult = nil
+        self.remoteCallError = error
+      }
+
+      var decoder = invocation.makeDecoder()
+
+      print(" > execute distributed target: \(target)")
+      try await executeDistributedTarget(
+        on: active,
+        target: target,
+        invocationDecoder: &decoder,
+        handler: resultHandler
+      )
+
+      switch (remoteCallResult, remoteCallError) {
+      case (.some, nil):
+        return
+      case (nil, .some(let error)):
+        print("  << remoteCall throw: \(error)")
+        throw error
+      default:
+        fatalError("No reply!")
+      }
+    }
+    try await _openExistential(targetActor, do: doIt)
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_accessor_caller_isolated_thunk.swift
+++ b/test/Distributed/Runtime/distributed_actor_accessor_caller_isolated_thunk.swift
@@ -1,0 +1,141 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeNonsendingActorSystems.swiftmodule -module-name FakeNonsendingActorSystems -target %target-swift-6.0-abi-triple -I %t %S/../Inputs/FakeNonsendingActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-6.0-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/FakeNonsendingActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=windows-msvc
+
+// Exercise the `executeDistributedTarget` path when accessible func is nonisolated(nonsending):
+// -- executeDistributedTarget  
+// -> compiler-generated distributed accessor 
+// -> nonisolated(nonsending) distributed thunk
+// -> the actual `distributed func`
+
+import Distributed
+import FakeDistributedActorSystems
+import FakeNonsendingActorSystems
+
+// ==== ------------------------------------------------------------------------
+// MARK: Actors
+//
+// Members are declared both in the actor body and in an extension: the thunk
+// for a body member is synthesized at a different point in type checking than
+// one for an extension member, and both must end up with the same ABI.
+
+@available(SwiftStdlib 6.0, *)
+distributed actor Hopper {
+  typealias ActorSystem = FakeRoundtripActorSystem
+  var count = 0
+
+  distributed func hello(_ s: String) -> String {
+    self.preconditionIsolated("not isolated to self")
+    count += 1
+    return "hopper-body-\(s)-\(count)"
+  }
+  distributed func helloVoid() {
+    self.preconditionIsolated("not isolated to self")
+    count += 1
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+extension Hopper {
+  distributed func helloInExtension(_ s: String) -> String {
+    self.preconditionIsolated("not isolated to self")
+    return "hopper-ext-\(s)"
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+distributed actor LessHopper {
+  typealias ActorSystem = FakeNonsendingRoundtripActorSystem
+  var count = 0
+
+  distributed func hello(_ s: String) -> String {
+    self.preconditionIsolated("not isolated to self")
+    count += 1
+    return "lesshopper-body-\(s)-\(count)"
+  }
+  distributed func helloVoid() {
+    self.preconditionIsolated("not isolated to self")
+    count += 1
+  }
+  distributed func twoArgs(_ a: String, _ b: Int) -> String {
+    self.preconditionIsolated("not isolated to self")
+    return "lesshopper-two-\(a)-\(b)"
+  }
+  distributed var computed: String {
+    self.preconditionIsolated("not isolated to self")
+    return "lesshopper-computed"
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+extension LessHopper {
+  distributed func helloInExtension(_ s: String) -> String {
+    self.preconditionIsolated("not isolated to self")
+    return "lesshopper-ext-\(s)"
+  }
+}
+
+// ==== ------------------------------------------------------------------------
+
+@available(SwiftStdlib 6.0, *)
+@main struct Main {
+  @MainActor
+  static func main() async throws {
+    // ---- hopping system: unchanged ABI ----------------------------------
+    let hopSys = FakeRoundtripActorSystem()
+    let hopLocal = Hopper(actorSystem: hopSys)
+    let hop = try Hopper.resolve(id: hopLocal.id, using: hopSys)
+    // CHECK: hopper-body-a-1
+    print(try await hop.hello("a"))
+    // CHECK: hopper-ext-b
+    print(try await hop.helloInExtension("b"))
+    try await hop.helloVoid()
+    // CHECK: hop void ok
+    print("hop void ok")
+
+    // ---- non-sending system: caller-isolated thunk ABI ------------------
+    let nsSys = FakeNonsendingRoundtripActorSystem()
+    nsSys.onRemoteCall = { _ in
+      // The sending side must not have hopped away from the caller
+      MainActor.preconditionIsolated("remoteCall lost the caller's isolation")
+    }
+    let nsLocal = LessHopper(actorSystem: nsSys)
+    let ns = try LessHopper.resolve(id: nsLocal.id, using: nsSys)
+
+    // zero-argument, non-void: the implicit actor parameter must not be
+    // decoded as if it were an argument
+    // CHECK: lesshopper-body-a-1
+    print(try await ns.hello("a"))
+
+    // zero-argument, void
+    try await ns.helloVoid()
+    // CHECK: ns void ok
+    print("ns void ok")
+
+    // more than one real argument, to catch off-by-one argument shifting
+    // CHECK: lesshopper-two-x-7
+    print(try await ns.twoArgs("x", 7))
+
+    // computed property accessor thunk
+    // CHECK: lesshopper-computed
+    print(try await ns.computed)
+
+    // extension member: must have the same ABI as the body members
+    // CHECK: lesshopper-ext-b
+    print(try await ns.helloInExtension("b"))
+
+    // CHECK: OK
+    print("OK")
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_thunk_generic_actor_system.swift
+++ b/test/Distributed/Runtime/distributed_actor_thunk_generic_actor_system.swift
@@ -1,0 +1,94 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeNonsendingActorSystems.swiftmodule -module-name FakeNonsendingActorSystems -target %target-swift-6.0-abi-triple -I %t %S/../Inputs/FakeNonsendingActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-6.0-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/FakeNonsendingActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=windows-msvc
+
+// A distributed actor generic over its `ActorSystem` cannot inherit the
+// system's `remoteCall` isolation at thunk-synthesis time -- the concrete
+// system, and therefore the concrete witness, is not yet known. The thunk
+// must fall back to `@concurrent nonisolated`, dispatching `remoteCall`
+// through the protocol witness table whose slot is plain `@async`.
+//
+// This test proves that fallback is *sound*: substituting a
+// `nonisolated(nonsending)` system into the generic actor still round-trips
+// correctly. The optimization simply does not apply -- the thunk hops to the
+// generic executor before invoking `remoteCall`, so the witness observes
+// `#isolation == nil` rather than the caller's isolation. For comparison a
+// concrete distributed actor over the same system observes the caller's
+// `MainActor` isolation, showing the optimization *does* fire once the system
+// is known.
+
+import Distributed
+import FakeDistributedActorSystems
+import FakeNonsendingActorSystems
+
+@available(SwiftStdlib 6.0, *)
+distributed actor Worker<ActorSystem>
+    where ActorSystem: DistributedActorSystem<any Codable> {
+  distributed func greet() -> String { "hi" }
+  distributed func poke() {}
+}
+
+@available(SwiftStdlib 6.0, *)
+distributed actor ConcreteWorker {
+  typealias ActorSystem = FakeNonsendingRoundtripActorSystem
+  distributed func greet() -> String { "hi" }
+}
+
+@available(SwiftStdlib 6.0, *)
+@main struct Main {
+  @MainActor
+  static func main() async throws {
+    let system = FakeNonsendingRoundtripActorSystem()
+
+    // Report what the witness saw. For the generic actor the thunk is
+    // `@concurrent`, so the caller has already hopped away by the time we get
+    // here and `#isolation` is nil. For the concrete actor the thunk is
+    // `nonisolated(nonsending)`, so the caller's isolation is forwarded
+    system.onRemoteCall = { isolation in
+      if isolation == nil {
+        print("remoteCall isolation == nil")
+      } else if let iso = isolation, iso === MainActor.shared {
+        print("remoteCall isolation == MainActor.shared")
+      } else {
+        print("remoteCall isolation == other")
+      }
+    }
+    system.stubbedRemoteCallReply = "stubbed"
+
+    // ==== -----------------------------------------------------------------
+    // Generic actor: thunk is `@concurrent`, witness sees isolation=nil
+    let local = Worker<FakeNonsendingRoundtripActorSystem>(actorSystem: system)
+    let remote = try Worker<FakeNonsendingRoundtripActorSystem>.resolve(
+        id: local.id, using: system)
+    // CHECK: remoteCall isolation == nil
+    let g = try await remote.greet()
+    // CHECK: generic greet -> stubbed
+    print("generic greet -> \(g)")
+    // CHECK: remoteCall isolation == nil
+    try await remote.poke()
+
+    // ==== -----------------------------------------------------------------
+    // Concrete actor over the same system: thunk is `nonisolated(nonsending)`,
+    // witness sees the caller's MainActor isolation
+    let cLocal = ConcreteWorker(actorSystem: system)
+    let cRemote = try ConcreteWorker.resolve(id: cLocal.id, using: system)
+    // CHECK: remoteCall isolation == MainActor.shared
+    let c = try await cRemote.greet()
+    // CHECK: concrete greet -> stubbed
+    print("concrete greet -> \(c)")
+
+    // CHECK: OK
+    print("OK")
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_thunk_nonisolated_nonsending.swift
+++ b/test/Distributed/Runtime/distributed_actor_thunk_nonisolated_nonsending.swift
@@ -1,0 +1,108 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeNonsendingActorSystems.swiftmodule -module-name FakeNonsendingActorSystems -target %target-swift-6.0-abi-triple -I %t %S/../Inputs/FakeNonsendingActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-6.0-abi-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/FakeNonsendingActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=windows-msvc
+
+// End-to-end check that a distributed actor system declaring its `remoteCall`
+// witness as `nonisolated(nonsending)` causes the synthesized distributed
+// thunks to forward the caller's actor isolation into `remoteCall` (SE-0461),
+// rather than hopping to the generic executor first.
+//
+// Two things must hold for such a thunk:
+//
+//   * Remote branch: the thunk must not hop off the caller before invoking
+//     `remoteCall`. `FakeNonsendingRoundtripActorSystem.onRemoteCall` reports
+//     the `#isolation` observed inside the witness; called from `@MainActor`
+//     it must be `MainActor.shared`, on the main actor's executor.
+//     `stubbedRemoteCallReply` prevents the target function from executing so
+//     the only executor changes we could observe are the ones under test
+//
+//   * Local branch: the thunk must still hop onto the target actor before
+//     calling the actual `distributed func`. `preconditionIsolated(self)`
+//     inside `greet`/`poke` traps otherwise
+
+import Distributed
+import FakeDistributedActorSystems
+import FakeNonsendingActorSystems
+
+@available(SwiftStdlib 6.0, *)
+distributed actor Greeter {
+  typealias ActorSystem = FakeNonsendingRoundtripActorSystem
+
+  var counter = 0
+
+  distributed func greet() -> String {
+    // Local branch only. The thunk must have hopped onto self before this
+    // executed - a 'nonisolated(nonsending)' thunk must not skip the local hop
+    self.preconditionIsolated("local distributed call is not isolated to self")
+    counter += 1
+    return "local-reply-\(counter)"
+  }
+
+  distributed func poke() {
+    self.preconditionIsolated("local distributed call is not isolated to self")
+    counter += 1
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
+@main struct Main {
+  @MainActor
+  static func main() async throws {
+    let system = FakeNonsendingRoundtripActorSystem()
+    system.onRemoteCall = { isolation in
+      // Assert the actual executor, not just the isolation value: checking
+      // '#isolation' alone can pass while really executing on the target
+      // actor's executor
+      MainActor.preconditionIsolated("remoteCall lost the caller's isolation")
+      if let isolation, isolation === MainActor.shared {
+        print("remoteCall isolation == MainActor.shared")
+      } else {
+        print("remoteCall isolation == \(String(describing: isolation))")
+      }
+    }
+
+    let local = Greeter(actorSystem: system)
+
+    // ==== -----------------------------------------------------------------
+    // Remote branch: must stay on the caller (MainActor), never hop
+    system.stubbedRemoteCallReply = "remote-reply" // prevent executing actual real target function
+    let remote = try Greeter.resolve(id: local.id, using: system)
+
+    // CHECK: remoteCall isolation == MainActor.shared
+    let r1 = try await remote.greet()
+    // CHECK: remote greet -> remote-reply
+    print("remote greet -> \(r1)")
+
+    // CHECK: remoteCall isolation == MainActor.shared
+    try await remote.poke()
+
+    // ==== -----------------------------------------------------------------
+    // Local branch: the thunk must hop onto the actor
+    system.stubbedRemoteCallReply = nil
+    system.resolveLocally = true
+    let resolved = try Greeter.resolve(id: local.id, using: system)
+
+    let l1 = try await resolved.greet()
+    // CHECK: local greet -> local-reply-1
+    print("local greet -> \(l1)")
+
+    try await resolved.poke()
+    let l2 = try await resolved.greet()
+    // CHECK: local greet -> local-reply-3
+    print("local greet -> \(l2)")
+
+    // CHECK: OK
+    print("OK")
+  }
+}

--- a/test/Distributed/SIL/distributed_thunk_nonisolated_nonsending.swift
+++ b/test/Distributed/SIL/distributed_thunk_nonisolated_nonsending.swift
@@ -1,0 +1,149 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeNonsendingActorSystems.swiftmodule -module-name FakeNonsendingActorSystems -target %target-swift-6.0-abi-triple -I %t %S/../Inputs/FakeNonsendingActorSystems.swift
+// RUN: %target-swift-emit-silgen %s -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t | %FileCheck %s
+// REQUIRES: swift_swift_parser
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// Verify that a synthesized distributed thunk mirrors the isolation of the
+// concrete actor-system's remoteCall/remoteCallVoid witness:
+
+import Distributed
+import FakeDistributedActorSystems
+import FakeNonsendingActorSystems
+
+// ==== ------------------------------------------------------------------------
+// MARK: Plain distributed actors
+
+// Hopping system: thunk stays `nonisolated` + `@concurrent`
+//
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}6HopperC5greetSSyYaKFTE : $@convention(method) @async (@guaranteed Hopper) -> (@owned String, @error any Error)
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}6HopperC4pingyyYaKFTE : $@convention(method) @async (@guaranteed Hopper) -> @error any Error
+distributed actor Hopper {
+  typealias ActorSystem = FakeActorSystem
+
+  distributed func greet() -> String { "hi" } // uses 'remoteCall'
+  distributed func ping() {}                  // uses 'remoteCallVoid'
+}
+
+// Nonsending system: thunk becomes `@caller_isolated`
+//
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}10LessHopperC5greetSSyYaKFTE : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed LessHopper) -> (@owned String, @error any Error)
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}10LessHopperC4pingyyYaKFTE : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed LessHopper) -> @error any Error
+distributed actor LessHopper {
+  typealias ActorSystem = FakeNonsendingActorSystem
+
+  distributed func greet() -> String { "hi" }
+  distributed func ping() {}
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: A `@Resolvable protocol` with a concrete actor system`where ActorSystem == ...`.
+
+// Legacy @concurrency remoteCall
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}9HopWorkerPAA11Distributed01_{{.*}}ActorStubRzrlE4workSSyYaKFTE : $@convention(method) @async <Self where
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}9HopWorkerPAA11Distributed01_{{.*}}ActorStubRzrlE5nudgeyyYaKFTE : $@convention(method) @async <Self where
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}9HopWorkerPAA11Distributed01_{{.*}}ActorStubRzrlE5labelSSyYaKFTE : $@convention(method) @async <Self where
+//
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}10$HopWorkerCAA{{.*}}4workSSyYaKFTWTE : $@convention(witness_method: HopWorker) @async (
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}10$HopWorkerCAA{{.*}}5nudgeyyYaKFTWTE : $@convention(witness_method: HopWorker) @async (
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}10$HopWorkerCAA{{.*}}5labelSSvgTWTE : $@convention(witness_method: HopWorker) @async (
+@Resolvable
+@available(SwiftStdlib 6.0, *)
+protocol HopWorker: DistributedActor where ActorSystem == FakeActorSystem {
+  distributed func work() -> String
+  distributed func nudge()
+  distributed var label: String { get }
+}
+
+// New nonisolated(nonsending) remoteCall
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13LessHopWorkerPAA11Distributed01_{{.*}}ActorStubRzrlE4workSSyYaKFTE : $@convention(method) @caller_isolated @async <Self where
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13LessHopWorkerPAA11Distributed01_{{.*}}ActorStubRzrlE5nudgeyyYaKFTE : $@convention(method) @caller_isolated @async <Self where
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13LessHopWorkerPAA11Distributed01_{{.*}}ActorStubRzrlE5labelSSyYaKFTE : $@convention(method) @caller_isolated @async <Self where
+//
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}14$LessHopWorkerCAA{{.*}}4workSSyYaKFTWTE : $@convention(witness_method: LessHopWorker) @caller_isolated @async (
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}14$LessHopWorkerCAA{{.*}}5nudgeyyYaKFTWTE : $@convention(witness_method: LessHopWorker) @caller_isolated @async (
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}14$LessHopWorkerCAA{{.*}}5labelSSvgTWTE : $@convention(witness_method: LessHopWorker) @caller_isolated @async (
+@Resolvable
+@available(SwiftStdlib 6.0, *)
+protocol LessHopWorker: DistributedActor where ActorSystem == FakeNonsendingActorSystem {
+  distributed func work() -> String
+  distributed func nudge()
+  distributed var label: String { get }
+}
+
+// Legacy @concurrency remoteCall
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13HopWorkerImplC4workSSyYaKFTE : $@convention(method) @async (@guaranteed HopWorkerImpl) -> (@owned String, @error any Error)
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13HopWorkerImplC5nudgeyyYaKFTE : $@convention(method) @async (@guaranteed HopWorkerImpl) -> @error any Error
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13HopWorkerImplC5labelSSyYaKFTE : $@convention(method) @async (@guaranteed HopWorkerImpl) -> (@owned String, @error any Error)
+//
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}13HopWorkerImplCAA{{.*}}4workSSyYaKFTWTE : $@convention(witness_method: HopWorker) @async (
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}13HopWorkerImplCAA{{.*}}5labelSSvgTWTE : $@convention(witness_method: HopWorker) @async (
+@available(SwiftStdlib 6.0, *)
+distributed actor HopWorkerImpl: HopWorker {
+  typealias ActorSystem = FakeActorSystem
+  distributed func work() -> String { "w" }
+  distributed func nudge() {}
+  distributed var label: String { "l" }
+}
+
+// New nonisolated(nonsending) remoteCall
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}17LessHopWorkerImplC4workSSyYaKFTE : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed LessHopWorkerImpl) -> (@owned String, @error any Error)
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}17LessHopWorkerImplC5nudgeyyYaKFTE : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed LessHopWorkerImpl) -> @error any Error
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}17LessHopWorkerImplC5labelSSyYaKFTE : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed LessHopWorkerImpl) -> (@owned String, @error any Error)
+//
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}17LessHopWorkerImplCAA{{.*}}4workSSyYaKFTWTE : $@convention(witness_method: LessHopWorker) @caller_isolated @async (
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}17LessHopWorkerImplCAA{{.*}}5nudgeyyYaKFTWTE : $@convention(witness_method: LessHopWorker) @caller_isolated @async (
+// CHECK-DAG: sil private [transparent] [distributed_thunk] {{.*}}@$s{{.*}}17LessHopWorkerImplCAA{{.*}}5labelSSvgTWTE : $@convention(witness_method: LessHopWorker) @caller_isolated @async (
+@available(SwiftStdlib 6.0, *)
+distributed actor LessHopWorkerImpl: LessHopWorker {
+  typealias ActorSystem = FakeNonsendingActorSystem
+  distributed func work() -> String { "w" }
+  distributed func nudge() {}
+  distributed var label: String { "l" }
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: 'resolvable proxy adapter' thunk
+//
+// That adapter is deliberately NOT `@caller_isolated`: it is invoked by the
+// hand-built distributed target accessor in IRGen (GenDistributed.cpp), which
+// does not pass the implicit `Builtin.ImplicitActor` leading parameter. Until
+// that accessor learns the caller-isolated ABI the adapter must stay
+// `@concurrent`, matching the TODO in CodeSynthesisDistributedActor.cpp.
+
+// The ordinary caller-side thunk still follows the witness
+//
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}9ProxyUserC9introduce2toSSAA13LessHopWorker_p_tYaKFTE : $@convention(method) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor,
+
+// The adapter takes `$LessHopWorker` and stays plain `@async`
+//
+// CHECK-DAG: sil hidden [distributed_proxy_adapter_thunk] {{.*}}@$s{{.*}}9ProxyUserC{{.*}}Adapter$introduce{{.*}} : $@convention(method) @async (@sil_sending @guaranteed $LessHopWorker, @guaranteed ProxyUser) -> (@owned String, @error any Error)
+@available(SwiftStdlib 6.0, *)
+distributed actor ProxyUser {
+  typealias ActorSystem = FakeNonsendingActorSystem
+  distributed func introduce(to other: any LessHopWorker) -> String { "x" }
+}
+
+// ==== ------------------------------------------------------------------------
+// MARK: Generic-system distributed actor
+//
+// When the actor's `ActorSystem` is generic we don't know at thunk emission
+// if we can use the nonsending(nonisolated) path, so we use the legacy shape.
+//
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13GenericWorkerC5greetSSyYaKFTE : $@convention(method) @async <ActorSystem where ActorSystem : DistributedActorSystem, {{.*}}> (@guaranteed GenericWorker<ActorSystem>) -> (@owned String, @error any Error)
+// CHECK-DAG: sil hidden [thunk] [distributed] {{.*}}@$s{{.*}}13GenericWorkerC4pingyyYaKFTE : $@convention(method) @async <ActorSystem where ActorSystem : DistributedActorSystem, {{.*}}> (@guaranteed GenericWorker<ActorSystem>) -> @error any Error
+
+// The thunk's remote branch reaches `remoteCall` via `witness_method` on
+// `DistributedActorSystem`. The slot's ABI is fixed by the protocol -- plain
+// `@async`, no implicit leading actor
+//
+// CHECK-DAG: witness_method $ActorSystem, #DistributedActorSystem.remoteCall {{.*}}: $@convention(witness_method: DistributedActorSystem) @async
+// CHECK-DAG: witness_method $ActorSystem, #DistributedActorSystem.remoteCallVoid {{.*}}: $@convention(witness_method: DistributedActorSystem) @async
+@available(SwiftStdlib 6.0, *)
+distributed actor GenericWorker<ActorSystem>
+    where ActorSystem: DistributedActorSystem<any Codable> {
+  distributed func greet() -> String { "hi" } // uses 'remoteCall'
+  distributed func ping() {}                  // uses 'remoteCallVoid'
+}

--- a/test/Distributed/distributed_actor_accessor_section_coff.swift
+++ b/test/Distributed/distributed_actor_accessor_section_coff.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -target %target-swift-5.7-abi-triple -I %t 2>&1 %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeNonsendingActorSystems.swiftmodule -module-name FakeNonsendingActorSystems -target %target-swift-6.0-abi-triple -I %t %S/Inputs/FakeNonsendingActorSystems.swift
+// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -target %target-swift-6.0-abi-triple -I %t 2>&1 %s | %IRGenFileCheck %s
 
 // UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency
@@ -12,6 +13,7 @@
 
 import Distributed
 import FakeDistributedActorSystems
+import FakeNonsendingActorSystems
 
 @available(SwiftStdlib 5.5, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
@@ -88,6 +90,13 @@ public distributed actor MyOtherActor {
   }
 }
 
+@available(SwiftStdlib 6.0, *)
+public distributed actor LessActor {
+  public typealias ActorSystem = FakeNonsendingActorSystem
+  distributed func simple1(_: Int) {
+  }
+}
+
 
 /// ---> Let's check that distributed accessors and thunks are emitted as accessible functions
 
@@ -139,6 +148,17 @@ public distributed actor MyOtherActor {
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
+/// -> `LessActor.simple1`: nonisolated(nonsending) distributed => flag i32 3
+///    (Distributed = bit 0, NonisolatedNonsending = bit 1)
+// CHECK:      @"$s27distributed_actor_accessors9LessActorC7simple1yySiYaKFTEHF" = private constant
+// CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors9LessActorC7simple1yySiYaKFTETFTu" to i{{32|64}})
+// Check the recorg flags:
+//   Bit 0: isDistributed
+// + Bit 1: isNonisolatedNonsending
+// ======== Flag must be `3`:
+// CHECK-SAME: i32 3
+// CHECK-SAME: , section ".sw5acfn$B", {{.*}}
+
 // CHECK:      @llvm.used = appending global [{{.*}} x i8*] [
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTEHF"
@@ -147,4 +167,5 @@ public distributed actor MyOtherActor {
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTEHF"
+// CHECK-SAME: @"$s27distributed_actor_accessors9LessActorC7simple1yySiYaKFTEHF"
 // CHECK-SAME: ], section "llvm.metadata"

--- a/test/Distributed/distributed_actor_accessor_section_elf.swift
+++ b/test/Distributed/distributed_actor_accessor_section_elf.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -target %target-swift-5.7-abi-triple -I %t 2>&1 %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeNonsendingActorSystems.swiftmodule -module-name FakeNonsendingActorSystems -target %target-swift-6.0-abi-triple -I %t %S/Inputs/FakeNonsendingActorSystems.swift
+// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -target %target-swift-6.0-abi-triple -I %t 2>&1 %s | %IRGenFileCheck %s
 
 // UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency
@@ -10,6 +11,7 @@
 
 import Distributed
 import FakeDistributedActorSystems
+import FakeNonsendingActorSystems
 
 @available(SwiftStdlib 5.5, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
@@ -86,6 +88,18 @@ public distributed actor MyOtherActor {
   }
 }
 
+// A distributed actor over a system whose 'remoteCall' witness is declared
+// 'nonisolated(nonsending)'. Its accessible-function record must set both
+// bits of AccessibleFunctionFlags: Distributed (bit 0) and NonisolatedNonsending
+// (bit 1), so the trailing i32 is 3 rather than the 1 the hopping records above
+// carry
+@available(SwiftStdlib 6.0, *)
+public distributed actor NonsendingSystemActor {
+  public typealias ActorSystem = FakeNonsendingActorSystem
+  distributed func simple1(_: Int) {
+  }
+}
+
 
 /// ---> Let's check that distributed accessors and thunks are emitted as accessible functions
 
@@ -137,6 +151,13 @@ public distributed actor MyOtherActor {
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
+/// -> `NonsendingSystemActor.simple1`: nonisolated(nonsending) distributed => flag i32 3
+///    (Distributed = bit 0, NonisolatedNonsending = bit 1)
+// CHECK:      @"$s27distributed_actor_accessors21NonsendingSystemActorC7simple1yySiYaKFTEHF" = private constant
+// CHECK-SAME: (ptr @"$s27distributed_actor_accessors21NonsendingSystemActorC7simple1yySiYaKFTETFTu" to i{{32|64}})
+// CHECK-SAME: i32 3
+// CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
+
 // CHECK:      @llvm.used = appending global [{{.*}} x ptr] [
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTEHF"
@@ -145,4 +166,5 @@ public distributed actor MyOtherActor {
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTEHF"
+// CHECK-SAME: @"$s27distributed_actor_accessors21NonsendingSystemActorC7simple1yySiYaKFTEHF"
 // CHECK-SAME: ], section "llvm.metadata"

--- a/test/Distributed/distributed_actor_accessor_section_macho.swift
+++ b/test/Distributed/distributed_actor_accessor_section_macho.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -target %target-swift-5.7-abi-triple -I %t 2>&1 %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeNonsendingActorSystems.swiftmodule -module-name FakeNonsendingActorSystems -target %target-swift-6.0-abi-triple -I %t %S/Inputs/FakeNonsendingActorSystems.swift
+// RUN: %target-swift-frontend -emit-irgen -module-name distributed_actor_accessors -target %target-swift-6.0-abi-triple -I %t 2>&1 %s | %IRGenFileCheck %s
 
 // UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency
@@ -10,6 +11,7 @@
 
 import Distributed
 import FakeDistributedActorSystems
+import FakeNonsendingActorSystems
 
 @available(SwiftStdlib 5.7, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
@@ -86,6 +88,18 @@ public distributed actor MyOtherActor {
   }
 }
 
+// A distributed actor over a system whose 'remoteCall' witness is declared
+// 'nonisolated(nonsending)'. Its accessible-function record must set both
+// bits of AccessibleFunctionFlags: Distributed (bit 0) and NonisolatedNonsending
+// (bit 1), so the trailing i32 is 3 rather than the 1 the hopping records above
+// carry
+@available(SwiftStdlib 6.0, *)
+public distributed actor NonsendingSystemActor {
+  public typealias ActorSystem = FakeNonsendingActorSystem
+  distributed func simple1(_: Int) {
+  }
+}
+
 
 /// ---> Let's check that distributed accessors and thunks are emitted as accessible functions
 
@@ -137,6 +151,13 @@ public distributed actor MyOtherActor {
 // CHECK-SAME: (ptr @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular, no_dead_strip"}}
 
+/// -> `NonsendingSystemActor.simple1`: nonisolated(nonsending) distributed => flag i32 3
+///    (Distributed = bit 0, NonisolatedNonsending = bit 1)
+// CHECK:      @"$s27distributed_actor_accessors21NonsendingSystemActorC7simple1yySiYaKFTEHF" = private constant
+// CHECK-SAME: (ptr @"$s27distributed_actor_accessors21NonsendingSystemActorC7simple1yySiYaKFTETFTu" to i{{32|64}})
+// CHECK-SAME: i32 3
+// CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular, no_dead_strip"}}
+
 // CHECK:      @llvm.used = appending global [{{.*}} x ptr] [
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTEHF"
@@ -145,4 +166,5 @@ public distributed actor MyOtherActor {
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF"
 // CHECK-SAME: @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTEHF"
+// CHECK-SAME: @"$s27distributed_actor_accessors21NonsendingSystemActorC7simple1yySiYaKFTEHF"
 // CHECK-SAME: ], section "llvm.metadata"

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_fixits.swift
@@ -8,9 +8,9 @@ import Distributed
 
 struct MissingRemoteCall: DistributedActorSystem { 
   // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{add stubs for conformance}}{{51-51=\nfunc remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
+  // expected-note@-2{{add stubs for conformance}}{{51-51=\nnonisolated(nonsending) func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
   // expected-error@-3{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-4{{add stubs for conformance}}{{51-51=\nfunc remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-note@-4{{add stubs for conformance}}{{51-51=\nnonisolated(nonsending) func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
   // expected-error@-5 {{type 'MissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-6{{add stubs for conformance}} {{51-51=\n    func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n\n    func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type) async throws where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n}}
   
@@ -45,9 +45,9 @@ struct MissingRemoteCall: DistributedActorSystem {
 
 public struct PublicMissingRemoteCall: DistributedActorSystem { 
   // expected-error@-1{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{add stubs for conformance}}{{64-64=\npublic func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
+  // expected-note@-2{{add stubs for conformance}}{{64-64=\npublic nonisolated(nonsending) func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act: DistributedActor, Act.ID == ActorID, Err: Error, Res: SerializationRequirement {\n    <#code#>\n}\n}}
   // expected-error@-3{{struct 'PublicMissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-4{{add stubs for conformance}}{{64-64=\npublic func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
+  // expected-note@-4{{add stubs for conformance}}{{64-64=\npublic nonisolated(nonsending) func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout InvocationEncoder, throwing: Err.Type) async throws where Act: DistributedActor, Act.ID == ActorID, Err: Error {\n    <#code#>\n}\n}}
   // expected-error@-5{{type 'PublicMissingRemoteCall' does not conform to protocol 'DistributedActorSystem'}}
   // expected-note@-6{{add stubs for conformance}}{{64-64=\n    public func remoteCall<Act, Err, Res>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type, returning: Res.Type) async throws -> Res where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n\n    public func remoteCallVoid<Act, Err>(on actor: Act, target: RemoteCallTarget, invocation: inout FakeInvocationEncoder, throwing: Err.Type) async throws where Act : DistributedActor, Err : Error, ActorAddress == Act.ID {\n        <#code#>\n    \}\n}}
   


### PR DESCRIPTION
This is a performance improvement for distributed remote calls.

Currently, the SIL generated in distributed thunks is just a nonisolated thunk, therefore it hops off the calling actor unconditionally:

```
  bb0(%0 : $Hopper):
    hop_to_executor Optional<any Actor>.none   // generic executor, UNCONDITIONAL
    cond_br isRemote, bb1, bb2
  bb1: remoteCall(...)
```

the remoteCall func it calls is also nonisolated concurrent.

The problem is that when performing a remote call, we don't actually want to hop _anywhere_ because the remote call will be quick and its entire purpose is to ship of the call somewhere else -- today, we hop off to the global pool to perform this work though because these APIs were implemented before nonisolated(nonsending) was a thing.

This mode of nonisolated(nonsending) thunks enables itself whenever the actor system in use adopts the nonisolated(nonsending) on the remoteCall/Void functions.

Existing code is unaffected until the actor system implementation makes this change.

In order to fix this we need to do a few things:

- remoteCall already has special witness matching because it is not expressible as a real requirement -- due to the serialization requirement -- so we further adjust this to support nonisolated nonsending when possible.
- thunks, when we're using a nonisolated(nonsending) system, must also become nonisolated(nonsending).
- accessible function records need to store if they are nonsending, such that we can insert the implicit actor argument when calling them from executeDistributedTarget. There, we can pass null/global, unless we introduce new API in executeDistributedTarget that would pass the caller actor as well -- this would avoid another actor hop to global.

### Results

Per call, hopping versus nonsending: `~7ns` versus `~3ns` from a default actor, `~7ns` versus `~3ns` from a `@concurrent` context, and `~9us` versus `~3ns` from the main actor.

In general, we've eliminated two hops per call, and on the remote path, these hops were very useless. If we want to move work off the calling actor, remoteCall should do so using tasks, but in order to facilitate fast-path and even synchronous IPC, the default overhead must be kept to a minimum, which this enables.


```
┌───────────────────────┬────────────────────┐
│         Case          │     ns / call      │
├───────────────────────┼────────────────────┤
│ Actor.Hopping         │             8.4 ns │
├───────────────────────┼────────────────────┤
│ Actor.Nonsending      │             3.1 ns │
├───────────────────────┼────────────────────┤
│ Concurrent.Hopping    │             6.0 ns │
├───────────────────────┼────────────────────┤
│ Concurrent.Nonsending │             3.1 ns │
├───────────────────────┼────────────────────┤
│ MainActor.Hopping     │ 9 256 ns (~9.3 μs) │
├───────────────────────┼────────────────────┤
│ MainActor.Nonsending  │             3.7 ns │
└───────────────────────┴────────────────────┘
```