### PR TITLE
[IRGenDebugInfo] Describe a default actor's storage field in DWARF

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "IRGenDebugInfo.h"
+#include "Field.h"
 #include "GenEnum.h"
 #include "GenOpaque.h"
 #include "GenStruct.h"
@@ -1203,11 +1204,62 @@ private:
     StringRef Name;
     unsigned AlignInBits;
     TrackingDIType DIType;
-    MemberDIType(StringRef Name, unsigned AlignInBits, llvm::DIType *DIType)
-        : Name(Name), AlignInBits(AlignInBits), DIType(DIType) {}
+    llvm::DINode::DIFlags Flags;
+    MemberDIType(StringRef Name, unsigned AlignInBits, llvm::DIType *DIType,
+                 llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero)
+        : Name(Name), AlignInBits(AlignInBits), DIType(DIType), Flags(Flags) {}
   };
 
   unsigned getByteSize() { return CI.getTargetInfo().getCharWidth(); }
+
+  /// Append the DWARF member describing \p field to \p MemberTypes, and return
+  /// false if \p RequireComplete was asked for but the member's size is not
+  /// known.
+  bool collectFieldMember(Field field, swift::Type ParentTy,
+                          llvm::DINode::DIFlags Flags, bool RequireComplete,
+                          SmallVectorImpl<MemberDIType> &MemberTypes) {
+    swift::Type MemberTy;
+    const TypeInfo *TI = nullptr;
+    switch (field.getKind()) {
+    case Field::MissingMember:
+      // A placeholder for a member the importer could not translate describes
+      // no storage of its own, and has no name to describe it with.
+      return true;
+
+    case Field::Var: {
+      VarDecl *VD = field.getVarDecl();
+      MemberTy = ParentTy->getTypeOfMember(VD);
+      TI = &IGM.getTypeInfoForUnlowered(
+          IGM.getSILTypes().getAbstractionPattern(VD), MemberTy);
+      break;
+    }
+
+    case Field::DefaultActorStorage:
+    case Field::NonDefaultDistributedActorStorage:
+      // There is no VarDecl and no abstraction pattern; the field's type is a
+      // builtin whose size IRGen already knows.
+      MemberTy = field.getInterfaceType(IGM);
+      TI = &IGM.getTypeInfoForUnlowered(MemberTy);
+      Flags |= llvm::DINode::FlagArtificial;
+      break;
+    }
+
+    std::optional<DebugTypeInfo> DbgTy;
+    if (RequireComplete) {
+      if (auto Completed =
+              CompletedDebugTypeInfo::getFromTypeInfo(MemberTy, *TI, IGM))
+        DbgTy = *Completed;
+      else
+        return false;
+    } else {
+      DbgTy = DebugTypeInfo::getFromTypeInfo(MemberTy, *TI, IGM);
+    }
+
+    MemberTypes.emplace_back(field.getName(), getAlignInBits(*DbgTy),
+                             getOrCreateType(*DbgTy), Flags);
+    anchorTypeAliasesIn(MemberTy);
+    return true;
+  }
 
   /// The alignment to record in the debug info for \p DbgTy, in bits, or 0 to
   /// record none. The DWARF emitter checks for a 0 and omits DW_AT_alignment 
