### PR TITLE
IRGen: Add -disable-objc-ivar-metadata to omit ObjC ivar lists

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -425,8 +425,7 @@ public:
 
   /// Omit the Objective-C ivar list of Swift classes that cannot need it,
   /// i.e. classes with a Swift-only superclass hierarchy and a fixed metadata
-  /// layout. Trades introspection of those ivars through the Objective-C
-  /// runtime for binary size.
+  /// layout.
   unsigned DisableObjCIvarMetadata : 1;
 
   unsigned DisableLLVMMergeFunctions : 1;

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -423,6 +423,12 @@ public:
   /// Emit names of struct stored properties and enum cases.
   unsigned EnableReflectionNames : 1;
 
+  /// Omit the Objective-C ivar list of Swift classes that cannot need it,
+  /// i.e. classes with a Swift-only superclass hierarchy and a fixed metadata
+  /// layout. Trades introspection of those ivars through the Objective-C
+  /// runtime for binary size.
+  unsigned DisableObjCIvarMetadata : 1;
+
   unsigned DisableLLVMMergeFunctions : 1;
 
   /// Emit mangled names of anonymous context descriptors.
@@ -667,7 +673,8 @@ public:
         SwiftAsyncFramePointer(SwiftAsyncFramePointerKind::Auto),
         HasValueNamesSetting(false), ValueNames(false),
         ReflectionMetadata(ReflectionMetadataMode::Runtime),
-        EnableReflectionNames(true), DisableLLVMMergeFunctions(false),
+        EnableReflectionNames(true), DisableObjCIvarMetadata(false),
+        DisableLLVMMergeFunctions(false),
         EnableAnonymousContextMangledNames(false), ForcePublicLinkage(false),
         LazyInitializeClassMetadata(false),
         LazyInitializeProtocolConformances(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -739,6 +739,10 @@ def disable_reflection_names : Flag<["-"], "disable-reflection-names">,
   HelpText<"Disable emission of names of stored properties and enum cases in"
            "reflection metadata">;
 
+def disable_objc_ivar_metadata : Flag<["-"], "disable-objc-ivar-metadata">,
+  HelpText<"Disable emission of the Objective-C ivar list for Swift classes "
+           "with a Swift-only superclass hierarchy and a fixed layout">;
+
 def disable_llvm_merge_functions_pass : Flag<["-"], "disable-llvm-merge-functions-pass">,
   HelpText<"Disable the MergeFunctionPass LLVM IR pass">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4018,6 +4018,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableReflectionNames = false;
   }
 
+  if (Args.hasArg(OPT_disable_objc_ivar_metadata)) {
+    Opts.DisableObjCIvarMetadata = true;
+  }
+
   if (Args.hasArg(OPT_disable_llvm_merge_functions_pass)) {
     Opts.DisableLLVMMergeFunctions = true;
   }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1574,6 +1574,44 @@ namespace {
                                  weakLinkage);
     }
 
