### PR TITLE
[region-isolation] Emit isolation-history notes for the remaining four diagnostics

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1486,13 +1486,19 @@ public:
     SILValue srcValue;
     SILDynamicMergedIsolationInfo srcIsolationRegionInfo;
 
+    /// The partition at the assignment, for isolation history rewinding. None
+    /// when history recording is off for this function.
+    std::optional<Partition> partition;
+
     AssignNeverSendableIntoSendingResultError(
         const PartitionOp &op, Element destElement,
         SILFunctionArgument *destValue, Element srcElement, SILValue srcValue,
-        SILDynamicMergedIsolationInfo srcIsolationRegionInfo)
+        SILDynamicMergedIsolationInfo srcIsolationRegionInfo,
+        std::optional<Partition> &&p)
         : op(&op), destElement(destElement), destValue(destValue),
           srcElement(srcElement), srcValue(srcValue),
-          srcIsolationRegionInfo(srcIsolationRegionInfo) {}
+          srcIsolationRegionInfo(srcIsolationRegionInfo),
+          partition(std::move(p)) {}
 
     AssignNeverSendableIntoSendingResultError(
         AssignNeverSendableIntoSendingResultError &&other) = default;
@@ -2056,7 +2062,8 @@ public:
     }
 
     handleError(AssignNeverSendableIntoSendingResultError(
-        op, op.getOpArg1(), fArg, op.getOpArg2(), rep, dynamicRegionIsolation));
+        op, op.getOpArg1(), fArg, op.getOpArg2(), rep, dynamicRegionIsolation,
+        getSnapshotForIsolationHistory()));
   }
 
   /// Apply \p op to the partition op.

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1577,18 +1577,26 @@ public:
     /// If set, the emitter should downgrade this error to a warning.
     bool downgradeToWarning = false;
 
-    InOutSendingReturnedError(const PartitionOp &op,
-                              Element inoutSendingElement,
-                              Element returnedValue,
-                              SILDynamicMergedIsolationInfo isolationInfo = {})
-        : op(&op), inoutSendingElement(inoutSendingElement),
-          returnedValue(returnedValue), isolationInfo(isolationInfo) {}
+    /// The partition at the exiting terminator, for isolation history rewinding.
+    /// None when history recording is off for this function.
+    std::optional<Partition> partition;
 
     InOutSendingReturnedError(const PartitionOp &op,
                               Element inoutSendingElement,
-                              SILDynamicMergedIsolationInfo isolationInfo = {})
+                              Element returnedValue,
+                              SILDynamicMergedIsolationInfo isolationInfo = {},
+                              std::optional<Partition> &&p = {})
+        : op(&op), inoutSendingElement(inoutSendingElement),
+          returnedValue(returnedValue), isolationInfo(isolationInfo),
+          partition(std::move(p)) {}
+
+    InOutSendingReturnedError(const PartitionOp &op,
+                              Element inoutSendingElement,
+                              SILDynamicMergedIsolationInfo isolationInfo = {},
+                              std::optional<Partition> &&p = {})
         : InOutSendingReturnedError(op, inoutSendingElement,
-                                    inoutSendingElement, isolationInfo) {}
+                                    inoutSendingElement, isolationInfo,
+                                    std::move(p)) {}
 
     InOutSendingReturnedError(InOutSendingReturnedError &&other) = default;
     InOutSendingReturnedError &
@@ -2407,15 +2415,17 @@ public:
           // determining element identity. When that changes, this code will
           // need to be updated to look through loads.
           if (*elt == op.getOpArg1()) {
-            handleError(InOutSendingReturnedError(op, op.getOpArg1(),
-                                                  dynamicRegionIsolation));
+            handleError(InOutSendingReturnedError(
+                op, op.getOpArg1(), dynamicRegionIsolation,
+                getSnapshotForIsolationHistory()));
             continue;
           }
 
           // Otherwise, we need to refer to a different value in the same region
           // as the 'inout sending' parameter. Emit a special error. For that.
-          handleError(InOutSendingReturnedError(op, op.getOpArg1(), *elt,
-                                                dynamicRegionIsolation));
+          handleError(InOutSendingReturnedError(
+              op, op.getOpArg1(), *elt, dynamicRegionIsolation,
+              getSnapshotForIsolationHistory()));
         }
 
         return emittedDiagnostic;
@@ -2431,9 +2441,9 @@ public:
         // This handles task-isolated captures.
         if (auto outParam =
                 findNonDisconnectedOutParameterInRegion(inoutSendingRegion)) {
-          handleError(InOutSendingReturnedError(op, op.getOpArg1(),
-                                                getElement(outParam).value(),
-                                                dynamicRegionIsolation));
+          handleError(InOutSendingReturnedError(
+              op, op.getOpArg1(), getElement(outParam).value(),
+              dynamicRegionIsolation, getSnapshotForIsolationHistory()));
           return;
         }
 
@@ -2484,7 +2494,8 @@ public:
       if (auto outParam =
           findSendingOutParameterInRegion(inoutSendingRegion)) {
         InOutSendingReturnedError error(op, op.getOpArg1(), outParam.value(),
-                                       dynamicRegionIsolation);
+                                        dynamicRegionIsolation,
+                                        getSnapshotForIsolationHistory());
         error.downgradeToWarning = true;
         handleError(std::move(error));
         return;

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1577,8 +1577,8 @@ public:
     /// If set, the emitter should downgrade this error to a warning.
     bool downgradeToWarning = false;
 
-    /// The partition at the exiting terminator, for isolation history rewinding.
-    /// None when history recording is off for this function.
+    /// The partition at the exiting terminator, for isolation history
+    /// rewinding. None when history recording is off for this function.
     std::optional<Partition> partition;
 
     InOutSendingReturnedError(const PartitionOp &op,
@@ -1614,11 +1614,17 @@ public:
     Element firstInoutSendingParam;
     SmallVector<Element, 1> otherInOutSendingParams;
 
+    /// The partition at the exiting terminator, for isolation history
+    /// rewinding. None when history recording is off for this function.
+    std::optional<Partition> partition;
+
     InOutSendingParametersInSameRegionError(
         const PartitionOp &op, Element firstInoutSendingParam,
-        SmallVector<Element, 1> &&otherInOutSendingParams)
+        SmallVector<Element, 1> &&otherInOutSendingParams,
+        std::optional<Partition> &&p)
         : op(&op), firstInoutSendingParam(firstInoutSendingParam),
-          otherInOutSendingParams(std::move(otherInOutSendingParams)) {}
+          otherInOutSendingParams(std::move(otherInOutSendingParams)),
+          partition(std::move(p)) {}
 
     InOutSendingParametersInSameRegionError(
         InOutSendingParametersInSameRegionError &&other) = default;
@@ -2466,7 +2472,8 @@ public:
       if (findOtherInOutSendingParameters(inoutSendingRegion, op.getOpArg1(),
                                           foundInOutSendingElts)) {
         handleError(InOutSendingParametersInSameRegionError(
-            op, op.getOpArg1(), std::move(foundInOutSendingElts)));
+            op, op.getOpArg1(), std::move(foundInOutSendingElts),
+            getSnapshotForIsolationHistory()));
         return;
       }
 

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1686,16 +1686,24 @@ public:
     SILDynamicMergedIsolationInfo dstIsolationRegionInfo;
     Reason reason;
 
+    /// The partition *before* the failed merge, for isolation history
+    /// rewinding. The two regions are still separate here -- the error is
+    /// raised before assignElement/merge runs -- which is what lets each side
+    /// be explained by its own independent walk. None when history recording is
+    /// off.
+    std::optional<Partition> partition;
+
     IncompatibleRegionMergeError(
         const PartitionOp &op, Element srcRegionElt,
         SILDynamicMergedIsolationInfo srcIsolationRegionInfo,
         Element dstRegionElt,
         SILDynamicMergedIsolationInfo dstIsolationRegionInfo,
-        Reason reason = Reason::Unknown)
+        Reason reason = Reason::Unknown, std::optional<Partition> &&p = {})
         : op(&op), srcRegionElt(srcRegionElt),
           srcIsolationRegionInfo(srcIsolationRegionInfo),
           dstRegionElt(dstRegionElt),
-          dstIsolationRegionInfo(dstIsolationRegionInfo), reason(reason) {}
+          dstIsolationRegionInfo(dstIsolationRegionInfo), reason(reason),
+          partition(std::move(p)) {}
 
     IncompatibleRegionMergeError(IncompatibleRegionMergeError &&other) =
         default;
@@ -2172,7 +2180,7 @@ public:
         }
         return handleError(IncompatibleRegionMergeError(
             op, srcElement, srcRegIsolation, destElement, destIsolation,
-            RegionMergeReason::Assign));
+            RegionMergeReason::Assign, getSnapshotForIsolationHistory()));
       }
 
       // Then perform the actual assignment.
@@ -2215,7 +2223,7 @@ public:
         }
         return handleError(IncompatibleRegionMergeError(
             op, srcElement, srcRegIsolation, destElement, destIsolation,
-            RegionMergeReason::Assign));
+            RegionMergeReason::Assign, getSnapshotForIsolationHistory()));
       }
 
       // Create extra region for our dest and merge it into dest's region.
@@ -2356,7 +2364,7 @@ public:
         }
         return handleError(IncompatibleRegionMergeError(
             op, srcElement, srcRegIsolation, destElement, destRegIsolation,
-            op.getRegionMergeReason()));
+            op.getRegionMergeReason(), getSnapshotForIsolationHistory()));
       }
 
       // Then perform the actual merge.

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -4641,6 +4641,15 @@ private:
   /// the never-sent value's region when the error was diagnosed.
   SILDynamicMergedIsolationInfo isolatedValueIsolationRegionInfo;
 
+  /// The region analysis for this function; forwarded to the isolation-history
+  /// note emitter so it can recover predecessor exit partitions across joins.
+  RegionAnalysisFunctionInfo *info;
+
+  /// The element of the never-sent value, and the partition at the assignment,
+  /// for the isolation-history notes.
+  Element neverSentElement;
+  std::optional<Partition> partition;
+
   bool emittedErrorDiagnostic = false;
 
 public:
@@ -4648,7 +4657,9 @@ public:
       RegionAnalysisFunctionInfo *info, Error &&error)
       : srcOperand(error.op->getSourceOp()), outSendingResult(error.destValue),
         neverSentValue(error.srcValue),
