### PR TITLE
[Compile Time Constant Extraction] Remove empty element keys from the const values file

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1098,6 +1098,10 @@ getConditionalMemberFromIfStmt(const IfStmt *ifStmt,
   if (auto thenBraceStmt = ifStmt->getThenStmt()) {
     for (auto elem : thenBraceStmt->getElements()) {
       if (auto memberElement = getResultBuilderElementFromASTNode(elem)) {
+        // Skip compiler-synthesized bindings (buildBlock, buildLimitedAvailability, etc)
+        if (auto *sfc = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
+          if (sfc->getLabel() != "buildExpression")
+            continue;
         IfElements.push_back(std::make_shared<BuilderValue::SingleMember>(
             memberElement.value()));
       }
@@ -1111,6 +1115,9 @@ getConditionalMemberFromIfStmt(const IfStmt *ifStmt,
     } else if (auto *elseBraceStmt = dyn_cast<BraceStmt>(elseStmt)) {
       for (auto elem : elseBraceStmt->getElements()) {
         if (auto memberElement = getResultBuilderElementFromASTNode(elem)) {
+          if (auto *sfc = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
+            if (sfc->getLabel() != "buildExpression")
+              continue;
           ElseElements.push_back(std::make_shared<BuilderValue::SingleMember>(
               memberElement.value()));
         }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1099,9 +1099,12 @@ getConditionalMemberFromIfStmt(const IfStmt *ifStmt,
     for (auto elem : thenBraceStmt->getElements()) {
       if (auto memberElement = getResultBuilderElementFromASTNode(elem)) {
         // Skip compiler-synthesized bindings (buildBlock, buildLimitedAvailability, etc)
-        if (auto *callValue = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
-          if (callValue->getLabel() != "buildExpression")
+        if (auto *callValue =
+                dyn_cast<StaticFunctionCallValue>(memberElement->get())) {
+          if (callValue->getLabel() != "buildExpression") {
             continue;
+          }
+        }
         IfElements.push_back(std::make_shared<BuilderValue::SingleMember>(
             memberElement.value()));
       }
@@ -1115,9 +1118,12 @@ getConditionalMemberFromIfStmt(const IfStmt *ifStmt,
     } else if (auto *elseBraceStmt = dyn_cast<BraceStmt>(elseStmt)) {
       for (auto elem : elseBraceStmt->getElements()) {
         if (auto memberElement = getResultBuilderElementFromASTNode(elem)) {
-          if (auto *callValue = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
-            if (callValue->getLabel() != "buildExpression")
+          if (auto *callValue =
+                  dyn_cast<StaticFunctionCallValue>(memberElement->get())) {
+            if (callValue->getLabel() != "buildExpression") {
               continue;
+            }
+          }
           ElseElements.push_back(std::make_shared<BuilderValue::SingleMember>(
               memberElement.value()));
         }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1099,8 +1099,8 @@ getConditionalMemberFromIfStmt(const IfStmt *ifStmt,
     for (auto elem : thenBraceStmt->getElements()) {
       if (auto memberElement = getResultBuilderElementFromASTNode(elem)) {
         // Skip compiler-synthesized bindings (buildBlock, buildLimitedAvailability, etc)
-        if (auto *sfc = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
-          if (sfc->getLabel() != "buildExpression")
+        if (auto *callValue = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
+          if (callValue->getLabel() != "buildExpression")
             continue;
         IfElements.push_back(std::make_shared<BuilderValue::SingleMember>(
             memberElement.value()));
@@ -1115,8 +1115,8 @@ getConditionalMemberFromIfStmt(const IfStmt *ifStmt,
     } else if (auto *elseBraceStmt = dyn_cast<BraceStmt>(elseStmt)) {
       for (auto elem : elseBraceStmt->getElements()) {
         if (auto memberElement = getResultBuilderElementFromASTNode(elem)) {
-          if (auto *sfc = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
-            if (sfc->getLabel() != "buildExpression")
+          if (auto *callValue = dyn_cast<StaticFunctionCallValue>(memberElement->get()))
+            if (callValue->getLabel() != "buildExpression")
               continue;
           ElseElements.push_back(std::make_shared<BuilderValue::SingleMember>(
               memberElement.value()));

--- a/test/ConstExtraction/ExtractResultBuilders.swift
+++ b/test/ConstExtraction/ExtractResultBuilders.swift
@@ -419,9 +419,6 @@ extension MyFooProviderInExtension: FooProvider {
 // CHECK-NEXT:                       ]
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   }
-// CHECK-NEXT:                 },
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ],
 // CHECK-NEXT:               "elseElements": [
@@ -442,9 +439,6 @@ extension MyFooProviderInExtension: FooProvider {
 // CHECK-NEXT:                           ]
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                       }
-// CHECK-NEXT:                     },
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                       "element": {}
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   ],
 // CHECK-NEXT:                   "elseElements": [
@@ -463,9 +457,6 @@ extension MyFooProviderInExtension: FooProvider {
 // CHECK-NEXT:                           ]
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                       }
-// CHECK-NEXT:                     },
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                       "element": {}
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   ]
 // CHECK-NEXT:                 }
@@ -524,9 +515,6 @@ extension MyFooProviderInExtension: FooProvider {
 // CHECK-NEXT:                       ]
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   }
-// CHECK-NEXT:                 },
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ],
 // CHECK-NEXT:               "elseElements": []
@@ -587,12 +575,6 @@ extension MyFooProviderInExtension: FooProvider {
 // CHECK-NEXT:                       ]
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   }
-// CHECK-NEXT:                 },
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                   "element": {}
-// CHECK-NEXT:                 },
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ],
 // CHECK-NEXT:               "elseElements": [
@@ -611,9 +593,6 @@ extension MyFooProviderInExtension: FooProvider {
 // CHECK-NEXT:                       ]
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                   }
-// CHECK-NEXT:                 },
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                   "element": {}
 // CHECK-NEXT:                 }
 // CHECK-NEXT:               ]
 // CHECK-NEXT:             }


### PR DESCRIPTION
Don't process compiler generated plumbing that does not represent what the user wrote. These empty "element" blocks were causing issues downstream. 

fixes: rdar://184534204