### PR TITLE
Diagnostics: Emit highlight ranges that cover whole syntax nodes

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2731,6 +2731,11 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   // diagnostic this can be used for better error presentation.
   SourceRange AttrRange;
 
+  auto attrRangeWithAt = [&]() -> SourceRange {
+    SourceLoc end = AttrRange.End.isValid() ? AttrRange.End : Loc;
+    return SourceRange(AtLoc.isValid() ? AtLoc : Loc, end);
+  };
+
   ParserStatus Status;
 
   switch (DK) {
@@ -2993,10 +2998,10 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       // this declaration with a different access level.
       if (access != cast<AccessControlAttr>(DuplicateAttribute)->getAccess()) {
         diagnose(Loc, diag::multiple_access_level_modifiers)
-            .highlight(AttrRange);
+            .highlight(attrRangeWithAt());
         diagnose(DuplicateAttribute->getLocation(),
                  diag::previous_access_level_modifier)
-            .highlight(DuplicateAttribute->getRange());
+            .highlight(DuplicateAttribute->getRangeWithAt());
 
         // Remove the reference to the duplicate attribute
         // to avoid the extra diagnostic.
@@ -3069,10 +3074,10 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     // this declaration with a different access level.
     if (access != cast<SetterAccessAttr>(DuplicateAttribute)->getAccess()) {
       diagnose(Loc, diag::multiple_access_level_modifiers)
-        .highlight(AttrRange);
+          .highlight(attrRangeWithAt());
       diagnose(DuplicateAttribute->getLocation(),
                diag::previous_access_level_modifier)
-          .highlight(DuplicateAttribute->getRange());
+          .highlight(DuplicateAttribute->getRangeWithAt());
 
       // Remove the reference to the duplicate attribute
       // to avoid the extra diagnostic.
@@ -4381,11 +4386,11 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
   if (DuplicateAttribute) {
     diagnose(Loc, diag::duplicate_attribute, DeclAttribute::isDeclModifier(DK))
-      .highlight(AttrRange);
+        .highlight(attrRangeWithAt());
     diagnose(DuplicateAttribute->getLocation(),
              diag::previous_attribute,
              DeclAttribute::isDeclModifier(DK))
-      .highlight(DuplicateAttribute->getRange());
+        .highlight(DuplicateAttribute->getRangeWithAt());
   }
 
   // If this is a decl modifier spelled with an @, emit an error and remove it

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6189,6 +6189,17 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
   auto firstRange = argRange(ArgIdx, first);
   auto secondRange = argRange(PrevArgIdx, second);
 
+  // A highlighted range has to cover a whole syntax node in order to be
+  // rendered, and a label together with its expression is not one: the syntax
+  // node for a labeled argument also covers its trailing comma. Highlight the
+  // label on its own, which is what this diagnostic is about anyway, and fall
+  // back to the expression for an unlabeled argument.
+  auto argHighlight = [&](unsigned argIdx, Identifier label) -> SourceRange {
+    if (!label.empty())
+      return SourceRange(args->getLabelLoc(argIdx));
+    return args->getExpr(argIdx)->getSourceRange();
+  };
+
   SourceLoc diagLoc = firstRange.Start;
 
   auto addFixIts = [&](InFlightDiagnostic diag) {
@@ -6201,7 +6212,8 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
         !SM.rangeContains(argsRange, secondRange))
       return;
 
-    diag.highlight(firstRange).highlight(secondRange);
+    diag.highlight(argHighlight(ArgIdx, first))
+        .highlight(argHighlight(PrevArgIdx, second));
 
     // Move the misplaced argument by removing it from one location and
     // inserting it in another location. To maintain argument comma
@@ -6412,7 +6424,7 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
       auto paramContext = getParameterContextForDiag(getRawAnchor());
       emitDiagnostic(diag::extra_argument_to_nullary_call,
                      static_cast<unsigned>(paramContext))
-          .highlight(args->getSourceRange())
+          .highlight(getRawAnchor().getSourceRange())
           .fixItRemove(args->getSourceRange());
       return true;
     }
@@ -6480,7 +6492,7 @@ bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
     if (TE && getType(TE)->getMetatypeInstanceType()->isVoid()) {
       emitDiagnosticAt(call->getLoc(), diag::extra_argument_to_nullary_call,
                        static_cast<unsigned>(paramContext))
-          .highlight(call->getArgs()->getSourceRange());
+          .highlight(call->getSourceRange());
       return true;
     }
   }
@@ -6508,16 +6520,16 @@ bool ExtraneousArgumentsFailure::diagnoseSingleExtraArgument() const {
     } else {
       emitDiagnosticAt(loc, diag::extra_argument_to_nullary_call,
                        static_cast<unsigned>(paramContext))
-          .highlight(arguments->getSourceRange());
+          .highlight(getRawAnchor().getSourceRange());
     }
   } else if (argument.hasLabel()) {
     emitDiagnosticAt(loc, diag::extra_argument_named, argument.getLabel(),
                      static_cast<unsigned>(paramContext))
-        .highlight(arguments->getSourceRange());
+        .highlight(getRawAnchor().getSourceRange());
   } else {
     emitDiagnosticAt(loc, diag::extra_argument_positional,
                      static_cast<unsigned>(paramContext))
-        .highlight(arguments->getSourceRange());
+        .highlight(getRawAnchor().getSourceRange());
   }
   return true;
 }