-        isolatedValueIsolationRegionInfo(error.srcIsolationRegionInfo) {}
+        isolatedValueIsolationRegionInfo(error.srcIsolationRegionInfo),
+        info(info), neverSentElement(error.srcElement),
+        partition(std::move(error.partition)) {}
 
   ~AssignNeverSendableIntoSendingResultDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
@@ -4669,6 +4680,27 @@ public:
                                srcOperand->getUser(),
                                getConcurrencyDiagnosticBehavior(),
                                /*pushToFuture=*/false);
+  }
+
+  /// Explain how the assigned value's region came to be isolated, when
+  /// isolation-history emission is on for this function.
+  ///
+  /// Deliberately still runs on emit()'s unknown-pattern paths: that error is
+  /// about this same value, a chain is useful context for it, and
+  /// emitUnknownPatternError sets emittedErrorDiagnostic, so the note still
+  /// follows its error. Do not "fix" that by narrowing the defer.
+  void emitIsolationHistoryNoteIfNeeded() {
+    // A note has to follow the diagnostic it annotates. When emit() bailed
+    // without emitting anything the unknown-pattern error comes from our
+    // destructor -- after this defer runs -- so there is nothing to attach to
+    // yet.
+    if (!emittedErrorDiagnostic || !partition)
+      return;
+    IsolationHistoryNoteEmitter::emit(
+        getFunction(), info, info->getValueMap(),
+        IsolationHistoryNoteEmitter::Request::howDidBecomeIsolatedTo(
+            neverSentElement, isolatedValueIsolationRegionInfo),
+        std::move(*partition));
   }
 
   void emit();
@@ -4751,6 +4783,9 @@ static SILValue findOutParameter(SILValue v) {
 }
 
 void AssignNeverSendableIntoSendingResultDiagnosticEmitter::emit() {
+  // Emit isolation history notes after the primary diagnostic returns.
+  SWIFT_DEFER { emitIsolationHistoryNoteIfNeeded(); };
+
   // Then emit the note with greater context.
   auto descriptiveKindStr =
       isolatedValueIsolationRegionInfo.printForDiagnostics(getFunction());

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -3869,17 +3869,18 @@ public:
   /// Exactly one chain per error, anchored on the elements the error carries
   /// rather than on anything emit() re-derives. emit() walks epilogue phis and
   /// resolves indirect out-parameters through LastValueEnum, and can emit
-  /// several primary diagnostics from one error -- but those paths exist to find
-  /// a better diagnostic *location*, not to describe more regions. Following
-  /// them here would be wrong twice over: LastValueEnum yields SILValues that
-  /// may have no Element in the value map at all, so there would be nothing to
-  /// ask the walk about; and the region fact being explained is singular, so one
-  /// chain is what matches it. The walk's own sequence boundaries place the
-  /// notes.
+  /// several primary diagnostics from one error -- but those paths exist to
+  /// find a better diagnostic *location*, not to describe more regions.
+  /// Following them here would be wrong twice over: LastValueEnum yields
+  /// SILValues that may have no Element in the value map at all, so there would
+  /// be nothing to ask the walk about; and the region fact being explained is
+  /// singular, so one chain is what matches it. The walk's own sequence
+  /// boundaries place the notes.
   ///
   /// Branch on the elements, not on the inoutSendingParam == returnedValue
   /// SILValue comparison emit() uses: two elements can share a representative
-  /// through load look-through, and it is the element identity the request needs.
+  /// through load look-through, and it is the element identity the request
+  /// needs.
   void emitIsolationHistoryNoteIfNeeded() {
     // A note has to follow the diagnostic it annotates. When emit() bailed
     // without emitting anything the unknown-pattern error comes from our
@@ -5173,15 +5174,30 @@ class InOutSendingParametersInSameRegionDiagnosticEmitter {
   /// The second 'inout sending' param in the region.
   SILValue secondInOutSendingParam;
 
+  /// The region analysis for this function; forwarded to the isolation-history
+  /// note emitter so it can recover predecessor exit partitions across joins.
+  RegionAnalysisFunctionInfo *info;
+
+  /// The elements of the two parameters, and the partition at the exit, for the
+  /// isolation-history notes. This emitter is constructed once per reported
+  /// pair, so each instance explains exactly its own pair.
+  Element firstElement;
+  Element secondElement;
+  std::optional<Partition> partition;
+
   bool emittedErrorDiagnostic = false;
 
 public:
   InOutSendingParametersInSameRegionDiagnosticEmitter(
-      TermInst *functionExitingInst, SILValue firstInOutSendingParam,
-      SILValue secondInOutSendingParam)
+      RegionAnalysisFunctionInfo *info, TermInst *functionExitingInst,
+      SILValue firstInOutSendingParam, SILValue secondInOutSendingParam,
+      Element firstElement, Element secondElement,
+      std::optional<Partition> &&partition)
       : functionExitingInst(functionExitingInst),
         firstInOutSendingParam(firstInOutSendingParam),
-        secondInOutSendingParam(secondInOutSendingParam) {}
+        secondInOutSendingParam(secondInOutSendingParam), info(info),
+        firstElement(firstElement), secondElement(secondElement),
+        partition(std::move(partition)) {}
 
   ~InOutSendingParametersInSameRegionDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
@@ -5213,6 +5229,26 @@ public:
         InOutSendingParametersInSameRegionDiagnosticEmitter,
         functionExitingInst, getBehaviorLimit(),
         /*pushToFuture=*/false);
+  }
+
+  /// Explain how the two 'inout sending' parameters came to share a region,
+  /// when isolation-history emission is on for this function.
+  ///
+  /// Both parameters are disconnected -- this diagnostic is purely about them
+  /// sharing a region -- so the request is a connect one and every link is a
+  /// plain "'a' is connected to 'b'" with no isolated terminus.
+  void emitIsolationHistoryNoteIfNeeded() {
+    // A note has to follow the diagnostic it annotates. When emit() bailed
+    // without emitting anything the unknown-pattern error comes from our
+    // destructor -- after this defer runs -- so there is nothing to attach to
+    // yet.
+    if (!emittedErrorDiagnostic || !partition)
+      return;
+    IsolationHistoryNoteEmitter::emit(
+        getFunction(), info, info->getValueMap(),
+        IsolationHistoryNoteEmitter::Request::howDidBecomeConnectedTo(
+            firstElement, secondElement),
+        std::move(*partition));
   }
 
   void emit();
@@ -5263,6 +5299,9 @@ public:
 } // namespace
 
 void InOutSendingParametersInSameRegionDiagnosticEmitter::emit() {
+  // Emit isolation history notes after the primary diagnostic returns.
+  SWIFT_DEFER { emitIsolationHistoryNoteIfNeeded(); };
+
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
   auto firstName = inferNameHelper(firstInOutSendingParam);
@@ -5670,9 +5709,18 @@ void SendNonSendableImpl::emitVerbatimErrors() {
             behavior && *behavior == DiagnosticBehavior::Ignore) {
           continue;
         }
+        // Each reported pair gets its own chain, emitted from inside this loop:
+        // a pair skipped above gets no primary diagnostic, so a chain for it
+        // would be a note with no error to attach to. The walk consumes the
+        // partition it rewinds, so hand each pair its own copy rather than
+        // moving the error's.
+        std::optional<Partition> pairPartition;
+        if (e.partition)
+          pairPartition.emplace(*e.partition);
         InOutSendingParametersInSameRegionDiagnosticEmitter diagnosticEmitter(
-            cast<TermInst>(e.op->getSourceInst()), firstParam.getValue(),
-            paramValue);
+            info, cast<TermInst>(e.op->getSourceInst()), firstParam.getValue(),
+            paramValue, e.firstInoutSendingParam, paramElt,
+            std::move(pairPartition));
         diagnosticEmitter.emit();
       }
       continue;

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -3815,6 +3815,13 @@ private:
   /// isolation.
   SILDynamicMergedIsolationInfo isolationInfo;
 
+  /// The element of the returned value, and the partition at the exit, for the
+  /// isolation-history notes. Kept alongside \c returnedValue because the
+  /// history walk works in elements, and because \c returnedValue is null'd out
+  /// in the "returned the parameter itself" case.
+  Element returnedValueElement;
+  std::optional<Partition> partition;
+
   bool downgradeToWarning = false;
   bool emittedErrorDiagnostic = false;
 
@@ -3831,6 +3838,8 @@ public:
         returnedValue(
             raFuncInfo->getValueMap().getRepresentative(error.returnedValue)),
         isolationInfo(error.isolationInfo),
+        returnedValueElement(error.returnedValue),
+        partition(std::move(error.partition)),
         downgradeToWarning(error.downgradeToWarning) {}
 
   ~InOutSendingReturnedDiagnosticEmitter() {
@@ -3852,6 +3861,43 @@ public:
     EMIT_UNKNOWN_PATTERN_ERROR(InOutSendingReturnedDiagnosticEmitter,
                                functionExitingInst, getBehaviorLimit(),
                                pushToFuture);
+  }
+
+  /// Explain the region fact behind this error, when isolation-history emission
+  /// is on for this function.
+  ///
+  /// Exactly one chain per error, anchored on the elements the error carries
+  /// rather than on anything emit() re-derives. emit() walks epilogue phis and
+  /// resolves indirect out-parameters through LastValueEnum, and can emit
+  /// several primary diagnostics from one error -- but those paths exist to find
+  /// a better diagnostic *location*, not to describe more regions. Following
+  /// them here would be wrong twice over: LastValueEnum yields SILValues that
+  /// may have no Element in the value map at all, so there would be nothing to
+  /// ask the walk about; and the region fact being explained is singular, so one
+  /// chain is what matches it. The walk's own sequence boundaries place the
+  /// notes.
+  ///
+  /// Branch on the elements, not on the inoutSendingParam == returnedValue
+  /// SILValue comparison emit() uses: two elements can share a representative
+  /// through load look-through, and it is the element identity the request needs.
+  void emitIsolationHistoryNoteIfNeeded() {
+    // A note has to follow the diagnostic it annotates. When emit() bailed
+    // without emitting anything the unknown-pattern error comes from our
+    // destructor -- after this defer runs -- so there is nothing to attach to
+    // yet.
+    if (!emittedErrorDiagnostic || !partition)
+      return;
+
+    auto request =
+        returnedValueElement == inoutSendingParamElement
+            ? IsolationHistoryNoteEmitter::Request::howDidBecomeIsolatedTo(
+                  inoutSendingParamElement, isolationInfo)
+            : IsolationHistoryNoteEmitter::Request::howDidBecomeConnectedTo(
+                  returnedValueElement, inoutSendingParamElement);
+
+    IsolationHistoryNoteEmitter::emit(getFunction(), raFuncInfo,
+                                      raFuncInfo->getValueMap(), request,
+                                      std::move(*partition));
   }
 
   void emit();