+    /// Whether every class in this class's superclass chain, including the
+    /// class itself, is a Swift class with a known Swift implementation, i.e.
+    /// the hierarchy contains no Objective-C or imported classes.
+    bool hasOnlyKnownSwiftHierarchy(ClassDecl *cls) {
+      return !cls->walkSuperclasses([](ClassDecl *superclass) {
+        if (superclass->isObjC() || !superclass->hasKnownSwiftImplementation())
+          return TypeWalker::Action::Stop;
+        return TypeWalker::Action::Continue;
+      });
+    }
+
+    /// Whether the ivar list of this class can be replaced by a null pointer
+    /// in the rodata.
+    ///
+    /// Under -disable-objc-ivar-metadata, a class whose entire hierarchy is
+    /// Swift-only and whose metadata layout is fixed does not need its ivars
+    /// described to the Objective-C runtime: the ivar offsets are statically
+    /// known, so the runtime never has to slide them. Emitting a null ivar
+    /// list for such classes saves binary size, at the cost of introspecting
+    /// their ivars through the Objective-C runtime.
+    ///
+    /// Classes with Objective-C ancestry keep their ivar metadata even under
+    /// the flag, so that runtime and reflection paths walking ObjC ivars
+    /// through mixed Swift/Objective-C inheritance keep working.
+    bool shouldOmitIvarList() {
+      if (!IGM.getOptions().DisableObjCIvarMetadata)
+        return false;
+
+      ClassDecl *cls = getClass();
+      if (cls->isObjC() || cls->hasClangNode() ||
+          cls->getObjCImplementationDecl())
+        return false;
+      if (!hasOnlyKnownSwiftHierarchy(cls))
+        return false;
+
+      return IGM.getClassMetadataStrategy(cls) == ClassMetadataStrategy::Fixed;
+    }
+
     void emitRODataFields(ConstantStructBuilder &b,
                           ForMetaClass_t forMeta,
                           HasUpdateCallback_t hasUpdater) {
@@ -1641,7 +1679,7 @@ namespace {
       b.add(buildProtocolList(llvm::GlobalVariable::InternalLinkage));
 
       //   const ivar_list_t *ivars;
-      if (forMeta) {
+      if (forMeta || shouldOmitIvarList()) {
         b.addNullPointer(IGM.Int8PtrTy);
       } else {
         b.add(buildIvarList());

--- a/test/IRGen/omit_swift_objc_ivar_metadata.swift
+++ b/test/IRGen/omit_swift_objc_ivar_metadata.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -emit-ir -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -validate-tbd-against-ir=none %s | %FileCheck --check-prefix=KEEP %s
+// RUN: %target-swift-frontend -emit-ir -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -validate-tbd-against-ir=none -disable-objc-ivar-metadata %s | %FileCheck --check-prefix=OMIT --implicit-check-not='@_IVARS__TtC{{.*}}10FixedSwift' --implicit-check-not='@_IVARS__TtC{{.*}}13PureSwiftBase' --implicit-check-not='@_IVARS__TtC{{.*}}13PureSwiftLeaf' %s
+
+// REQUIRES: objc_codegen
+
+precedencegroup AssignmentPrecedence {
+  assignment: true
+}
+
+// Under -disable-objc-ivar-metadata, Swift-only hierarchies with a fixed
+// metadata layout get a null ivar list.
+// OMIT-DAG: @_DATA__TtC{{.*}}10FixedSwift = internal constant {{.*}}ptr null, ptr @.str.{{.*}}._TtC{{.*}}10FixedSwift, ptr null, ptr null, ptr null, ptr null, ptr null
+// OMIT-DAG: @_DATA__TtC{{.*}}13PureSwiftBase = internal constant {{.*}}ptr null, ptr @.str.{{.*}}._TtC{{.*}}13PureSwiftBase, ptr null, ptr null, ptr null, ptr null, ptr null
+// OMIT-DAG: @_DATA__TtC{{.*}}13PureSwiftLeaf = internal constant {{.*}}ptr null, ptr @.str.{{.*}}._TtC{{.*}}13PureSwiftLeaf, ptr null, ptr null, ptr null, ptr null, ptr null
+
+// Classes that are themselves @objc, or that inherit from one, keep their
+// ivar metadata even under the flag.
+// OMIT-DAG: @_IVARS__TtC{{.*}}16ObjCExposedSwift = internal constant
+// OMIT-DAG: @_IVARS__TtC{{.*}}21SwiftObjCAncestryLeaf = internal constant
+
+// Without the flag, every class keeps its ivar metadata.
+// KEEP-DAG: @_IVARS__TtC{{.*}}10FixedSwift = internal constant
+// KEEP-DAG: @_IVARS__TtC{{.*}}13PureSwiftBase = internal constant
+// KEEP-DAG: @_IVARS__TtC{{.*}}13PureSwiftLeaf = internal constant
+// KEEP-DAG: @_IVARS__TtC{{.*}}16ObjCExposedSwift = internal constant
+// KEEP-DAG: @_IVARS__TtC{{.*}}21SwiftObjCAncestryLeaf = internal constant
+// KEEP-DAG: @_DATA__TtC{{.*}}10FixedSwift = internal constant {{.*}}@_IVARS__TtC{{.*}}10FixedSwift
+
+class FixedSwift {
+  var value: Builtin.Int64
+
+  init(value: Builtin.Int64) {
+    self.value = value
+  }
+}
+
+class PureSwiftBase {
+  var baseValue: Builtin.Int64 = Builtin.zeroInitializer()
+}
+
+class PureSwiftLeaf : PureSwiftBase {
+  var leafValue: Builtin.Int64 = Builtin.zeroInitializer()
+}
+
+@objc public class ObjCExposedSwift {
+  var objcValue: Builtin.Int64 = Builtin.zeroInitializer()
+}
+
+@objc public class SwiftObjCAncestryRoot {
+  var rootValue: Builtin.Int64 = Builtin.zeroInitializer()
+}
+
+public class SwiftObjCAncestryLeaf : SwiftObjCAncestryRoot {
+  var leafValue: Builtin.Int64 = Builtin.zeroInitializer()
+}
+
+public func useSwiftObjCAncestryLeaf(_ value: SwiftObjCAncestryLeaf) {}


### PR DESCRIPTION
Add a frontend flag that emits a null ivar-list pointer in the Objective-C class rodata for Swift classes that cannot need one, in order to save binary size.

A class is eligible only when its entire superclass hierarchy is Swift-only, i.e. it is not `@objc`, imported (`hasClangNode`), or an `@_objcImplementation` class, and every superclass has a known Swift implementation and is not `@objc`. It must also use `ClassMetadataStrategy` `Fixed`. Together these guarantee the ivar offsets are statically known and the Objective-C runtime never has to slide them: no Objective-C ancestor can change size out from under the class.

Keeping ivar metadata for Swift classes with Objective-C ancestry avoids breaking runtime and reflection paths that walk Objective-C ivars through mixed Swift/Objective-C inheritance.


Test plan:
New test at `test/IRGen/omit_swift_objc_ivar_metadata.swift` checks both directions: without the flag every class keeps its `@_IVARS` global, and with the flag the Swift-only fixed-layout classes get `ptr null` in the ivar slot of their `@_DATA` rodata while the `@objc` and Objective-C-ancestry classes keep theirs.

Note: used AI to generate the code

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