@@ -7567,7 +7579,7 @@ bool InvalidTupleSplatWithSingleParameterFailure::diagnoseAsError() {
                                                    args->getLabelLoc(0));
   }
 
-  diagnostic.highlight(args->getSourceRange())
+  diagnostic.highlight(getRawAnchor().getSourceRange())
       .fixItInsertAfter(newLeftParenLoc, "(")
       .fixItInsert(args->getEndLoc(), ")");
 

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -2135,7 +2135,7 @@ bool PreCheckTarget::correctInterpolationIfStrange(
             Context.Diags
                 .diagnose(argLabelLoc,
                           diag::string_interpolation_label_changing)
-                .highlightChars(argLabelLoc, argLoc);
+                .highlight(SourceRange(argLabelLoc));
             Context.Diags
                 .diagnose(argLabelLoc,
                           diag::string_interpolation_remove_label,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4957,7 +4957,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     // Diagnose and ignore arguments.
     if (attr->hasArgs()) {
       diagnose(attr->getLocation(), diag::result_builder_arguments)
-        .highlight(attr->getArgs()->getSourceRange());
+          .highlight(attr->getRangeWithAt());
     }
 
     // Complain if this isn't the primary result-builder attribute.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2379,12 +2379,12 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     // Diagnose unused constructor calls.
     if (isa_and_nonnull<ConstructorDecl>(callee) && !call->isImplicit()) {
       DE.diagnose(fn->getLoc(), diag::expression_unused_init_result,
-               callee->getDeclContext()->getDeclaredInterfaceType())
-        .highlight(call->getArgs()->getSourceRange());
+                  callee->getDeclContext()->getDeclaredInterfaceType())
+          .highlight(call->getSourceRange());
       return;
     }
-    
-    SourceRange SR1 = call->getArgs()->getSourceRange(), SR2;
+
+    SourceRange SR1 = call->getSourceRange(), SR2;
     if (auto *BO = dyn_cast<BinaryExpr>(call)) {
       SR1 = BO->getLHS()->getSourceRange();
       SR2 = BO->getRHS()->getSourceRange();

--- a/test/ASTGen/sourcelocation.swift
+++ b/test/ASTGen/sourcelocation.swift
@@ -19,11 +19,11 @@ test(arg: 2)
 
 // CHECK:      {{^}}second/foo.swift:102:1: warning: result of call to 'test(arg:)' is unused
 // CHECK-NEXT: {{^}}test(arg: 2)
-// CHECK-NEXT: {{^}}^   ~~~~~~~~
+// CHECK-NEXT: {{^}}^~~~~~~~~~~~
 
 // CHECK:      {{^}}first/foo.swift:100:3: warning: result of call to 'test(arg:)' is unused
 // CHECK-NEXT: {{^}}  test(arg: 1)
-// CHECK-NEXT: {{^}}  ^   ~~~~~~~~
+// CHECK-NEXT: {{^}}  ^~~~~~~~~~~~
 
 // CHECK:      {{^SOURCE_DIR[\//]test[/\\]ASTGen[\//]sourcelocation\.swift}}:4:25: warning: '#sourceLocation' directive produces '#fileID' string of 'MyMod/foo.swift', which conflicts with '#fileID' strings produced by other paths in the module
 // CHECK-NEXT: {{^}}  #sourceLocation(file: "first/foo.swift", line: 100)

--- a/test/diagnostics/highlights.swift
+++ b/test/diagnostics/highlights.swift
@@ -1,0 +1,144 @@
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 \
+// RUN:   -diagnostic-style llvm %s 2>&1 \
+// RUN:   | %FileCheck --strict-whitespace --enable-windows-compatibility %s
+
+struct Struct { init(_ x: Int) {} }
+func unusedInitResult() { Struct(1) }
+
+func fn(_ x: Int) -> Int { x }
+func unusedCallResult() { fn(2) }
+
+func withClosure<T>(_ v: T, _ body: (T) -> T) -> T { body(v) }
+func unusedTrailingClosureResult(v: Int) { withClosure(v) { $0 } }
+
+func unusedOperatorResult(a: Int, b: Int) { a + b }
+
+struct Nullary { init() {} }
+func extraArgumentToNullaryCall() { _ = Nullary(extra: 1) }
+
+func voidCall() { _ = Void(1) }
+
+func named(a: Int) {}
+func extraNamedArgument() { named(a: 1, b: 2) }
+
+func positional(_ a: Int) {}
+func extraPositionalArgument() { positional(1, 2) }
+
+func tupleParam(x: (Int, Int)) {}
+func tupleSplat() { tupleParam(x: 0, 1) }
+
+func labeled(a: Int, b: Int) {}
+func outOfOrderArguments() { labeled(b: 1, a: 2) }
+
+@resultBuilder struct Builder { static func buildBlock(_ x: Int...) -> Int { 0 } }
+@Builder(1) func resultBuilderArguments() -> Int { 1 }
+
+@unsafe @safe func safeAndUnsafe() {}
+
+@available(*, unavailable) func unavailableFn() {}
+func useUnavailable() { unavailableFn() }
+
+@available(swift, obsoleted: 3.0) func obsoletedFn() {}
+func useObsoleted() { obsoletedFn() }
+
+@available(swift, introduced: 99) func unintroducedFn() {}
+func useUnintroduced() { unintroducedFn() }
+
+protocol P {}
+func requiresP<T: P>(_ t: T) {}
+
+struct Unavail {}
+@available(*, unavailable) extension Unavail: P {}
+func useUnavailableConformance(v: Unavail) { requiresP(v) }
+
+struct Obs {}
+@available(swift, obsoleted: 3.0) extension Obs: P {}
+func useObsoletedConformance(v: Obs) { requiresP(v) }
+
+// CHECK:      error: result builder attributes cannot have arguments
+// CHECK-NEXT: {{^}}@Builder(1) func resultBuilderArguments() -> Int { 1 }
+// CHECK-NEXT: {{^}}^~~~~~~~~~~{{$}}
+
+// CHECK:      error: global function 'safeAndUnsafe' cannot be both '@safe' and '@unsafe'
+// CHECK-NEXT: {{^}}@unsafe @safe func safeAndUnsafe() {}
+// CHECK-NEXT: {{^}}~~~~~~~ ~~~~~      ^{{$}}
+
+// CHECK:      warning: result of 'Struct' initializer is unused
+// CHECK-NEXT: {{^}}func unusedInitResult() { Struct(1) }
+// CHECK-NEXT: {{^}}                          ^~~~~~~~~{{$}}
+
+// CHECK:      warning: result of call to 'fn' is unused
+// CHECK-NEXT: {{^}}func unusedCallResult() { fn(2) }
+// CHECK-NEXT: {{^}}                          ^~~~~{{$}}
+
+// CHECK:      warning: result of call to 'withClosure' is unused
+// CHECK-NEXT: {{^}}func unusedTrailingClosureResult(v: Int) { withClosure(v) { $0 } }
+// CHECK-NEXT: {{^}}                                           ^~~~~~~~~~~~~~~~~~~~~{{$}}
+
+// CHECK:      warning: result of operator '+' is unused
+// CHECK-NEXT: {{^}}func unusedOperatorResult(a: Int, b: Int) { a + b }
+// CHECK-NEXT: {{^}}                                            ~ ^ ~{{$}}
+
+// CHECK:      error: argument passed to call that takes no arguments
+// CHECK-NEXT: {{^}}func extraArgumentToNullaryCall() { _ = Nullary(extra: 1) }
+// CHECK-NEXT: {{^}}                                        ~~~~~~~~~~~~~~~^~{{$}}
+
+// CHECK:      error: argument passed to call that takes no arguments
+// CHECK-NEXT: {{^}}func voidCall() { _ = Void(1) }
+// CHECK-NEXT: {{^}}                      ^~~~~~~{{$}}
+
+// CHECK:      error: extra argument 'b' in call
+// CHECK-NEXT: {{^}}func extraNamedArgument() { named(a: 1, b: 2) }
+// CHECK-NEXT: {{^}}                            ~~~~~~~~~~~~~~~^~{{$}}
+
+// CHECK:      error: extra argument in call
+// CHECK-NEXT: {{^}}func extraPositionalArgument() { positional(1, 2) }
+// CHECK-NEXT: {{^}}                                 ~~~~~~~~~~~~~~^~{{$}}
+
+// CHECK:      error: global function 'tupleParam' expects a single parameter of type '(Int, Int)'
+// CHECK-NEXT: {{^}}func tupleSplat() { tupleParam(x: 0, 1) }
+// CHECK-NEXT: {{^}}                    ~~~~~~~~~~^~~~~~~~~{{$}}
+
+// CHECK:      error: argument 'a' must precede argument 'b'
+// CHECK-NEXT: {{^}}func outOfOrderArguments() { labeled(b: 1, a: 2) }
+// CHECK-NEXT: {{^}}                                     ~   ~~^~~~{{$}}
+
+// CHECK:      error: 'unavailableFn()' is unavailable
+// CHECK-NEXT: {{^}}func useUnavailable() { unavailableFn() }
+// CHECK-NEXT: {{^}}                        ^~~~~~~~~~~~~{{$}}
+
+// CHECK:      note: 'unavailableFn()' has been explicitly marked unavailable here
+// CHECK-NEXT: {{^}}@available(*, unavailable) func unavailableFn() {}
+// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~      ^{{$}}
+
+// CHECK:      error: 'obsoletedFn()' is unavailable
+// CHECK-NEXT: {{^}}func useObsoleted() { obsoletedFn() }
+// CHECK-NEXT: {{^}}                      ^~~~~~~~~~~{{$}}
+
+// CHECK:      note: 'obsoletedFn()' was obsoleted in Swift 3.0
+// CHECK-NEXT: {{^}}@available(swift, obsoleted: 3.0) func obsoletedFn() {}
+// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      ^{{$}}
+
+// CHECK:      error: 'unintroducedFn()' is unavailable in Swift
+// CHECK-NEXT: {{^}}func useUnintroduced() { unintroducedFn() }
+// CHECK-NEXT: {{^}}                         ^~~~~~~~~~~~~~{{$}}
+
+// CHECK:      note: 'unintroducedFn()' was introduced in Swift 99
+// CHECK-NEXT: {{^}}@available(swift, introduced: 99) func unintroducedFn() {}
+// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      ^{{$}}
+
+// CHECK:      error: conformance of 'Unavail' to 'P' is unavailable
+// CHECK-NEXT: {{^}}func useUnavailableConformance(v: Unavail) { requiresP(v) }
+// CHECK-NEXT: {{^}}                                             ^{{$}}
+
+// CHECK:      note: conformance of 'Unavail' to 'P' has been explicitly marked unavailable here
+// CHECK-NEXT: {{^}}@available(*, unavailable) extension Unavail: P {}
+// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~ ^{{$}}
+
+// CHECK:      error: conformance of 'Obs' to 'P' is unavailable
+// CHECK-NEXT: {{^}}func useObsoletedConformance(v: Obs) { requiresP(v) }
+// CHECK-NEXT: {{^}}                                       ^{{$}}
+
+// CHECK:      note: conformance of 'Obs' to 'P' was obsoleted in Swift 3.0
+// CHECK-NEXT: {{^}}@available(swift, obsoleted: 3.0) extension Obs: P {}
+// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^{{$}}

--- a/test/diagnostics/highlights_parse.swift
+++ b/test/diagnostics/highlights_parse.swift
@@ -1,0 +1,63 @@
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 \
+// RUN:   -diagnostic-style llvm %s 2>&1 \
+// RUN:   | %FileCheck --strict-whitespace --enable-windows-compatibility %s
+
+@inline(__always) @inline(never) func duplicateAttributeWithArguments() {}
+
+@inlinable @inlinable public func duplicateSimpleAttribute() {}
+
+final final class DuplicateModifier {}
+
+public private var multipleAccessLevels = 0
+
+public private(set) internal(set) var multipleSetterAccessLevels = 0
+
+public private(set) private(set) var duplicateSetterModifier = 0
+
+// CHECK:      error: duplicate attribute
+// CHECK-NEXT: {{^}}@inline(__always) @inline(never) func duplicateAttributeWithArguments() {}
+// CHECK-NEXT: {{^}}                  ~^~~~~~~~~~~~~{{$}}
+
+// CHECK:      note: attribute already specified here
+// CHECK-NEXT: {{^}}@inline(__always) @inline(never) func duplicateAttributeWithArguments() {}
+// CHECK-NEXT: {{^}}~^~~~~~~~~~~~~~~~{{$}}
+
+// CHECK:      error: duplicate attribute
+// CHECK-NEXT: {{^}}@inlinable @inlinable public func duplicateSimpleAttribute() {}
+// CHECK-NEXT: {{^}}           ~^~~~~~~~~{{$}}
+
+// CHECK:      note: attribute already specified here
+// CHECK-NEXT: {{^}}@inlinable @inlinable public func duplicateSimpleAttribute() {}
+// CHECK-NEXT: {{^}}^~~~~~~~~~{{$}}
+
+// CHECK:      error: duplicate modifier
+// CHECK-NEXT: {{^}}final final class DuplicateModifier {}
+// CHECK-NEXT: {{^}}      ^~~~~{{$}}
+
+// CHECK:      note: modifier already specified here
+// CHECK-NEXT: {{^}}final final class DuplicateModifier {}
+// CHECK-NEXT: {{^}}^~~~~{{$}}
+
+// CHECK:      error: multiple incompatible access-level modifiers specified
+// CHECK-NEXT: {{^}}public private var multipleAccessLevels = 0
+// CHECK-NEXT: {{^}}       ^~~~~~~{{$}}
+
+// CHECK:      note: previous modifier specified here
+// CHECK-NEXT: {{^}}public private var multipleAccessLevels = 0
+// CHECK-NEXT: {{^}}^~~~~~{{$}}
+
+// CHECK:      error: multiple incompatible access-level modifiers specified
+// CHECK-NEXT: {{^}}public private(set) internal(set) var multipleSetterAccessLevels = 0
+// CHECK-NEXT: {{^}}                    ^~~~~~~~~~~~~{{$}}
+
+// CHECK:      note: previous modifier specified here
+// CHECK-NEXT: {{^}}public private(set) internal(set) var multipleSetterAccessLevels = 0
+// CHECK-NEXT: {{^}}       ^~~~~~~~~~~~{{$}}
+
+// CHECK:      error: duplicate modifier
+// CHECK-NEXT: {{^}}public private(set) private(set) var duplicateSetterModifier = 0
+// CHECK-NEXT: {{^}}                    ^~~~~~~~~~~~{{$}}
+
+// CHECK:      note: modifier already specified here
+// CHECK-NEXT: {{^}}public private(set) private(set) var duplicateSetterModifier = 0
+// CHECK-NEXT: {{^}}       ^~~~~~~~~~~~{{$}}


### PR DESCRIPTION
`swift_ASTGen_addQueuedDiagnostic` renders a highlight by walking up from the token at the start of its range until it finds a syntax node with exactly matching bounds, so a range that doesn't line up with a node is dropped and the highlight never appears in `-diagnostic-style=swift` output. Widen the ranges that were being dropped.

Add tests that verify `-diagnostic-style=llvm` output for most diagnostics with a highlighted range. Unfortunately these tests don't also verify that the highlight actually gets rendered by `-diagnostic-style=swift`, but they'll at least make it harder for the now corrected ranges to regress.