@@ -4344,6 +4390,9 @@ bool InOutSendingReturnedDiagnosticEmitter::emitOutParamIncomingValueError(
 }
 
 void InOutSendingReturnedDiagnosticEmitter::emit() {
+  // Emit isolation history notes after the primary diagnostic returns.
+  SWIFT_DEFER { emitIsolationHistoryNoteIfNeeded(); };
+
   // Check if we had a separate erroring value that is our returned value. If we
   // do not then we just returned the 'inout sending' parameter. Emit a special
   // message and return.

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -5372,6 +5372,15 @@ struct IncompatibleRegionMergeDiagnosticEmitter {
   SILDynamicMergedIsolationInfo dstIsolationInfo;
   RegionMergeReason reason;
 
+  /// The region analysis for this function; forwarded to the isolation-history
+  /// note emitter so it can recover predecessor exit partitions across joins.
+  RegionAnalysisFunctionInfo *info;
+
+  /// The partition before the failed merge. See the error struct's comment: the
+  /// two regions are still separate here, so each side is explained by its own
+  /// independent walk. None when history recording is off for this function.
+  std::optional<Partition> partition;
+
   IncompatibleRegionMergeDiagnosticEmitter(RegionAnalysisFunctionInfo *info,
                                            Error &&error)
       : valueMap(info->getValueMap()), op(error.op->getSourceOp()),
@@ -5383,7 +5392,8 @@ struct IncompatibleRegionMergeDiagnosticEmitter {
         // the error since we may have an error reason that was specified
         // explicitly when the error was created, not from the actual
         // PartitionOp.
-        reason(error.reason) {}
+        reason(error.reason), info(info),
+        partition(std::move(error.partition)) {}
 
   void emit();
 
@@ -5398,6 +5408,43 @@ private:
     EMIT_UNKNOWN_PATTERN_ERROR(IncompatibleRegionMergeErrorEmitter,
                                op->getUser(), getBehaviorLimit(),
                                /*pushToFuture=*/true);
+  }
+
+  /// Explain one side of the failed merge: how that side's region came to have
+  /// the isolation it has.
+  ///
+  /// The isolation-history chain is the deep version of the shallow
+  /// "X is exposed to <iso> code" note -- it names every hop rather than just
+  /// the endpoint -- so when a chain is emitted the shallow note would only
+  /// restate its last link. Fall back to the shallow note when there is no
+  /// chain to show, which is the common case: history recording is off unless
+  /// the function opted in. The fallback keys off whether the walk actually
+  /// emitted anything, not off whether recording is on: recording can be on and
+  /// the walk still find nothing, and the user must keep the shallow note in
+  /// that case.
+  ///
+  /// Called exactly where the shallow note was called, i.e. after the primary
+  /// diagnostic, rather than from a SWIFT_DEFER -- the unknown-pattern paths
+  /// return before reaching here and must stay note-free. Being downstream of
+  /// each sub-emitter's leading !srcIsolationInfo / !dstIsolationInfo guards is
+  /// also what makes the isolation safe to format at all.
+  void emitSideNote(Element elt, RepresentativeValue regionValue,
+                    SILDynamicMergedIsolationInfo isolation,
+                    StringRef isolationStr) {
+    if (partition) {
+      // Each walk consumes the partition it rewinds, and there are two sides to
+      // explain, so hand it a copy.
+      if (IsolationHistoryNoteEmitter::emit(
+              getFunction(), info, valueMap,
+              IsolationHistoryNoteEmitter::Request::howDidBecomeIsolatedTo(
+                  elt, isolation),
+              Partition(*partition)))
+        return;
+    }
+
+    if (auto value = regionValue.maybeGetValue())
+      emitMergeRegionValueNote(value, isolationStr,
+                               isolation->isTaskIsolated());
   }
 
   // Emit incompatible-region-merge diagnostics as warnings until the future
@@ -5435,9 +5482,14 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
 
   // Canonicalize so that srcRegionValue is always the task-isolated value when
   // possible. This only affects which isolation string is rendered first.
+  // The elements must travel with the values they name: a swapped isolation
+  // paired with an unswapped element would explain the wrong region.
+  auto srcElt = srcRegionValueElt;
+  auto dstElt = dstRegionValueElt;
   if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
     std::swap(srcIsolation, dstIsolation);
     std::swap(srcRegionValue, dstRegionValue);
+    std::swap(srcElt, dstElt);
   }
 
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
@@ -5448,12 +5500,8 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
                 dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
 
-  if (auto srcValue = srcRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(srcValue, srcIsolationStr,
-                             srcIsolation->isTaskIsolated());
-  if (auto dstValue = dstRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(dstValue, dstIsolationStr,
-                             dstIsolation->isTaskIsolated());
+  emitSideNote(srcElt, srcRegionValue, srcIsolation, srcIsolationStr);
+  emitSideNote(dstElt, dstRegionValue, dstIsolation, dstIsolationStr);
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
@@ -5470,9 +5518,14 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
 
   // Canonicalize so that srcRegionValue is always the task-isolated value when
   // possible. This only affects which isolation string is rendered first.
+  // The elements must travel with the values they name: a swapped isolation
+  // paired with an unswapped element would explain the wrong region.
+  auto srcElt = srcRegionValueElt;
+  auto dstElt = dstRegionValueElt;
   if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
     std::swap(srcIsolation, dstIsolation);
     std::swap(srcRegionValue, dstRegionValue);
+    std::swap(srcElt, dstElt);
   }
 
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
@@ -5483,12 +5536,8 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
                 dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
 
-  if (auto srcValue = srcRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(srcValue, srcIsolationStr,
-                             srcIsolation->isTaskIsolated());
-  if (auto dstValue = dstRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(dstValue, dstIsolationStr,
-                             dstIsolation->isTaskIsolated());
+  emitSideNote(srcElt, srcRegionValue, srcIsolation, srcIsolationStr);
+  emitSideNote(dstElt, dstRegionValue, dstIsolation, dstIsolationStr);
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
@@ -5504,9 +5553,14 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
 
   // Canonicalize so that srcRegionValue is always the task-isolated value when
   // possible. This only affects which isolation string is rendered first.
+  // The elements must travel with the values they name: a swapped isolation
+  // paired with an unswapped element would explain the wrong region.
+  auto srcElt = srcRegionValueElt;
+  auto dstElt = dstRegionValueElt;
   if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
     std::swap(srcIsolation, dstIsolation);
     std::swap(srcRegionValue, dstRegionValue);
+    std::swap(srcElt, dstElt);
   }
 
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
@@ -5526,12 +5580,8 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
                 srcIsolation->isTaskIsolated(), dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
 
-  if (auto srcValue = srcRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(srcValue, srcIsolationStr,
-                             srcIsolation->isTaskIsolated());
-  if (auto dstValue = dstRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(dstValue, dstIsolationStr,
-                             dstIsolation->isTaskIsolated());
+  emitSideNote(srcElt, srcRegionValue, srcIsolation, srcIsolationStr);
+  emitSideNote(dstElt, dstRegionValue, dstIsolation, dstIsolationStr);
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
@@ -5580,9 +5630,8 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
         .limitBehaviorIf(getBehaviorLimit());
   }
 
-  if (auto srcValue = srcRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(srcValue, srcIsolationStr,
-                             srcIsolation->isTaskIsolated());
+  emitSideNote(srcRegionValueElt, srcRegionValue, srcIsolation,
+               srcIsolationStr);
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitCast() {
@@ -5626,9 +5675,8 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitCast() {
                 srcIsolation->isTaskIsolated(), dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
 
-  if (auto srcValue = srcRegionValue.maybeGetValue())
-    emitMergeRegionValueNote(srcValue, srcIsolationStr,
-                             srcIsolation->isTaskIsolated());
+  emitSideNote(srcRegionValueElt, srcRegionValue, srcIsolation,
+               srcIsolationStr);
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emit() {

--- a/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
@@ -111,3 +111,46 @@ func same_region_opted_in(_ a: inout sending NS, _ b: inout sending NS) {
 func same_region_no_attr(_ a: inout sending NS, _ b: inout sending NS) {
   a = b
 } // expected-warning {{}} expected-note {{}}
+
+////////////////////////////////////////////////////////////////////////////////
+// The same pair for IncompatibleRegionMerge. This one is a stronger assertion
+// than the pairs above: for every other diagnostic the attribute-free case means
+// "no notes", but this diagnostic already shipped a shallow per-side note, so
+// here the attribute-free case means "the *old* notes, unchanged". The opted-in
+// case replaces them with chains. Both halves are matched in full.
+////////////////////////////////////////////////////////////////////////////////
+
+actor MergeCustomActorInstance {}
+@globalActor struct MergeCustomActor {
+  static let shared = MergeCustomActorInstance()
+}
+
+func mergeTwoValues<T, U>(_ t: T, _ u: U) {}
+
+@MainActor
+struct MergeOptedIn {
+  var mainField: NS? = nil
+  @MergeCustomActor var customField: NS? = nil
+
+  @diagnose(RegionIsolationIsolationHistory, as: warning)
+  init(chained: Void) {
+    let a = mainField!
+    // expected-note@+2 {{'b' is connected to 'self.customField' which is accessible to global actor 'MergeCustomActor'-isolated code}}
+    // expected-note@+1 {{'a' is connected to 'self.mainField' which is accessible to main actor-isolated code}}
+    let b = customField!
+    mergeTwoValues(a, b) // expected-warning {{}}
+  }
+
+  // No attribute: the shallow notes that shipped before this change, and no
+  // chains. Both locals are named, so the shallow notes name them too -- which
+  // makes this a tight assertion: the chain notes name the same locals but say
+  // where they came from, so a leaked gate would swap these two lines for the
+  // deeper wording and -verify would fail on both.
+  init(shallow: Void) {
+    let a = mainField!
+    let b = customField!
+    // expected-note@+2 {{'a' is exposed to main actor-isolated code}}
+    // expected-note@+1 {{'b' is exposed to global actor 'MergeCustomActor'-isolated code}}
+    mergeTwoValues(a, b) // expected-warning {{}}
+  }
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
@@ -98,3 +98,16 @@ func inout_sending_returned_no_attr(_ x: inout sending NS, _ y: NS) -> sending N
   x = y
   return y // expected-warning 2 {{}} expected-note 2 {{}}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// The same pair for InOutSendingParametersInSameRegion.
+////////////////////////////////////////////////////////////////////////////////
+
+@diagnose(RegionIsolationIsolationHistory, as: warning)
+func same_region_opted_in(_ a: inout sending NS, _ b: inout sending NS) {
+  a = b // expected-note {{'a' is connected to 'b'}}
+} // expected-warning {{}} expected-note {{}}
+
+func same_region_no_attr(_ a: inout sending NS, _ b: inout sending NS) {
+  a = b
+} // expected-warning {{}} expected-note {{}}

--- a/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
@@ -65,3 +65,21 @@ func inout_sending_no_attr(_ x: inout sending NS) {
   x = globalNS
 } // expected-warning {{'inout sending' parameter 'x' cannot be main actor-isolated at end of function}}
 // expected-note @-1 {{main actor-isolated 'x' risks causing races in between main actor-isolated uses and caller uses since caller assumes value is not actor isolated}}
+
+////////////////////////////////////////////////////////////////////////////////
+// The same pair for AssignNeverSendableIntoSendingResult.
+////////////////////////////////////////////////////////////////////////////////
+
+@diagnose(RegionIsolationIsolationHistory, as: warning)
+func sending_result_opted_in<T>(_ t: T) -> sending T {
+  // expected-note@+1 {{'y' is connected to 't' which is accessible to code in the current isolation context}}
+  let y = t
+  return y // expected-warning {{returning 'y' as a 'sending' result risks causing data races}}
+  // expected-note @-1 {{returning 'y' risks causing data races since the caller assumes that 'y' can be safely sent to other isolation domains}}
+}
+
+func sending_result_no_attr<T>(_ t: T) -> sending T {
+  let y = t
+  return y // expected-warning {{returning 'y' as a 'sending' result risks causing data races}}
+  // expected-note @-1 {{returning 'y' risks causing data races since the caller assumes that 'y' can be safely sent to other isolation domains}}
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
@@ -83,3 +83,18 @@ func sending_result_no_attr<T>(_ t: T) -> sending T {
   return y // expected-warning {{returning 'y' as a 'sending' result risks causing data races}}
   // expected-note @-1 {{returning 'y' risks causing data races since the caller assumes that 'y' can be safely sent to other isolation domains}}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// The same pair for InOutSendingReturned, using its connect request shape.
+////////////////////////////////////////////////////////////////////////////////
+
+@diagnose(RegionIsolationIsolationHistory, as: warning)
+func inout_sending_returned_opted_in(_ x: inout sending NS, _ y: NS) -> sending NS {
+  x = y // expected-note {{'y' is connected to 'x'}}
+  return y // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+func inout_sending_returned_no_attr(_ x: inout sending NS, _ y: NS) -> sending NS {
+  x = y
+  return y // expected-warning 2 {{}} expected-note 2 {{}}
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_incompatible_merge.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory_incompatible_merge.sil
@@ -1,0 +1,171 @@
+// RUN: %target-sil-opt -send-non-sendable -sil-region-isolation-emit-isolation-history -strict-concurrency=complete %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// SIL coverage for isolation-history notes on the IncompatibleRegionMerge
+// diagnostic. See the companion
+// transfernonsendable_isolationhistory_incompatible_merge.swift for the full
+// discussion; in brief, this is the only diagnostic in the series whose existing
+// output changes. Its shallow per-side "X is exposed to <iso> code" note is a
+// one-level-deep version of what a chain says, so a chain replaces it where one
+// is available and it survives where one is not.
+//
+// The severity is a warning until the *future* language mode rather than v6, so
+// these are warnings.
+//
+// The three shapes are pinned separately here because they are three distinct
+// outcomes of one per-side decision:
+//   both_chained  -> two chains, no shallow notes  (the behavior change)
+//   mixed         -> one chain, one shallow note   (the decision is per side)
+//   neither       -> two shallow notes             (unchanged from today)
+//
+// Primary diagnostics use empty-body matchers; chain and shallow notes have their
+// full text matched, since which of the two appears is exactly what is under test.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+class NonSendableKlass {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared: CustomActorInstance
+}
+
+class NonisolatedClassWithMixedFields {
+  @MainActor var mainField: NonSendableKlass
+  @CustomActor var customField: NonSendableKlass
+}
+
+sil @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
+sil @mergeTwo : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// MARK: Both sides chained — each side is explained by its own walk, and neither
+// shallow note is emitted. Their absence is asserted by omission: -verify fails
+// on any unexpected note, so if a shallow note came back this test would fail.
+//
+// The two sides are still in separate regions in the snapshot, because the error
+// is raised before the merge that would join them. That is what lets each side be
+// walked independently.
+sil [ossa] @merge_both_chained : $@convention(thin) (@guaranteed NonisolatedClassWithMixedFields) -> () {
+bb0(%self : @guaranteed $NonisolatedClassWithMixedFields):
+  debug_value %self : $NonisolatedClassWithMixedFields, var, name "self"
+
+  %mainAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField
+  %mainVal = load [copy] %mainAddr : $*NonSendableKlass
+  // expected-note@+1 {{'a' is connected to 'self.mainField' which is accessible to main actor-isolated code}}
+  %a = move_value [lexical] [var_decl] %mainVal : $NonSendableKlass
+  debug_value %a : $NonSendableKlass, let, name "a"
+
+  %customAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField
+  %customVal = load [copy] %customAddr : $*NonSendableKlass
+  // expected-note@+1 {{'b' is connected to 'self.customField' which is accessible to global actor 'CustomActor'-isolated code}}
+  %b = move_value [lexical] [var_decl] %customVal : $NonSendableKlass
+  debug_value %b : $NonSendableKlass, let, name "b"
+
+  // Passing both locals to a nonisolated function is what asks for the two
+  // regions to be merged, so both sides of the failed merge are locals with
+  // histories of their own -- unlike a store, where one side is the field.
+  %f = function_ref @mergeTwo : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> ()
+  %ab = begin_borrow %a : $NonSendableKlass
+  %bb = begin_borrow %b : $NonSendableKlass
+  apply %f(%ab, %bb) : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () // expected-warning {{}}
+  end_borrow %bb : $NonSendableKlass
+  end_borrow %ab : $NonSendableKlass
+
+  destroy_value %b : $NonSendableKlass
+  destroy_value %a : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// MARK: Mixed — the source side is a local with a chain, the destination side is
+// the directly-isolated field and keeps its shallow note. Recording is on for the
+// whole function, so this is what proves the choice is made per side, on whether
+// the walk actually emitted anything, rather than on whether recording is on.
+sil [ossa] @merge_mixed : $@convention(thin) (@guaranteed NonisolatedClassWithMixedFields) -> () {
+bb0(%self : @guaranteed $NonisolatedClassWithMixedFields):
+  debug_value %self : $NonisolatedClassWithMixedFields, var, name "self"
+
+  %mainAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField
+  %mainVal = load [copy] %mainAddr : $*NonSendableKlass
+  // expected-note@+1 {{'a' is connected to 'self.mainField' which is accessible to main actor-isolated code}}
+  %a = move_value [lexical] [var_decl] %mainVal : $NonSendableKlass
+  debug_value %a : $NonSendableKlass, let, name "a"
+
+  // expected-note@+1 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+  %customAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField
+  %acc = begin_access [modify] [unknown] %customAddr : $*NonSendableKlass
+  %ac = copy_value %a : $NonSendableKlass
+  store %ac to [assign] %acc : $*NonSendableKlass // expected-warning {{}}
+  end_access %acc : $*NonSendableKlass
+
+  destroy_value %a : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// MARK: Neither side chained — both values are directly isolated fields, so this
+// is byte-for-byte the output that shipped before isolation-history notes reached
+// this diagnostic: two shallow notes and no chains. This is the same shape as
+// @regionMergeAssignMismerge in transfernonsendable.sil, which must keep passing
+// unedited.
+sil [ossa] @merge_neither : $@convention(thin) (@guaranteed NonisolatedClassWithMixedFields) -> () {
+bb0(%self : @guaranteed $NonisolatedClassWithMixedFields):
+  debug_value %self : $NonisolatedClassWithMixedFields, var, name "self"
+  // expected-note@+1 {{'self.mainField' is exposed to main actor-isolated code}}
+  %mainAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField
+  %mainVal = load [copy] %mainAddr : $*NonSendableKlass
+  // expected-note@+1 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+  %customAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField
+  store %mainVal to [assign] %customAddr : $*NonSendableKlass // expected-warning {{}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// MARK: CFG diamond — the merge that isolates the source side happens in bb1
+// only; bb2 assigns a fresh disconnected value. The chain must come from bb1, and
+// bb2 must contribute nothing.
+sil [ossa] @merge_diamond : $@convention(thin) (@guaranteed NonisolatedClassWithMixedFields, Builtin.Int1) -> () {
+bb0(%self : @guaranteed $NonisolatedClassWithMixedFields, %cond : $Builtin.Int1):
+  debug_value %self : $NonisolatedClassWithMixedFields, var, name "self"
+  %box = alloc_stack [lexical] [var_decl] $NonSendableKlass, let, name "a"
+  cond_br %cond, bb1, bb2
+
+// The isolating arm.
+bb1:
+  %mainAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField
+  %mainVal = load [copy] %mainAddr : $*NonSendableKlass
+  // expected-note@+1 {{'a' is connected to 'self.mainField' which is accessible to main actor-isolated code}}
+  store %mainVal to [init] %box : $*NonSendableKlass
+  br bb3
+
+// The unrelated arm: a fresh disconnected value, which must contribute no note.
+bb2:
+  %mk = function_ref @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
+  %fresh = apply %mk() : $@convention(thin) () -> @owned NonSendableKlass
+  store %fresh to [init] %box : $*NonSendableKlass
+  br bb3
+
+bb3:
+  // expected-note@+1 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+  %customAddr = ref_element_addr %self : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField
+  %av = load [copy] %box : $*NonSendableKlass
+  %acc = begin_access [modify] [unknown] %customAddr : $*NonSendableKlass
+  store %av to [assign] %acc : $*NonSendableKlass // expected-warning {{}}
+  end_access %acc : $*NonSendableKlass
+  destroy_addr %box : $*NonSendableKlass
+  dealloc_stack %box : $*NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_incompatible_merge.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_incompatible_merge.swift
@@ -1,0 +1,134 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability -sil-region-isolation-emit-isolation-history -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+
+// Swift-source coverage for isolation-history notes on the
+// IncompatibleRegionMerge diagnostic, which fires when the analysis tries to
+// merge two regions whose isolation domains are incompatible.
+//
+// This is the only diagnostic in the isolation-history series whose *existing*
+// output changes. It already emitted a shallow per-side note -- "X is exposed to
+// <iso> code" -- which names a value and its isolation but not how it got there.
+// The chain is the deep version of exactly that, so where a chain is available it
+// replaces the shallow note rather than being emitted alongside it; where there
+// is no chain, the shallow note stays. The three cases below pin all three
+// outcomes, and the mixed one is what proves the choice is made per side.
+//
+// Note the severity: this diagnostic warns until the *future* language mode, not
+// v6, so these are warnings even under -swift-version 6.
+//
+// Two requests per error, one per side, each rewinding its own copy of the
+// snapshot. The snapshot is taken *before* the failed merge -- the error is
+// raised ahead of the assign/merge that would join the regions -- so the two
+// regions are still separate in it and each side has its own independent
+// history. That is what makes two independent walks meaningful.
+
+class NS {}
+
+func mergeValues<T, U>(_ t: T, _ u: U) {}
+
+actor CustomActorInstance {}
+@globalActor struct CustomActor { static let shared = CustomActorInstance() }
+
+////////////////////////////////////////////////////////////////////////////////
+// Both sides have chains — the behavior change. Each side is explained by its
+// own chain, and *neither* shallow "is exposed to" note is emitted. The absence
+// is the point, so it is asserted by omission: -verify fails on any unexpected
+// note.
+//
+// FIXME: The two chains are both anchored on the second local's line rather than
+// each on the line that created it -- 'a' is bound on the line above but its note
+// lands with 'b'. Pinned as-is. This is the same family of mislocation FIXME'd in
+// transfernonsendable_isolationhistory_sending_result.swift: a note's location
+// comes from the sequence boundary the walk reaches, which is not required to be
+// the one that performed the merge being described.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor
+struct BothChained {
+  var mainField: NS? = nil
+  @CustomActor var customField: NS? = nil
+  init() {
+    let a = mainField!
+    // expected-note@+2 {{'b' is connected to 'self.customField' which is accessible to global actor 'CustomActor'-isolated code}}
+    // expected-note@+1 {{'a' is connected to 'self.mainField' which is accessible to main actor-isolated code}}
+    let b = customField!
+    mergeValues(a, b) // expected-warning {{}}
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Mixed — one side has a chain, the other keeps its shallow note. This is the
+// case that proves the per-side choice is driven by whether the walk actually
+// emitted anything, rather than by whether history recording is on: recording is
+// on for the whole function here, yet 'self.customField' is directly isolated, so
+// it has no chain and must keep the old note.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor
+struct Mixed {
+  var mainField: NS? = nil
+  @CustomActor var customField: NS? = nil
+  init() {
+    let a = mainField!
+    // expected-note@+2 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-note@+1 {{'a' is connected to 'self.mainField' which is accessible to main actor-isolated code}}
+    mergeValues(a, customField!) // expected-warning {{}}
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Neither side has a chain — both values are directly isolated, so the output is
+// identical to what shipped before this change: two shallow notes, no chains.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor
+struct Neither {
+  var mainField: NS? = nil
+  @CustomActor var customField: NS? = nil
+  init() {
+    // expected-note@+2 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-note@+1 {{'self.mainField' is exposed to main actor-isolated code}}
+    mergeValues(mainField!, customField!) // expected-warning {{}}
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Per-reason coverage. Each RegionMergeReason routes to its own sub-emitter with
+// its own note call sites, and three of the five swap the two sides to put the
+// task-isolated one first -- a swapped isolation paired with an unswapped element
+// would explain the wrong region, so the isolation strings below are what catch a
+// mis-paired call site.
+//
+// The cases above cover NonisolatedFunction (the mergeValues calls). Below:
+// Assign, and ActorIntroducingInst on its src-only path. Cast and Unknown reach
+// emitSideNote through the same helper and are covered with shallow notes by
+// transfernonsendable_merge_region_diagnostics.swift, which this change leaves
+// byte-identical.
+////////////////////////////////////////////////////////////////////////////////
+
+// Assign: a tuple joining two differently-isolated locals. Both sides chained.
+@MainActor
+struct AssignReason {
+  var mainField: NS? = nil
+  @CustomActor var customField: NS? = nil
+  init() {
+    let a = mainField!
+    // expected-note@+2 {{'b' is connected to 'self.customField' which is accessible to global actor 'CustomActor'-isolated code}}
+    // expected-note@+1 {{'a' is connected to 'self.mainField' which is accessible to main actor-isolated code}}
+    let b = customField!
+    let t = (a, b) // expected-warning {{}}
+    _ = t
+  }
+}
+
+// ActorIntroducingInst, src-only: a main-actor getter reached through a
+// task-isolated 'self'. 'self' is directly task-isolated, so this exercises the
+// src-only call site taking its shallow fallback.
+final class TaskIsolatedSelf { // expected-note {{class 'TaskIsolatedSelf' does not conform to the 'Sendable' protocol}}
+  @MainActor var x: Int { 0 }
+  func call() async { // expected-note {{'self' is exposed to code in the current isolation context}}
+    _ = await x // expected-warning {{}} expected-warning {{}}
+  }
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_returned.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_returned.sil
@@ -1,0 +1,156 @@
+// RUN: %target-sil-opt -send-non-sendable -sil-region-isolation-emit-isolation-history -strict-concurrency=complete %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// SIL coverage for isolation-history notes on the InOutSendingReturned
+// diagnostic, which fires when the returned value shares a region with an
+// 'inout sending' parameter. See the companion
+// transfernonsendable_isolationhistory_inout_sending_returned.swift for the
+// source-level shapes and for the full discussion of the two request kinds.
+//
+// Both request kinds are covered here:
+//
+//   - Returning the parameter itself asks howDidBecomeIsolatedTo, whose chain
+//     terminates at the isolated value ("... which is accessible to <iso>").
+//   - Returning a different value in the same region asks
+//     howDidBecomeConnectedTo, whose chain has no isolated terminus and so ends
+//     on a plain "'a' is connected to 'b'".
+//
+// The task-isolated first parameter is the isolated source; 'debug_value' and
+// 'alloc_stack [var_decl] ... name' supply the names the notes need, since an
+// unnamed link is silently dropped.
+//
+// Primary diagnostics use empty-body matchers; chain notes have their full text
+// matched.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+class NonSendableKlass {}
+
+sil @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// MARK: howDidBecomeIsolatedTo, one hop — the 'inout sending' parameter is
+// merged with the task-isolated parameter and then returned. One terminal note.
+sil [ossa] @returned_reach_one_hop : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_sending @inout NonSendableKlass) -> @sil_sending @owned NonSendableKlass {
+bb0(%x : @guaranteed $NonSendableKlass, %out : $*NonSendableKlass):
+  debug_value %x : $NonSendableKlass, let, name "x", argno 1
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+
+  %c = copy_value %x : $NonSendableKlass
+  %acc = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  // expected-note@+1 2 {{'out' is connected to 'x' which is accessible to code in the current isolation context}}
+  store %c to [assign] %acc : $*NonSendableKlass
+  end_access %acc : $*NonSendableKlass
+
+  %r = load [copy] %out : $*NonSendableKlass
+  return %r : $NonSendableKlass // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+// MARK: howDidBecomeIsolatedTo, two hops — through a named intermediate 'y'.
+sil [ossa] @returned_reach_two_hop : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_sending @inout NonSendableKlass) -> @sil_sending @owned NonSendableKlass {
+bb0(%x : @guaranteed $NonSendableKlass, %out : $*NonSendableKlass):
+  debug_value %x : $NonSendableKlass, let, name "x", argno 1
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+
+  %f1 = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  // expected-note@+1 2 {{result of 'mergeOne()' is connected to 'x' which is accessible to code in the current isolation context}}
+  %r1 = apply %f1(%x) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %y = move_value [lexical] [var_decl] %r1 : $NonSendableKlass // expected-note 2 {{'y' is connected to result of 'mergeOne()'}}
+  debug_value %y : $NonSendableKlass, let, name "y"
+
+  %c = copy_value %y : $NonSendableKlass
+  %acc = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  store %c to [assign] %acc : $*NonSendableKlass // expected-note 2 {{'out' is connected to 'y'}}
+  end_access %acc : $*NonSendableKlass
+
+  destroy_value %y : $NonSendableKlass
+  %r = load [copy] %out : $*NonSendableKlass
+  return %r : $NonSendableKlass // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+// MARK: howDidBecomeConnectedTo, one hop — a value distinct from the
+// 'inout sending' parameter is merged into its region and then returned. This is
+// the first coverage anywhere of the connect request from a real emitter. The
+// chain ends on a plain "is connected to": there is no isolated terminus.
+sil [ossa] @returned_connect_one_hop : $@convention(thin) (@owned NonSendableKlass, @sil_sending @inout NonSendableKlass) -> @sil_sending @owned NonSendableKlass {
+bb0(%y : @owned $NonSendableKlass, %out : $*NonSendableKlass):
+  %yv = move_value [lexical] [var_decl] %y : $NonSendableKlass
+  debug_value %yv : $NonSendableKlass, let, name "y"
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+
+  %c = copy_value %yv : $NonSendableKlass
+  %acc = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  store %c to [assign] %acc : $*NonSendableKlass // expected-note {{'y' is connected to 'out'}}
+  end_access %acc : $*NonSendableKlass
+
+  %r = copy_value %yv : $NonSendableKlass
+  destroy_value %yv : $NonSendableKlass
+  return %r : $NonSendableKlass // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+// MARK: howDidBecomeConnectedTo, two hops — the returned value reaches the
+// parameter through a named intermediate 'z'.
+sil [ossa] @returned_connect_two_hop : $@convention(thin) (@owned NonSendableKlass, @sil_sending @inout NonSendableKlass) -> @sil_sending @owned NonSendableKlass {
+bb0(%y : @owned $NonSendableKlass, %out : $*NonSendableKlass):
+  %yv = move_value [lexical] [var_decl] %y : $NonSendableKlass
+  debug_value %yv : $NonSendableKlass, let, name "y"
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+
+  %f1 = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %yb = begin_borrow %yv : $NonSendableKlass
+  %r1 = apply %f1(%yb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass // expected-note {{'y' is connected to result of 'mergeOne()'}}
+  end_borrow %yb : $NonSendableKlass
+  %z = move_value [lexical] [var_decl] %r1 : $NonSendableKlass // expected-note {{'z' is connected to result of 'mergeOne()'}}
+  debug_value %z : $NonSendableKlass, let, name "z"
+
+  %c = copy_value %z : $NonSendableKlass
+  %acc = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  store %c to [assign] %acc : $*NonSendableKlass // expected-note {{'z' is connected to 'out'}}
+  end_access %acc : $*NonSendableKlass
+
+  destroy_value %z : $NonSendableKlass
+  %r = copy_value %yv : $NonSendableKlass
+  destroy_value %yv : $NonSendableKlass
+  return %r : $NonSendableKlass // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+// MARK: CFG diamond — only bb1 connects the returned value to the parameter.
+// The note lands there, and bb2's fresh value produces none.
+sil [ossa] @returned_connect_diamond : $@convention(thin) (@owned NonSendableKlass, @sil_sending @inout NonSendableKlass, Builtin.Int1) -> @sil_sending @owned NonSendableKlass {
+bb0(%y : @owned $NonSendableKlass, %out : $*NonSendableKlass, %cond : $Builtin.Int1):
+  %yv = move_value [lexical] [var_decl] %y : $NonSendableKlass
+  debug_value %yv : $NonSendableKlass, let, name "y"
+  debug_value %out : $*NonSendableKlass, var, name "out", argno 2, expr op_deref
+  cond_br %cond, bb1, bb2
+
+// The connecting arm.
+bb1:
+  %c1 = copy_value %yv : $NonSendableKlass
+  %acc1 = begin_access [modify] [unknown] %out : $*NonSendableKlass
+  store %c1 to [assign] %acc1 : $*NonSendableKlass // expected-note {{'y' is connected to 'out'}}
+  end_access %acc1 : $*NonSendableKlass
+  br bb3
+
+// The unrelated arm: a fresh value, which must not be reported.
+bb2:
+  %mk = function_ref @mergeOne : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  %yb = begin_borrow %yv : $NonSendableKlass
+  %fresh = apply %mk(%yb) : $@convention(thin) (@guaranteed NonSendableKlass) -> @owned NonSendableKlass
+  end_borrow %yb : $NonSendableKlass
+  destroy_value %fresh : $NonSendableKlass
+  br bb3
+
+bb3:
+  %r = copy_value %yv : $NonSendableKlass
+  destroy_value %yv : $NonSendableKlass
+  return %r : $NonSendableKlass // expected-warning 2 {{}} expected-note 2 {{}}
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_returned.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_returned.swift
@@ -1,0 +1,129 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -parse-as-library -sil-region-isolation-emit-isolation-history -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+
+// Swift-source coverage for isolation-history notes on the InOutSendingReturned
+// diagnostic, which fires at a function exit when the returned value is in the
+// same region as an 'inout sending' parameter. The caller treats the two as
+// independent regions, so it could send them to different isolation domains.
+//
+// This diagnostic is the first user of *both* request shapes:
+//
+//   - Returned the parameter itself -> nothing pairs up, so the question is why
+//     the parameter's region is isolated (howDidBecomeIsolatedTo). The chain
+//     terminates at the isolated value, "... which is accessible to <iso>".
+//   - Returned some other value in the same region -> the question is how the
+//     two came to share one (howDidBecomeConnectedTo). Such a chain has no
+//     isolated terminus, so its last link is a plain 'a' is connected to 'b'.
+//     That reads a little abruptly; a dedicated terminal diagnostic is a
+//     deliberate follow-up, not an omission here.
+//
+// Primary diagnostics use empty-body matchers; chain notes have their full text
+// matched. Several of these functions trip more than one diagnostic on the same
+// line, and where a second diagnostic also carries a chain it is matched too --
+// those extra chains belong to other emitters and are pinned so this file
+// notices if they change.
+//
+// NOT COVERED, and why: README.md §5 asks for a suppression case where the
+// element is directly isolated rather than merged. For the reach-isolation shape
+// that element is the 'inout sending' parameter, and SILIsolationInfo::get
+// returns getDisconnected() unconditionally for a sending argument ("Sending is
+// always disconnected"), so it can never be directly isolated. For the connect
+// shape, suppression would mean the two ends are in different regions -- but then
+// the diagnostic does not fire at all. 'return_disconnected' below covers the
+// nearest reachable thing and is the more valuable test anyway; see its comment.
+
+class NS {}
+
+@MainActor var globalNS = NS()
+
+////////////////////////////////////////////////////////////////////////////////
+// howDidBecomeIsolatedTo — returned the 'inout sending' parameter itself.
+////////////////////////////////////////////////////////////////////////////////
+
+@MainActor
+func reach_one_hop(_ x: inout sending NS) -> sending NS {
+  // expected-note@+1 2 {{'x' is connected to 'globalNS' which is accessible to main actor-isolated code}}
+  x = globalNS
+  return x // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+@MainActor
+func reach_two_hop(_ x: inout sending NS) -> sending NS {
+  // expected-note@+1 2 {{'z' is connected to 'globalNS' which is accessible to main actor-isolated code}}
+  let z = globalNS
+  x = z // expected-note 2 {{'x' is connected to 'z'}}
+  return x // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// howDidBecomeConnectedTo — returned a different value sharing the parameter's
+// region. Note the last link is a plain "is connected to": a connect chain has
+// no isolated terminus.
+////////////////////////////////////////////////////////////////////////////////
+
+func connect_one_hop(_ x: inout sending NS, _ y: NS) -> sending NS {
+  x = y // expected-note {{'y' is connected to 'x'}}
+  return y // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+func connect_two_hop(_ x: inout sending NS, _ y: NS) -> sending NS {
+  let z = y // expected-note {{'y' is connected to 'z'}}
+  x = z // expected-note {{'z' is connected to 'x'}}
+  return y // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The guard from README.md §4.1, exercised.
+//
+// InOutSendingReturnedError's constructors default isolationInfo to {}, which is
+// the Invalid lattice element, and emitNotes() would hand that to
+// printForDiagnostics, which report_fatal_error()s on it. All four construction
+// sites happen to pass an explicit isolation today, so the literal default is
+// unreachable -- but this function reaches the reach-isolation shape down the
+// *disconnected* path, which carries the weakest isolation the error can hold.
+// shouldEmit() must decline it rather than format it: no chain, and above all no
+// crash. If this ever starts printing a chain, the isolation being formatted
+// needs re-checking.
+////////////////////////////////////////////////////////////////////////////////
+
+func return_disconnected(_ x: inout sending NS) -> sending NS {
+  return x // expected-warning {{}} expected-note {{}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CFG diamond — only the 'if' arm connects the returned value to the parameter.
+// The note lands in that arm, and the 'else' arm produces none. (Unlike the
+// diamond in transfernonsendable_isolationhistory_sending_result.swift, this one
+// is located correctly: the merge being explained has a sequence boundary in the
+// arm that performed it.)
+////////////////////////////////////////////////////////////////////////////////
+
+func diamond(_ x: inout sending NS, _ y: NS, _ cond: Bool) -> sending NS {
+  if cond {
+    x = y // expected-note {{'y' is connected to 'x'}}
+  } else {
+    let fresh = NS()
+    x = fresh
+  }
+  return y // expected-warning 2 {{}} expected-note 2 {{}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Two returns, i.e. the epilogue-phi / multi-finalValues path in emit(). That
+// path can emit several primary diagnostics from one error, but the note emitter
+// deliberately emits exactly one chain per error -- see the comment on
+// emitIsolationHistoryNoteIfNeeded. The counts below pin what that produces so a
+// change in the primaries does not silently multiply the notes.
+////////////////////////////////////////////////////////////////////////////////
+
+func multi_return(_ x: inout sending NS, _ y: NS, _ cond: Bool) -> sending NS {
+  x = y
+  if cond {
+    return y // expected-warning {{}} expected-note {{}}
+  }
+  // expected-note@+3 {{'x' is connected to 'y' which is accessible to code in the current isolation context}}
+  // expected-note@+2 2 {{'y' is connected to 'x'}}
+  // expected-warning@+1 {{}} expected-note@+1 {{}}
+  return y
+} // expected-warning {{}} expected-note {{}}

--- a/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_same_region.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_same_region.sil
@@ -1,0 +1,127 @@
+// RUN: %target-sil-opt -send-non-sendable -sil-region-isolation-emit-isolation-history -strict-concurrency=complete %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// SIL coverage for isolation-history notes on the
+// InOutSendingParametersInSameRegion diagnostic, which fires at a function exit
+// when two or more 'inout sending' parameters share a region. See the companion
+// transfernonsendable_isolationhistory_inout_sending_same_region.swift for the
+// source-level shapes.
+//
+// Both parameters are disconnected, so the request is a connect one: every link
+// reads as a plain "'a' is connected to 'b'" and there is no isolated terminus.
+// This diagnostic is the one whose wording maps most directly onto what a chain
+// says.
+//
+// This is also the only error whose emitter is not constructed by the X-macro:
+// one error reports several pairs, each with its own emitter and its own chain,
+// which is why each pair is handed a copy of the partition rather than the
+// error's. The three-parameter case below is what catches a regression to
+// moving it -- the walk consumes the partition it rewinds.
+//
+// Primary diagnostics use empty-body matchers; chain notes have their full text
+// matched.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+class NonSendableKlass {}
+
+sil @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// MARK: One hop — the two 'inout sending' parameters are merged directly.
+sil [ossa] @same_region_one_hop : $@convention(thin) (@sil_sending @inout NonSendableKlass, @sil_sending @inout NonSendableKlass) -> () {
+bb0(%a : $*NonSendableKlass, %b : $*NonSendableKlass):
+  debug_value %a : $*NonSendableKlass, var, name "a", argno 1, expr op_deref
+  debug_value %b : $*NonSendableKlass, var, name "b", argno 2, expr op_deref
+
+  %bv = load [copy] %b : $*NonSendableKlass
+  %acc = begin_access [modify] [unknown] %a : $*NonSendableKlass
+  store %bv to [assign] %acc : $*NonSendableKlass // expected-note {{'a' is connected to 'b'}}
+  end_access %acc : $*NonSendableKlass
+
+  %r = tuple ()
+  return %r : $() // expected-warning {{}} expected-note {{}}
+}
+
+// MARK: Two hops — the two parameters reach each other through a named local.
+sil [ossa] @same_region_two_hop : $@convention(thin) (@sil_sending @inout NonSendableKlass, @sil_sending @inout NonSendableKlass) -> () {
+bb0(%a : $*NonSendableKlass, %b : $*NonSendableKlass):
+  debug_value %a : $*NonSendableKlass, var, name "a", argno 1, expr op_deref
+  debug_value %b : $*NonSendableKlass, var, name "b", argno 2, expr op_deref
+
+  %bv = load [copy] %b : $*NonSendableKlass
+  %z = move_value [lexical] [var_decl] %bv : $NonSendableKlass // expected-note {{'z' is connected to 'b'}}
+  debug_value %z : $NonSendableKlass, let, name "z"
+
+  %c = copy_value %z : $NonSendableKlass
+  %acc = begin_access [modify] [unknown] %a : $*NonSendableKlass
+  store %c to [assign] %acc : $*NonSendableKlass // expected-note {{'a' is connected to 'z'}}
+  end_access %acc : $*NonSendableKlass
+
+  destroy_value %z : $NonSendableKlass
+  %r = tuple ()
+  return %r : $() // expected-warning {{}} expected-note {{}}
+}
+
+// MARK: Three parameters in one region — the multi-pair case. One chain per
+// reported pair, each rewinding its own copy of the partition. If the partition
+// were moved instead, only the first pair would get a chain; the note counts
+// here are what would catch that.
+sil [ossa] @same_region_three_params : $@convention(thin) (@sil_sending @inout NonSendableKlass, @sil_sending @inout NonSendableKlass, @sil_sending @inout NonSendableKlass) -> () {
+bb0(%a : $*NonSendableKlass, %b : $*NonSendableKlass, %c : $*NonSendableKlass):
+  debug_value %a : $*NonSendableKlass, var, name "a", argno 1, expr op_deref
+  debug_value %b : $*NonSendableKlass, var, name "b", argno 2, expr op_deref
+  debug_value %c : $*NonSendableKlass, var, name "c", argno 3, expr op_deref
+
+  %bv1 = load [copy] %b : $*NonSendableKlass
+  %acc1 = begin_access [modify] [unknown] %a : $*NonSendableKlass
+  store %bv1 to [assign] %acc1 : $*NonSendableKlass // expected-note 2 {{'a' is connected to 'b'}}
+  end_access %acc1 : $*NonSendableKlass
+
+  %bv2 = load [copy] %b : $*NonSendableKlass
+  %acc2 = begin_access [modify] [unknown] %c : $*NonSendableKlass
+  store %bv2 to [assign] %acc2 : $*NonSendableKlass // expected-note 2 {{'b' is connected to 'c'}}
+  end_access %acc2 : $*NonSendableKlass
+
+  %r = tuple ()
+  return %r : $() // expected-warning 3 {{}} expected-note 3 {{}}
+}
+
+// MARK: CFG diamond — only bb1 joins the two parameters; bb2's fresh value must
+// produce no note.
+sil [ossa] @same_region_diamond : $@convention(thin) (@sil_sending @inout NonSendableKlass, @sil_sending @inout NonSendableKlass, Builtin.Int1) -> () {
+bb0(%a : $*NonSendableKlass, %b : $*NonSendableKlass, %cond : $Builtin.Int1):
+  debug_value %a : $*NonSendableKlass, var, name "a", argno 1, expr op_deref
+  debug_value %b : $*NonSendableKlass, var, name "b", argno 2, expr op_deref
+  cond_br %cond, bb1, bb2
+
+// The joining arm.
+bb1:
+  %bv = load [copy] %b : $*NonSendableKlass
+  %acc1 = begin_access [modify] [unknown] %a : $*NonSendableKlass
+  store %bv to [assign] %acc1 : $*NonSendableKlass // expected-note {{'a' is connected to 'b'}}
+  end_access %acc1 : $*NonSendableKlass
+  br bb3
+
+// The unrelated arm: a fresh value stored into 'a', which must not be reported.
+bb2:
+  %mk = function_ref @makeFresh : $@convention(thin) () -> @owned NonSendableKlass
+  %fresh = apply %mk() : $@convention(thin) () -> @owned NonSendableKlass
+  %acc2 = begin_access [modify] [unknown] %a : $*NonSendableKlass
+  store %fresh to [assign] %acc2 : $*NonSendableKlass
+  end_access %acc2 : $*NonSendableKlass
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $() // expected-warning {{}} expected-note {{}}
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_same_region.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_inout_sending_same_region.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -parse-as-library -sil-region-isolation-emit-isolation-history -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+
+// Swift-source coverage for isolation-history notes on the
+// InOutSendingParametersInSameRegion diagnostic, which fires at a function exit
+// when two or more 'inout sending' parameters share a region. The caller treats
+// each as its own region on return, so it could send them to different isolation
+// domains.
+//
+// Both parameters are disconnected here -- this diagnostic is purely about them
+// sharing a region -- so the request is a connect one and every link reads as a
+// plain "'a' is connected to 'b'" with no isolated terminus. That is correct for
+// this diagnostic: there is no isolated value in the story.
+//
+// Primary diagnostics use empty-body matchers; chain notes have their full text
+// matched.
+
+class NS {}
+
+////////////////////////////////////////////////////////////////////////////////
+// One hop — the two parameters are assigned to each other directly.
+////////////////////////////////////////////////////////////////////////////////
+
+func one_hop(_ x: inout sending NS, _ y: inout sending NS) {
+  x = y // expected-note {{'x' is connected to 'y'}}
+} // expected-warning {{}} expected-note {{}}
+
+////////////////////////////////////////////////////////////////////////////////
+// Two hops — the two parameters reach each other through a named local.
+////////////////////////////////////////////////////////////////////////////////
+
+func two_hop(_ x: inout sending NS, _ y: inout sending NS) {
+  let z = y // expected-note {{'z' is connected to 'y'}}
+  x = z // expected-note {{'x' is connected to 'z'}}
+} // expected-warning {{}} expected-note {{}}
+
+////////////////////////////////////////////////////////////////////////////////
+// Three parameters in one region — the multi-pair case, and the reason each
+// reported pair is handed its own copy of the partition rather than the error's.
+// The walk consumes the partition it rewinds, so if it were moved instead of
+// copied only the first pair would get a chain and the rest would silently emit
+// nothing. Three pairs are reported here (x/y, x/z, y/z), and the note counts
+// below are what catches a regression to moving: 'x is connected to y' is needed
+// by the x/y and x/z chains, and 'y is connected to z' by the x/z and y/z ones.
+////////////////////////////////////////////////////////////////////////////////
+
+func three_params(_ x: inout sending NS, _ y: inout sending NS,
+                  _ z: inout sending NS) {
+  x = y // expected-note 2 {{'x' is connected to 'y'}}
+  z = y // expected-note 2 {{'y' is connected to 'z'}}
+} // expected-warning 3 {{}} expected-note 3 {{}}
+
+////////////////////////////////////////////////////////////////////////////////
+// CFG diamond — only the 'if' arm joins the two parameters. The note lands in
+// that arm; the 'else' arm's fresh value produces none.
+////////////////////////////////////////////////////////////////////////////////
+
+func diamond(_ x: inout sending NS, _ y: inout sending NS, _ cond: Bool) {
+  if cond {
+    x = y // expected-note {{'x' is connected to 'y'}}
+  } else {
+    x = NS()
+  }
+} // expected-warning {{}} expected-note {{}}

--- a/test/Concurrency/transfernonsendable_isolationhistory_sending_result.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory_sending_result.sil
@@ -1,0 +1,126 @@
+// RUN: %target-sil-opt -send-non-sendable -sil-region-isolation-emit-isolation-history -strict-concurrency=complete %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// SIL coverage for isolation-history notes on the
+// AssignNeverSendableIntoSendingResult diagnostic, which fires when a value
+// whose region is not disconnected is assigned into an indirect 'sending'
+// result. See the companion
+// transfernonsendable_isolationhistory_sending_result.swift for the same shapes
+// at source level.
+//
+// The diagnostic needs an indirect result, so every function is generic and
+// takes '@in_guaranteed T' -> '@sil_sending @out T'; the signature is lifted
+// from SILGen output for 'func f<T>(_ t: T) -> sending T'. The task-isolated
+// parameter is the isolated source. 'alloc_stack [var_decl] ... name' and
+// 'debug_value' supply the user-visible names the notes need, since an unnamed
+// link is silently dropped.
+//
+// Primary diagnostics use empty-body matchers; the chain notes have their full
+// text matched.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+sil @makeFresh : $@convention(thin) <T> () -> @out T
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// MARK: Suppression — the value assigned into the result is the task-isolated
+// parameter itself, not something merged into its region, so there is no chain
+// and no history note.
+sil [ossa] @sending_result_suppress_direct : $@convention(thin) <T> (@in_guaranteed T) -> @sil_sending @out T {
+bb0(%out : $*T, %t : $*T):
+  debug_value %t : $*T, let, name "t", argno 1, expr op_deref
+  copy_addr %t to [init] %out : $*T // expected-warning {{}} expected-note {{}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// MARK: One hop — a named local picks up the task-isolated parameter's region
+// and is then copied into the result. One terminal note.
+sil [ossa] @sending_result_one_hop : $@convention(thin) <T> (@in_guaranteed T) -> @sil_sending @out T {
+bb0(%out : $*T, %t : $*T):
+  debug_value %t : $*T, let, name "t", argno 1, expr op_deref
+  %y = alloc_stack [lexical] [var_decl] $T, let, name "y"
+  // expected-note@+1 {{'y' is connected to 't' which is accessible to code in the current isolation context}}
+  copy_addr %t to [init] %y : $*T
+  copy_addr %y to [init] %out : $*T // expected-warning {{}} expected-note {{}}
+  destroy_addr %y : $*T
+  dealloc_stack %y : $*T
+  %r = tuple ()
+  return %r : $()
+}
+
+// MARK: Two hops — through a second named local. Both links are reported.
+sil [ossa] @sending_result_two_hop : $@convention(thin) <T> (@in_guaranteed T) -> @sil_sending @out T {
+bb0(%out : $*T, %t : $*T):
+  debug_value %t : $*T, let, name "t", argno 1, expr op_deref
+  %y = alloc_stack [lexical] [var_decl] $T, let, name "y"
+  // expected-note@+1 {{'y' is connected to 't' which is accessible to code in the current isolation context}}
+  copy_addr %t to [init] %y : $*T
+  %z = alloc_stack [lexical] [var_decl] $T, let, name "z"
+  copy_addr %y to [init] %z : $*T // expected-note {{'z' is connected to 'y'}}
+  copy_addr %z to [init] %out : $*T // expected-warning {{}} expected-note {{}}
+  destroy_addr %z : $*T
+  dealloc_stack %z : $*T
+  destroy_addr %y : $*T
+  dealloc_stack %y : $*T
+  %r = tuple ()
+  return %r : $()
+}
+
+// MARK: CFG diamond — only bb1 merges the local into the task-isolated region;
+// bb2 initializes it from a fresh value.
+//
+// FIXME: This pins a mislocated note. It requires the dataflow join and so is
+// absent from the straight-line cases above.
+//
+// The note is attributed to bb2, which never touched 't', rather than to bb1's
+// 'copy_addr %t to [init] %y'. A join-performed merge has no sequence boundary
+// in the joining block, so its notes stay pending and are located when the walk
+// enters a predecessor -- without requiring that predecessor to be the one that
+// answered the question. That is prepareStatesForPredecessors' candidate filter,
+// which README.md §5 flags as the part of the walk most likely to misbehave on a
+// non-apply anchor.
+//
+// The note also degrades to the unnamed "value was merged into ... region here"
+// wording, because the far end of the terminal link is the indirect result,
+// which a hand-written SIL function gives no name. On SILGen output that
+// argument is named '$return_value' and the note prints it -- a SIL-internal
+// name reaching a user-facing diagnostic, which is a second defect. The
+// companion .swift file pins that spelling.
+//
+// When fixed, the note should instead land on bb1's copy_addr and read:
+//   'y' is connected to 't' which is accessible to code in the current isolation context
+sil [ossa] @sending_result_diamond : $@convention(thin) <T> (@in_guaranteed T, Builtin.Int1) -> @sil_sending @out T {
+bb0(%out : $*T, %t : $*T, %cond : $Builtin.Int1):
+  debug_value %t : $*T, let, name "t", argno 1, expr op_deref
+  %y = alloc_stack [lexical] [var_decl] $T, let, name "y"
+  cond_br %cond, bb1, bb2
+
+// The merging arm.
+bb1:
+  copy_addr %t to [init] %y : $*T
+  br bb3
+
+// The unrelated arm: a fresh value, which must not be reported.
+bb2:
+  %mk = function_ref @makeFresh : $@convention(thin) <T> () -> @out T
+  // expected-note@+1 {{value was merged into code in the current isolation context region here}}
+  apply %mk<T>(%y) : $@convention(thin) <T> () -> @out T
+  br bb3
+
+bb3:
+  copy_addr %y to [init] %out : $*T // expected-warning {{}} expected-note {{}}
+  destroy_addr %y : $*T
+  dealloc_stack %y : $*T
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_sending_result.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_sending_result.swift
@@ -1,0 +1,91 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -parse-as-library -sil-region-isolation-emit-isolation-history -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+
+// Swift-source coverage for isolation-history notes on the
+// AssignNeverSendableIntoSendingResult diagnostic, which fires when a value
+// whose region is not disconnected is assigned into an indirect 'sending'
+// result. The caller expects such a result to arrive in its own region, so the
+// notes explain which merge tied it to someone else's.
+//
+// The diagnostic needs an *indirect* sending result, so every function here is
+// generic in its return type. The task-isolated parameter is the isolated
+// source: a nonisolated function's non-sending arguments are task-isolated.
+//
+// Primary diagnostics use empty-body matchers; the chain notes have their full
+// text matched, since they are what is under test.
+
+////////////////////////////////////////////////////////////////////////////////
+// Suppression — the returned value is *itself* task-isolated rather than having
+// been merged into an isolated region, so there is no chain to explain and no
+// history note should fire.
+////////////////////////////////////////////////////////////////////////////////
+
+func suppress_direct<T>(_ t: T) -> sending T {
+  return t // expected-warning {{}} expected-note {{}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// One hop — a local picks up the task-isolated parameter's region, then is
+// returned. One terminal note names the isolated source.
+////////////////////////////////////////////////////////////////////////////////
+
+func one_hop<T>(_ t: T) -> sending T {
+  // expected-note@+1 {{'y' is connected to 't' which is accessible to code in the current isolation context}}
+  let y = t
+  return y // expected-warning {{}} expected-note {{}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Two hops — through a named intermediate. Both links are reported.
+////////////////////////////////////////////////////////////////////////////////
+
+func two_hop<T>(_ t: T) -> sending T {
+  // expected-note@+1 {{'y' is connected to 't' which is accessible to code in the current isolation context}}
+  let y = t
+  let z = y // expected-note {{'z' is connected to 'y'}}
+  return z // expected-warning {{}} expected-note {{}}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CFG diamond — only the 'if' arm merges the returned local into the isolated
+// region; the 'else' arm assigns a fresh value.
+//
+// FIXME: Two defects are pinned here rather than smoothed over. Both are
+// specific to this diagnostic's shape -- the one-hop and two-hop cases above
+// are correct -- and both need the join, so they do not reproduce on a
+// straight-line function.
+//
+//  1. The notes name '$return_value', which is the SIL name of the indirect
+//     result and not anything the user wrote. A user-facing note should never
+//     print it. It appears because the out parameter is in the merged region, so
+//     the walk's pairwise question splits through it, giving y -> $return_value
+//     -> t instead of y -> t.
+//
+//  2. The notes are attributed to the *wrong arm*: they land on the 'else' arm's
+//     assignment, which never touched 't', instead of the 'if' arm's 'y = t'.
+//     Verified at the SIL level -- bb1 is the arm holding 'copy_addr %1 to
+//     [init]' for the task-isolated argument, bb2 is the fresh assignment, and
+//     the notes come out attributed to bb2. The merge being explained is one the
+//     dataflow join performed, which has no sequence boundary in the joining
+//     block, so its notes stay pending and are located only once the walk enters
+//     a predecessor -- and the located boundary is not required to come from the
+//     predecessor that actually answered the question. That is
+//     prepareStatesForPredecessors' candidate filter, which README.md §5 flags as
+//     the part of the walk most likely to misbehave on a non-apply anchor.
+//
+// When either is fixed this case should instead report, on the 'y = t' line:
+//   'y' is connected to 't' which is accessible to code in the current isolation context
+////////////////////////////////////////////////////////////////////////////////
+
+func diamond<T>(_ t: T, _ makeFresh: () -> T, _ cond: Bool) -> sending T {
+  var y = makeFresh()
+  if cond {
+    y = t
+  } else {
+    // expected-note@+2 {{'y' is connected to '$return_value'}}
+    // expected-note@+1 {{'$return_value' is connected to 't' which is accessible to code in the current isolation context}}
+    y = makeFresh()
+  }
+  return y // expected-warning {{}} expected-note {{}}
+}


### PR DESCRIPTION
Isolation-history notes explain *how* a value came to share a region, by
rewinding the partition captured at the error and naming each merge along the
way. The previous PR generalized the emitter entry point into a `Request` with
two shapes -- `howDidBecomeIsolatedTo` and `howDidBecomeConnectedTo` -- and
wired up the first consumer. This wires up the remaining four:
`AssignNeverSendableIntoSendingResult`, `InOutSendingReturned`,
`InOutSendingParametersInSameRegion`, and `IncompatibleRegionMerge`, one commit
each, with tests.

Emission stays opt-in per function (`-sil-region-isolation-emit-isolation-history`
or `@diagnose(RegionIsolationIsolationHistory, as: ...)`). With recording off the
error carries no `Partition` at all -- each new field is a
`std::optional<Partition>` filled from `getSnapshotForIsolationHistory()`.

The interesting parts:

- **`IncompatibleRegionMerge` is the only one whose shipping output changes.** It
  already emitted a shallow per-side note, `'a' is exposed to main actor-isolated
  code`; a chain is the deep version of exactly that, so both sides now route
  through one `emitSideNote` that prefers a chain and keeps the shallow note when
  there is none. The fallback keys off `emit()`'s bool return, not off whether
  recording is on: recording can be on and the walk still find nothing, and the
  user must keep the shallow note there. Its snapshot is taken *before* the failed
  merge, so the two sides are still separate and each gets its own walk.

- **`InOutSendingReturned` is the first user of both request shapes.** Returning
  the parameter itself asks why its region is isolated; returning some other value
  in that region asks how the two connected. A connect chain has no isolated
  terminus, so its last link is a plain `'a' is connected to 'b'` -- a dedicated
  terminal diagnostic for that is a follow-up. One chain per error, anchored on
  the error's elements rather than on what `emit()` re-derives: its epilogue-phi
  and `LastValueEnum` paths exist to pick a better *location*, not to describe
  more regions, and they yield `SILValue`s that may have no `Element` at all.

- **`InOutSendingParametersInSameRegion` reports several pairs per error,** so the
  chain is emitted from inside that loop -- a pair filtered out as `Ignore` has no
  primary to hang a note on -- and each pair gets its own *copy* of the partition,
  since the walk consumes what it rewinds. Moving it would leave every pair after
  the first silently chainless.

- **Notes must not outrun their error.** The three defer-based consumers gate on
  `emittedErrorDiagnostic`: on a bailing path the unknown-pattern error comes from
  the emitter's destructor, i.e. after the defer runs.
  `IncompatibleRegionMerge` instead emits in place of the shallow note, since its
  unknown-pattern paths return earlier and must stay note-free, and being
  downstream of the isolation-validity guards is what makes the isolation safe to
  format at all.

Two walk defects show up only in the CFG-diamond cases and are pinned with FIXMEs
rather than smoothed over: a note located in the wrong arm when the merge was
performed by the dataflow join (which has no sequence boundary in the joining
block), and `'$return_value'` leaking into a user-facing note on SILGen'd
`sending` results. Both are properties of the walk, not of this wiring;
straight-line cases are correct.

Each diagnostic gets a `.sil` and a `.swift` test (one hop, multi hop, CFG
diamond, suppression where the shape admits one) plus an opted-in / no-attribute
pair in the `@diagnose` test, since the recording gate and each consuming gate
are separate conditions that have to agree.