@@ -1230,24 +1282,21 @@ private:
     // Collect the members.
     SmallVector<MemberDIType, 16> MemberTypes;
     if (!IGM.isResilient(Decl, ResilienceExpansion::Maximal)) {
-      for (VarDecl *VD : Decl->getStoredProperties()) {
-        auto memberTy = Type->getTypeOfMember(VD);
-        if (auto DbgTy = CompletedDebugTypeInfo::getFromTypeInfo(
-                memberTy,
-                IGM.getTypeInfoForUnlowered(
-                    IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
-                IGM)) {
-          MemberTypes.emplace_back(VD->getName().str(),
-                                   getAlignInBits(*DbgTy),
-                                   getOrCreateType(*DbgTy));
-          anchorTypeAliasesIn(memberTy);
-        } else {
-          // Without complete type info we can only create a forward decl.
-          return DBuilder.createForwardDecl(
-              llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, Line,
-              llvm::dwarf::DW_LANG_Swift, SizeInBits, 0);
-        }
-      }
+      bool Incomplete = false;
+      // forEachField(), not getStoredProperties(): a root default actor has an
+      // artificial storage field ahead of its stored properties, which
+      // getStoredProperties() does not know about. See collectFieldMember.
+      forEachField(IGM, Decl, [&](Field field) {
+        if (Incomplete)
+          return;
+        Incomplete = !collectFieldMember(field, Type, Flags,
+                                         /*RequireComplete=*/true, MemberTypes);
+      });
+      if (Incomplete)
+        // Without complete type info we can only create a forward decl.
+        return DBuilder.createForwardDecl(
+            llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, Line,
+            llvm::dwarf::DW_LANG_Swift, SizeInBits, 0);
     }
 
     SmallVector<llvm::Metadata *, 16> Members;
@@ -1255,7 +1304,7 @@ private:
     for (auto &Member : MemberTypes)
       Members.push_back(createMemberType(Member.DIType, Member.Name,
                                          OffsetInBits, Member.AlignInBits,
-                                         Scope, File, Flags));
+                                         Scope, File, Member.Flags));
 
     llvm::DINodeArray BoundParams = collectGenericParams(Type);
     llvm::DICompositeType *DITy = createStruct(
@@ -1290,26 +1339,18 @@ private:
     SmallVector<MemberDIType, 16> MemberTypes;
 
     if (!IGM.isResilient(Decl, ResilienceExpansion::Maximal)) {
-      for (VarDecl *VD : Decl->getStoredProperties()) {
-        Type memberTy = UnsubstitutedType->getTypeOfMember(VD);
-        auto DbgTy = DebugTypeInfo::getFromTypeInfo(
-            memberTy,
-            IGM.getTypeInfoForUnlowered(
-                IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
-            IGM);
-        MemberTypes.emplace_back(VD->getName().str(),
-                                 getAlignInBits(DbgTy),
-                                 getOrCreateType(DbgTy));
-        anchorTypeAliasesIn(memberTy);
-      }
+      forEachField(IGM, Decl, [&](Field field) {
+        collectFieldMember(field, UnsubstitutedType, Flags,
+                           /*RequireComplete=*/false, MemberTypes);
+      });
     }
 
     SmallVector<llvm::Metadata *, 16> Members;
     for (auto &Member : MemberTypes) {
       unsigned OffsetInBits = 0;
-      auto *member = createMemberType(Member.DIType, Member.Name,
-                                         OffsetInBits, Member.AlignInBits,
-                                      Scope, File, Flags);
+      auto *member =
+          createMemberType(Member.DIType, Member.Name, OffsetInBits,
+                           Member.AlignInBits, Scope, File, Member.Flags);
       Members.push_back(member);
     }
 
@@ -2538,9 +2579,11 @@ private:
           nullptr, llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
     }
 
-    // A special stdlib builtin type, which the debugger looks up by mangled
-    // name, so it must not be renamed to "<unknown>" below.
+    // Special stdlib builtin types, which the debugger looks up by mangled
+    // name, so they must not be renamed to "<unknown>" below.
     case TypeKind::BuiltinUnsafeValueBuffer:
+    case TypeKind::BuiltinDefaultActorStorage:
+    case TypeKind::BuiltinNonDefaultDistributedActorStorage:
       break;
 
     // The following types exist primarily for internal use by the type
@@ -2548,8 +2591,6 @@ private:
     case TypeKind::Error:
     case TypeKind::SILBlockStorage:
     case TypeKind::SILToken:
-    case TypeKind::BuiltinDefaultActorStorage:
-    case TypeKind::BuiltinNonDefaultDistributedActorStorage:
     case TypeKind::SILMoveOnlyWrapped:
     case TypeKind::Integer:
       LLVM_DEBUG(llvm::dbgs() << "Unhandled type: ";

--- a/test/DebugInfo/default-actor-storage-member.swift
+++ b/test/DebugInfo/default-actor-storage-member.swift
@@ -1,0 +1,49 @@
+// A root default actor has a fixed-size storage field laid out immediately
+// after the object header and ahead of its stored properties.
+// NominalTypeDecl::getStoredProperties() does not report it — forEachField()
+// does — and GenReflection already emits it into the field descriptor, so DWARF
+// used to be the only description of the layout that left it out. Anything that
+// reconstructs the layout from DWARF alone, which is every consumer under
+// embedded Swift where no reflection metadata exists, then placed the first
+// stored property at the top of the instance and read a wrong value rather than
+// no value.
+
+// RUN: %target-swift-frontend %s -emit-ir -g -gdwarf-types \
+// RUN:   -parse-as-library -module-name main -o - \
+// RUN:   | %FileCheck %s --check-prefixes=CHECK,CHECK-%target-ptrsize
+
+// REQUIRES: concurrency
+
+public actor Plain {
+  public let str = "Hello"
+}
+
+// A non-actor class must not gain the field.
+public class NotAnActor {
+  public let str = "Hello"
+}
+
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Plain",{{.*}}elements: ![[PLAIN_ELTS:[0-9]+]]
+// CHECK-DAG: ![[PLAIN_ELTS]] = !{![[STORAGE:[0-9]+]], ![[STR:[0-9]+]]}
+
+// The member is artificial, and its size is the whole default-actor buffer —
+// NumWords_DefaultActor (12) pointer-sized words — not a single pointer. Its
+// type keeps its mangled name — `Builtin.DefaultActorStorage` is deliberately
+// not lowered to the "<unknown>" placeholder — because that name is how a
+// debugger recovers the buffer's size. The stored property follows the buffer,
+// at the buffer's size.
+
+// CHECK-64-DAG: ![[STORAGE]] = !DIDerivedType(tag: DW_TAG_member, name: "$defaultActor",{{.*}}baseType: ![[STORAGE_TY:[0-9]+]], size: 768, flags: DIFlagArtificial)
+// CHECK-64-DAG: ![[STORAGE_TY]] = !DIBasicType(name: "$sBDD", size: 768)
+// CHECK-64-DAG: ![[STR]] = !DIDerivedType(tag: DW_TAG_member, name: "str",{{.*}}offset: 768)
+
+// CHECK-32-DAG: ![[STORAGE]] = !DIDerivedType(tag: DW_TAG_member, name: "$defaultActor",{{.*}}baseType: ![[STORAGE_TY:[0-9]+]], size: 384, flags: DIFlagArtificial)
+// CHECK-32-DAG: ![[STORAGE_TY]] = !DIBasicType(name: "$sBDD", size: 384)
+// CHECK-32-DAG: ![[STR]] = !DIDerivedType(tag: DW_TAG_member, name: "str",{{.*}}offset: 384)
+
+// A non-actor class keeps a one-element member list, and its member stays at
+// offset 0 — which the metadata printer spells by omitting `offset:`, so the
+// closing parenthesis is the assertion here.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "NotAnActor",{{.*}}elements: ![[NOT_ELTS:[0-9]+]]
+// CHECK-DAG: ![[NOT_ELTS]] = !{![[NOT_STR:[0-9]+]]}
+// CHECK-DAG: ![[NOT_STR]] = !DIDerivedType(tag: DW_TAG_member, name: "str", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, baseType: !{{[0-9]+}}, size: {{[0-9]+}})

--- a/test/DebugInfo/recursive_actor.swift
+++ b/test/DebugInfo/recursive_actor.swift
@@ -1,7 +1,10 @@
 // RUN: %target-swift-frontend  %s -emit-ir -g -o - | %FileCheck %s
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "A",{{.*}}elements: ![[A_ELTS:[0-9]+]], runtimeLang: DW_LANG_Swift, identifier: "$s15recursive_actor1ACyxGD")
-// CHECK: ![[A_ELTS]] = !{![[M_CHILD:[0-9]+]]}
+// A root default actor's artificial storage field is laid out ahead of its
+// stored properties, so it is the first element.
+// CHECK: ![[A_ELTS]] = !{![[M_ACTOR:[0-9]+]], ![[M_CHILD:[0-9]+]]}
+// CHECK: ![[M_ACTOR]] = !DIDerivedType(tag: DW_TAG_member, name: "$defaultActor", {{.*}}flags: DIFlagArtificial
 // CHECK: ![[M_CHILD]] = !DIDerivedType(tag: DW_TAG_member, name: "children", {{.*}}baseType: ![[CONT_AB:[0-9]+]]
 // CHECK: ![[CONT_AB]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}elements: ![[C_ELTS:[0-9]+]]
 // CHECK: ![[C_ELTS]] = !{![[M_AB:[0-9]+]]}


### PR DESCRIPTION
`createStructType` and `createUnsubstitutedGenericStructOrClassType` built a class's DWARF member list from `NominalTypeDecl::getStoredProperties()`. That misses the artificial fixed-size storage field a root default actor has immediately after the object header and ahead of its stored properties. `forEachField()` reports it, so use that instead.

Assisted-by: claude

rdar://184553158
