### PR TITLE
[cxx-interop] Various small cleanups

### DIFF
--- a/lib/ClangImporter/CFTypeInfo.cpp
+++ b/lib/ClangImporter/CFTypeInfo.cpp
@@ -100,8 +100,7 @@ StringRef importer::getCFTypeName(
   if (auto pointee = CFPointeeInfo::classifyTypedef(decl)) {
     auto name = decl->getName();
     if (pointee.isRecord() || pointee.isTypedef())
-      if (name.ends_with(SWIFT_CFTYPE_SUFFIX))
-        return name.drop_back(strlen(SWIFT_CFTYPE_SUFFIX));
+      name.consume_back(CFTypeSuffix);
 
     return name;
   }

--- a/lib/ClangImporter/CXXMethodBridging.h
+++ b/lib/ClangImporter/CXXMethodBridging.h
@@ -3,6 +3,7 @@
 
 #include "clang/AST/DeclCXX.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
 #include <string>
 
 namespace swift {
@@ -158,10 +159,10 @@ private:
   const clang::CXXMethodDecl *method = nullptr;
 
   bool nameIsBlacklist() {
-    auto loweredName = getClangName().lower();
     // Names that start with "get" or "set" but aren't getters or setters.
-    return loweredName == "getter" || loweredName == "setter" ||
-           loweredName == "get" || loweredName == "set";
+    return llvm::StringSwitch<bool>(getClangName())
+        .CasesLower({"getter", "setter", "get", "set"}, true)
+        .Default(false);
   }
 };
 

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -292,22 +292,22 @@ OmissionTypeName importer::getClangTypeNameForOmission(clang::ASTContext &ctx,
   // Handle builtin types by importing them and getting the Swift name.
   if (auto builtinTy = type->getAs<clang::BuiltinType>()) {
     // Names of integer types.
-    static const char *intTypeNames[] = {"UInt8", "UInt16", "UInt32", "UInt64",
-                                         "UInt128"};
+    static constexpr llvm::StringLiteral intTypeNames[] = {
+        "UInt8", "UInt16", "UInt32", "UInt64", "UInt128"};
 
     /// Retrieve the name for an integer type based on its size.
     auto getIntTypeName = [&](bool isSigned) -> StringRef {
       switch (ctx.getTypeSize(builtinTy)) {
       case 8:
-        return StringRef(intTypeNames[0]).substr(isSigned ? 1 : 0);
+        return intTypeNames[0].substr(isSigned ? 1 : 0);
       case 16:
-        return StringRef(intTypeNames[1]).substr(isSigned ? 1 : 0);
+        return intTypeNames[1].substr(isSigned ? 1 : 0);
       case 32:
-        return StringRef(intTypeNames[2]).substr(isSigned ? 1 : 0);
+        return intTypeNames[2].substr(isSigned ? 1 : 0);
       case 64:
-        return StringRef(intTypeNames[3]).substr(isSigned ? 1 : 0);
+        return intTypeNames[3].substr(isSigned ? 1 : 0);
       case 128:
-        return StringRef(intTypeNames[4]).substr(isSigned ? 1 : 0);
+        return intTypeNames[4].substr(isSigned ? 1 : 0);
       default:
         llvm_unreachable("bad integer type size");
       }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -100,9 +100,11 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/CAS/CASReference.h"
 #include "llvm/CAS/ObjectStore.h"
@@ -555,8 +557,7 @@ void importer::getNormalInvocationArguments(
 
   auto bridgingPCH = importerOpts.getPCHInputPath();
   if (!bridgingPCH.empty())
-    invocationArgStrs.insert(invocationArgStrs.end(),
-                             {"-include-pch", bridgingPCH});
+    llvm::append_values(invocationArgStrs, "-include-pch", bridgingPCH);
 
   // If there are no shims in the resource dir, add a search path in the SDK.
   SmallString<128> shimsPath(searchPathOpts.RuntimeResourcePath);
@@ -564,13 +565,13 @@ void importer::getNormalInvocationArguments(
   if (!llvm::sys::fs::exists(shimsPath)) {
     shimsPath = searchPathOpts.getSDKPath();
     llvm::sys::path::append(shimsPath, "usr", "lib", "swift", "shims");
-    invocationArgStrs.insert(invocationArgStrs.end(),
-                             {"-isystem", std::string(shimsPath.str())});
+    llvm::append_values(invocationArgStrs, "-isystem",
+                        std::string(shimsPath.str()));
   }
 
   // Construct the invocation arguments for the current target.
   // Add target-independent options first.
-  invocationArgStrs.insert(invocationArgStrs.end(), {
+  llvm::append_values(invocationArgStrs,
       // Don't emit LLVM IR.
       "-fsyntax-only",
 
@@ -581,11 +582,11 @@ void importer::getNormalInvocationArguments(
 
       "-fretain-comments-from-system-headers",
 
-      "-isystem", searchPathOpts.RuntimeResourcePath,
-  });
+      "-isystem", searchPathOpts.RuntimeResourcePath
+  );
 
   if (LangOpts.hasFeature(Feature::Embedded)) {
-    invocationArgStrs.insert(invocationArgStrs.end(), {"-D__swift_embedded__"});
+    llvm::append_values(invocationArgStrs, "-D__swift_embedded__");
   }
 
   // Swift generates position-independent code by default, so establish `-fPIC`
@@ -602,30 +603,25 @@ void importer::getNormalInvocationArguments(
   bool bareMetalEmbedded =
       LangOpts.hasFeature(Feature::Embedded) && triple.getOSName() == "none";
   if (!triple.isOSWindows() && !bareMetalEmbedded)
-    invocationArgStrs.insert(invocationArgStrs.end(), {"-fPIC"});
+    llvm::append_values(invocationArgStrs, "-fPIC");
 
   // Enable modules.
-  invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-fmodules",
-      "-Xclang", "-fmodule-feature", "-Xclang", "swift"
-  });
+  llvm::append_values(invocationArgStrs, "-fmodules", "-Xclang",
+                      "-fmodule-feature", "-Xclang", "swift");
 
   bool EnableCXXInterop = LangOpts.EnableCXXInterop;
 
   if (LangOpts.EnableObjCInterop) {
-    invocationArgStrs.insert(invocationArgStrs.end(), {"-fobjc-arc"});
+    llvm::append_values(invocationArgStrs, "-fobjc-arc");
     // TODO: Investigate whether 7.0 is a suitable default version.
     if (!triple.isOSDarwin())
-      invocationArgStrs.insert(invocationArgStrs.end(),
-                               {"-fobjc-runtime=ios-7.0"});
+      llvm::append_values(invocationArgStrs, "-fobjc-runtime=ios-7.0");
 
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-x", EnableCXXInterop ? "objective-c++" : "objective-c",
-    });
+    llvm::append_values(invocationArgStrs, "-x",
+                        EnableCXXInterop ? "objective-c++" : "objective-c");
   } else {
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-x", EnableCXXInterop ? "c++" : "c",
-    });
+    llvm::append_values(invocationArgStrs, "-x",
+                        EnableCXXInterop ? "c++" : "c");
   }
 
   {
@@ -645,10 +641,11 @@ void importer::getNormalInvocationArguments(
             clang::LangStandard::lang_gnu11);
 #endif
 
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      (Twine("-std=") + StringRef(EnableCXXInterop ? stdcxx.getName()
-                                                   : stdc.getName())).str()
-    });
+    llvm::append_values(
+        invocationArgStrs,
+        (Twine("-std=") +
+         StringRef(EnableCXXInterop ? stdcxx.getName() : stdc.getName()))
+            .str());
   }
 
   if (LangOpts.EnableCXXInterop) {
@@ -659,7 +656,7 @@ void importer::getNormalInvocationArguments(
 
   // Set C language options.
   if (triple.isOSDarwin()) {
-    invocationArgStrs.insert(invocationArgStrs.end(), {
+    llvm::append_values(invocationArgStrs,
       // Avoid including the iso646.h header because some headers from OS X
       // frameworks are broken by it.
       "-D_ISO646_H_", "-D__ISO646_H",
@@ -696,8 +693,8 @@ void importer::getNormalInvocationArguments(
 
       // Backwards compatibility for headers that were checking this instead of
       // '__swift__'.
-      "-DSWIFT_CLASS_EXTRA=",
-    });
+      "-DSWIFT_CLASS_EXTRA="
+    );
 
     // Indicate that using '__attribute__((swift_attr))' with '@Sendable' and
     // '@_nonSendable' on Clang declarations is fully supported, including the
@@ -707,9 +704,7 @@ void importer::getNormalInvocationArguments(
 
     if (triple.isXROS()) {
       // FIXME: This is a gnarly hack until some macros get adjusted in the SDK.
-      invocationArgStrs.insert(invocationArgStrs.end(), {
-        "-DOS_OBJECT_HAVE_OBJC_SUPPORT=1",
-      });
+      llvm::append_values(invocationArgStrs, "-DOS_OBJECT_HAVE_OBJC_SUPPORT=1");
     }
 
     // Get the version of this compiler and pass it to C/Objective-C
@@ -718,14 +713,13 @@ void importer::getNormalInvocationArguments(
     if (!V.empty()) {
       // Note: Prior to Swift 5.7, the "Y" version component was omitted and the
       // "X" component resided in its digits.
-      invocationArgStrs.insert(invocationArgStrs.end(), {
+      llvm::append_values(invocationArgStrs,
         V.preprocessorDefinition("__SWIFT_COMPILER_VERSION",
                                  {1000000000000,   // X
                                      1000000000,   // Y
                                         1000000,   // Z
                                            1000,   // a
-                                              1}), // b
-      });
+                                              1})); // b
     }
   } else {
     // Ideally we should turn this on for all Glibc targets that are actually
@@ -735,15 +729,12 @@ void importer::getNormalInvocationArguments(
     if (triple.isOSFuchsia() || triple.isAndroid() || triple.isMusl()) {
       // Many of the modern libc features are hidden behind feature macros like
       // _GNU_SOURCE or _XOPEN_SOURCE.
-      invocationArgStrs.insert(invocationArgStrs.end(), {
-        "-D_GNU_SOURCE",
-      });
+      llvm::append_values(invocationArgStrs, "-D_GNU_SOURCE");
     }
 
     if (triple.isAndroid()) {
-      invocationArgStrs.insert(invocationArgStrs.end(), {
-        "-D__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__",
-      });
+      llvm::append_values(invocationArgStrs,
+                          "-D__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__");
     }
 
     if (triple.isOSWindows()) {
@@ -751,17 +742,17 @@ void importer::getNormalInvocationArguments(
       default: llvm_unreachable("unsupported Windows architecture");
       case llvm::Triple::arm:
       case llvm::Triple::thumb:
-        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_ARM_"});
+        llvm::append_values(invocationArgStrs, "-D_ARM_");
         break;
       case llvm::Triple::aarch64:
       case llvm::Triple::aarch64_32:
-        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_ARM64_"});
+        llvm::append_values(invocationArgStrs, "-D_ARM64_");
         break;
       case llvm::Triple::x86:
-        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_X86_"});
+        llvm::append_values(invocationArgStrs, "-D_X86_");
         break;
       case llvm::Triple::x86_64:
-        invocationArgStrs.insert(invocationArgStrs.end(), {"-D_AMD64_"});
+        llvm::append_values(invocationArgStrs, "-D_AMD64_");
         break;
       }
     }
@@ -837,14 +828,11 @@ void importer::getNormalInvocationArguments(
   }
 
   if (importerOpts.DetailedPreprocessingRecord) {
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-Xclang", "-detailed-preprocessing-record",
-      "-Xclang", "-fmodule-format=raw",
-    });
+    llvm::append_values(invocationArgStrs, "-Xclang",
+                        "-detailed-preprocessing-record", "-Xclang",
+                        "-fmodule-format=raw");
   } else {
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-Xclang", "-fmodule-format=obj",
-    });
+    llvm::append_values(invocationArgStrs, "-Xclang", "-fmodule-format=obj");
   }
 
   // Enable API notes alongside headers/in frameworks.
@@ -871,8 +859,8 @@ void importer::getNormalInvocationArguments(
   }
 
   if (importerOpts.LoadVersionIndependentAPINotes)
-    invocationArgStrs.insert(invocationArgStrs.end(),
-                             {"-fswift-version-independent-apinotes"});
+    llvm::append_values(invocationArgStrs,
+                        "-fswift-version-independent-apinotes");
 
   if (!LangOpts.DisableSafeInteropWrappers)
     invocationArgStrs.push_back("-fexperimental-bounds-safety-attributes");
@@ -907,15 +895,15 @@ void importer::getNormalInvocationArguments(
 static void
 getEmbedBitcodeInvocationArguments(std::vector<std::string> &invocationArgStrs,
                                    ASTContext &ctx) {
-  invocationArgStrs.insert(invocationArgStrs.end(), {
+  llvm::append_values(invocationArgStrs,
     // Backend mode.
     "-fembed-bitcode",
 
     // ...but Clang isn't doing the emission.
     "-fsyntax-only",
 
-    "-x", "ir",
-  });
+    "-x", "ir"
+  );
 }
 
 void importer::addCommonInvocationArguments(
@@ -945,7 +933,7 @@ void importer::addCommonInvocationArguments(
         "-target-sdk-version=" + ctx.LangOpts.SDKVersion->getAsString());
   }
 
-  invocationArgStrs.push_back(ImporterImpl::moduleImportBufferName);
+  invocationArgStrs.push_back(ImporterImpl::moduleImportBufferName.str());
 
   if (ctx.LangOpts.EnableAppExtensionRestrictions) {
     invocationArgStrs.push_back("-fapplication-extension");
@@ -1795,9 +1783,8 @@ bool ClangImporter::addSearchPath(StringRef newSearchPath, bool isFramework,
   auto entry = *optionalEntry;
 
   auto &headerSearchInfo = Impl.getClangPreprocessor().getHeaderSearchInfo();
-  auto exists = std::any_of(headerSearchInfo.search_dir_begin(),
-                            headerSearchInfo.search_dir_end(),
-                            [&](const clang::DirectoryLookup &lookup) -> bool {
+  auto exists = llvm::any_of(headerSearchInfo.search_dir_range(),
+                             [&](const clang::DirectoryLookup &lookup) -> bool {
     if (isFramework)
       return lookup.getFrameworkDir() == &entry.getDirEntry();
     return lookup.getDir() == &entry.getDirEntry();
@@ -1838,7 +1825,7 @@ ClangImporter::Implementation::getNextIncludeLoc() {
     includeLoc = includeLoc.getLocWithOffset(1);
     DummyIncludeBuffer = srcMgr.createFileID(
         std::make_unique<ZeroFilledMemoryBuffer>(
-          256*1024, StringRef(moduleImportBufferName)),
+          256*1024, moduleImportBufferName),
         clang::SrcMgr::C_User, /*LoadedID*/0, /*LoadedOffset*/0, includeLoc);
   }
 
@@ -5547,49 +5534,44 @@ bool ClangImporter::Implementation::emitDiagnosticsForTarget(
   return ImportDiagnostics[target].size();
 }
 
-// These conditional "conformances" are used for both escapability and
-// copiability.
-static const llvm::StringMap<SmallVector<int>> STLConditionalParams{
-    {"basic_string", {0}},
-    {"vector", {0}},
-    {"array", {0}},
-    {"inplace_vector", {0}},
-    {"deque", {0}},
-    {"forward_list", {0}},
-    {"list", {0}},
-    {"set", {0}},
-    {"flat_set", {0}},
-    {"unordered_set", {0}},
-    {"multiset", {0}},
-    {"flat_multiset", {0}},
-    {"unordered_multiset", {0}},
-    {"stack", {0}},
-    {"queue", {0}},
-    {"priority_queue", {0}},
-    {"tuple", {0}},
-    {"variant", {0}},
-    {"optional", {0}},
-    {"pair", {0, 1}},
-    {"expected", {0, 1}},
-    {"map", {0, 1}},
-    {"flat_map", {0, 1}},
-    {"unordered_map", {0, 1}},
-    {"multimap", {0, 1}},
-    {"flat_multimap", {0, 1}},
-    {"unordered_multimap", {0, 1}},
-};
+/// The indices of the template parameters that a std type's escapability and
+/// copiability are conditional on, or an empty range if it has none.
+///
+/// These conditional "conformances" are used for both escapability and
+/// copiability.
+static llvm::ArrayRef<int> getSTLConditionalParams(StringRef name) {
+  static constexpr int FirstParam[] = {0};
+  static constexpr int FirstTwoParams[] = {0, 1};
+  return llvm::StringSwitch<llvm::ArrayRef<int>>(name)
+      .Cases({"basic_string", "vector", "array", "inplace_vector", "deque",
+              "forward_list", "list", "set", "flat_set", "unordered_set",
+              "multiset", "flat_multiset", "unordered_multiset", "stack",
+              "queue", "priority_queue", "tuple", "variant", "optional"},
+             FirstParam)
+      .Cases({"pair", "expected", "map", "flat_map", "unordered_map",
+              "multimap", "flat_multimap", "unordered_multimap"},
+             FirstTwoParams)
+      .Default({});
+}
 
-static const llvm::StringMap<SmallVector<int>> STLConditionalEscapabilityParams{
-    {"unique_ptr", {0}},
-    {"shared_ptr", {0}},
-    {"weak_ptr", {0}},
-    {"auto_ptr", {0}},
-};
+/// Like getSTLConditionalParams, but for the std types whose copiability is
+/// unconditional and only whose escapability depends on a template parameter.
+static llvm::ArrayRef<int>
+getSTLConditionalEscapabilityParams(StringRef name) {
+  static constexpr int FirstParam[] = {0};
+  return llvm::StringSwitch<llvm::ArrayRef<int>>(name)
+      .Cases({"unique_ptr", "shared_ptr", "weak_ptr", "auto_ptr"}, FirstParam)
+      .Default({});
+}
+
+/// The template parameter names listed by a conditional annotation such as
+/// `SWIFT_ESCAPABLE_IF(T, U)`. These are always few enough to stay inline.
+using ConditionalAttrParams = llvm::SmallSet<StringRef, 4>;
 
 template <typename Kind>
 static bool checkConditionalParams(
     const clang::RecordDecl *recordDecl, ClangImporter::Implementation *impl,
-    llvm::ArrayRef<int> STLParams, std::set<StringRef> &conditionalParams,
+    llvm::ArrayRef<int> STLParams, ConditionalAttrParams &conditionalParams,
     llvm::function_ref<void(const clang::Type *, bool)> maybePushToStack) {
   bool foundErrors = false;
   auto specDecl = cast<clang::ClassTemplateSpecializationDecl>(recordDecl);
@@ -5628,8 +5610,9 @@ static bool checkConditionalParams(
           maybePushToStack(
               nonPackArg.getAsType()->getUnqualifiedDesugaredType(),
               /*isBase=*/false); // None of the STL template parameters (for the
-                                 // classes enumerated in STLConditionalParams)
-                                 // are used as base classes.
+                                 // classes enumerated in
+                                 // getSTLConditionalParams) are used as base
+                                 // classes.
         }
       }
     }
@@ -5646,9 +5629,9 @@ static bool checkConditionalParams(
   return foundErrors;
 }
 
-static std::set<StringRef>
+static ConditionalAttrParams
 getConditionalAttrParams(clang::SwiftAttrAttr *swiftAttr, StringRef attrName) {
-  std::set<StringRef> result;
+  ConditionalAttrParams result;
   StringRef params = swiftAttr->getAttribute();
   if (params.consume_front(attrName)) {
     auto commaPos = params.find(',');
@@ -5663,7 +5646,7 @@ getConditionalAttrParams(clang::SwiftAttrAttr *swiftAttr, StringRef attrName) {
   return result;
 }
 
-static std::set<StringRef>
+static ConditionalAttrParams
 getConditionalAttrParams(const clang::NamedDecl *decl, StringRef attrName) {
   if (decl->hasAttrs()) {
     for (auto attr : decl->getAttrs()) {
@@ -5675,12 +5658,12 @@ getConditionalAttrParams(const clang::NamedDecl *decl, StringRef attrName) {
   return {};
 }
 
-static std::set<StringRef>
+static ConditionalAttrParams
 getConditionalEscapableAttrParams(const clang::RecordDecl *decl) {
   return getConditionalAttrParams(decl, "escapable_if:");
 }
 
-static std::set<StringRef>
+static ConditionalAttrParams
 getConditionalCopyableAttrParams(const clang::RecordDecl *decl) {
   return getConditionalAttrParams(decl, "copyable_if:");
 }
@@ -5759,12 +5742,12 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
         continue;
       if (hasSwiftAttribute(recordDecl, {"unsafe", "unsafe(always)"}))
         return CxxEscapability::Unknown;
-      SmallVector<int> STLParams;
+      llvm::ArrayRef<int> STLParams;
       if (recordDecl->isInStdNamespace()) {
-        STLParams = STLConditionalParams.lookup(recordDecl->getName());
+        STLParams = getSTLConditionalParams(recordDecl->getName());
         if (STLParams.empty())
           STLParams =
-              STLConditionalEscapabilityParams.lookup(recordDecl->getName());
+              getSTLConditionalEscapabilityParams(recordDecl->getName());
       }
       auto conditionalParams = getConditionalEscapableAttrParams(recordDecl);
 
@@ -8324,10 +8307,8 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
         NLFlags::UnqualifiedDefault);
 
     // Filter out any declarations that didn't come from Clang.
-    auto newEnd =
-        std::remove_if(results.begin(), results.end(),
-                       [&](ValueDecl *decl) { return !decl->getClangDecl(); });
-    results.erase(newEnd, results.end());
+    llvm::erase_if(results,
+                   [&](ValueDecl *decl) { return !decl->getClangDecl(); });
   }
   return TinyPtrVector<ValueDecl *>(ArrayRef(results));
 }
@@ -8557,8 +8538,8 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
   // - The type has a SWIFT_NONCOPYABLE annotation
   // - The type has a SWIFT_COPYABLE_IF(T...) annotation, where at least one of
   // T is ~Copyable
-  // - It is one of the STL types in `STLConditionalParams`, and at least one of
-  // its revelant types is ~Copyable
+  // - It is one of the STL types in `getSTLConditionalParams`, and at least one
+  // of its revelant types is ~Copyable
 
   const auto *type = desc.type->getUnqualifiedDesugaredType();
   auto *importerImpl = desc.importerImpl;
@@ -8606,9 +8587,9 @@ CxxValueSemantics::evaluate(Evaluator &evaluator,
     stack.pop_back();
     bool isExplicitlyNonCopyable = hasNonCopyableAttr(recordDecl);
     if (!isExplicitlyNonCopyable) {
-      SmallVector<int> STLParams;
+      llvm::ArrayRef<int> STLParams;
       if (recordDecl->isInStdNamespace())
-        STLParams = STLConditionalParams.lookup(recordDecl->getName());
+        STLParams = getSTLConditionalParams(recordDecl->getName());
       auto conditionalParams = getConditionalCopyableAttrParams(recordDecl);
 
       if (!STLParams.empty() || !conditionalParams.empty()) {
@@ -9155,7 +9136,7 @@ bool ClangInheritanceInfo::setUnavailableIfNecessary(
 SmallVector<std::pair<StringRef, clang::SourceLocation>, 1>
 importer::getPrivateFileIDAttrs(const clang::CXXRecordDecl *decl) {
   llvm::SmallVector<std::pair<StringRef, clang::SourceLocation>, 1> files;
-  constexpr auto prefix = StringRef("private_fileid:");
+  constexpr llvm::StringLiteral prefix = "private_fileid:";
 
   if (decl->hasAttrs()) {
     for (const auto *attr : decl->getAttrs()) {

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -46,8 +46,7 @@ static std::optional<Path> getActualModuleMapPath(
   Path result;
 
   if (!Opts.RuntimeResourcePath.empty()) {
-    result.append(Opts.RuntimeResourcePath.begin(),
-                  Opts.RuntimeResourcePath.end());
+    result.assign(Opts.RuntimeResourcePath);
     llvm::sys::path::append(result, platform);
     if (isArchSpecific) {
       llvm::sys::path::append(result, arch);
@@ -63,8 +62,7 @@ static std::optional<Path> getActualModuleMapPath(
 
   StringRef SDKPath = Opts.getSDKPath();
   if (!SDKPath.empty()) {
-    result.clear();
-    result.append(SDKPath.begin(), SDKPath.end());
+    result.assign(SDKPath);
     llvm::sys::path::append(result, "usr", "lib", "swift");
     llvm::sys::path::append(result, platform);
     if (isArchSpecific) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8566,8 +8566,7 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
           return;
 
         bool inNearbyCategory =
-            std::any_of(interfaceDecl->known_categories_begin(),
-                        interfaceDecl->known_categories_end(),
+            llvm::any_of(interfaceDecl->known_categories(),
                         [=](const clang::ObjCCategoryDecl *category) -> bool {
                           if (!Impl.getClangSema().isVisible(category)) {
                             return false;
@@ -9195,6 +9194,10 @@ void ClangImporter::Implementation::importNontrivialAttribute(
   }
 }
 
+/// The `swift_attr` prefix introducing an explicit protocol conformance,
+/// e.g. `SWIFT_CONFORMS_TO_PROTOCOL(Module.Protocol)`.
+constexpr static llvm::StringLiteral conformsToPrefix = "conforms_to:";
+
 void
 ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
   auto ClangDecl =
@@ -9338,7 +9341,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         continue;
       }
 
-      if (swiftAttr->getAttribute().starts_with("conforms_to:")) {
+      if (swiftAttr->getAttribute().starts_with(conformsToPrefix)) {
         if (auto nominal = dyn_cast<NominalTypeDecl>(MappedDecl))
           addExplicitProtocolConformance(nominal, swiftAttr, conformancesSeen);
       }
@@ -9451,7 +9454,7 @@ void ClangImporter::Implementation::addExplicitProtocolConformance(
     clang::SwiftAttrAttr *conformsToAttr,
     llvm::SmallSet<ProtocolDecl *, 4> &alreadyAdded) {
   auto conformsToValue = conformsToAttr->getAttribute()
-                             .drop_front(StringRef("conforms_to:").size())
+                             .drop_front(conformsToPrefix.size())
                              .str();
   auto names = StringRef(conformsToValue).split('.');
   auto moduleName = names.first;
@@ -9525,7 +9528,7 @@ void ClangImporter::Implementation::addExplicitProtocolConformancesFromBases(
     llvm::SmallSet<ProtocolDecl *, 4> alreadyAdded;
     llvm::for_each(cxxRecordDecl->getAttrs(), [&](auto *attr) {
       if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-        if (swiftAttr->getAttribute().starts_with("conforms_to:"))
+        if (swiftAttr->getAttribute().starts_with(conformsToPrefix))
           addExplicitProtocolConformance(nominal, swiftAttr, alreadyAdded);
       }
     });

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -25,6 +25,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/Preprocessor.h"
+#include "llvm/ADT/StringSwitch.h"
 
 #include "llvm/ADT/Statistic.h"
 #define DEBUG_TYPE "Enum Info"
@@ -125,18 +126,15 @@ void EnumInfo::classifyEnum(const clang::EnumDecl *decl,
   // only.
   auto loc = decl->getBeginLoc();
   if (loc.isMacroID()) {
-    StringRef MacroName = pp.getImmediateMacroName(loc);
-    if (MacroName == "CF_ENUM" || MacroName == "__CF_NAMED_ENUM" ||
-        MacroName == "OBJC_ENUM" || MacroName == "SWIFT_ENUM" ||
-        MacroName == "SWIFT_ENUM_NAMED") {
-      kind = EnumKind::NonFrozenEnum;
+    kind = llvm::StringSwitch<EnumKind>(pp.getImmediateMacroName(loc))
+               .Cases({"CF_ENUM", "__CF_NAMED_ENUM", "OBJC_ENUM", "SWIFT_ENUM",
+                       "SWIFT_ENUM_NAMED"},
+                      EnumKind::NonFrozenEnum)
+               .Cases({"CF_OPTIONS", "OBJC_OPTIONS", "SWIFT_OPTIONS"},
+                      EnumKind::Options)
+               .Default(EnumKind::Unknown);
+    if (kind != EnumKind::Unknown)
       return;
-    }
-    if (MacroName == "CF_OPTIONS" || MacroName == "OBJC_OPTIONS" ||
-        MacroName == "SWIFT_OPTIONS") {
-      kind = EnumKind::Options;
-      return;
-    }
   }
 
   // Hardcode a particular annoying case in the OS X headers.

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -47,6 +47,7 @@
 #include "clang/Sema/Sema.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
 #include <memory>
@@ -429,13 +430,9 @@ namespace {
     using OverriddenName = std::pair<const DeclType *, ImportedName>;
     llvm::SmallPtrSet<DeclName, 4> known;
     (void)known.insert(DeclName());
-    overriddenNames.erase(
-        std::remove_if(overriddenNames.begin(), overriddenNames.end(),
-                       [&](OverriddenName overridden) {
-                         return !known.insert(overridden.second.getDeclName())
-                                     .second;
-                       }),
-        overriddenNames.end());
+    llvm::erase_if(overriddenNames, [&](OverriddenName overridden) {
+      return !known.insert(overridden.second.getDeclName()).second;
+    });
 
     if (overriddenNames.size() < 2)
       return;
@@ -1323,12 +1320,12 @@ NameImporter::considerErrorImport(const clang::ObjCMethodDecl *clangDecl,
 }
 
 bool swift::isCompletionHandlerParamName(StringRef paramName) {
-  return paramName == "completionHandler" ||
-      paramName == "withCompletionHandler" ||
-      paramName == "completion" || paramName == "withCompletion" ||
-      paramName == "completionBlock" || paramName == "withCompletionBlock" ||
-      paramName == "reply" || paramName == "withReply" ||
-      paramName == "replyTo" || paramName == "withReplyTo";
+  return llvm::StringSwitch<bool>(paramName)
+      .Cases({"completionHandler", "withCompletionHandler", "completion",
+              "withCompletion", "completionBlock", "withCompletionBlock"},
+             true)
+      .Cases({"reply", "withReply", "replyTo", "withReplyTo"}, true)
+      .Default(false);
 }
 
 // Determine whether the given type is a nullable NSError type.
@@ -2255,11 +2252,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       auto argName = selector.getNameForSlot(0).substr(initializerPrefixLen);
 
       // Drop "With" if present after the "init".
-      bool droppedWith = false;
-      if (argName.starts_with("With")) {
-        argName = argName.substr(4);
-        droppedWith = true;
-      }
+      bool droppedWith = argName.consume_front("With");
 
       // Lowercase the remaining argument name.
       argName = camel_case::toLowercaseWord(argName, selectorSplitScratch);
@@ -2336,8 +2329,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
     StringRef removePrefix = enumInfo.getConstantNamePrefix();
     if (!removePrefix.empty()) {
-      if (baseName.starts_with(removePrefix)) {
-        baseName = baseName.substr(removePrefix.size());
+      if (baseName.consume_front(removePrefix)) {
         strippedPrefix = true;
       } else if (givenName) {
         // Calculate the new prefix.
@@ -2377,7 +2369,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (objcProto->hasDefinition()) {
       if (hasNamingConflict(D, objcProto->getIdentifier(), nullptr)) {
         baseNameWithProtocolSuffix = baseName;
-        baseNameWithProtocolSuffix += SWIFT_PROTOCOL_SUFFIX;
+        baseNameWithProtocolSuffix += ProtocolSuffix;
         baseName = baseNameWithProtocolSuffix;
       }
     }
@@ -2453,12 +2445,13 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         newName += "Consuming";
       baseName = newName;
     }
-    if (method->isImplicit() &&
-        baseName.starts_with("__synthesizedVirtualCall_")) {
+    constexpr llvm::StringLiteral virtualCallPrefix =
+        "__synthesizedVirtualCall_";
+    if (method->isImplicit() && baseName.starts_with(virtualCallPrefix)) {
       // If this is a thunk for a virtual method of a C++ reference type, we
       // strip away the underscored prefix. This method should be visible and
       // callable from Swift.
-      newName = baseName.substr(StringRef("__synthesizedVirtualCall_").size());
+      newName = baseName.substr(virtualCallPrefix.size());
       baseName = newName;
     }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -52,6 +52,7 @@
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Sema.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Compiler.h"
 #include <optional>
 
@@ -965,27 +966,21 @@ namespace {
           break;
         }
 
-        static const llvm::StringLiteral vaListNames[] = {
-          "va_list", "__gnuc_va_list", "__va_list"
-        };
-
-        ImportHint hint = ImportHint::None;
-        if (type->getDecl()->getName() == "BOOL") {
-          hint = ImportHint::Boolean;
-        } else if (type->getDecl()->getName() == "Boolean") {
-          // FIXME: Darwin only?
-          hint = ImportHint::Boolean;
-        } else if (type->getDecl()->getName() == "NSUInteger") {
-          hint = ImportHint::NSUInteger;
-        } else if (llvm::is_contained(vaListNames,
-                                      type->getDecl()->getName())) {
-          hint = ImportHint::VAList;
-        } else if (isImportedCFPointer(type->desugar(), mappedType)) {
-          hint = ImportHint::CFPointer;
-        } else if (mappedType->isAnyExistentialType()) { // id, Class
-          hint = ImportHint::ObjCPointer;
-        } else if (type->isPointerType() || type->isBlockPointerType()) {
-          hint = ImportHint::OtherPointer;
+        ImportHint hint =
+            llvm::StringSwitch<ImportHint>(type->getDecl()->getName())
+                // FIXME: Is "Boolean" Darwin only?
+                .Cases({"BOOL", "Boolean"}, ImportHint::Boolean)
+                .Case("NSUInteger", ImportHint::NSUInteger)
+                .Cases({"va_list", "__gnuc_va_list", "__va_list"},
+                       ImportHint::VAList)
+                .Default(ImportHint::None);
+        if (hint == ImportHint::None) {
+          if (isImportedCFPointer(type->desugar(), mappedType))
+            hint = ImportHint::CFPointer;
+          else if (mappedType->isAnyExistentialType()) // id, Class
+            hint = ImportHint::ObjCPointer;
+          else if (type->isPointerType() || type->isBlockPointerType())
+            hint = ImportHint::OtherPointer;
         }
         // Any other interesting mapped types should be hinted here.
         return { mappedType, hint };

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -318,8 +318,8 @@ enum class SpecialMethodKind {
   NSDictionarySubscriptGetter
 };
 
-#define SWIFT_PROTOCOL_SUFFIX "Protocol"
-#define SWIFT_CFTYPE_SUFFIX "Ref"
+constexpr static const llvm::StringLiteral ProtocolSuffix = "Protocol";
+constexpr static const llvm::StringLiteral CFTypeSuffix = "Ref";
 
 /// Describes whether to classify a factory method as an initializer.
 enum class FactoryAsInitKind {
@@ -504,12 +504,12 @@ public:
 
   const Version CurrentVersion;
 
-  constexpr static const char *const moduleImportBufferName =
+  static constexpr llvm::StringLiteral moduleImportBufferName =
       "<swift-imported-modules>";
-  constexpr static const char *const bridgingHeaderBufferName =
+  static constexpr llvm::StringLiteral bridgingHeaderBufferName =
       "<bridging-header-import>";
   /// The name of system vfsoverlay.
-  constexpr static const char *const clangSystemVFSOverlayName =
+  static constexpr llvm::StringLiteral clangSystemVFSOverlayName =
       "<clang-system-vfs-overlay>";
 
 private:

--- a/lib/ClangImporter/PolyglotAST.cpp
+++ b/lib/ClangImporter/PolyglotAST.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "llvm/ADT/STLExtras.h"
 #include "ImporterImpl.h"
 
 using namespace swift;
@@ -282,12 +283,11 @@ ClangImporter::printPolyglotAST(StringRef Filename, raw_ostream &OS) {
 
   // Sort imported declarations in source order.
   auto &ClangSM = getClangASTContext().getSourceManager();
-  std::sort(ClangDecls.begin(), ClangDecls.end(),
-            [&](const clang::Decl *LHS, const clang::Decl *RHS) -> bool {
-              return ClangSM.isBeforeInTranslationUnit(
-                                            LHS->getLocation(),
-                                            RHS->getLocation());
-            });
+  llvm::sort(ClangDecls,
+             [&](const clang::Decl *LHS, const clang::Decl *RHS) -> bool {
+               return ClangSM.isBeforeInTranslationUnit(LHS->getLocation(),
+                                                        RHS->getLocation());
+             });
 
   auto Json = llvm::json::OStream(OS, /*indent*/2);
   Json.object([&] {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -43,6 +43,7 @@
 #include "clang/Basic/Specifiers.h"
 #include "clang/Sema/DelayedDiagnostic.h"
 #include "clang/Sema/Sema.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
 using namespace importer;
@@ -2435,7 +2436,7 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
   auto oldArgNames = operatorMethod->getName().getArgumentNames();
   SmallVector<Identifier, 4> newArgNames;
   newArgNames.emplace_back();
-  newArgNames.append(oldArgNames.begin(), oldArgNames.end());
+  llvm::append_range(newArgNames, oldArgNames);
 
   auto opDeclName =
       DeclName(ctx, opId, {newArgNames.begin(), newArgNames.end()});
@@ -2477,10 +2478,11 @@ FuncDecl *SwiftDeclSynthesizer::makeVirtualMethod(
       ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
       /*forceConstQualifier*/ false);
 
+  constexpr llvm::StringLiteral initName = "init";
   llvm::SmallString<64> backtickedSwiftName;
-  if (swiftName == "init" || swiftName.starts_with("init(")) {
+  if (swiftName == initName || swiftName.starts_with("init(")) {
     backtickedSwiftName = "`init`";
-    backtickedSwiftName += swiftName.drop_front(StringRef("init").size());
+    backtickedSwiftName += swiftName.drop_front(initName.size());
     swiftName = backtickedSwiftName;
   }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -193,8 +193,7 @@ public:
 
   bool isEmptyExtensionDecl(const ExtensionDecl *ED) {
     auto members = ED->getAllMembers();
-    auto hasMembers = std::any_of(members.begin(), members.end(),
-                                  [this](const Decl *D) -> bool {
+    auto hasMembers = llvm::any_of(members, [this](const Decl *D) -> bool {
       if (auto VD = dyn_cast<ValueDecl>(D))
         if (shouldInclude(VD))
           return true;
@@ -202,10 +201,9 @@ public:
     });
 
     auto protocols = ED->getLocalProtocols(ConformanceLookupKind::OnlyExplicit);
-    auto hasProtocols = std::any_of(protocols.begin(), protocols.end(),
-                                    [this](const ProtocolDecl *PD) -> bool {
-      return shouldInclude(PD);
-    });
+    auto hasProtocols = llvm::any_of(
+        protocols,
+        [this](const ProtocolDecl *PD) -> bool { return shouldInclude(PD); });
 
     return (!hasMembers && !hasProtocols);
   }

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -40,6 +40,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/Module.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/raw_ostream.h"
 #include <utility>
@@ -704,10 +705,9 @@ public:
           // Don't emit nested types that are just implicitly @objc.
           // You should have to opt into this, since they are even less
           // namespaced than usual.
-          if (std::any_of(VD->getAttrs().begin(), VD->getAttrs().end(),
-                          [](const DeclAttribute *attr) {
-                            return isa<ObjCAttr>(attr) && !attr->isImplicit();
-                          })) {
+          if (llvm::any_of(VD->getAttrs(), [](const DeclAttribute *attr) {
+                return isa<ObjCAttr>(attr) && !attr->isImplicit();
+              })) {
             nestedTypes.push_back(VD);
           }
         }
@@ -948,11 +948,10 @@ public:
     auto errorTypeProto = ctx.getProtocol(KnownProtocolKind::Error);
     if (outputLangMode == OutputLanguageMode::ObjC
         && ED->lookupConformance(errorTypeProto, conformances)) {
-      bool hasDomainCase = std::any_of(ED->getAllElements().begin(),
-                                       ED->getAllElements().end(),
-                                       [](const EnumElementDecl *elem) {
-        return elem->getBaseIdentifier().str() == "Domain";
-      });
+      bool hasDomainCase =
+          llvm::any_of(ED->getAllElements(), [](const EnumElementDecl *elem) {
+            return elem->getBaseIdentifier().str() == "Domain";
+          });
       if (!hasDomainCase) {
         os << "static NSString * _Nonnull const " << getNameForObjC(ED)
            << "Domain = @\"" << getErrorDomainStringForObjC(ED) << "\";\n";
@@ -967,30 +966,26 @@ public:
     M.getTopLevelDeclsWithAuxiliaryDecls(decls);
     llvm::SmallSetVector<const ValueDecl *, 4> removedValueDecls;
 
-    auto newEnd =
-        std::remove_if(decls.begin(), decls.end(),
-                       [this, &removedValueDecls](const Decl *D) -> bool {
-                         if (auto VD = dyn_cast<ValueDecl>(D)) {
-                           auto shouldRemove = !printer.shouldInclude(VD);
-                           if (shouldRemove)
-                             removedValueDecls.insert(VD);
-                           return shouldRemove;
-                         }
+    llvm::erase_if(decls, [this, &removedValueDecls](const Decl *D) -> bool {
+      if (auto VD = dyn_cast<ValueDecl>(D)) {
+        auto shouldRemove = !printer.shouldInclude(VD);
+        if (shouldRemove)
+          removedValueDecls.insert(VD);
+        return shouldRemove;
+      }
 
-                         if (auto ED = dyn_cast<ExtensionDecl>(D)) {
-                           // Immediately filter out invalid extensions.
-                           if (ED->isInvalid())
-                             return true;
-                           if (outputLangMode == OutputLanguageMode::Cxx)
-                             return false;
-                           auto baseClass = ED->getSelfClassDecl();
-                           return !baseClass ||
-                                  !printer.shouldInclude(baseClass) ||
-                                  baseClass->isForeign();
-                         }
-                         return true;
-                       });
-    decls.erase(newEnd, decls.end());
+      if (auto ED = dyn_cast<ExtensionDecl>(D)) {
+        // Immediately filter out invalid extensions.
+        if (ED->isInvalid())
+          return true;
+        if (outputLangMode == OutputLanguageMode::Cxx)
+          return false;
+        auto baseClass = ED->getSelfClassDecl();
+        return !baseClass || !printer.shouldInclude(baseClass) ||
+               baseClass->isForeign();
+      }
+      return true;
+    });
 
     if (M.isStdlibModule()) {
       llvm::SmallVector<Decl *, 2> nestedAdds;

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -30,6 +30,7 @@
 #include "clang/Basic/Module.h"
 #include "clang/Lex/HeaderSearch.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
@@ -589,11 +590,10 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
         } else {
           SmallVector<llvm::SmallString<128>, 4> sortedIncludes{
               quotedIncludes.begin(), quotedIncludes.end()};
-          std::sort(sortedIncludes.begin(), sortedIncludes.end(),
-                    [](const llvm::SmallString<128> &lhs,
-                       const llvm::SmallString<128> &rhs) {
-                      return lhs.str() < rhs.str();
-                    });
+          llvm::sort(sortedIncludes, [](const llvm::SmallString<128> &lhs,
+                                        const llvm::SmallString<128> &rhs) {
+            return lhs.str() < rhs.str();
+          });
           for (const auto &header : sortedIncludes) {
             out << "#import \"" << header << "\"\n";
           }

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1907,7 +1907,7 @@ bool DeclAndTypeClangFunctionPrinter::hasKnownOptionalNullableCxxMapping(
 }
 
 void DeclAndTypeClangFunctionPrinter::printCustomCxxFunction(
-    const SmallVector<Type> &neededTypes, bool NeedsReturnTypes,
+    ArrayRef<Type> neededTypes, bool NeedsReturnTypes,
     PrinterTy retTypeAndNamePrinter, PrinterTy paramPrinter, bool isConstFunc,
     PrinterTy bodyPrinter, ValueDecl *valueDecl, ModuleDecl *emittedModule,
     raw_ostream &outOfLineOS) {

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -166,7 +166,7 @@ public:
       llvm::function_ref<void(llvm::MapVector<Type, std::string> &)>;
 
   /// Print generated C++ helper function
-  void printCustomCxxFunction(const SmallVector<Type> &neededTypes,
+  void printCustomCxxFunction(ArrayRef<Type> neededTypes,
                               bool NeedsReturnTypes,
                               PrinterTy retTypeAndNamePrinter,
                               PrinterTy paramPrinter, bool isConstFunc,


### PR DESCRIPTION
* Use llvm::StringLiteral to push some string length computation to compile time
* Use llvm::StringSwitch to simplify some checks
* Use some llvm::algorithms to shorten the code
* Prefer llvm::ArrayRef over const SmallVectorImpl&
* Simplify some code via StringRef::consume_front/back