### PR TITLE
AST: Note the attribute that makes a declaration unavailable

### DIFF
--- a/include/swift/AST/AvailabilityRestriction.h
+++ b/include/swift/AST/AvailabilityRestriction.h
@@ -30,6 +30,9 @@ namespace swift {
 class ASTContext;
 class AvailabilityContext;
 class Decl;
+class ExtensionDecl;
+class ValueDecl;
+class RootProtocolConformance;
 
 /// Represents the reason a declaration is considered not available in a
 /// specific `AvailabilityContext`.
@@ -198,6 +201,13 @@ public:
   /// Some availability restrictions are active for type-checking but cannot
   /// be translated directly into an `if #available(...)` runtime query.
   bool isActiveForRuntimeQueries(const ASTContext &ctx) const;
+
+  /// Emit a note indicating the source of availability restriction.
+  bool emitNoteForDecl(const ValueDecl *decl) const;
+
+  /// Emit a note indicating the source of availability restriction.
+  bool emitNoteForConformance(const ExtensionDecl *ext,
+                              const RootProtocolConformance *rootConf) const;
 
   void print(raw_ostream &os) const;
 };

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -72,21 +72,28 @@ bool AvailabilityRestriction::emitNoteForDecl(const ValueDecl *decl) const {
   auto sourceRange = parsedAttr->getRangeWithAt();
   auto domainAndRange = getDomainAndRange(ctx);
 
+  // Point at the attribute so that the reason for the restriction is always
+  // rendered. Implicit attributes, like the ones on imported or synthesized
+  // declarations, have no location; refer to the declaration instead.
+  auto loc = parsedAttr->AtLoc;
+  auto diagnose = [&](const Diagnostic &diag) {
+    return loc.isValid() ? diags.diagnose(loc, diag)
+                         : diags.diagnose(decl, diag);
+  };
+
   switch (getReason()) {
   case Reason::UnavailableUnconditionally:
-    diags.diagnose(decl, diag::availability_marked_unavailable, decl)
+    diagnose({diag::availability_marked_unavailable, decl})
         .highlight(sourceRange);
     break;
   case Reason::UnavailableUnintroduced:
-    diags
-        .diagnose(decl, diag::availability_introduced_in_version, decl,
-                  domainAndRange.getDomain(), domainAndRange.getRange())
+    diagnose({diag::availability_introduced_in_version, decl,
+              domainAndRange.getDomain(), domainAndRange.getRange()})
         .highlight(sourceRange);
     break;
   case Reason::UnavailableObsolete:
-    diags
-        .diagnose(decl, diag::availability_obsoleted, decl,
-                  domainAndRange.getDomain(), domainAndRange.getRange())
+    diagnose({diag::availability_obsoleted, decl, domainAndRange.getDomain(),
+              domainAndRange.getRange()})
         .highlight(sourceRange);
     break;
   case Reason::Unintroduced:
@@ -100,28 +107,34 @@ bool AvailabilityRestriction::emitNoteForConformance(
     const ExtensionDecl *ext, const RootProtocolConformance *rootConf) const {
   auto &ctx = ext->getASTContext();
   auto &diags = ctx.Diags;
+  auto parsedAttr = getAttr().getParsedAttr();
+  auto sourceRange = parsedAttr->getRangeWithAt();
   auto type = rootConf->getType();
   auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
-  auto parsedAttr = getAttr().getParsedAttr();
   auto domainAndRange = getDomainAndRange(ctx);
+
+  // Point at the attribute so that the reason for the restriction is always
+  // rendered. Implicit attributes, like the ones on imported or synthesized
+  // extensions, have no location; refer to the extension instead.
+  auto loc = parsedAttr->AtLoc;
+  auto diagnose = [&](const Diagnostic &diag) {
+    return loc.isValid() ? diags.diagnose(loc, diag)
+                         : diags.diagnose(ext, diag);
+  };
 
   switch (getReason()) {
   case Reason::UnavailableUnconditionally:
-    diags
-        .diagnose(ext, diag::conformance_availability_marked_unavailable, type,
-                  proto)
-        .highlight(parsedAttr->getRangeWithAt());
+    diagnose({diag::conformance_availability_marked_unavailable, type, proto})
+        .highlight(sourceRange);
     break;
   case Reason::UnavailableUnintroduced:
-    diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
-                   type, proto, domainAndRange.getDomain(),
-                   domainAndRange.getRange());
+    diagnose({diag::conformance_availability_introduced_in_version, type, proto,
+              domainAndRange.getDomain(), domainAndRange.getRange()});
     break;
   case Reason::UnavailableObsolete:
-    diags
-        .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
-                  domainAndRange.getDomain(), domainAndRange.getRange())
-        .highlight(parsedAttr->getRangeWithAt());
+    diagnose({diag::conformance_availability_obsoleted, type, proto,
+              domainAndRange.getDomain(), domainAndRange.getRange()})
+        .highlight(sourceRange);
     break;
   case Reason::Unintroduced:
   case Reason::Deprecated:

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -14,6 +14,8 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/ProtocolConformance.h"
 
 using namespace swift;
 
@@ -61,6 +63,71 @@ bool AvailabilityRestriction::isActiveForRuntimeQueries(
   return swift::isPlatformActive(getAttr().getPlatform(), ctx.LangOpts,
                                  /*forTargetVariant=*/false,
                                  /*forRuntimeQuery=*/true);
+}
+
+bool AvailabilityRestriction::emitNoteForDecl(const ValueDecl *decl) const {
+  auto &ctx = decl->getASTContext();
+  auto &diags = ctx.Diags;
+  auto parsedAttr = getAttr().getParsedAttr();
+  auto sourceRange = parsedAttr->getRangeWithAt();
+  auto domainAndRange = getDomainAndRange(ctx);
+
+  switch (getReason()) {
+  case Reason::UnavailableUnconditionally:
+    diags.diagnose(decl, diag::availability_marked_unavailable, decl)
+        .highlight(sourceRange);
+    break;
+  case Reason::UnavailableUnintroduced:
+    diags
+        .diagnose(decl, diag::availability_introduced_in_version, decl,
+                  domainAndRange.getDomain(), domainAndRange.getRange())
+        .highlight(sourceRange);
+    break;
+  case Reason::UnavailableObsolete:
+    diags
+        .diagnose(decl, diag::availability_obsoleted, decl,
+                  domainAndRange.getDomain(), domainAndRange.getRange())
+        .highlight(sourceRange);
+    break;
+  case Reason::Unintroduced:
+  case Reason::Deprecated:
+    return false;
+  }
+  return true;
+}
+
+bool AvailabilityRestriction::emitNoteForConformance(
+    const ExtensionDecl *ext, const RootProtocolConformance *rootConf) const {
+  auto &ctx = ext->getASTContext();
+  auto &diags = ctx.Diags;
+  auto type = rootConf->getType();
+  auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
+  auto parsedAttr = getAttr().getParsedAttr();
+  auto domainAndRange = getDomainAndRange(ctx);
+
+  switch (getReason()) {
+  case Reason::UnavailableUnconditionally:
+    diags
+        .diagnose(ext, diag::conformance_availability_marked_unavailable, type,
+                  proto)
+        .highlight(parsedAttr->getRangeWithAt());
+    break;
+  case Reason::UnavailableUnintroduced:
+    diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
+                   type, proto, domainAndRange.getDomain(),
+                   domainAndRange.getRange());
+    break;
+  case Reason::UnavailableObsolete:
+    diags
+        .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
+                  domainAndRange.getDomain(), domainAndRange.getRange())
+        .highlight(parsedAttr->getRangeWithAt());
+    break;
+  case Reason::Unintroduced:
+  case Reason::Deprecated:
+    return false;
+  }
+  return true;
 }
 
 void AvailabilityRestriction::print(llvm::raw_ostream &os) const {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5848,6 +5848,7 @@ void AttributeChecker::checkBackDeployedAttrs(
       // Find the attribute that makes the declaration unavailable.
       const Decl *attrDecl = D;
       do {
+        // FIXME: Adopt AvailabilityRestriction::emitNoteForDecl()
         if (auto unavailableAttr = attrDecl->getUnavailableAttr()) {
           diagnose(unavailableAttr->getParsedAttr()->AtLoc,
                    diag::availability_marked_unavailable, VD)

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1918,28 +1918,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
       .warnUntilLanguageModeIf(warnIfConformanceUnavailablePreSwift6,
                                LanguageMode::v6);
 
-  switch (restriction.getReason()) {
-  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
-    diags
-        .diagnose(ext, diag::conformance_availability_marked_unavailable, type,
-                  proto)
-        .highlight(attr.getParsedAttr()->getRangeWithAt());
-    break;
-  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
-    diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
-                   type, proto, domainAndRange.getDomain(),
-                   domainAndRange.getRange());
-    break;
-  case AvailabilityRestriction::Reason::UnavailableObsolete:
-    diags
-        .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
-                  domainAndRange.getDomain(), domainAndRange.getRange())
-        .highlight(attr.getParsedAttr()->getRangeWithAt());
-    break;
-  case AvailabilityRestriction::Reason::Unintroduced:
-  case AvailabilityRestriction::Reason::Deprecated:
-    llvm_unreachable("unexpected restriction");
-  }
+  restriction.emitNoteForConformance(ext, rootConf);
   return true;
 }
 
@@ -2279,29 +2258,7 @@ bool diagnoseExplicitUnavailability(
         .limitBehavior(limit);
   }
 
-  auto sourceRange = Attr.getParsedAttr()->getRangeWithAt();
-  switch (restriction.getReason()) {
-  case AvailabilityRestriction::Reason::UnavailableUnconditionally:
-    diags.diagnose(D, diag::availability_marked_unavailable, D)
-        .highlight(sourceRange);
-    break;
-  case AvailabilityRestriction::Reason::UnavailableUnintroduced:
-    diags
-        .diagnose(D, diag::availability_introduced_in_version, D,
-                  domainAndRange.getDomain(), domainAndRange.getRange())
-        .highlight(sourceRange);
-    break;
-  case AvailabilityRestriction::Reason::UnavailableObsolete:
-    diags
-        .diagnose(D, diag::availability_obsoleted, D,
-                  domainAndRange.getDomain(), domainAndRange.getRange())
-        .highlight(sourceRange);
-    break;
-  case AvailabilityRestriction::Reason::Unintroduced:
-  case AvailabilityRestriction::Reason::Deprecated:
-    llvm_unreachable("unexpected restriction");
-    break;
-  }
+  restriction.emitNoteForDecl(D);
   return true;
 }
 

--- a/test/ASTGen/availability.swift
+++ b/test/ASTGen/availability.swift
@@ -73,14 +73,14 @@ public class ClassWithMembers {
   public func spiFunc() {}
 }
 
-@available(*, unavailable, renamed: "`class`")
-func keyword_renamed() {} // expected-note {{'keyword_renamed()' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "`class`") // expected-note {{'keyword_renamed()' has been explicitly marked unavailable here}}
+func keyword_renamed() {}
 
-@available(*, unavailable, renamed: "`foo bar`")
-func spaces_renamed() {} // expected-note {{'spaces_renamed()' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "`foo bar`") // expected-note {{'spaces_renamed()' has been explicitly marked unavailable here}}
+func spaces_renamed() {}
 
-@available(*, unavailable, renamed: "foo(`3bar baz`:)")
-func keywords_in_arguments(x: Int) {} // expected-note {{'keywords_in_arguments(x:)' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "foo(`3bar baz`:)") // expected-note {{'keywords_in_arguments(x:)' has been explicitly marked unavailable here}}
+func keywords_in_arguments(x: Int) {}
 
 func testEscapedRenamed() {
   keyword_renamed() // expected-error {{'keyword_renamed()' has been renamed to '`class`'}}

--- a/test/ASTGen/embedded_availability.swift
+++ b/test/ASTGen/embedded_availability.swift
@@ -6,19 +6,19 @@
 
 @_unavailableInEmbedded
 public struct UnavailableInEmbedded {}
-// expected-note@-1 {{'UnavailableInEmbedded' has been explicitly marked unavailable here}}
+// expected-note@-2 {{'UnavailableInEmbedded' has been explicitly marked unavailable here}}
 
 @available(*, unavailable, message: "always unavailable")
 public struct UniverallyUnavailable {}
-// expected-note@-1 3 {{'UniverallyUnavailable' has been explicitly marked unavailable here}}
+// expected-note@-2 3 {{'UniverallyUnavailable' has been explicitly marked unavailable here}}
 
 @_unavailableInEmbedded
 public func unavailable_in_embedded() { }
-// expected-note@-1 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
+// expected-note@-2 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
 
 @available(*, unavailable, message: "always unavailable")
 public func universally_unavailable() { }
-// expected-note@-1 4 {{'universally_unavailable()' has been explicitly marked unavailable here}}
+// expected-note@-2 4 {{'universally_unavailable()' has been explicitly marked unavailable here}}
 
 @_unavailableInEmbedded
 public func unused() { } // no error
@@ -38,9 +38,9 @@ public func has_universally_unavailable_overload(_ s2: S2) { }
 
 public struct Available {}
 
-@_unavailableInEmbedded
+@_unavailableInEmbedded // expected-note {{'unavailable_in_embedded_method' has been explicitly marked unavailable here}}
 extension Available {
-  public func unavailable_in_embedded_method( // expected-note {{'unavailable_in_embedded_method' has been explicitly marked unavailable here}}
+  public func unavailable_in_embedded_method(
     _ uie: UnavailableInEmbedded,
     _ uu: UniverallyUnavailable, // expected-error {{'UniverallyUnavailable' is unavailable: always unavailable}}
     _ a: Available,

--- a/test/Availability/availability.swift
+++ b/test/Availability/availability.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library -module-name MyModule
 
-@available(*, unavailable)
-func unavailable_foo() {} // expected-note {{'unavailable_foo()' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{'unavailable_foo()' has been explicitly marked unavailable here}}
+func unavailable_foo() {}
 
 @_unavailableInEmbedded // no-op without -enable-experimental-feature Embedded
 public func unavailable_in_embedded() { }
@@ -11,12 +11,12 @@ func test() {
   unavailable_in_embedded() // ok
 }
 
-@available(*,unavailable,message: "use 'Int' instead")
-struct NSUInteger {} // expected-note 3 {{explicitly marked unavailable here}}
+@available(*,unavailable,message: "use 'Int' instead") // expected-note 3 {{explicitly marked unavailable here}}
+struct NSUInteger {}
 
 struct Outer {
-  @available(*,unavailable,message: "use 'UInt' instead")
-  struct NSUInteger {} // expected-note 2 {{explicitly marked unavailable here}}
+  @available(*,unavailable,message: "use 'UInt' instead") // expected-note 2 {{explicitly marked unavailable here}}
+  struct NSUInteger {}
 }
 
 func foo(x : NSUInteger) { // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}
@@ -34,14 +34,14 @@ func foo(x : NSUInteger) { // expected-error {{'NSUInteger' is unavailable: use 
 }
 
 struct VarToFunc {
-  @available(*, unavailable, renamed: "function()")
-  var variable: Int { // expected-note 2 {{explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "function()") // expected-note 2 {{explicitly marked unavailable here}}
+  var variable: Int {
     get { 0 }
     set {}
   }
 
-  @available(*, unavailable, renamed: "function()")
-  func oldFunction() -> Int { return 42 } // expected-note 2 {{explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "function()") // expected-note 2 {{explicitly marked unavailable here}}
+  func oldFunction() -> Int { return 42 }
 
   func function() -> Int {
     _ = variable // expected-error{{'variable' has been renamed to 'function()'}}{{9-17=function()}}
@@ -75,8 +75,8 @@ struct DeferBody {
   }
 
   func bar() {
-    @available(*, unavailable)
-    enum No: Error { // expected-note 2 {{'No' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note 2 {{'No' has been explicitly marked unavailable here}}
+    enum No: Error {
       case no
     }
     do {
@@ -122,8 +122,8 @@ func test_contextual_member_with_availability() {
   _ = Test(.foo) // Ok
 }
 
-@available(*, unavailable)
-func unavailableFunction(_ x: Int) -> Bool { true } // expected-note {{'unavailableFunction' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{'unavailableFunction' has been explicitly marked unavailable here}}
+func unavailableFunction(_ x: Int) -> Bool { true }
 
 /// https://github.com/apple/swift/issues/55700
 /// Availability checking not working in the `where` clause of a `for` loop

--- a/test/Availability/availability_accessors.swift
+++ b/test/Availability/availability_accessors.swift
@@ -55,22 +55,22 @@ struct BaseStruct<T> {
   }
 
   var unavailableGetter: T {
-    @available(*, unavailable)
-    get { fatalError() } // expected-note 73 {{getter for 'unavailableGetter' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note 73 {{getter for 'unavailableGetter' has been explicitly marked unavailable here}}
+    get { fatalError() }
     set { }
   }
 
   var unavailableSetter: T {
     get { fatalError() }
-    @available(*, unavailable)
-    set { fatalError() } // expected-note 34 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note 34 {{setter for 'unavailableSetter' has been explicitly marked unavailable here}}
+    set { fatalError() }
   }
 
   var unavailableGetterAndSetter: T {
-    @available(*, unavailable)
-    get { fatalError() } // expected-note 71 {{getter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
-    @available(*, unavailable)
-    set { fatalError() } // expected-note 34 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note 71 {{getter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    get { fatalError() }
+    @available(*, unavailable) // expected-note 34 {{setter for 'unavailableGetterAndSetter' has been explicitly marked unavailable here}}
+    set { fatalError() }
   }
 
   var deprecatedGetter: T {
@@ -93,22 +93,22 @@ struct SubscriptHelper {
   }
 
   subscript<T>(unavailableGetter t: T) -> () {
-    @available(*, unavailable)
-    get { } // expected-note {{getter for 'subscript(unavailableGetter:)' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note {{getter for 'subscript(unavailableGetter:)' has been explicitly marked unavailable here}}
+    get { }
     set { }
   }
 
   subscript<T>(unavailableSetter t: T) -> () {
     get { }
-    @available(*, unavailable)
-    set { } // expected-note {{setter for 'subscript(unavailableSetter:)' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note {{setter for 'subscript(unavailableSetter:)' has been explicitly marked unavailable here}}
+    set { }
   }
 
   subscript<T>(unavailableGetterAndSetter t: T) -> () {
-    @available(*, unavailable)
-    get { } // expected-note {{getter for 'subscript(unavailableGetterAndSetter:)' has been explicitly marked unavailable here}}
-    @available(*, unavailable)
-    set { } // expected-note {{setter for 'subscript(unavailableGetterAndSetter:)' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note {{getter for 'subscript(unavailableGetterAndSetter:)' has been explicitly marked unavailable here}}
+    get { }
+    @available(*, unavailable) // expected-note {{setter for 'subscript(unavailableGetterAndSetter:)' has been explicitly marked unavailable here}}
+    set { }
   }
 }
 

--- a/test/Availability/availability_any_apple_os.swift
+++ b/test/Availability/availability_any_apple_os.swift
@@ -14,11 +14,11 @@ func deprecatedInAnyAppleOS26() { }
 
 @available(anyAppleOS, obsoleted: 26)
 func obsoletedInAnyAppleOS26() { }
-// expected-macos-note@-1 {{'obsoletedInAnyAppleOS26()' was obsoleted in macOS 26}}
-// expected-ios-note@-2 {{'obsoletedInAnyAppleOS26()' was obsoleted in iOS 26}}
-// expected-watchos-note@-3 {{'obsoletedInAnyAppleOS26()' was obsoleted in watchOS 26}}
-// expected-tvos-note@-4 {{'obsoletedInAnyAppleOS26()' was obsoleted in tvOS 26}}
-// expected-visionos-note@-5 {{'obsoletedInAnyAppleOS26()' was obsoleted in visionOS 26}}
+// expected-macos-note@-2 {{'obsoletedInAnyAppleOS26()' was obsoleted in macOS 26}}
+// expected-ios-note@-3 {{'obsoletedInAnyAppleOS26()' was obsoleted in iOS 26}}
+// expected-watchos-note@-4 {{'obsoletedInAnyAppleOS26()' was obsoleted in watchOS 26}}
+// expected-tvos-note@-5 {{'obsoletedInAnyAppleOS26()' was obsoleted in tvOS 26}}
+// expected-visionos-note@-6 {{'obsoletedInAnyAppleOS26()' was obsoleted in visionOS 26}}
 
 @available(anyAppleOS 26, macOS 26.1, *)
 func availableInAnyAppleOS26AndMacOS26_1() { }
@@ -41,8 +41,8 @@ func unavailableInEveryAppleOS() {
   unavailableInAnyAppleOS()
 }
 
-@available(anyAppleOS, unavailable)
-func unavailableInAnyAppleOS() { // expected-apple-note {{'unavailableInAnyAppleOS()' has been explicitly marked unavailable here}}
+@available(anyAppleOS, unavailable) // expected-apple-note {{'unavailableInAnyAppleOS()' has been explicitly marked unavailable here}}
+func unavailableInAnyAppleOS() {
   availableInAnyAppleOS26_1()
   availableInMacOS26_1AndAnyAppleOS26()
   availableInEveryAppleOS26_1()

--- a/test/Availability/availability_compound.swift
+++ b/test/Availability/availability_compound.swift
@@ -4,13 +4,13 @@ public struct Pair<A, B> {}
 
 public struct PublicStruct {
   public struct Inner {}
-  @available(*, unavailable)
-  internal struct Obsolete {} // expected-note * {{marked unavailable here}}
+  @available(*, unavailable) // expected-note * {{marked unavailable here}}
+  internal struct Obsolete {}
   // expected-note@-1 3{{type declared here}}
 }
 
-@available(*, unavailable, renamed: "PublicStruct")
-public typealias ObsoleteAlias = PublicStruct // expected-note * {{marked unavailable here}}
+@available(*, unavailable, renamed: "PublicStruct") // expected-note * {{marked unavailable here}}
+public typealias ObsoleteAlias = PublicStruct
 
 public let a: ObsoleteAlias.Inner? // expected-error {{'ObsoleteAlias' has been renamed to 'PublicStruct'}}
 

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -15,17 +15,17 @@ func availableInEnabledDomain() { }
 @available(AlwaysEnabledDomain)
 func availableInAlwaysEnabledDomain() { }
 
-@available(EnabledDomain, unavailable)
-func unavailableInEnabledDomain() { } // expected-note * {{'unavailableInEnabledDomain()' has been explicitly marked unavailable here}}
+@available(EnabledDomain, unavailable) // expected-note * {{'unavailableInEnabledDomain()' has been explicitly marked unavailable here}}
+func unavailableInEnabledDomain() { }
 
-@available(AlwaysEnabledDomain, unavailable)
-func unavailableInAlwaysEnabledDomain() { } // expected-note * {{'unavailableInAlwaysEnabledDomain()' has been explicitly marked unavailable here}}
+@available(AlwaysEnabledDomain, unavailable) // expected-note * {{'unavailableInAlwaysEnabledDomain()' has been explicitly marked unavailable here}}
+func unavailableInAlwaysEnabledDomain() { }
 
 @available(AlwaysEnabledDomain, deprecated)
 func deprecatedInAlwaysEnabledDomain() { }
 
-@available(DisabledDomain, unavailable)
-func unavailableInDisabledDomain() { } // expected-note * {{'unavailableInDisabledDomain()' has been explicitly marked unavailable here}}
+@available(DisabledDomain, unavailable) // expected-note * {{'unavailableInDisabledDomain()' has been explicitly marked unavailable here}}
+func unavailableInDisabledDomain() { }
 
 @available(DynamicDomain)
 func availableInDynamicDomain() { }
@@ -33,8 +33,8 @@ func availableInDynamicDomain() { }
 @available(DynamicDomain, deprecated, message: "Use something else")
 func deprecatedInDynamicDomain() { }
 
-@available(DynamicDomain, unavailable)
-func unavailableInDynamicDomain() { } // expected-note * {{'unavailableInDynamicDomain()' has been explicitly marked unavailable here}}
+@available(DynamicDomain, unavailable) // expected-note * {{'unavailableInDynamicDomain()' has been explicitly marked unavailable here}}
+func unavailableInDynamicDomain() { }
 
 @available(UnknownDomain) // expected-error {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
@@ -44,8 +44,8 @@ func availableInUnknownDomain() { }
 func availableInEnabledDomainTwice() { }
 
 @available(EnabledDomain)
-@available(EnabledDomain, unavailable)
-func availableAndUnavailableInEnabledDomain() { } // expected-note {{'availableAndUnavailableInEnabledDomain()' has been explicitly marked unavailable here}}
+@available(EnabledDomain, unavailable) // expected-note {{'availableAndUnavailableInEnabledDomain()' has been explicitly marked unavailable here}}
+func availableAndUnavailableInEnabledDomain() { }
 
 func testDeployment() { // expected-note 3 {{add '@available' attribute to enclosing global function}}
   alwaysAvailable()
@@ -309,7 +309,7 @@ func testLocalDeclsWithExplicitAvailability() {
 
     @available(EnabledDomain, unavailable)
     func localUnavailableInEnabledDomain() { }
-    // expected-note@-1 2 {{'localUnavailableInEnabledDomain()' has been explicitly marked unavailable here}}
+    // expected-note@-2 2 {{'localUnavailableInEnabledDomain()' has been explicitly marked unavailable here}}
     localUnavailableInEnabledDomain() // expected-error {{'localUnavailableInEnabledDomain()' is unavailable}}
 
     if #unavailable(EnabledDomain) {

--- a/test/Availability/availability_global_actor.swift
+++ b/test/Availability/availability_global_actor.swift
@@ -14,8 +14,8 @@ actor SomeActor {}
   static let shared = SomeActor()
 }
 
-@available(*, unavailable)
-@globalActor struct UnavailableGA { // expected-note {{'UnavailableGA' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{'UnavailableGA' has been explicitly marked unavailable here}}
+@globalActor struct UnavailableGA {
   static let shared = SomeActor()
 }
 

--- a/test/Availability/availability_literals_inferred.swift
+++ b/test/Availability/availability_literals_inferred.swift
@@ -2,8 +2,8 @@
 
 // https://github.com/apple/swift/issues/61890
 
-@available(*, unavailable)
-struct S: ExpressibleByStringLiteral { // expected-note{{'S' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note{{'S' has been explicitly marked unavailable here}}
+struct S: ExpressibleByStringLiteral {
   init(stringLiteral value: String) {}
 }
 @available(*, unavailable)
@@ -11,8 +11,8 @@ typealias StringLiteralType = S
 
 let i = "" // expected-error{{'S' is unavailable}}
 
-@available(*, unavailable)
-struct S1<T>: ExpressibleByIntegerLiteral { // expected-note{{'S1' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note{{'S1' has been explicitly marked unavailable here}}
+struct S1<T>: ExpressibleByIntegerLiteral {
   init(integerLiteral value: Int) {}
 }
 @available(*, unavailable)

--- a/test/Availability/availability_script_mode.swift
+++ b/test/Availability/availability_script_mode.swift
@@ -10,11 +10,11 @@ struct Available50 {}
 @available(macOS, introduced: 51)
 struct Available51 {}
 
-@available(macOS, unavailable)
-struct UnavailableOnMacOS {} // expected-note {{'UnavailableOnMacOS' has been explicitly marked unavailable here}}
+@available(macOS, unavailable) // expected-note {{'UnavailableOnMacOS' has been explicitly marked unavailable here}}
+struct UnavailableOnMacOS {}
 
-@available(*, unavailable)
-struct UnavailableUnconditionally {} // expected-note {{'UnavailableUnconditionally' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{'UnavailableUnconditionally' has been explicitly marked unavailable here}}
+struct UnavailableUnconditionally {}
 
 var alwaysAvailableVar: AlwaysAvailable = .init() // Ok
 

--- a/test/Availability/availability_stored_unavailable.swift
+++ b/test/Availability/availability_stored_unavailable.swift
@@ -2,15 +2,15 @@
 
 // REQUIRES: OS=macosx
 
-@available(macOS, unavailable)
-struct UnavailableMacOSStruct {} // expected-note 4 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
+@available(macOS, unavailable) // expected-note 4 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
+struct UnavailableMacOSStruct {}
 
 @available(iOS, introduced: 8.0)
 @_spi_available(macOS, introduced: 10.9)
 public struct SPIAvailableMacOSStruct {}
 
-@available(*, unavailable)
-public struct UniversallyUnavailableStruct {} // expected-note 3 {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note 3 {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
+public struct UniversallyUnavailableStruct {}
 
 // Ok, initialization of globals is lazy and boxed.
 @available(macOS, unavailable)

--- a/test/Availability/availability_swift_runtime.swift
+++ b/test/Availability/availability_swift_runtime.swift
@@ -31,7 +31,7 @@ func availableSwift6() {
 
 @available(Swift, introduced: 5.0, obsoleted: 5.1)
 func obsoletedBeforeSwiftRuntime() {}
-// expected-note@-1 3{{'obsoletedBeforeSwiftRuntime()' was obsoleted in Swift 5.1}}
+// expected-note@-2 3{{'obsoletedBeforeSwiftRuntime()' was obsoleted in Swift 5.1}}
 
 func reachableUseStillDiagnosed() {
   obsoletedBeforeSwiftRuntime()

--- a/test/Availability/availability_target_min_inlining.swift
+++ b/test/Availability/availability_target_min_inlining.swift
@@ -69,20 +69,20 @@ public struct AfterDeploymentTarget {
   init<T>(_ t: T) {}
 }
 
-@available(macOS, obsoleted: 10.14.5)
-public struct ObsoletedBetweenTargets { // expected-note * {{'ObsoletedBetweenTargets' was obsoleted in macOS 10.14.5}}
+@available(macOS, obsoleted: 10.14.5) // expected-note * {{'ObsoletedBetweenTargets' was obsoleted in macOS 10.14.5}}
+public struct ObsoletedBetweenTargets {
   @usableFromInline internal init() {}
   init<T>(_ t: T) {}
 }
 
-@available(macOS, obsoleted: 10.15)
-public struct ObsoletedAtDeploymentTarget { // expected-note * {{'ObsoletedAtDeploymentTarget' was obsoleted in macOS 10.15}}
+@available(macOS, obsoleted: 10.15) // expected-note * {{'ObsoletedAtDeploymentTarget' was obsoleted in macOS 10.15}}
+public struct ObsoletedAtDeploymentTarget {
   @usableFromInline internal init() {}
   init<T>(_ t: T) {}
 }
 
-@available(macOS, unavailable)
-public struct Unavailable { // expected-note * {{'Unavailable' has been explicitly marked unavailable here}}
+@available(macOS, unavailable) // expected-note * {{'Unavailable' has been explicitly marked unavailable here}}
+public struct Unavailable {
   @usableFromInline internal init() {}
   init<T>(_ t: T) {}
 }
@@ -112,8 +112,8 @@ public protocol AtDeploymentTargetProto {}
 @available(macOS 11, *)
 public protocol AfterDeploymentTargetProto {}
 
-@available(macOS, obsoleted: 10.14.5)
-public protocol ObsoletedBetweenTargetsProto {} // expected-note * {{'ObsoletedBetweenTargetsProto' was obsoleted in macOS 10.14.5}}
+@available(macOS, obsoleted: 10.14.5) // expected-note * {{'ObsoletedBetweenTargetsProto' was obsoleted in macOS 10.14.5}}
+public protocol ObsoletedBetweenTargetsProto {}
 
 @available(macOS, unavailable)
 public protocol UnavailableProto {}
@@ -137,8 +137,8 @@ public class AtDeploymentTargetClass {}
 @available(macOS 11, *)
 public class AfterDeploymentTargetClass {}
 
-@available(macOS, obsoleted: 10.14.5)
-public class ObsoletedBetweenTargetsClass {} // expected-note * {{'ObsoletedBetweenTargetsClass' was obsoleted in macOS 10.14.5}}
+@available(macOS, obsoleted: 10.14.5) // expected-note * {{'ObsoletedBetweenTargetsClass' was obsoleted in macOS 10.14.5}}
+public class ObsoletedBetweenTargetsClass {}
 
 @available(macOS, unavailable)
 public class UnavailableClass {}

--- a/test/Availability/availability_unavailable_overrides.swift
+++ b/test/Availability/availability_unavailable_overrides.swift
@@ -2,25 +2,25 @@
 
 func testAvailableOverrideOfUnavailableDecl() {
   class Base {
-    @available(*, unavailable)
+    @available(*, unavailable) // expected-note {{'unavailableMethod()' has been explicitly marked unavailable here}}
     func unavailableMethod() {}
-    // expected-note@-1 2 {{'unavailableMethod()' has been explicitly marked unavailable here}}
+    // expected-note@-1 {{'unavailableMethod()' has been explicitly marked unavailable here}}
 
-    @available(*, unavailable)
+    @available(*, unavailable) // expected-note {{'init(x:)' has been explicitly marked unavailable here}}
     init(x: Int) {}
-    // expected-note@-1 2 {{'init(x:)' has been explicitly marked unavailable here}}
+    // expected-note@-1 {{'init(x:)' has been explicitly marked unavailable here}}
 
     @available(*, unavailable)
     required init(requiredX: Int) {}
-    // expected-note@-1 {{'init(requiredX:)' has been explicitly marked unavailable here}}
+    // expected-note@-2 {{'init(requiredX:)' has been explicitly marked unavailable here}}
 
-    @available(*, unavailable)
+    @available(*, unavailable) // expected-note {{'subscript(_:)' has been explicitly marked unavailable here}}
     subscript (i: Int) -> Int { return i }
-    // expected-note@-1 2 {{'subscript(_:)' has been explicitly marked unavailable here}}
+    // expected-note@-1 {{'subscript(_:)' has been explicitly marked unavailable here}}
 
-    @available(*, unavailable)
+    @available(*, unavailable) // expected-note {{'unavailableComputedProperty' has been explicitly marked unavailable here}}
     var unavailableComputedProperty: Int {
-      // expected-note@-1 2 {{'unavailableComputedProperty' has been explicitly marked unavailable here}}
+      // expected-note@-1 {{'unavailableComputedProperty' has been explicitly marked unavailable here}}
       get { 0 }
       set {}
     }
@@ -244,8 +244,8 @@ func testImplicitSuperInit() {
   // relaxed since both initializers are unreachable and the developer cannot
   // wrap the call to super in a conditional compilation block.
   class Base {
-    @available(*, unavailable)
-    init() {} // expected-note {{'init()' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note {{'init()' has been explicitly marked unavailable here}}
+    init() {}
   }
 
   class Derived: Base {

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -145,11 +145,11 @@ func globalFuncDeprecatedAndAvailableOn51() -> Int { return 51 }
 @available(OSX, introduced: 51, deprecated: 52)
 func globalFuncAvailableOn51Deprecated52() -> Int { return 51 }
 
-@available(OSX, introduced: 51, obsoleted: 52)
-func globalFuncAvailableOn51Obsoleted52() -> Int { return 51 } // expected-note {{'globalFuncAvailableOn51Obsoleted52()' was obsoleted in macOS 52}}
+@available(OSX, introduced: 51, obsoleted: 52) // expected-note {{'globalFuncAvailableOn51Obsoleted52()' was obsoleted in macOS 52}}
+func globalFuncAvailableOn51Obsoleted52() -> Int { return 51 }
 
-@available(OSX, unavailable, introduced: 51)
-func globalFuncUnavailableAndIntroducedOn51() -> Int { return 51 } // expected-note 3 {{'globalFuncUnavailableAndIntroducedOn51()' has been explicitly marked unavailable here}}
+@available(OSX, unavailable, introduced: 51) // expected-note 3 {{'globalFuncUnavailableAndIntroducedOn51()' has been explicitly marked unavailable here}}
+func globalFuncUnavailableAndIntroducedOn51() -> Int { return 51 }
 
 @available(OSX, deprecated: 11, message: "11")
 @available(OSX, deprecated: 12, message: "12")
@@ -159,13 +159,13 @@ func globalFuncDeprecatedIn11And12() -> Int { return 11 }
 @available(OSX, deprecated: 11, message: "11")
 func globalFuncDeprecatedIn12And11() -> Int { return 11 }
 
-@available(OSX, obsoleted: 51, message: "51")
+@available(OSX, obsoleted: 51, message: "51") // expected-note 2 {{'globalFuncObsoletedIn51And52()' was obsoleted in macOS 51}}
 @available(OSX, obsoleted: 52, message: "52")
-func globalFuncObsoletedIn51And52() -> Int { return 51 } // expected-note 2 {{'globalFuncObsoletedIn51And52()' was obsoleted in macOS 51}}
+func globalFuncObsoletedIn51And52() -> Int { return 51 }
 
 @available(OSX, obsoleted: 52, message: "52")
-@available(OSX, obsoleted: 51, message: "51")
-func globalFuncObsoletedIn52And51() -> Int { return 51 }  // expected-note 2 {{'globalFuncObsoletedIn52And51()' was obsoleted in macOS 51}}
+@available(OSX, obsoleted: 51, message: "51") // expected-note 2 {{'globalFuncObsoletedIn52And51()' was obsoleted in macOS 51}}
+func globalFuncObsoletedIn52And51() -> Int { return 51 }
 
 let _ = globalFuncDeprecatedAndAvailableOn51() // expected-error {{'globalFuncDeprecatedAndAvailableOn51()' is only available in macOS 51 or newer}}
 // expected-note@-1 {{add 'if #available' version check}}
@@ -1377,8 +1377,8 @@ class NestedClassTest {
   class InnerClass : WidelyAvailableBase {}
 }
 
-@available(OSX, unavailable)
-func explicitlyUnavailable() { } // expected-note 2{{'explicitlyUnavailable()' has been explicitly marked unavailable here}}
+@available(OSX, unavailable) // expected-note 2{{'explicitlyUnavailable()' has been explicitly marked unavailable here}}
+func explicitlyUnavailable() { }
 
 func functionWithUnavailableInDeadBranch() {
 
@@ -1549,12 +1549,12 @@ func localDeclsWithExplicitAvailability() {
 
     @available(OSX, unavailable)
     func unavailableOnMacOS() { }
-        // expected-note@-1 {{'unavailableOnMacOS()' has been explicitly marked unavailable here}}
+        // expected-note@-2 {{'unavailableOnMacOS()' has been explicitly marked unavailable here}}
     unavailableOnMacOS() // expected-error {{'unavailableOnMacOS()' is unavailable in macOS}}
 
     @available(*, unavailable)
     func neverAvailable() { }
-        // expected-note@-1 {{'neverAvailable()' has been explicitly marked unavailable here}}
+        // expected-note@-2 {{'neverAvailable()' has been explicitly marked unavailable here}}
     neverAvailable() // expected-error {{'neverAvailable()' is unavailable}}
 
     @available(OSX, deprecated: 51)
@@ -2020,23 +2020,23 @@ func useShortFormAvailable() {
 @available(OSX 10.9, *)
 @available(OSX, unavailable)
 func unavailableWins() { }
-    // expected-note@-1 {{'unavailableWins()' has been explicitly marked unavailable here}}
+    // expected-note@-2 {{'unavailableWins()' has been explicitly marked unavailable here}}
 
 struct HasUnavailableExtension {
   @available(OSX, unavailable)
   public func directlyUnavailable() { }
-      // expected-note@-1 {{'directlyUnavailable()' has been explicitly marked unavailable here}}
+      // expected-note@-2 {{'directlyUnavailable()' has been explicitly marked unavailable here}}
 }
 
 @available(OSX, unavailable)
 extension HasUnavailableExtension {
 
   public func inheritsUnavailable() { }
-      // expected-note@-1 {{'inheritsUnavailable()' has been explicitly marked unavailable here}}
+      // expected-note@-4 {{'inheritsUnavailable()' has been explicitly marked unavailable here}}
 
   @available(OSX 10.9, *)
   public func moreAvailableButStillUnavailable() { }
-      // expected-note@-1 {{'moreAvailableButStillUnavailable()' has been explicitly marked unavailable here}}
+      // expected-note@-8 {{'moreAvailableButStillUnavailable()' has been explicitly marked unavailable here}}
 }
 
 func useHasUnavailableExtension(_ s: HasUnavailableExtension) {
@@ -2117,7 +2117,7 @@ struct PropertyObservers {
 
 @available(macOS, introduced: 10, obsoleted: 14)
 func obsoletedBeforeDeploymentTarget() {}
-// expected-note@-1 {{'obsoletedBeforeDeploymentTarget()' was obsoleted in macOS 14}}
+// expected-note@-2 {{'obsoletedBeforeDeploymentTarget()' was obsoleted in macOS 14}}
 
 func reachableUseStillDiagnosed() {
   obsoletedBeforeDeploymentTarget()

--- a/test/Availability/conformance_availability.swift
+++ b/test/Availability/conformance_availability.swift
@@ -18,7 +18,7 @@ public struct HasUnavailableConformance1 {}
 
 @available(*, unavailable)
 extension HasUnavailableConformance1 : Horse {}
-// expected-note@-1 7{{conformance of 'HasUnavailableConformance1' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-2 7{{conformance of 'HasUnavailableConformance1' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance1(x: HasUnavailableConformance1) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
@@ -44,7 +44,7 @@ public struct HasUnavailableConformance2 {}
 
 @available(macOS, unavailable)
 extension HasUnavailableConformance2 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-2 6{{conformance of 'HasUnavailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance2(x: HasUnavailableConformance2) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
@@ -70,7 +70,7 @@ public struct HasUnavailableConformance3 {}
 
 @available(swift 12)
 extension HasUnavailableConformance3 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance3' to 'Horse' was introduced in Swift 12}}
+// expected-note@-2 6{{conformance of 'HasUnavailableConformance3' to 'Horse' was introduced in Swift 12}}
 
 func passUnavailableConformance3(x: HasUnavailableConformance3) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
@@ -96,7 +96,7 @@ public struct HasUnavailableConformance4 {}
 
 @available(macOS, obsoleted: 10.1)
 extension HasUnavailableConformance4 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance4' to 'Horse' was obsoleted in macOS 10.1}}
+// expected-note@-2 6{{conformance of 'HasUnavailableConformance4' to 'Horse' was obsoleted in macOS 10.1}}
 
 func passUnavailableConformance4(x: HasUnavailableConformance4) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
@@ -122,7 +122,7 @@ public struct HasUnavailableConformance5 {}
 
 @available(swift, obsoleted: 4)
 extension HasUnavailableConformance5 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance5' to 'Horse' was obsoleted in Swift 4}}
+// expected-note@-2 6{{conformance of 'HasUnavailableConformance5' to 'Horse' was obsoleted in Swift 4}}
 
 func passUnavailableConformance5(x: HasUnavailableConformance5) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
@@ -148,7 +148,7 @@ public struct HasUnavailableConformance6 {}
 
 @available(*, unavailable, message: "This conformance is bad")
 extension HasUnavailableConformance6 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance6' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-2 6{{conformance of 'HasUnavailableConformance6' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance6(x: HasUnavailableConformance6) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}

--- a/test/Availability/conformance_availability_warn.swift
+++ b/test/Availability/conformance_availability_warn.swift
@@ -56,8 +56,8 @@ func passAvailableConformance1a(x: HasAvailableConformance1) {
 // Explicit unavailability
 public struct HasAvailableConformance2 {}
 
-@available(*, unavailable)
-extension HasAvailableConformance2 : Horse {} // expected-note 6 {{conformance of 'HasAvailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note 6 {{conformance of 'HasAvailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
+extension HasAvailableConformance2 : Horse {}
 
 // Some availability diagnostics become warnings in Swift 5 mode without
 // because they were incorrectly accepted before and rejecting them would break

--- a/test/Availability/operator_availability.swift
+++ b/test/Availability/operator_availability.swift
@@ -21,8 +21,8 @@ extension Int32 {
   @available(swift, obsoleted: 4)
   public static func <=< (_ x: Int32, _ y: Int32) {}
 
-  @available(swift, obsoleted: 4)
-  public static func >=> (_ x: Int32, _ y: Int32) {} // expected-note{{'>=>' was obsoleted in Swift 4}}
+  @available(swift, obsoleted: 4) // expected-note{{'>=>' was obsoleted in Swift 4}}
+  public static func >=> (_ x: Int32, _ y: Int32) {}
 }
 
 func testAvailability() {

--- a/test/Availability/pack_conformance_availability.swift
+++ b/test/Availability/pack_conformance_availability.swift
@@ -8,7 +8,7 @@ struct S {}
 
 @available(*, unavailable)
 extension S: P {}
-// expected-note@-1 {{conformance of 'S' to 'P' has been explicitly marked unavailable here}}
+// expected-note@-2 {{conformance of 'S' to 'P' has been explicitly marked unavailable here}}
 
 f(S())
 // expected-error@-1 {{conformance of 'S' to 'P' is unavailable}}

--- a/test/Availability/property_wrapper_accessors_availability.swift
+++ b/test/Availability/property_wrapper_accessors_availability.swift
@@ -169,10 +169,10 @@ func butt(x: inout Butt) { // expected-note * {{}}
     }
 }
 
-@available(macOS, unavailable)
+@available(macOS, unavailable) // expected-note {{has been explicitly marked unavailable here}}
 extension Butt {
   @available(iOS, unavailable)
-  struct Nested { // expected-note {{has been explicitly marked unavailable here}}
+  struct Nested {
     @SetterMoreAvailable
     var wrapped_setter_more_available: Int // expected-note 2 {{has been explicitly marked unavailable here}}
 
@@ -192,8 +192,8 @@ func testButtNested(x: inout Butt.Nested) { // expected-error {{'Nested' is unav
 @_spi_available(macOS, introduced: 51)
 extension Butt {
   struct NestedInSPIAvailableExtension {
-    @available(macOS, unavailable)
-    public var unavailable: Int {// expected-note {{'unavailable' has been explicitly marked unavailable here}}
+    @available(macOS, unavailable) // expected-note {{'unavailable' has been explicitly marked unavailable here}}
+    public var unavailable: Int {
       get { 0 }
       set {}
     }

--- a/test/Availability/property_wrapper_availability.swift
+++ b/test/Availability/property_wrapper_availability.swift
@@ -21,9 +21,9 @@ struct DeprecatedWrapper<T> {
   var wrappedValue: T
 }
 
-@available(*, unavailable)
+@available(*, unavailable) // expected-note 12 {{'UnavailableWrapper' has been explicitly marked unavailable here}}
 @propertyWrapper
-struct UnavailableWrapper<T> { // expected-note 12 {{'UnavailableWrapper' has been explicitly marked unavailable here}}
+struct UnavailableWrapper<T> {
   var wrappedValue: T
 }
 
@@ -31,8 +31,8 @@ struct UnavailableWrapper<T> { // expected-note 12 {{'UnavailableWrapper' has be
 struct WrappedValueUnavailableOnMacOS<T> {
   init(wrappedValue: T) { fatalError() }
 
-  @available(macOS, unavailable)
-  var wrappedValue: T { // expected-note 6 {{'wrappedValue' has been explicitly marked unavailable here}}
+  @available(macOS, unavailable) // expected-note 6 {{'wrappedValue' has been explicitly marked unavailable here}}
+  var wrappedValue: T {
     get { fatalError() }
     set { fatalError() }
   }

--- a/test/Availability/result_builder_availability.swift
+++ b/test/Availability/result_builder_availability.swift
@@ -5,7 +5,7 @@
 @available(*, unavailable)
 @resultBuilder
 struct UnavailableBuilder {
-// expected-note@-1 2 {{'UnavailableBuilder' has been explicitly marked unavailable here}}
+// expected-note@-3 2 {{'UnavailableBuilder' has been explicitly marked unavailable here}}
   static func buildBlock() {}
 }
 
@@ -198,7 +198,7 @@ func testUnavailableBuildPartialBlock() -> Int {
 struct UnavailableBuildPartialBlockAndBuildBlock {
   @available(*, unavailable)
   static func buildPartialBlock(first: Int) -> Int { 0 }
-  // expected-note@-1 {{'buildPartialBlock(first:)' has been explicitly marked unavailable here}}
+  // expected-note@-2 {{'buildPartialBlock(first:)' has been explicitly marked unavailable here}}
 
   static func buildPartialBlock(accumulated: Int, next: Int) -> Int { 0 }
 
@@ -214,9 +214,9 @@ func testUnavailableBuildPartialBlockAndBuildBlock() -> Int {
   3
 }
 
-@available(*, unavailable)
+@available(*, unavailable) // expected-note {{'UnavailableBuilderWithPartialBlock' has been explicitly marked unavailable here}}
 @resultBuilder
-struct UnavailableBuilderWithPartialBlock { // expected-note {{'UnavailableBuilderWithPartialBlock' has been explicitly marked unavailable here}}
+struct UnavailableBuilderWithPartialBlock {
   @available(*, unavailable)
   static func buildPartialBlock(first: String) -> Int { 0 }
   static func buildPartialBlock(accumulated: Int, next: Int) -> Int { 0 }

--- a/test/ClangImporter/availability_custom_domains.swift
+++ b/test/ClangImporter/availability_custom_domains.swift
@@ -37,14 +37,14 @@ func testClangDecls() { // expected-note 3 {{add '@available' attribute to enclo
 @available(BayBridge)
 func availableInBayBridge() { }
 
-@available(BayBridge, unavailable)
-func unavailableInBayBridge() { } // expected-note {{'unavailableInBayBridge()' has been explicitly marked unavailable here}}
+@available(BayBridge, unavailable) // expected-note {{'unavailableInBayBridge()' has been explicitly marked unavailable here}}
+func unavailableInBayBridge() { }
 
 @available(Pacific)
 func availableInPacific() { }
 
-@available(Colorado, unavailable)
-func unavailableInColorado() { } // expected-note {{'unavailableInColorado()' has been explicitly marked unavailable here}}
+@available(Colorado, unavailable) // expected-note {{'unavailableInColorado()' has been explicitly marked unavailable here}}
+func unavailableInColorado() { }
 
 // The Seas module is only imported directly by the other source file.
 @available(Baltic) // expected-error {{unrecognized platform name 'Baltic'}}

--- a/test/ClangImporter/availability_implicit_macosx.swift
+++ b/test/ClangImporter/availability_implicit_macosx.swift
@@ -86,8 +86,8 @@ class ClassWithLimitedAvailabilityAccessors {
   }
 }
 
-@available(*, unavailable)
-func unavailableFunction() -> Int { return 10 } // expected-note 3{{'unavailableFunction()' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note 3{{'unavailableFunction()' has been explicitly marked unavailable here}}
+func unavailableFunction() -> Int { return 10 }
 
 class ClassWithReferencesLazyInitializers {
   var propWithUnavailableInInitializer: Int = unavailableFunction() // expected-error {{'unavailableFunction()' is unavailable}}

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -8,8 +8,8 @@
 class C1 { } // expected-note{{class 'C1' does not conform to the 'Sendable' protocol}}
 class C2 { }
 
-@available(*, unavailable)
-extension C2: Sendable {} // expected-note{{conformance of 'C2' to 'Sendable' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note{{conformance of 'C2' to 'Sendable' has been explicitly marked unavailable here}}
+extension C2: Sendable {}
 
 protocol TestProtocol {
   associatedtype Value: Sendable

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -202,7 +202,7 @@ class UnavailableSendable {}
 
 @available(*, unavailable)
 extension UnavailableSendable: @unchecked Sendable {}
-// expected-note@-1 8 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+// expected-note@-2 8 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
 
 typealias T = RequireSendable<NotSendable>
 // expected-warning@-1 {{type 'NotSendable' does not conform to the 'Sendable' protocol}}

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -49,7 +49,7 @@ public struct S5 { } // no diagnostic: S5 is not Sendable
 
 @available(*, unavailable)
 extension S5: Sendable { }
-// expected-note@-1{{conformance of 'S5' to 'Sendable' has been explicitly marked unavailable here}}
+// expected-note@-2{{conformance of 'S5' to 'Sendable' has been explicitly marked unavailable here}}
 
 // Public type with a conditional conformance, so don't complain
 public struct S6<T, U> {
@@ -67,7 +67,7 @@ struct S7 { // FIXME: expected-note{{consider making struct 'S7' conform to the 
 
 @available(*, unavailable)
 extension S7: Sendable { }
-// expected-note@-1{{conformance of 'S7' to 'Sendable' has been explicitly marked unavailable here}}
+// expected-note@-2{{conformance of 'S7' to 'Sendable' has been explicitly marked unavailable here}}
 
 
 func testMe(s5: S5, s7: S7) {

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -13,7 +13,7 @@ struct NS1 { }
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable)
 extension NS1: Sendable { }
-// expected-note@-1 4{{conformance of 'NS1' to 'Sendable' has been explicitly marked unavailable here}}
+// expected-note@-2 4{{conformance of 'NS1' to 'Sendable' has been explicitly marked unavailable here}}
 
 @available(SwiftStdlib 5.1, *)
 struct NS2 { // expected-note {{consider making struct 'NS2' conform to the 'Sendable' protocol}}
@@ -104,8 +104,8 @@ public actor MyActor: MyProto {
 // Make sure the generic signature doesn't minimize away Sendable requirements.
 class NSClass { }
 
-@available(*, unavailable)
-extension NSClass: @unchecked Sendable {} // expected-note {{conformance of 'NSClass' to 'Sendable' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{conformance of 'NSClass' to 'Sendable' has been explicitly marked unavailable here}}
+extension NSClass: @unchecked Sendable {}
 
 struct WrapClass<T: NSClass> {
   var t: T
@@ -511,7 +511,7 @@ struct UnavailableSendable {}
 
 @available(*, unavailable)
 extension UnavailableSendable: Sendable {}
-// expected-note@-1 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+// expected-note@-2 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
 
 @available(SwiftStdlib 5.1, *)
 func checkOpaqueType() -> some Sendable {

--- a/test/Concurrency/sendable_checking_swift6.swift
+++ b/test/Concurrency/sendable_checking_swift6.swift
@@ -7,7 +7,7 @@ struct UnavailableSendable {}
 
 @available(*, unavailable)
 extension UnavailableSendable: Sendable {}
-// expected-note@-1 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
+// expected-note@-2 {{conformance of 'UnavailableSendable' to 'Sendable' has been explicitly marked unavailable here}}
 
 @available(SwiftStdlib 5.1, *)
 func checkOpaqueType() -> some Sendable {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -147,8 +147,8 @@ infix operator ***~ : Starry
 func ***~(_: Int, _: String) { }
 i ***~ i // expected-error{{cannot convert value of type 'Int' to expected argument type 'String'}}
 
-@available(*, unavailable, message: "call the 'map()' method on the sequence")
-public func myMap<C : Collection, T>( // expected-note {{'myMap' has been explicitly marked unavailable here}}
+@available(*, unavailable, message: "call the 'map()' method on the sequence") // expected-note {{'myMap' has been explicitly marked unavailable here}}
+public func myMap<C : Collection, T>(
   _ source: C, _ transform: (C.Iterator.Element) -> T
 ) -> [T] {
   fatalError("unavailable function can't be called")
@@ -607,8 +607,8 @@ func r22470302(_ c: r22470302Class) {
 
 // <rdar://problem/21928143> QoI: Pointfree reference to generic initializer in generic context does not compile
 extension String {
-  @available(*, unavailable, message: "calling this is unwise")
-  func unavail<T : Sequence> // expected-note {{'unavail' has been explicitly marked unavailable here}}
+  @available(*, unavailable, message: "calling this is unwise") // expected-note {{'unavail' has been explicitly marked unavailable here}}
+  func unavail<T : Sequence>
     (_ a : T) -> String where T.Iterator.Element == String {}
 }
 extension Array {

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -300,8 +300,8 @@ func test15117741(_ s: r15117741S) {
 
 // <rdar://problem/22491394> References to unavailable decls sometimes diagnosed as ambiguous
 struct UnavailMember {
-  @available(*, unavailable)
-  static var XYZ : UnavailMember { get {} } // expected-note {{'XYZ' has been explicitly marked unavailable here}}
+  @available(*, unavailable) // expected-note {{'XYZ' has been explicitly marked unavailable here}}
+  static var XYZ : UnavailMember { get {} }
 }
 
 let _ : [UnavailMember] = [.XYZ] // expected-error {{'XYZ' is unavailable}}

--- a/test/Constraints/rdar139812024.swift
+++ b/test/Constraints/rdar139812024.swift
@@ -10,8 +10,8 @@ import Foundation
 final class Image: NSObject {
 }
 
-@available(*, unavailable)
-extension Image: Sendable {} // expected-note {{explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{explicitly marked unavailable here}}
+extension Image: Sendable {}
 
 class Lock<State> {
   func withLock<R: Sendable>(_: @Sendable (inout State) -> R) -> R {

--- a/test/Macros/member_attribute_macro_availability.swift
+++ b/test/Macros/member_attribute_macro_availability.swift
@@ -29,8 +29,14 @@ public struct UnavailableMembersMacro: MemberAttributeMacro {
 macro UnavailableMembers() = #externalMacro(module: "MacroDefinition", type: "UnavailableMembersMacro")
 
 @UnavailableMembers
+// expected-note@-1 {{in expansion of macro 'UnavailableMembers' on instance method 'member()' here}}
 class Base {
-  func member() {} // expected-note 2 {{'member()' has been explicitly marked unavailable here}}
+  func member() {} // expected-note {{'member()' has been explicitly marked unavailable here}}
+  /*
+  expected-expansion@-2:3{{
+    expected-note@1{{'member()' has been explicitly marked unavailable here}}
+  }}
+  */
 }
 
 class Sub: Base {

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -80,13 +80,13 @@ func interpolatedMessage() {}
 func multilineMessage() {}
 multilineMessage()
 // expected-error@-1{{'multilineMessage()' is unavailable: foobar message.}}
-// expected-note@-3{{'multilineMessage()' has been explicitly marked unavailable here}}
+// expected-note@-6{{'multilineMessage()' has been explicitly marked unavailable here}}
 
 @available(*, unavailable, message: " ")
 func emptyMessage() {}
 emptyMessage()
 // expected-error@-1{{'emptyMessage()' is unavailable:  }}
-// expected-note@-3{{'emptyMessage()' has been explicitly marked unavailable here}}
+// expected-note@-4{{'emptyMessage()' has been explicitly marked unavailable here}}
 
 // expected-error@+1{{'message' cannot be an extended escaping string literal}}
 @available(*, unavailable, message: #"""

--- a/test/Parse/diagnose_availability_windows.swift
+++ b/test/Parse/diagnose_availability_windows.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -target x86_64-unknown-windows-msvc -parse-stdlib -verify-additional-prefix no-target-
 // RUN: %target-typecheck-verify-swift -target x86_64-unknown-windows8.0-msvc -parse-stdlib
 
-// expected-note@+2{{'unavailable()' has been explicitly marked unavailable here}}
+// expected-note@+1{{'unavailable()' has been explicitly marked unavailable here}}
 @available(Windows, unavailable, message: "unsupported")
 func unavailable() {}
 

--- a/test/Sema/issue-75389.swift
+++ b/test/Sema/issue-75389.swift
@@ -4,7 +4,7 @@
 
 @available(*, unavailable)
 func unavailableFn() -> Int { 0 }
-// expected-note@-1 5{{'unavailableFn()' has been explicitly marked unavailable here}}
+// expected-note@-2 5{{'unavailableFn()' has been explicitly marked unavailable here}}
 
 if case unavailableFn() = 0 {}
 // expected-error@-1 {{'unavailableFn()' is unavailable}}

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -137,9 +137,9 @@ public func f1(@Wrapper value: Int) {}
 // expected-error@+1 {{the parameter API wrapper of a '@usableFromInline' function must be '@usableFromInline' or public}}
 @usableFromInline func f3(@Wrapper value: Int) {}
 
-@available(*, unavailable)
+@available(*, unavailable) // expected-note {{'UnavailableWrapper' has been explicitly marked unavailable here}}
 @propertyWrapper
-struct UnavailableWrapper<T> { // expected-note {{'UnavailableWrapper' has been explicitly marked unavailable here}}
+struct UnavailableWrapper<T> {
   var wrappedValue: T
 }
 

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -49,27 +49,27 @@ func swiftLanguageMode6_0() {}
 func anyAppleOS26() {}
 
 // <rdar://problem/17669805> Availability can't appear on a typealias
-@available(*, unavailable, message: "oh no you don't")
-typealias int = Int // expected-note {{'int' has been explicitly marked unavailable here}}
+@available(*, unavailable, message: "oh no you don't") // expected-note {{'int' has been explicitly marked unavailable here}}
+typealias int = Int
 
-@available(*, unavailable, renamed: "Float")
-typealias float = Float // expected-note {{'float' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "Float") // expected-note {{'float' has been explicitly marked unavailable here}}
+typealias float = Float
 
 protocol MyNewerProtocol {}
 
-@available(*, unavailable, renamed: "MyNewerProtocol")
-protocol MyOlderProtocol {} // expected-note {{'MyOlderProtocol' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "MyNewerProtocol") // expected-note {{'MyOlderProtocol' has been explicitly marked unavailable here}}
+protocol MyOlderProtocol {}
 
 extension Int: MyOlderProtocol {} // expected-error {{'MyOlderProtocol' has been renamed to 'MyNewerProtocol'}} 
 
-@available(*, unavailable, renamed: "`class`")
-func keyword_renamed() {} // expected-note {{'keyword_renamed()' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "`class`") // expected-note {{'keyword_renamed()' has been explicitly marked unavailable here}}
+func keyword_renamed() {}
 
-@available(*, unavailable, renamed: "`foo bar`")
-func spaces_renamed() {} // expected-note {{'spaces_renamed()' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "`foo bar`") // expected-note {{'spaces_renamed()' has been explicitly marked unavailable here}}
+func spaces_renamed() {}
 
-@available(*, unavailable, renamed: "foo(`3bar baz`:)")
-func keywords_in_arguments(x: Int) {} // expected-note {{'keywords_in_arguments(x:)' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "foo(`3bar baz`:)") // expected-note {{'keywords_in_arguments(x:)' has been explicitly marked unavailable here}}
+func keywords_in_arguments(x: Int) {}
 
 func testEscapedRenamed() {
   keyword_renamed() // expected-error {{'keyword_renamed()' has been renamed to '`class`'}}
@@ -78,8 +78,8 @@ func testEscapedRenamed() {
 }
 
 struct MyCollection<Element> {
-  @available(*, unavailable, renamed: "Element")
-  typealias T = Element // expected-note 2{{'T' has been explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "Element") // expected-note 2{{'T' has been explicitly marked unavailable here}}
+  typealias T = Element
 
   func foo(x: T) { } // expected-error {{'T' has been renamed to 'Element'}} {{15-16=Element}}
 }
@@ -88,8 +88,8 @@ extension MyCollection {
   func append(element: T) { } // expected-error {{'T' has been renamed to 'Element'}} {{24-25=Element}}
 }
 
-@available(*, unavailable, renamed: "MyCollection")
-typealias YourCollection<Element> = MyCollection<Element> // expected-note {{'YourCollection' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "MyCollection") // expected-note {{'YourCollection' has been explicitly marked unavailable here}}
+typealias YourCollection<Element> = MyCollection<Element>
 
 var x : YourCollection<Int> // expected-error {{'YourCollection' has been renamed to 'MyCollection'}}{{9-23=MyCollection}}
 
@@ -97,8 +97,8 @@ var y : int // expected-error {{'int' is unavailable: oh no you don't}}
 var z : float // expected-error {{'float' has been renamed to 'Float'}}{{9-14=Float}}
 
 // Encoded message
-@available(*, unavailable, message: "This message has a double quote \"")
-func unavailableWithDoubleQuoteInMessage() {} // expected-note {{'unavailableWithDoubleQuoteInMessage()' has been explicitly marked unavailable here}}
+@available(*, unavailable, message: "This message has a double quote \"") // expected-note {{'unavailableWithDoubleQuoteInMessage()' has been explicitly marked unavailable here}}
+func unavailableWithDoubleQuoteInMessage() {}
 
 func useWithEscapedMessage() {
   unavailableWithDoubleQuoteInMessage() // expected-error {{'unavailableWithDoubleQuoteInMessage()' is unavailable: This message has a double quote \"}}
@@ -323,8 +323,8 @@ func someFuncUsingOldAttribute() { }
 
 
 // <rdar://problem/23853709> Compiler crash on call to unavailable "print"
-@available(*, unavailable, message: "Please use the 'to' label for the target stream: 'print((...), to: &...)'")		
-func print<T>(_: T, _: inout TextOutputStream) {} // expected-note {{}}
+@available(*, unavailable, message: "Please use the 'to' label for the target stream: 'print((...), to: &...)'") // expected-note {{}}
+func print<T>(_: T, _: inout TextOutputStream) {}
 func TextOutputStreamTest(message: String, to: inout TextOutputStream) {
   print(message, &to)  // expected-error {{'print' is unavailable: Please use the 'to' label for the target stream: 'print((...), to: &...)'}}
 }
@@ -332,8 +332,8 @@ func TextOutputStreamTest(message: String, to: inout TextOutputStream) {
 
 struct DummyType {}
 
-@available(*, unavailable, renamed: "&+")
-func +(x: DummyType, y: DummyType) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "&+") // expected-note {{here}}
+func +(x: DummyType, y: DummyType) {}
 @available(*, deprecated, renamed: "&-")
 func -(x: DummyType, y: DummyType) {}
 
@@ -342,15 +342,15 @@ func testOperators(x: DummyType, y: DummyType) {
   x - y // expected-warning {{'-' is deprecated: renamed to '&-'}}{{documentation-file=deprecated-declaration}} expected-note {{use '&-' instead}} {{5-6=&-}}
 }
 
-@available(*, unavailable, renamed: "DummyType.foo")
-func unavailableMember() {} // expected-note {{here}}
+@available(*, unavailable, renamed: "DummyType.foo") // expected-note {{here}}
+func unavailableMember() {}
 @available(*, deprecated, renamed: "DummyType.bar")
 func deprecatedMember() {}
-@available(*, unavailable, renamed: "DummyType.Inner.foo")
-func unavailableNestedMember() {} // expected-note {{here}}
+@available(*, unavailable, renamed: "DummyType.Inner.foo") // expected-note {{here}}
+func unavailableNestedMember() {}
 
-@available(*, unavailable, renamed: "DummyType.Foo")
-struct UnavailableType {} // expected-note {{here}}
+@available(*, unavailable, renamed: "DummyType.Foo") // expected-note {{here}}
+struct UnavailableType {}
 @available(*, deprecated, renamed: "DummyType.Bar")
 typealias DeprecatedType = Int
 
@@ -365,46 +365,46 @@ func testGlobalToMembers() {
 }
 
 
-@available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-func unavailableArgNames(a: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+func unavailableArgNames(a: Int) {}
 @available(*, deprecated, renamed: "moreShinyLabeledArguments(example:)")
 func deprecatedArgNames(b: Int) {}
-@available(*, unavailable, renamed: "DummyType.shinyLabeledArguments(example:)")
-func unavailableMemberArgNames(a: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "DummyType.shinyLabeledArguments(example:)") // expected-note {{here}}
+func unavailableMemberArgNames(a: Int) {}
 @available(*, deprecated, renamed: "DummyType.moreShinyLabeledArguments(example:)")
 func deprecatedMemberArgNames(b: Int) {}
-@available(*, unavailable, renamed: "DummyType.shinyLabeledArguments(example:)", message: "ha")
-func unavailableMemberArgNamesMsg(a: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "DummyType.shinyLabeledArguments(example:)", message: "ha") // expected-note {{here}}
+func unavailableMemberArgNamesMsg(a: Int) {}
 @available(*, deprecated, renamed: "DummyType.moreShinyLabeledArguments(example:)", message: "ha")
 func deprecatedMemberArgNamesMsg(b: Int) {}
 
-@available(*, unavailable, renamed: "shinyLabeledArguments()")
-func unavailableNoArgs() {} // expected-note {{here}}
+@available(*, unavailable, renamed: "shinyLabeledArguments()") // expected-note {{here}}
+func unavailableNoArgs() {}
 
-@available(*, unavailable, renamed: "shinyLabeledArguments(a:)")
-func unavailableSame(a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-func unavailableUnnamed(_ a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(_:)")
-func unavailableUnnamedSame(_ a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(_:)")
-func unavailableNewlyUnnamed(a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(veryLongNameToOverflowASmallStringABCDEFGHIJKLMNOPQRSTUVWXYZ:)")
-func unavailableVeryLongArgNames(a: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "shinyLabeledArguments(a:)") // expected-note {{here}}
+func unavailableSame(a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+func unavailableUnnamed(_ a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(_:)") // expected-note {{here}}
+func unavailableUnnamedSame(_ a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(_:)") // expected-note {{here}}
+func unavailableNewlyUnnamed(a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(veryLongNameToOverflowASmallStringABCDEFGHIJKLMNOPQRSTUVWXYZ:)") // expected-note {{here}}
+func unavailableVeryLongArgNames(a: Int) {}
 
-@available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)")
-func unavailableMultiSame(a: Int, b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(example:another:)")
-func unavailableMultiUnnamed(_ a: Int, _ b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)")
-func unavailableMultiUnnamedSame(_ a: Int, _ b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)")
-func unavailableMultiNewlyUnnamed(a: Int, b: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)") // expected-note {{here}}
+func unavailableMultiSame(a: Int, b: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(example:another:)") // expected-note {{here}}
+func unavailableMultiUnnamed(_ a: Int, _ b: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)") // expected-note {{here}}
+func unavailableMultiUnnamedSame(_ a: Int, _ b: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)") // expected-note {{here}}
+func unavailableMultiNewlyUnnamed(a: Int, b: Int) {}
 
-@available(*, unavailable, renamed: "Int.init(other:)")
-func unavailableInit(a: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "Foo.Bar.init(other:)")
-func unavailableNestedInit(a: Int) {} // expected-note 2 {{here}}
+@available(*, unavailable, renamed: "Int.init(other:)") // expected-note 2 {{here}}
+func unavailableInit(a: Int) {}
+@available(*, unavailable, renamed: "Foo.Bar.init(other:)") // expected-note 2 {{here}}
+func unavailableNestedInit(a: Int) {}
 
 
 func testArgNames() {
@@ -437,16 +437,16 @@ func testArgNames() {
   fn2(1)
 }
 
-@available(*, unavailable, renamed: "shinyLabeledArguments()")
-func unavailableTooFew(a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments()")
-func unavailableTooFewUnnamed(_ a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)")
-func unavailableTooMany(a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)")
-func unavailableTooManyUnnamed(_ a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "shinyLabeledArguments(a:)")
-func unavailableNoArgsTooMany() {} // expected-note {{here}}
+@available(*, unavailable, renamed: "shinyLabeledArguments()") // expected-note {{here}}
+func unavailableTooFew(a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments()") // expected-note {{here}}
+func unavailableTooFewUnnamed(_ a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)") // expected-note {{here}}
+func unavailableTooMany(a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)") // expected-note {{here}}
+func unavailableTooManyUnnamed(_ a: Int) {}
+@available(*, unavailable, renamed: "shinyLabeledArguments(a:)") // expected-note {{here}}
+func unavailableNoArgsTooMany() {}
 
 func testRenameArgMismatch() {
   unavailableTooFew(a: 0) // expected-error{{'unavailableTooFew(a:)' has been renamed to 'shinyLabeledArguments()'}} {{3-20=shinyLabeledArguments}}
@@ -456,26 +456,26 @@ func testRenameArgMismatch() {
   unavailableNoArgsTooMany() // expected-error{{'unavailableNoArgsTooMany()' has been renamed to 'shinyLabeledArguments(a:)'}} {{3-27=shinyLabeledArguments}}
 }
 
-@available(*, unavailable, renamed: "Int.foo(self:)")
-func unavailableInstance(a: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "Int.foo(self:)")
-func unavailableInstanceUnlabeled(_ a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(self:other:)")
-func unavailableInstanceFirst(a: Int, b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(other:self:)")
-func unavailableInstanceSecond(a: Int, b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(_:self:c:)")
-func unavailableInstanceSecondOfThree(a: Int, b: Int, c: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:)") // expected-note 2 {{here}}
+func unavailableInstance(a: Int) {}
+@available(*, unavailable, renamed: "Int.foo(self:)") // expected-note {{here}}
+func unavailableInstanceUnlabeled(_ a: Int) {}
+@available(*, unavailable, renamed: "Int.foo(self:other:)") // expected-note {{here}}
+func unavailableInstanceFirst(a: Int, b: Int) {}
+@available(*, unavailable, renamed: "Int.foo(other:self:)") // expected-note {{here}}
+func unavailableInstanceSecond(a: Int, b: Int) {}
+@available(*, unavailable, renamed: "Int.foo(_:self:c:)") // expected-note {{here}}
+func unavailableInstanceSecondOfThree(a: Int, b: Int, c: Int) {}
 
-@available(*, unavailable, renamed: "Int.foo(self:)", message: "blah")
-func unavailableInstanceMessage(a: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:)", message: "blah") // expected-note {{here}}
+func unavailableInstanceMessage(a: Int) {}
 @available(*, deprecated, renamed: "Int.foo(self:)")
 func deprecatedInstance(a: Int) {}
 @available(*, deprecated, renamed: "Int.foo(self:)", message: "blah")
 func deprecatedInstanceMessage(a: Int) {}
 
-@available(*, unavailable, renamed: "Foo.Bar.foo(self:)")
-func unavailableNestedInstance(a: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Foo.Bar.foo(self:)") // expected-note {{here}}
+func unavailableNestedInstance(a: Int) {}
 
 func testRenameInstance() {
   unavailableInstance(a: 0) // expected-error{{'unavailableInstance(a:)' has been replaced by instance method 'Int.foo()'}} {{3-22=0.foo}} {{23-27=}}
@@ -493,16 +493,16 @@ func testRenameInstance() {
   unavailableNestedInstance(a: 0) // expected-error{{'unavailableNestedInstance(a:)' has been replaced by instance method 'Foo.Bar.foo()'}} {{3-28=0.foo}} {{29-33=}}
 }
 
-@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:)")
-func unavailableInstanceTooFew(a: Int, b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:)")
-func unavailableInstanceTooFewUnnamed(_ a: Int, _ b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:b:)")
-func unavailableInstanceTooMany(a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:b:)")
-func unavailableInstanceTooManyUnnamed(_ a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:)")
-func unavailableInstanceNoArgsTooMany() {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:)") // expected-note {{here}}
+func unavailableInstanceTooFew(a: Int, b: Int) {}
+@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:)") // expected-note {{here}}
+func unavailableInstanceTooFewUnnamed(_ a: Int, _ b: Int) {}
+@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:b:)") // expected-note {{here}}
+func unavailableInstanceTooMany(a: Int) {}
+@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:b:)") // expected-note {{here}}
+func unavailableInstanceTooManyUnnamed(_ a: Int) {}
+@available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:)") // expected-note {{here}}
+func unavailableInstanceNoArgsTooMany() {}
 
 func testRenameInstanceArgMismatch() {
   unavailableInstanceTooFew(a: 0, b: 1) // expected-error{{'unavailableInstanceTooFew(a:b:)' has been replaced by instance method 'Int.shinyLabeledArguments()'}} {{none}}
@@ -512,21 +512,21 @@ func testRenameInstanceArgMismatch() {
   unavailableInstanceNoArgsTooMany() // expected-error{{'unavailableInstanceNoArgsTooMany()' has been replaced by instance method 'Int.shinyLabeledArguments()'}} {{none}}
 }
 
-@available(*, unavailable, renamed: "getter:Int.prop(self:)")
-func unavailableInstanceProperty(a: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "getter:Int.prop(self:)")
-func unavailableInstancePropertyUnlabeled(_ a: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "getter:Int.prop()")
-func unavailableClassProperty() {} // expected-note {{here}}
-@available(*, unavailable, renamed: "getter:global()")
-func unavailableGlobalProperty() {} // expected-note {{here}}
+@available(*, unavailable, renamed: "getter:Int.prop(self:)") // expected-note 2 {{here}}
+func unavailableInstanceProperty(a: Int) {}
+@available(*, unavailable, renamed: "getter:Int.prop(self:)") // expected-note 2 {{here}}
+func unavailableInstancePropertyUnlabeled(_ a: Int) {}
+@available(*, unavailable, renamed: "getter:Int.prop()") // expected-note {{here}}
+func unavailableClassProperty() {}
+@available(*, unavailable, renamed: "getter:global()") // expected-note {{here}}
+func unavailableGlobalProperty() {}
 
-@available(*, unavailable, renamed: "getter:Int.prop(self:)", message: "blah")
-func unavailableInstancePropertyMessage(a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "getter:Int.prop()", message: "blah")
-func unavailableClassPropertyMessage() {} // expected-note {{here}}
-@available(*, unavailable, renamed: "getter:global()", message: "blah")
-func unavailableGlobalPropertyMessage() {} // expected-note {{here}}
+@available(*, unavailable, renamed: "getter:Int.prop(self:)", message: "blah") // expected-note {{here}}
+func unavailableInstancePropertyMessage(a: Int) {}
+@available(*, unavailable, renamed: "getter:Int.prop()", message: "blah") // expected-note {{here}}
+func unavailableClassPropertyMessage() {}
+@available(*, unavailable, renamed: "getter:global()", message: "blah") // expected-note {{here}}
+func unavailableGlobalPropertyMessage() {}
 
 @available(*, deprecated, renamed: "getter:Int.prop(self:)")
 func deprecatedInstanceProperty(a: Int) {}
@@ -563,21 +563,21 @@ func testRenameGetters() {
   deprecatedGlobalPropertyMessage() // expected-warning {{'deprecatedGlobalPropertyMessage()' is deprecated: blah}}{{documentation-file=deprecated-declaration}} expected-note{{use 'global' instead}} {{3-34=global}} {{34-36=}}
 }
 
-@available(*, unavailable, renamed: "setter:Int.prop(self:_:)")
-func unavailableSetInstanceProperty(a: Int, b: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "setter:Int.prop(_:self:)")
-func unavailableSetInstancePropertyReverse(a: Int, b: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "setter:Int.prop(self:newValue:)")
-func unavailableSetInstancePropertyUnlabeled(_ a: Int, _ b: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "setter:Int.prop(newValue:self:)")
-func unavailableSetInstancePropertyUnlabeledReverse(_ a: Int, _ b: Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "setter:Int.prop(x:)")
-func unavailableSetClassProperty(a: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "setter:global(_:)")
-func unavailableSetGlobalProperty(_ a: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "setter:Int.prop(self:_:)") // expected-note 2 {{here}}
+func unavailableSetInstanceProperty(a: Int, b: Int) {}
+@available(*, unavailable, renamed: "setter:Int.prop(_:self:)") // expected-note 2 {{here}}
+func unavailableSetInstancePropertyReverse(a: Int, b: Int) {}
+@available(*, unavailable, renamed: "setter:Int.prop(self:newValue:)") // expected-note 2 {{here}}
+func unavailableSetInstancePropertyUnlabeled(_ a: Int, _ b: Int) {}
+@available(*, unavailable, renamed: "setter:Int.prop(newValue:self:)") // expected-note 2 {{here}}
+func unavailableSetInstancePropertyUnlabeledReverse(_ a: Int, _ b: Int) {}
+@available(*, unavailable, renamed: "setter:Int.prop(x:)") // expected-note {{here}}
+func unavailableSetClassProperty(a: Int) {}
+@available(*, unavailable, renamed: "setter:global(_:)") // expected-note {{here}}
+func unavailableSetGlobalProperty(_ a: Int) {}
 
-@available(*, unavailable, renamed: "setter:Int.prop(self:_:)")
-func unavailableSetInstancePropertyInout(a: inout Int, b: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "setter:Int.prop(self:_:)") // expected-note {{here}}
+func unavailableSetInstancePropertyInout(a: inout Int, b: Int) {}
 
 func testRenameSetters() {
   unavailableSetInstanceProperty(a: 1, b: 2) // expected-error{{'unavailableSetInstanceProperty(a:b:)' has been replaced by property 'Int.prop'}} {{3-33=1.prop}} {{33-43= = }} {{44-45=}}
@@ -595,12 +595,12 @@ func testRenameSetters() {
   unavailableSetInstancePropertyInout(a: &x, b: 2) // expected-error{{'unavailableSetInstancePropertyInout(a:b:)' has been replaced by property 'Int.prop'}} {{3-38=x.prop}} {{38-49= = }} {{50-51=}}
 }
 
-@available(*, unavailable, renamed: "Int.foo(self:execute:)")
-func trailingClosure(_ value: Int, fn: () -> Void) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(self:bar:execute:)")
-func trailingClosureArg(_ value: Int, _ other: Int, fn: () -> Void) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(bar:self:execute:)")
-func trailingClosureArg2(_ value: Int, _ other: Int, fn: () -> Void) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:execute:)") // expected-note {{here}}
+func trailingClosure(_ value: Int, fn: () -> Void) {}
+@available(*, unavailable, renamed: "Int.foo(self:bar:execute:)") // expected-note {{here}}
+func trailingClosureArg(_ value: Int, _ other: Int, fn: () -> Void) {}
+@available(*, unavailable, renamed: "Int.foo(bar:self:execute:)") // expected-note {{here}}
+func trailingClosureArg2(_ value: Int, _ other: Int, fn: () -> Void) {}
 
 func testInstanceTrailingClosure() {
   // FIXME: regression in fixit due to noescape-by-default
@@ -609,26 +609,26 @@ func testInstanceTrailingClosure() {
   trailingClosureArg2(0, 1) {} // expected-error {{'trailingClosureArg2(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} // FIXME: {{3-22=1.foo}} {{23-23=bar: }} {{24-27=}}
 }
 
-@available(*, unavailable, renamed: "+")
-func add(_ value: Int, _ other: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "+") // expected-note {{here}}
+func add(_ value: Int, _ other: Int) {}
 
 infix operator ***
-@available(*, unavailable, renamed: "add")
-func ***(value: (), other: ()) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(self:_:)")
-func ***(value: Int, other: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "add") // expected-note {{here}}
+func ***(value: (), other: ()) {}
+@available(*, unavailable, renamed: "Int.foo(self:_:)") // expected-note {{here}}
+func ***(value: Int, other: Int) {}
 
 prefix operator ***
-@available(*, unavailable, renamed: "add")
-prefix func ***(value: Int?) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(self:)")
-prefix func ***(value: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "add") // expected-note {{here}}
+prefix func ***(value: Int?) {}
+@available(*, unavailable, renamed: "Int.foo(self:)") // expected-note {{here}}
+prefix func ***(value: Int) {}
 
 postfix operator ***
-@available(*, unavailable, renamed: "add")
-postfix func ***(value: Int?) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "Int.foo(self:)")
-postfix func ***(value: Int) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "add") // expected-note {{here}}
+postfix func ***(value: Int?) {}
+@available(*, unavailable, renamed: "Int.foo(self:)") // expected-note {{here}}
+postfix func ***(value: Int) {}
 
 func testOperators() {
   add(0, 1) // expected-error {{'add' has been renamed to '+'}} {{none}}
@@ -643,13 +643,13 @@ func testOperators() {
 }
 
 extension Int {
-  @available(*, unavailable, renamed: "init(other:)")
+  @available(*, unavailable, renamed: "init(other:)") // expected-note 2 {{here}}
   @discardableResult
-  static func factory(other: Int) -> Int { return other } // expected-note 2 {{here}}
+  static func factory(other: Int) -> Int { return other }
 
-  @available(*, unavailable, renamed: "Int.init(other:)")
+  @available(*, unavailable, renamed: "Int.init(other:)") // expected-note 2 {{here}}
   @discardableResult
-  static func factory2(other: Int) -> Int { return other } // expected-note 2 {{here}}
+  static func factory2(other: Int) -> Int { return other }
 
   static func testFactoryMethods() {
     factory(other: 1) // expected-error {{'factory(other:)' has been replaced by 'init(other:)'}} {{none}}
@@ -723,10 +723,10 @@ class Base {
   func bad() {} // expected-note {{here}}
   @available(*, unavailable, message: "it was smelly")
   func smelly() {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "new")
-  func old() {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "new", message: "it was smelly")
-  func oldAndSmelly() {} // expected-note {{here}}
+  @available(*, unavailable, renamed: "new") // expected-note {{here}}
+  func old() {}
+  @available(*, unavailable, renamed: "new", message: "it was smelly") // expected-note {{here}}
+  func oldAndSmelly() {}
   @available(*, unavailable)
   func expendable() {}
 
@@ -734,66 +734,66 @@ class Base {
   var badProp: Int { return 0 } // expected-note {{here}}
   @available(*, unavailable, message: "it was smelly")
   var smellyProp: Int { return 0 } // expected-note {{here}}
-  @available(*, unavailable, renamed: "new")
-  var oldProp: Int { return 0 } // expected-note {{here}}
-  @available(*, unavailable, renamed: "new", message: "it was smelly")
-  var oldAndSmellyProp: Int { return 0 } // expected-note {{here}}
+  @available(*, unavailable, renamed: "new") // expected-note {{here}}
+  var oldProp: Int { return 0 }
+  @available(*, unavailable, renamed: "new", message: "it was smelly") // expected-note {{here}}
+  var oldAndSmellyProp: Int { return 0 }
   @available(*, unavailable)
   var expendableProp: Int { return 0 }
 
-  @available(*, unavailable, renamed: "init")
-  func nowAnInitializer() {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "init()")
-  func nowAnInitializer2() {} // expected-note {{here}}
+  @available(*, unavailable, renamed: "init") // expected-note {{here}}
+  func nowAnInitializer() {}
+  @available(*, unavailable, renamed: "init()") // expected-note {{here}}
+  func nowAnInitializer2() {}
 
-  @available(*, unavailable, renamed: "foo")
-  init(nowAFunction: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "foo(_:)")
-  init(nowAFunction2: Int) {} // expected-note {{here}}
+  @available(*, unavailable, renamed: "foo") // expected-note {{here}}
+  init(nowAFunction: Int) {}
+  @available(*, unavailable, renamed: "foo(_:)") // expected-note {{here}}
+  init(nowAFunction2: Int) {}
 
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-  func unavailableArgNames(a: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-  func unavailableArgRenamed(a: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments()")
-  func unavailableNoArgs() {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(a:)")
-  func unavailableSame(a: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-  func unavailableUnnamed(_ a: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)")
-  func unavailableUnnamedSame(_ a: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)")
-  func unavailableNewlyUnnamed(a: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)")
-  func unavailableMultiSame(a: Int, b: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:another:)")
-  func unavailableMultiUnnamed(_ a: Int, _ b: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)")
-  func unavailableMultiUnnamedSame(_ a: Int, _ b: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)")
-  func unavailableMultiNewlyUnnamed(a: Int, b: Int) {} // expected-note {{here}}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+  func unavailableArgNames(a: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+  func unavailableArgRenamed(a: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments()") // expected-note {{here}}
+  func unavailableNoArgs() {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(a:)") // expected-note {{here}}
+  func unavailableSame(a: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+  func unavailableUnnamed(_ a: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)") // expected-note {{here}}
+  func unavailableUnnamedSame(_ a: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)") // expected-note {{here}}
+  func unavailableNewlyUnnamed(a: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)") // expected-note {{here}}
+  func unavailableMultiSame(a: Int, b: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:another:)") // expected-note {{here}}
+  func unavailableMultiUnnamed(_ a: Int, _ b: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)") // expected-note {{here}}
+  func unavailableMultiUnnamedSame(_ a: Int, _ b: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)") // expected-note {{here}}
+  func unavailableMultiNewlyUnnamed(a: Int, b: Int) {}
 
-  @available(*, unavailable, renamed: "init(shinyNewName:)")
-  init(unavailableArgNames: Int) {} // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(a:)")
-  init(_ unavailableUnnamed: Int) {} // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(_:)")
-  init(unavailableNewlyUnnamed: Int) {} // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(a:b:)")
-  init(_ unavailableMultiUnnamed: Int, _ b: Int) {} // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(_:_:)")
-  init(unavailableMultiNewlyUnnamed a: Int, b: Int) {} // expected-note{{here}}
+  @available(*, unavailable, renamed: "init(shinyNewName:)") // expected-note{{here}}
+  init(unavailableArgNames: Int) {}
+  @available(*, unavailable, renamed: "init(a:)") // expected-note{{here}}
+  init(_ unavailableUnnamed: Int) {}
+  @available(*, unavailable, renamed: "init(_:)") // expected-note{{here}}
+  init(unavailableNewlyUnnamed: Int) {}
+  @available(*, unavailable, renamed: "init(a:b:)") // expected-note{{here}}
+  init(_ unavailableMultiUnnamed: Int, _ b: Int) {}
+  @available(*, unavailable, renamed: "init(_:_:)") // expected-note{{here}}
+  init(unavailableMultiNewlyUnnamed a: Int, b: Int) {}
 
-  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)")
-  func unavailableTooFew(a: Int, b: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(x:b:)")
-  func unavailableTooMany(a: Int) {} // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)")
-  func unavailableNoArgsTooMany() {} // expected-note {{here}}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)") // expected-note {{here}}
+  func unavailableTooFew(a: Int, b: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(x:b:)") // expected-note {{here}}
+  func unavailableTooMany(a: Int) {}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)") // expected-note {{here}}
+  func unavailableNoArgsTooMany() {}
 
-  @available(*, unavailable, renamed: "Base.shinyLabeledArguments()")
-  func unavailableHasType() {} // expected-note {{here}}
+  @available(*, unavailable, renamed: "Base.shinyLabeledArguments()") // expected-note {{here}}
+  func unavailableHasType() {}
 
   @available(*, deprecated)
   func deprecated() {}
@@ -849,30 +849,30 @@ class Sub : Base {
 }
 
 // U: Unnamed, L: Labeled
-@available(*, unavailable, renamed: "after(fn:)")
-func closure_U_L(_ x: () -> Int) {} // expected-note 3 {{here}}
-@available(*, unavailable, renamed: "after(fn:)")
-func closure_L_L(x: () -> Int) {} // expected-note 3 {{here}}
-@available(*, unavailable, renamed: "after(_:)")
-func closure_L_U(x: () -> Int) {} // expected-note 3 {{here}}
+@available(*, unavailable, renamed: "after(fn:)") // expected-note 3 {{here}}
+func closure_U_L(_ x: () -> Int) {}
+@available(*, unavailable, renamed: "after(fn:)") // expected-note 3 {{here}}
+func closure_L_L(x: () -> Int) {}
+@available(*, unavailable, renamed: "after(_:)") // expected-note 3 {{here}}
+func closure_L_U(x: () -> Int) {}
 
-@available(*, unavailable, renamed: "after(arg:fn:)")
-func closure_UU_LL(_ x: Int, _ y: () -> Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(arg:fn:)")
-func closure_LU_LL(x: Int, _ y: () -> Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(arg:fn:)")
-func closure_LL_LL(x: Int, y: () -> Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(arg:fn:)")
-func closure_UU_LL_ne(_ x: Int, _ y: () -> Int) {} // expected-note 2 {{here}}
+@available(*, unavailable, renamed: "after(arg:fn:)") // expected-note 2 {{here}}
+func closure_UU_LL(_ x: Int, _ y: () -> Int) {}
+@available(*, unavailable, renamed: "after(arg:fn:)") // expected-note 2 {{here}}
+func closure_LU_LL(x: Int, _ y: () -> Int) {}
+@available(*, unavailable, renamed: "after(arg:fn:)") // expected-note 2 {{here}}
+func closure_LL_LL(x: Int, y: () -> Int) {}
+@available(*, unavailable, renamed: "after(arg:fn:)") // expected-note 2 {{here}}
+func closure_UU_LL_ne(_ x: Int, _ y: () -> Int) {}
 
-@available(*, unavailable, renamed: "after(arg:_:)")
-func closure_UU_LU(_ x: Int, _ closure: () -> Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(arg:_:)")
-func closure_LU_LU(x: Int, _ closure: () -> Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(arg:_:)")
-func closure_LL_LU(x: Int, y: () -> Int) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(arg:_:)")
-func closure_UU_LU_ne(_ x: Int, _ y: () -> Int) {} // expected-note 2 {{here}}
+@available(*, unavailable, renamed: "after(arg:_:)") // expected-note 2 {{here}}
+func closure_UU_LU(_ x: Int, _ closure: () -> Int) {}
+@available(*, unavailable, renamed: "after(arg:_:)") // expected-note 2 {{here}}
+func closure_LU_LU(x: Int, _ closure: () -> Int) {}
+@available(*, unavailable, renamed: "after(arg:_:)") // expected-note 2 {{here}}
+func closure_LL_LU(x: Int, y: () -> Int) {}
+@available(*, unavailable, renamed: "after(arg:_:)") // expected-note 2 {{here}}
+func closure_UU_LU_ne(_ x: Int, _ y: () -> Int) {}
 
 func testTrailingClosure() {
   closure_U_L { 0 } // expected-error {{'closure_U_L' has been renamed to 'after(fn:)'}} {{3-14=after}} {{none}}
@@ -912,12 +912,12 @@ func testTrailingClosure() {
   closure_UU_LU_ne(1, { 0 }) // expected-error {{'closure_UU_LU_ne' has been renamed to 'after(arg:_:)'}} {{3-19=after}} {{20-20=arg: }} {{none}}
 }
 
-@available(*, unavailable, renamed: "after(x:)")
-func defaultUnnamed(_ a: Int = 1) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(x:y:)")
-func defaultBeforeRequired(a: Int = 1, b: Int) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "after(x:y:z:)")
-func defaultPlusTrailingClosure(a: Int = 1, b: Int = 2, c: () -> Void) {} // expected-note 3 {{here}}
+@available(*, unavailable, renamed: "after(x:)") // expected-note 2 {{here}}
+func defaultUnnamed(_ a: Int = 1) {}
+@available(*, unavailable, renamed: "after(x:y:)") // expected-note {{here}}
+func defaultBeforeRequired(a: Int = 1, b: Int) {}
+@available(*, unavailable, renamed: "after(x:y:z:)") // expected-note 3 {{here}}
+func defaultPlusTrailingClosure(a: Int = 1, b: Int = 2, c: () -> Void) {}
 
 func testDefaults() {
   defaultUnnamed() // expected-error {{'defaultUnnamed' has been renamed to 'after(x:)'}} {{3-17=after}} {{none}}
@@ -928,12 +928,12 @@ func testDefaults() {
   defaultPlusTrailingClosure(a: 1) {} // expected-error {{'defaultPlusTrailingClosure(a:b:c:)' has been renamed to 'after(x:y:z:)'}} {{3-29=after}} {{30-31=x}} {{none}}
 }
 
-@available(*, unavailable, renamed: "after(x:y:)")
-func variadic1(a: Int ..., b: Int = 0) {} // expected-note 2 {{here}}
-@available(*, unavailable, renamed: "after(x:y:)")
-func variadic2(a: Int, _ b: Int ...) {} // expected-note {{here}}
-@available(*, unavailable, renamed: "after(x:_:y:z:)")
-func variadic3(_ a: Int, b: Int ..., c: String = "", d: String) {} // expected-note 2 {{here}}
+@available(*, unavailable, renamed: "after(x:y:)") // expected-note 2 {{here}}
+func variadic1(a: Int ..., b: Int = 0) {}
+@available(*, unavailable, renamed: "after(x:y:)") // expected-note {{here}}
+func variadic2(a: Int, _ b: Int ...) {}
+@available(*, unavailable, renamed: "after(x:_:y:z:)") // expected-note 2 {{here}}
+func variadic3(_ a: Int, b: Int ..., c: String = "", d: String) {}
 
 func testVariadic() {
   variadic1(a: 1, 2) // expected-error {{'variadic1(a:b:)' has been renamed to 'after(x:y:)'}} {{3-12=after}} {{13-14=x}} {{none}}
@@ -950,18 +950,18 @@ enum E_32526620 {
   func set() {}
 }
 
-@available(*, unavailable, renamed: "E_32526620.set(self:)")
-func rdar32526620_1(a: E_32526620) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "E_32526620.set(self:)") // expected-note {{here}}
+func rdar32526620_1(a: E_32526620) {}
 rdar32526620_1(a: .foo)
 // expected-error@-1 {{'rdar32526620_1(a:)' has been replaced by instance method 'E_32526620.set()'}} {{1-15=E_32526620.foo.set}} {{16-23=}}
 
-@available(*, unavailable, renamed: "E_32526620.set(a:self:)")
-func rdar32526620_2(a: Int, b: E_32526620) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "E_32526620.set(a:self:)") // expected-note {{here}}
+func rdar32526620_2(a: Int, b: E_32526620) {}
 rdar32526620_2(a: 42, b: .bar)
 // expected-error@-1 {{'rdar32526620_2(a:b:)' has been replaced by instance method 'E_32526620.set(a:)'}} {{1-15=E_32526620.bar.set}} {{21-30=}}
 
-@available(*, unavailable, renamed: "E_32526620.set(a:self:c:)")
-func rdar32526620_3(a: Int, b: E_32526620, c: String) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "E_32526620.set(a:self:c:)") // expected-note {{here}}
+func rdar32526620_3(a: Int, b: E_32526620, c: String) {}
 rdar32526620_3(a: 42, b: .bar, c: "question")
 // expected-error@-1 {{'rdar32526620_3(a:b:c:)' has been replaced by instance method 'E_32526620.set(a:c:)'}} {{1-15=E_32526620.bar.set}} {{23-32=}}
 
@@ -1044,8 +1044,8 @@ var unavailableRename: Int {
   @available(*, unavailable, renamed: "betterThing()") get { return 0 } // expected-note * {{here}}
   @available(*, unavailable, renamed: "setBetterThing(_:)") set {} // expected-note * {{here}}
 }
-@available(*, unavailable, message: "bad variable")
-var unavailableProperty: Int { // expected-note * {{here}}
+@available(*, unavailable, message: "bad variable") // expected-note * {{here}}
+var unavailableProperty: Int {
   @available(*, unavailable, message: "bad getter") get { return 0 }
   @available(*, unavailable, message: "bad setter") set {}
 }
@@ -1142,8 +1142,8 @@ struct UnavailableAccessors {
     @available(*, unavailable, message: "bad setter") set {} // expected-note * {{here}}
   }
 
-  @available(*, unavailable, message: "bad property")
-  var unavailableProperty: Int { // expected-note * {{here}}
+  @available(*, unavailable, message: "bad property") // expected-note * {{here}}
+  var unavailableProperty: Int {
     @available(*, unavailable, message: "bad getter") get { return 0 }
     @available(*, unavailable, message: "bad setter") set {}
   }
@@ -1153,8 +1153,8 @@ struct UnavailableAccessors {
     @available(*, unavailable, message: "bad subscript setter") set {} // expected-note * {{here}}
   }
 
-  @available(*, unavailable, message: "bad subscript!")
-  subscript(alsoUnavailable _: Int) -> Int { // expected-note * {{here}}
+  @available(*, unavailable, message: "bad subscript!") // expected-note * {{here}}
+  subscript(alsoUnavailable _: Int) -> Int {
     @available(*, unavailable, message: "bad subscript getter") get { return 0 }
     @available(*, unavailable, message: "bad subscript setter") set {}
   }
@@ -1244,8 +1244,8 @@ struct BadRename {
 
 func log(message: String) { }
 
-@available(*, unavailable, renamed: "log(message:)")
-func log(format: String, _ args: Any...) { fatalError() } // expected-note {{'log(format:_:)' has been explicitly marked unavailable here}}
+@available(*, unavailable, renamed: "log(message:)") // expected-note {{'log(format:_:)' has been explicitly marked unavailable here}}
+func log(format: String, _ args: Any...) { fatalError() }
 
 func testBadRename() {
   _ = BadRename(from: 5, to: 17) // expected-warning{{'init(from:to:step:)' is deprecated: renamed to 'init(range:step:)'}}{{documentation-file=deprecated-declaration}}
@@ -1310,19 +1310,19 @@ func testMultipleTrailingClosures(_ x: TypeWithTrailingClosures) {
 }
 
 struct UnavailableSubscripts { 
-  @available(*, unavailable, renamed: "subscript(new:)")
-  subscript(old index: Int) -> Int { 3 } // expected-note * {{'subscript(old:)' has been explicitly marked unavailable here}}
-  @available(*, unavailable, renamed: "subscript(new:)")
-  func getValue(old: Int) -> Int { 3 } // expected-note * {{'getValue(old:)' has been explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "subscript(new:)") // expected-note * {{'subscript(old:)' has been explicitly marked unavailable here}}
+  subscript(old index: Int) -> Int { 3 }
+  @available(*, unavailable, renamed: "subscript(new:)") // expected-note * {{'getValue(old:)' has been explicitly marked unavailable here}}
+  func getValue(old: Int) -> Int { 3 }
 
   subscript(new index: Int) -> Int { 3 }
 
-  @available(*, unavailable, renamed: "getAValue(new:)")
-  subscript(getAValue index: Int) -> Int { 3 } // expected-note * {{'subscript(getAValue:)' has been explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "getAValue(new:)") // expected-note * {{'subscript(getAValue:)' has been explicitly marked unavailable here}}
+  subscript(getAValue index: Int) -> Int { 3 }
   func getAValue(new: Int) -> Int { 3 }
 
-  @available(*, unavailable, renamed: "subscript(arg1:arg2:arg3:)")
-  subscript(_ argg1: Int, _ argg2: Int, _ argg3: Int) -> Int { 3 } // expected-note * {{'subscript(_:_:_:)' has been explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "subscript(arg1:arg2:arg3:)") // expected-note * {{'subscript(_:_:_:)' has been explicitly marked unavailable here}}
+  subscript(_ argg1: Int, _ argg2: Int, _ argg3: Int) -> Int { 3 }
 
   @available(*, deprecated, renamed: "subscript(arg1:arg2:arg3:)")
   subscript(argg1 argg1: Int, argg2 argg2: Int, argg3 argg3: Int) -> Int { 3 }

--- a/test/attr/attr_availability_android.swift
+++ b/test/attr/attr_availability_android.swift
@@ -3,14 +3,14 @@
 @available(Android, introduced: 1.0, deprecated: 2.0, obsoleted: 28.0,
               message: "you don't want to do that anyway")
 func doSomething() { }
-// expected-note @-1{{'doSomething()' was obsoleted in Android 28.0}}
+// expected-note @-3{{'doSomething()' was obsoleted in Android 28.0}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable in Android: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
 @available(Android, introduced: 1.0, deprecated: 2.0, obsoleted: 27.0)
 func doSomethingElse() { }
-// expected-note @-1{{'doSomethingElse()' was obsoleted in Android 27.0}}
+// expected-note @-2{{'doSomethingElse()' was obsoleted in Android 27.0}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in Android}}
 

--- a/test/attr/attr_availability_appext_unavailable.swift
+++ b/test/attr/attr_availability_appext_unavailable.swift
@@ -1,18 +1,20 @@
 // Verify that declarations unavailable to application extensions are diagnosed
 // as unavailable when compiling with `-application-extension`
-// RUN: %target-typecheck-verify-swift -application-extension
+// RUN: %target-typecheck-verify-swift -application-extension -verify-additional-prefix %target-os-
 
 // Remove `-application-extension` and verify no errors are emitted.
 // RUN: %target-swift-frontend -typecheck %s
 
 // REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
 
-@available(macOSApplicationExtension, unavailable)
-@available(macCatalystApplicationExtension, unavailable)
-@available(iOSApplicationExtension, unavailable)
-@available(tvOSApplicationExtension, unavailable)
-@available(watchOSApplicationExtension, unavailable)
-func unavailableToExtensions() {} // expected-note {{'unavailableToExtensions()' has been explicitly marked unavailable here}}
+// The note points at whichever attribute makes the declaration unavailable on
+// the target platform.
+@available(macOSApplicationExtension, unavailable) // expected-macosx-note {{'unavailableToExtensions()' has been explicitly marked unavailable here}}
+@available(macCatalystApplicationExtension, unavailable) // expected-maccatalyst-note {{'unavailableToExtensions()' has been explicitly marked unavailable here}}
+@available(iOSApplicationExtension, unavailable) // expected-ios-note {{'unavailableToExtensions()' has been explicitly marked unavailable here}}
+@available(tvOSApplicationExtension, unavailable) // expected-tvos-note {{'unavailableToExtensions()' has been explicitly marked unavailable here}}
+@available(watchOSApplicationExtension, unavailable) // expected-watchos-note {{'unavailableToExtensions()' has been explicitly marked unavailable here}}
+func unavailableToExtensions() {}
 
 func alwaysAvailable() {
   unavailableToExtensions() // expected-error {{'unavailableToExtensions()' is unavailable in application extensions for}}

--- a/test/attr/attr_availability_canonical_macos_version.swift
+++ b/test/attr/attr_availability_canonical_macos_version.swift
@@ -4,7 +4,7 @@
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 11.0,
               message: "you don't want to do that anyway")
 func obsoletedIn11() { }
-// expected-note @-1{{'obsoletedIn11()' was obsoleted in macOS 11.0}}
+// expected-note @-3{{'obsoletedIn11()' was obsoleted in macOS 11.0}}
 
 obsoletedIn11() // expected-error{{'obsoletedIn11()' is unavailable in macOS: you don't want to do that anyway}}
 
@@ -12,21 +12,21 @@ obsoletedIn11() // expected-error{{'obsoletedIn11()' is unavailable in macOS: yo
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.16,
               message: "you don't want to do that anyway")
 func obsoletedIn10_16() { }
-// expected-note @-1{{'obsoletedIn10_16()' was obsoleted in macOS 11.0}}
+// expected-note @-3{{'obsoletedIn10_16()' was obsoleted in macOS 11.0}}
 
 obsoletedIn10_16() // expected-error{{'obsoletedIn10_16()' is unavailable in macOS: you don't want to do that anyway}}
 
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 16.0,
               message: "you don't want to do that anyway")
 func obsoletedIn16() { }
-// expected-note @-1{{'obsoletedIn16()' was obsoleted in macOS 26.0}}
+// expected-note @-3{{'obsoletedIn16()' was obsoleted in macOS 26.0}}
 
 obsoletedIn16() // expected-error{{'obsoletedIn16()' is unavailable in macOS: you don't want to do that anyway}}
 
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 26.0,
               message: "you don't want to do that anyway")
 func obsoletedIn26() { }
-// expected-note @-1{{'obsoletedIn26()' was obsoleted in macOS 26.0}}
+// expected-note @-3{{'obsoletedIn26()' was obsoleted in macOS 26.0}}
 
 obsoletedIn26() // expected-error{{'obsoletedIn26()' is unavailable in macOS: you don't want to do that anyway}}
 

--- a/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
+++ b/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
@@ -8,7 +8,7 @@ public func doSomethingFarFuture() { }
 
 @available(iOS, introduced: 16.0, obsoleted: 17.0, message: "you don't want to do that anyway")
 public func doSomethingElse() { }
-// expected-note@-1 3 {{'doSomethingElse()' was obsoleted in visionOS 1.0}}
+// expected-note@-2 3 {{'doSomethingElse()' was obsoleted in visionOS 1.0}}
 
 @available(iOS, introduced: 16.0, deprecated: 17.0, message: "please don't")
 public func doSomethingInadvisable() { }
@@ -42,7 +42,7 @@ public struct ConformsToProtoObsoletedIniOS17 { }
 
 @available(iOS, introduced: 16.0, obsoleted: 17.0, message: "you don't want to do that anyway")
 extension ConformsToProtoObsoletedIniOS17: SomeProto { }
-// expected-note@-1 {{conformance of 'ConformsToProtoObsoletedIniOS17' to 'SomeProto' was obsoleted in visionOS 1.0}}
+// expected-note@-2 {{conformance of 'ConformsToProtoObsoletedIniOS17' to 'SomeProto' was obsoleted in visionOS 1.0}}
 
 
 func testDeploymentTarget() {

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -5,14 +5,14 @@
 @available(macCatalyst, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
            message: "you don't want to do that anyway")
 func obsoletedOnMacCatalyst() { }
-// expected-note @-1{{'obsoletedOnMacCatalyst()' was obsoleted in Mac Catalyst 9.0}}
+// expected-note @-3{{'obsoletedOnMacCatalyst()' was obsoleted in Mac Catalyst 9.0}}
 
 obsoletedOnMacCatalyst() // expected-error{{'obsoletedOnMacCatalyst()' is unavailable in Mac Catalyst: you don't want to do that anyway}}
 
 @available(iOS, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
            message: "you don't want to do that anyway")
 func obsoletedOnIOS() { }
-// expected-note @-1{{'obsoletedOnIOS()' was obsoleted in iOS 9.0}}
+// expected-note @-3{{'obsoletedOnIOS()' was obsoleted in iOS 9.0}}
 
 obsoletedOnIOS() // expected-error{{'obsoletedOnIOS()' is unavailable in iOS: you don't want to do that anyway}}
 
@@ -20,7 +20,7 @@ obsoletedOnIOS() // expected-error{{'obsoletedOnIOS()' is unavailable in iOS: yo
 @available(iOS, introduced: 1.0)
 @available(macCatalyst, introduced: 1.0, obsoleted: 12.0)
 func obsoletedOnMacCatalystButNotIOS() { }
-// expected-note @-1{{'obsoletedOnMacCatalystButNotIOS()' was obsoleted in Mac Catalyst 12.0}}
+// expected-note @-2{{'obsoletedOnMacCatalystButNotIOS()' was obsoleted in Mac Catalyst 12.0}}
 
 obsoletedOnMacCatalystButNotIOS() // expected-error {{'obsoletedOnMacCatalystButNotIOS()' is unavailable}}
 
@@ -146,11 +146,11 @@ extension X: P {}
 
 func takesAnything<T>(_ t: T) { }
 
-@available(macCatalyst, unavailable)
-struct UnavailableOnMacCatalyst { } // expected-note * {{'UnavailableOnMacCatalyst' has been explicitly marked unavailable here}}
+@available(macCatalyst, unavailable) // expected-note * {{'UnavailableOnMacCatalyst' has been explicitly marked unavailable here}}
+struct UnavailableOnMacCatalyst { }
 
-@available(iOS, unavailable)
-struct UnavailableOniOS { } // expected-note * {{'UnavailableOniOS' has been explicitly marked unavailable here}}
+@available(iOS, unavailable) // expected-note * {{'UnavailableOniOS' has been explicitly marked unavailable here}}
+struct UnavailableOniOS { }
 
 @available(iOS, unavailable)
 @available(macCatalyst, introduced: 13.0)

--- a/test/attr/attr_availability_objc.swift
+++ b/test/attr/attr_availability_objc.swift
@@ -8,73 +8,73 @@ protocol OlfactoryProtocol {
   func bad() // expected-note {{here}}
   @available(*, unavailable, message: "it was smelly")
   func smelly() // expected-note {{here}}
-  @available(*, unavailable, renamed: "new")
-  func old() // expected-note {{here}}
-  @available(*, unavailable, renamed: "new", message: "it was smelly")
-  func oldAndSmelly() // expected-note {{here}}
+  @available(*, unavailable, renamed: "new") // expected-note {{here}}
+  func old()
+  @available(*, unavailable, renamed: "new", message: "it was smelly") // expected-note {{here}}
+  func oldAndSmelly()
 
   @available(*, unavailable)
   var badProp: Int { get } // expected-note {{here}}
   @available(*, unavailable, message: "it was smelly")
   var smellyProp: Int { get } // expected-note {{here}}
-  @available(*, unavailable, renamed: "new")
-  var oldProp: Int { get } // expected-note {{here}}
-  @available(*, unavailable, renamed: "new", message: "it was smelly")
-  var oldAndSmellyProp: Int { get } // expected-note {{here}}
+  @available(*, unavailable, renamed: "new") // expected-note {{here}}
+  var oldProp: Int { get }
+  @available(*, unavailable, renamed: "new", message: "it was smelly") // expected-note {{here}}
+  var oldAndSmellyProp: Int { get }
 
-  @available(*, unavailable, renamed: "init")
-  func nowAnInitializer() // expected-note {{here}}
-  @available(*, unavailable, renamed: "init()")
-  func nowAnInitializer2() // expected-note {{here}}
+  @available(*, unavailable, renamed: "init") // expected-note {{here}}
+  func nowAnInitializer()
+  @available(*, unavailable, renamed: "init()") // expected-note {{here}}
+  func nowAnInitializer2()
 
-  @available(*, unavailable, renamed: "foo")
-  init(nowAFunction: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "foo(_:)")
-  init(nowAFunction2: Int) // expected-note {{here}}
+  @available(*, unavailable, renamed: "foo") // expected-note {{here}}
+  init(nowAFunction: Int)
+  @available(*, unavailable, renamed: "foo(_:)") // expected-note {{here}}
+  init(nowAFunction2: Int)
 
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-  func unavailableArgNames(a: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-  func unavailableArgRenamed(a: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments()")
-  func unavailableNoArgs() // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(a:)")
-  func unavailableSame(a: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)")
-  func unavailableUnnamed(_ a: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)")
-  func unavailableUnnamedSame(_ a: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)")
-  func unavailableNewlyUnnamed(a: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)")
-  func unavailableMultiSame(a: Int, b: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(example:another:)")
-  func unavailableMultiUnnamed(_ a: Int, _ b: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)")
-  func unavailableMultiUnnamedSame(_ a: Int, _ b: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)")
-  func unavailableMultiNewlyUnnamed(a: Int, b: Int) // expected-note {{here}}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+  func unavailableArgNames(a: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+  func unavailableArgRenamed(a: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments()") // expected-note {{here}}
+  func unavailableNoArgs()
+  @available(*, unavailable, renamed: "shinyLabeledArguments(a:)") // expected-note {{here}}
+  func unavailableSame(a: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:)") // expected-note {{here}}
+  func unavailableUnnamed(_ a: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)") // expected-note {{here}}
+  func unavailableUnnamedSame(_ a: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:)") // expected-note {{here}}
+  func unavailableNewlyUnnamed(a: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(a:b:)") // expected-note {{here}}
+  func unavailableMultiSame(a: Int, b: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(example:another:)") // expected-note {{here}}
+  func unavailableMultiUnnamed(_ a: Int, _ b: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)") // expected-note {{here}}
+  func unavailableMultiUnnamedSame(_ a: Int, _ b: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(_:_:)") // expected-note {{here}}
+  func unavailableMultiNewlyUnnamed(a: Int, b: Int)
 
-  @available(*, unavailable, renamed: "init(shinyNewName:)")
-  init(unavailableArgNames: Int) // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(a:)")
-  init(_ unavailableUnnamed: Int) // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(_:)")
-  init(unavailableNewlyUnnamed: Int) // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(a:b:)")
-  init(_ unavailableMultiUnnamed: Int, _ b: Int) // expected-note{{here}}
-  @available(*, unavailable, renamed: "init(_:_:)")
-  init(unavailableMultiNewlyUnnamed a: Int, b: Int) // expected-note{{here}}
+  @available(*, unavailable, renamed: "init(shinyNewName:)") // expected-note{{here}}
+  init(unavailableArgNames: Int)
+  @available(*, unavailable, renamed: "init(a:)") // expected-note{{here}}
+  init(_ unavailableUnnamed: Int)
+  @available(*, unavailable, renamed: "init(_:)") // expected-note{{here}}
+  init(unavailableNewlyUnnamed: Int)
+  @available(*, unavailable, renamed: "init(a:b:)") // expected-note{{here}}
+  init(_ unavailableMultiUnnamed: Int, _ b: Int)
+  @available(*, unavailable, renamed: "init(_:_:)") // expected-note{{here}}
+  init(unavailableMultiNewlyUnnamed a: Int, b: Int)
 
-  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)")
-  func unavailableTooFew(a: Int, b: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(x:b:)")
-  func unavailableTooMany(a: Int) // expected-note {{here}}
-  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)")
-  func unavailableNoArgsTooMany() // expected-note {{here}}
+  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)") // expected-note {{here}}
+  func unavailableTooFew(a: Int, b: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(x:b:)") // expected-note {{here}}
+  func unavailableTooMany(a: Int)
+  @available(*, unavailable, renamed: "shinyLabeledArguments(x:)") // expected-note {{here}}
+  func unavailableNoArgsTooMany()
 
-  @available(*, unavailable, renamed: "Base.shinyLabeledArguments()")
-  func unavailableHasType() // expected-note {{here}}
+  @available(*, unavailable, renamed: "Base.shinyLabeledArguments()") // expected-note {{here}}
+  func unavailableHasType()
 }
 
 final class SchnozType : OlfactoryProtocol {
@@ -146,8 +146,8 @@ extension Kitten {
 // Test preventing protocol witnesses for unavailable requirements
 @objc
 protocol ProtocolWithRenamedRequirement {
-  @available(*, unavailable, renamed: "new(bar:)")
-  @objc optional func old(foo: Int) // expected-note{{'old(foo:)' has been explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "new(bar:)") // expected-note{{'old(foo:)' has been explicitly marked unavailable here}}
+  @objc optional func old(foo: Int)
   func new(bar: Int)
 }
 

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -11,7 +11,7 @@ enum Optional<T> {
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9,
               message: "you don't want to do that anyway")
 func doSomething() { }
-// expected-note @-1{{'doSomething()' was obsoleted in macOS 10.9}}
+// expected-note @-3{{'doSomething()' was obsoleted in macOS 10.9}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable in macOS: you don't want to do that anyway}}
 
@@ -19,14 +19,14 @@ doSomething() // expected-error{{'doSomething()' is unavailable in macOS: you do
 // Preservation of major.minor.micro
 @available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9.1)
 func doSomethingElse() { }
-// expected-note @-1{{'doSomethingElse()' was obsoleted in macOS 10.9.1}}
+// expected-note @-2{{'doSomethingElse()' was obsoleted in macOS 10.9.1}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in macOS}}
 
 // Preservation of minor-only version
 @available(OSX, introduced: 8.0, deprecated: 8.5, obsoleted: 10)
 func doSomethingReallyOld() { }
-// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in macOS 10}}
+// expected-note @-2{{'doSomethingReallyOld()' was obsoleted in macOS 10}}
 
 doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable in macOS}}
 
@@ -60,7 +60,7 @@ func functionWithDeprecatedLaterParameter(p: DeprecatedClassIn10_11) { }
 // Unconditional platform unavailability
 @available(OSX, unavailable)
 func doSomethingNotOnOSX() { }
-// expected-note @-1{{'doSomethingNotOnOSX()' has been explicitly marked unavailable here}}
+// expected-note @-2{{'doSomethingNotOnOSX()' has been explicitly marked unavailable here}}
 
 doSomethingNotOnOSX() // expected-error{{'doSomethingNotOnOSX()' is unavailable in macOS}}
 
@@ -85,16 +85,16 @@ struct TestStruct {} // expected-note 2 {{enclosing scope requires availability 
 
 @available(macOS 10.10, *)
 extension TestStruct { // expected-note 2 {{enclosing scope requires availability of macOS 10.10 or newer}}
-  @available(swift 400)
-  func doTheThing() {} // expected-note {{'doTheThing()' was introduced in Swift 400}}
+  @available(swift 400) // expected-note {{'doTheThing()' was introduced in Swift 400}}
+  func doTheThing() {}
 
   @available(macOS 10.9, *) // expected-error {{instance method cannot be more available than enclosing scope}}
-  @available(swift 400)
-  func doAnotherThing() {} // expected-note {{'doAnotherThing()' was introduced in Swift 400}}
+  @available(swift 400) // expected-note {{'doAnotherThing()' was introduced in Swift 400}}
+  func doAnotherThing() {}
 
   @available(macOS 10.12, *)
-  @available(swift 400)
-  func doThirdThing() {} // expected-note {{'doThirdThing()' was introduced in Swift 400}}
+  @available(swift 400) // expected-note {{'doThirdThing()' was introduced in Swift 400}}
+  func doThirdThing() {}
 
   @available(macOS 10.12, *)
   @available(swift 1)
@@ -137,15 +137,15 @@ extension TestStruct {
   }
 
   var unavailableGetter: Data {
-    @available(macOS, unavailable, message: "bad getter")
-    get { return Data() } // expected-note 2 {{here}}
+    @available(macOS, unavailable, message: "bad getter") // expected-note 2 {{here}}
+    get { return Data() }
     set {}
   }
 
   var unavailableSetter: Data {
     get { return Data() }
-    @available(macOS, obsoleted: 10.5, message: "bad setter")
-    set {} // expected-note 2 {{setter for 'unavailableSetter' was obsoleted in macOS 10.5}}
+    @available(macOS, obsoleted: 10.5, message: "bad setter") // expected-note 2 {{setter for 'unavailableSetter' was obsoleted in macOS 10.5}}
+    set {}
   }
 }
 
@@ -162,14 +162,14 @@ func testAccessors() {
 
 // Check available on extensions
 
-@available(macOS, unavailable)
+@available(macOS, unavailable) // expected-note 2 {{'unavailInExtension()' has been explicitly marked unavailable here}}
 extension TestStruct {
-  func unavailInExtension() {} // expected-note 2 {{'unavailInExtension()' has been explicitly marked unavailable here}}
+  func unavailInExtension() {}
 }
 
-@available(macOS, obsoleted: 10.0)
+@available(macOS, obsoleted: 10.0) // expected-note 2 {{'obsoletedInExtension()' was obsoleted in macOS 10.0}}
 extension TestStruct {
-  func obsoletedInExtension() {} // expected-note 2 {{'obsoletedInExtension()' was obsoleted in macOS 10.0}}
+  func obsoletedInExtension() {}
 }
 
 @available(macOS, deprecated: 10.0)
@@ -177,9 +177,9 @@ extension TestStruct {
   func deprecatedInExtension() {}
 }
 
-@available(swift, introduced: 50.0)
+@available(swift, introduced: 50.0) // expected-note 2 {{'introducedInExtensionSwift()' was introduced in Swift 50.0}}
 extension TestStruct {
-  func introducedInExtensionSwift() {} // expected-note 2 {{'introducedInExtensionSwift()' was introduced in Swift 50.0}}
+  func introducedInExtensionSwift() {}
 }
 
 @available(macOS, introduced: 50)

--- a/test/attr/attr_availability_swift_language_mode.swift
+++ b/test/attr/attr_availability_swift_language_mode.swift
@@ -43,13 +43,13 @@ struct TestStruct {}
 
 @available(macOS 10.11, *)
 extension TestStruct {
-  @available(swift 400)
-  func doTheThing() {} // expected-note {{'doTheThing()' was introduced in Swift 400}}
+  @available(swift 400) // expected-note {{'doTheThing()' was introduced in Swift 400}}
+  func doTheThing() {}
 }
 
-@available(swift 400)
+@available(swift 400) // expected-note {{'doAnotherThing()' was introduced in Swift 400}}
 extension TestStruct {
-  func doAnotherThing() {} // expected-note {{'doAnotherThing()' was introduced in Swift 400}}
+  func doAnotherThing() {}
 }
 
 @available(macOS 10.11, *)

--- a/test/attr/attr_availability_swift_v4.swift
+++ b/test/attr/attr_availability_swift_v4.swift
@@ -9,20 +9,20 @@ func swiftShortThreePointOh() {}
 @available(swift, introduced: 3.0)
 func swiftThreePointOh() {}
 
-@available(swift, introduced: 3.0, obsoleted: 4.0)
-func swiftThreePointOhOnly() {} // expected-note {{was obsoleted in Swift 4.0}}
+@available(swift, introduced: 3.0, obsoleted: 4.0) // expected-note {{was obsoleted in Swift 4.0}}
+func swiftThreePointOhOnly() {}
 
 @available(swift, deprecated: 3.0)
 func swiftDeprecatedThreePointOh() {}
 
-@available(swift, obsoleted: 3.0)
-func swiftObsoletedThreePointOh() {} // expected-note {{was obsoleted in Swift 3.0}}
+@available(swift, obsoleted: 3.0) // expected-note {{was obsoleted in Swift 3.0}}
+func swiftObsoletedThreePointOh() {}
 
-@available(swift, introduced: 3.0, obsoleted: 4.0)
-class SwiftThreePointOhOnly {} // expected-note {{was obsoleted in Swift 4.0}}
+@available(swift, introduced: 3.0, obsoleted: 4.0) // expected-note {{was obsoleted in Swift 4.0}}
+class SwiftThreePointOhOnly {}
 
-@available(swift, introduced: 3, obsoleted: 4, message: "uses abc")
-class SwiftThreeOnlyWithMessage {} // expected-note {{was obsoleted in Swift 4}}
+@available(swift, introduced: 3, obsoleted: 4, message: "uses abc") // expected-note {{was obsoleted in Swift 4}}
+class SwiftThreeOnlyWithMessage {}
 
 
 @available(swift 4)

--- a/test/attr/attr_availability_swiftpm_v4.swift
+++ b/test/attr/attr_availability_swiftpm_v4.swift
@@ -6,20 +6,20 @@ func shortThree() {}
 @available(_PackageDescription, introduced: 3.0)
 func threePointOh() {}
 
-@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0)
-func threePointOhOnly() {} // expected-note {{was obsoleted in PackageDescription 4.0}}
+@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0) // expected-note {{was obsoleted in PackageDescription 4.0}}
+func threePointOhOnly() {}
 
 @available(_PackageDescription, deprecated: 3.0)
 func deprecatedThreePointOh() {}
 
-@available(_PackageDescription, obsoleted: 3.0)
-func obsoletedThreePointOh() {} // expected-note {{was obsoleted in PackageDescription 3.0}}
+@available(_PackageDescription, obsoleted: 3.0) // expected-note {{was obsoleted in PackageDescription 3.0}}
+func obsoletedThreePointOh() {}
 
-@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0)
-class ThreePointOhOnly {} // expected-note {{was obsoleted in PackageDescription 4.0}}
+@available(_PackageDescription, introduced: 3.0, obsoleted: 4.0) // expected-note {{was obsoleted in PackageDescription 4.0}}
+class ThreePointOhOnly {}
 
-@available(_PackageDescription, introduced: 3, obsoleted: 4, message: "use abc")
-class ThreeOnlyWithMessage {} // expected-note {{was obsoleted in PackageDescription 4}}
+@available(_PackageDescription, introduced: 3, obsoleted: 4, message: "use abc") // expected-note {{was obsoleted in PackageDescription 4}}
+class ThreeOnlyWithMessage {}
 
 
 @available(_PackageDescription 4)
@@ -37,8 +37,8 @@ func fourPointOh() {}
 @available(_PackageDescription 4)
 class ShortFour {}
 
-@available(_PackageDescription 99)
-func ninetyNine() {} // expected-note {{'ninetyNine()' was introduced in PackageDescription 99}}
+@available(_PackageDescription 99) // expected-note {{'ninetyNine()' was introduced in PackageDescription 99}}
+func ninetyNine() {}
 
 shortThree()
 threePointOh()
@@ -68,15 +68,15 @@ func shouldBeAlone() {}
 @available(_PackageDescription 4.0, swift 2.0, *) // expected-error {{PackageDescription version availability must be specified alone}} // expected-error {{Swift version availability must be specified alone}}
 func shouldBeAlone2() {}
 
-@available(*, unavailable, renamed: "shortFour")
+@available(*, unavailable, renamed: "shortFour") // expected-note {{'unconditionallyRenamed()' has been explicitly marked unavailable here}}
 @available(_PackageDescription 3)
-func unconditionallyRenamed() {} // expected-note {{'unconditionallyRenamed()' has been explicitly marked unavailable here}}
+func unconditionallyRenamed() {}
 
 unconditionallyRenamed() // expected-error {{'unconditionallyRenamed()' has been renamed to 'shortFour'}}
 
-@available(*, unavailable, renamed: "shortFour")
+@available(*, unavailable, renamed: "shortFour") // expected-note {{'unconditionallyRenamedAndIntroducedLater()' has been explicitly marked unavailable here}}
 @available(_PackageDescription 5)
-func unconditionallyRenamedAndIntroducedLater() {} // expected-note {{'unconditionallyRenamedAndIntroducedLater()' has been explicitly marked unavailable here}}
+func unconditionallyRenamedAndIntroducedLater() {}
 
 unconditionallyRenamedAndIntroducedLater() // expected-error {{'unconditionallyRenamedAndIntroducedLater()' has been renamed to 'shortFour'}}
 

--- a/test/attr/attr_availability_transitive.swift
+++ b/test/attr/attr_availability_transitive.swift
@@ -4,14 +4,14 @@
 
 struct AlwaysAvailable {}
 
-@available(*, unavailable)
-struct NeverAvailable {} // expected-note * {{'NeverAvailable' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note * {{'NeverAvailable' has been explicitly marked unavailable here}}
+struct NeverAvailable {}
 
-@available(swift, obsoleted: 4)
-struct UnavailableInSwift4 {} // expected-note * {{'UnavailableInSwift4' was obsoleted in Swift 4}}
+@available(swift, obsoleted: 4) // expected-note * {{'UnavailableInSwift4' was obsoleted in Swift 4}}
+struct UnavailableInSwift4 {}
 
-@available(swift, introduced: 99)
-struct AvailableInFutureSwift {} // expected-note * {{'AvailableInFutureSwift' was introduced in Swift 99}}
+@available(swift, introduced: 99) // expected-note * {{'AvailableInFutureSwift' was introduced in Swift 99}}
+struct AvailableInFutureSwift {}
 
 @available(*, deprecated)
 struct Deprecated {}
@@ -21,21 +21,21 @@ func always() -> AlwaysAvailable {
   AlwaysAvailable()
 }
 
-@available(*, unavailable)
+@available(*, unavailable) // expected-note * {{'never()' has been explicitly marked unavailable here}}
 @discardableResult
-func never() -> NeverAvailable { // expected-note * {{'never()' has been explicitly marked unavailable here}}
+func never() -> NeverAvailable {
   NeverAvailable()
 }
 
-@available(swift, obsoleted: 4)
+@available(swift, obsoleted: 4) // expected-note * {{'unavailableInSwift4()' was obsoleted in Swift 4}}
 @discardableResult
-func unavailableInSwift4() -> UnavailableInSwift4 { // expected-note * {{'unavailableInSwift4()' was obsoleted in Swift 4}}
+func unavailableInSwift4() -> UnavailableInSwift4 {
   UnavailableInSwift4()
 }
 
-@available(swift, introduced: 99)
+@available(swift, introduced: 99) // expected-note * {{'availableInFutureSwift()' was introduced in Swift 99}}
 @discardableResult
-func availableInFutureSwift() -> AvailableInFutureSwift { // expected-note * {{'availableInFutureSwift()' was introduced in Swift 99}}
+func availableInFutureSwift() -> AvailableInFutureSwift {
   AvailableInFutureSwift()
 }
 
@@ -212,8 +212,8 @@ struct AlwaysAvailableContainer {
   // expected-warning@-1 {{'Deprecated' is deprecated}}
 }
 
-@available(*, unavailable)
-struct NeverAvailableContainer { // expected-note * {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note * {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
+struct NeverAvailableContainer {
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   let unavailable_in_swift4_var: UnavailableInSwift4 = unavailableInSwift4() // expected-error {{'unavailableInSwift4()' is unavailable}}
@@ -221,8 +221,8 @@ struct NeverAvailableContainer { // expected-note * {{'NeverAvailableContainer' 
   let deprecated_var: Deprecated = deprecated() // expected-warning {{'deprecated()' is deprecated}}
 }
 
-@available(swift, obsoleted: 4)
-struct UnavailableInSwift4Container { // expected-note * {{'UnavailableInSwift4Container' was obsoleted in Swift 4}}
+@available(swift, obsoleted: 4) // expected-note * {{'UnavailableInSwift4Container' was obsoleted in Swift 4}}
+struct UnavailableInSwift4Container {
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
@@ -231,8 +231,8 @@ struct UnavailableInSwift4Container { // expected-note * {{'UnavailableInSwift4C
   let deprecated_var: Deprecated = deprecated() // expected-warning {{'deprecated()' is deprecated}}
 }
 
-@available(swift, introduced: 99)
-struct AvailableInFutureSwiftContainer { // expected-note * {{'AvailableInFutureSwiftContainer' was introduced in Swift 99}}
+@available(swift, introduced: 99) // expected-note * {{'AvailableInFutureSwiftContainer' was introduced in Swift 99}}
+struct AvailableInFutureSwiftContainer {
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
@@ -309,9 +309,9 @@ struct ExtendMe {}
 
 @available(*, unavailable)
 extension ExtendMe {
-  func never_available_extension_available_method() {} // expected-note * {{has been explicitly marked unavailable here}}
+  func never_available_extension_available_method() {} // expected-note@-2 * {{has been explicitly marked unavailable here}}
 
-  typealias AvailableAliasInNeverAvailableExtension = Self // expected-note * {{'AvailableAliasInNeverAvailableExtension' has been explicitly marked unavailable here}}
+  typealias AvailableAliasInNeverAvailableExtension = Self // expected-note@-4 * {{'AvailableAliasInNeverAvailableExtension' has been explicitly marked unavailable here}}
 
   func never_available_extension_available_method( // expected-note * {{add '@available' attribute to enclosing instance method}}
     _: AlwaysAvailable,
@@ -390,9 +390,9 @@ extension ExtendMe {
 
 @available(swift, obsoleted: 4)
 extension ExtendMe {
-  func unavailable_in_swift4_extension_available_method() {} // expected-note * {{'unavailable_in_swift4_extension_available_method()' was obsoleted in Swift 4}}
+  func unavailable_in_swift4_extension_available_method() {} // expected-note@-2 * {{'unavailable_in_swift4_extension_available_method()' was obsoleted in Swift 4}}
 
-  typealias AvailableAliasInSwift4ObsoletedExtension = Self // expected-note * {{'AvailableAliasInSwift4ObsoletedExtension' was obsoleted in Swift 4}}
+  typealias AvailableAliasInSwift4ObsoletedExtension = Self // expected-note@-4 * {{'AvailableAliasInSwift4ObsoletedExtension' was obsoleted in Swift 4}}
 
   @available(*, unavailable)
   func unavailable_in_swift4_extension_never_available_method(
@@ -412,9 +412,9 @@ extension ExtendMe {
 
 @available(swift, introduced: 99)
 extension ExtendMe {
-  func available_in_future_swift_extension_available_method() {} // expected-note * {{'available_in_future_swift_extension_available_method()' was introduced in Swift 99}}
+  func available_in_future_swift_extension_available_method() {} // expected-note@-2 * {{'available_in_future_swift_extension_available_method()' was introduced in Swift 99}}
 
-  typealias AvailableAliasInSwift99Extension = Self // expected-note * {{'AvailableAliasInSwift99Extension' was introduced in Swift 99}}
+  typealias AvailableAliasInSwift99Extension = Self // expected-note@-4 * {{'AvailableAliasInSwift99Extension' was introduced in Swift 99}}
 
   @available(*, unavailable)
   func available_in_future_swift_extension_never_available_method(

--- a/test/attr/attr_availability_transitive_ios.swift
+++ b/test/attr/attr_availability_transitive_ios.swift
@@ -2,8 +2,8 @@
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
-@available(iOS, unavailable)
-func ios() {} // expected-note 2{{'ios()' has been explicitly marked unavailable here}}
+@available(iOS, unavailable) // expected-note 2{{'ios()' has been explicitly marked unavailable here}}
+func ios() {}
 
 @available(iOSApplicationExtension, unavailable)
 func ios_extension() {}

--- a/test/attr/attr_availability_transitive_ios_appext.swift
+++ b/test/attr/attr_availability_transitive_ios_appext.swift
@@ -3,11 +3,11 @@
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
-@available(iOS, unavailable)
-func ios() {} // expected-note {{'ios()' has been explicitly marked unavailable here}}
+@available(iOS, unavailable) // expected-note {{'ios()' has been explicitly marked unavailable here}}
+func ios() {}
 
-@available(iOSApplicationExtension, unavailable)
-func ios_extension() {} // expected-note {{'ios_extension()' has been explicitly marked unavailable here}}
+@available(iOSApplicationExtension, unavailable) // expected-note {{'ios_extension()' has been explicitly marked unavailable here}}
+func ios_extension() {}
 
 func call_ios_extension() {
     ios_extension() // expected-error {{'ios_extension()' is unavailable}}

--- a/test/attr/attr_availability_transitive_nested.swift
+++ b/test/attr/attr_availability_transitive_nested.swift
@@ -4,8 +4,8 @@
 
 @available(iOS, unavailable)
 class Outer {
-  @available(*, unavailable)
-  func completelyBadMethod() {} // expected-note {{'completelyBadMethod()' has been explicitly marked unavailable here}}
+  @available(*, unavailable) // expected-note {{'completelyBadMethod()' has been explicitly marked unavailable here}}
+  func completelyBadMethod() {}
 }
 
 @available(iOS, unavailable)
@@ -13,8 +13,8 @@ func test(outer: Outer) {
   outer.completelyBadMethod() // expected-error {{'completelyBadMethod()' is unavailable}}
 }
 
-@available(*, unavailable)
-class Outer2 { // expected-note {{'Outer2' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{'Outer2' has been explicitly marked unavailable here}}
+class Outer2 {
 	@available(iOS, unavailable)
     func innerUnavailable() {}
 }

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -4,8 +4,8 @@
 
 struct AlwaysAvailable {}
 
-@available(*, unavailable)
-struct NeverAvailable {} // expected-note * {{'NeverAvailable' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note * {{'NeverAvailable' has been explicitly marked unavailable here}}
+struct NeverAvailable {}
 
 @available(OSX 99, *)
 struct OSXFutureAvailable {}
@@ -13,12 +13,12 @@ struct OSXFutureAvailable {}
 @available(anyAppleOS 99, *)
 struct AnyAppleOSFutureAvailable {}
 
-@available(OSX, unavailable)
-struct OSXUnavailable {} // expected-note * {{'OSXUnavailable' has been explicitly marked unavailable here}}
+@available(OSX, unavailable) // expected-note * {{'OSXUnavailable' has been explicitly marked unavailable here}}
+struct OSXUnavailable {}
 
 @available(iOS, unavailable)
-@available(OSX, unavailable)
-struct MultiPlatformUnavailable {} // expected-note * {{'MultiPlatformUnavailable' has been explicitly marked unavailable here}}
+@available(OSX, unavailable) // expected-note * {{'MultiPlatformUnavailable' has been explicitly marked unavailable here}}
+struct MultiPlatformUnavailable {}
 
 @available(OSXApplicationExtension, unavailable)
 struct OSXAppExtensionsUnavailable {}
@@ -28,9 +28,9 @@ func always() -> AlwaysAvailable {
   AlwaysAvailable()
 }
 
-@available(*, unavailable)
+@available(*, unavailable) // expected-note * {{'never()' has been explicitly marked unavailable here}}
 @discardableResult
-func never() -> NeverAvailable { // expected-note * {{'never()' has been explicitly marked unavailable here}}
+func never() -> NeverAvailable {
   NeverAvailable()
 }
 
@@ -46,16 +46,16 @@ func any_apple_os_future() -> AnyAppleOSFutureAvailable {
   AnyAppleOSFutureAvailable()
 }
 
-@available(OSX, unavailable)
+@available(OSX, unavailable) // expected-note * {{'osx()' has been explicitly marked unavailable here}}
 @discardableResult
-func osx() -> OSXUnavailable { // expected-note * {{'osx()' has been explicitly marked unavailable here}}
+func osx() -> OSXUnavailable {
   OSXUnavailable()
 }
 
 @available(iOS, unavailable)
-@available(OSX, unavailable)
+@available(OSX, unavailable) // expected-note * {{'osx_ios()' has been explicitly marked unavailable here}}
 @discardableResult
-func osx_ios() -> MultiPlatformUnavailable { // expected-note * {{'osx_ios()' has been explicitly marked unavailable here}}
+func osx_ios() -> MultiPlatformUnavailable {
   MultiPlatformUnavailable()
 }
 
@@ -240,8 +240,8 @@ struct AlwaysAvailableContainer { // expected-note 4 {{add '@available' attribut
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
-@available(*, unavailable)
-struct NeverAvailableContainer { // expected-note 3 {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note 3 {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
+struct NeverAvailableContainer {
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   let osx_future_var: OSXFutureAvailable = osx_future()
@@ -251,8 +251,8 @@ struct NeverAvailableContainer { // expected-note 3 {{'NeverAvailableContainer' 
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
-@available(OSX, unavailable)
-struct OSXUnavailableContainer { // expected-note 2 {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
+@available(OSX, unavailable) // expected-note 2 {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
+struct OSXUnavailableContainer {
   let always_var: AlwaysAvailable = always()
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
@@ -317,10 +317,10 @@ struct ExtendMe {}
 
 @available(*, unavailable)
 extension ExtendMe {
-  func never_available_extension_available_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func never_available_extension_available_method() {} // expected-note@-2 {{has been explicitly marked unavailable here}}
 
   @available(OSX 99, *)
-  func never_available_extension_osx_future_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func never_available_extension_osx_future_method() {} // expected-note@-5 {{has been explicitly marked unavailable here}}
 
   func never_available_extension_available_method( // expected-note * {{add '@available' attribute to enclosing instance method}}
     _: AlwaysAvailable,
@@ -400,10 +400,10 @@ extension ExtendMe {
 
 @available(OSX, unavailable)
 extension ExtendMe {
-  func osx_extension_available_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func osx_extension_available_method() {} // expected-note@-2 {{has been explicitly marked unavailable here}}
 
   @available(OSX 99, *)
-  func osx_extension_osx_future_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func osx_extension_osx_future_method() {} // expected-note@-5 {{has been explicitly marked unavailable here}}
 
   func osx_extension_available_method( // expected-note * {{add '@available' attribute to enclosing instance method}}
     _: AlwaysAvailable,

--- a/test/attr/attr_availability_transitive_osx_appext.swift
+++ b/test/attr/attr_availability_transitive_osx_appext.swift
@@ -2,30 +2,30 @@
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
-@available(*, unavailable)
-struct NeverAvailable {} // expected-note * {{'NeverAvailable' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note * {{'NeverAvailable' has been explicitly marked unavailable here}}
+struct NeverAvailable {}
 
-@available(OSX, unavailable)
-struct OSXUnavailable {} // expected-note * {{'OSXUnavailable' has been explicitly marked unavailable here}}
+@available(OSX, unavailable) // expected-note * {{'OSXUnavailable' has been explicitly marked unavailable here}}
+struct OSXUnavailable {}
 
-@available(OSXApplicationExtension, unavailable)
-struct OSXAppExtensionsUnavailable {} // expected-note * {{'OSXAppExtensionsUnavailable' has been explicitly marked unavailable here}}
+@available(OSXApplicationExtension, unavailable) // expected-note * {{'OSXAppExtensionsUnavailable' has been explicitly marked unavailable here}}
+struct OSXAppExtensionsUnavailable {}
 
-@available(*, unavailable)
+@available(*, unavailable) // expected-note * {{'never()' has been explicitly marked unavailable here}}
 @discardableResult
-func never() -> NeverAvailable { // expected-note * {{'never()' has been explicitly marked unavailable here}}
+func never() -> NeverAvailable {
   NeverAvailable()
 }
 
-@available(OSX, unavailable)
+@available(OSX, unavailable) // expected-note * {{'osx()' has been explicitly marked unavailable here}}
 @discardableResult
-func osx() -> OSXUnavailable { // expected-note * {{'osx()' has been explicitly marked unavailable here}}
+func osx() -> OSXUnavailable {
   OSXUnavailable()
 }
 
-@available(OSXApplicationExtension, unavailable)
+@available(OSXApplicationExtension, unavailable) // expected-note * {{'osx_extension()' has been explicitly marked unavailable here}}
 @discardableResult
-func osx_extension() -> OSXAppExtensionsUnavailable { // expected-note * {{'osx_extension()' has been explicitly marked unavailable here}}
+func osx_extension() -> OSXAppExtensionsUnavailable {
   OSXAppExtensionsUnavailable()
 }
 
@@ -130,23 +130,23 @@ struct AlwaysAvailabileContainer {
   // expected-error@-1 {{'OSXAppExtensionsUnavailable' is unavailable in application extensions for macOS}}
 }
 
-@available(*, unavailable)
-struct NeverAvailableContainer { // expected-note 3 {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note 3 {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
+struct NeverAvailableContainer {
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   let osx_var: OSXUnavailable = osx()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
-@available(OSX, unavailable)
-struct OSXUnavailableContainer { // expected-note {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
+@available(OSX, unavailable) // expected-note {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
+struct OSXUnavailableContainer {
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let osx_var: OSXUnavailable = osx()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
 }
 
-@available(OSXApplicationExtension, unavailable)
-struct OSXAppExtensionsUnavailableContainer { // expected-note {{'OSXAppExtensionsUnavailableContainer' has been explicitly marked unavailable here}}
+@available(OSXApplicationExtension, unavailable) // expected-note {{'OSXAppExtensionsUnavailableContainer' has been explicitly marked unavailable here}}
+struct OSXAppExtensionsUnavailableContainer {
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let osx_var: OSXUnavailable = osx()
@@ -191,10 +191,10 @@ struct ExtendMe {}
 
 @available(*, unavailable)
 extension ExtendMe {
-  func never_available_extension_available_method() {} // expected-note 3 {{has been explicitly marked unavailable here}}
+  func never_available_extension_available_method() {} // expected-note@-2 3 {{has been explicitly marked unavailable here}}
 
   @available(OSX 99, *)
-  func never_available_extension_osx_future_method() {} // expected-note 3 {{has been explicitly marked unavailable here}}
+  func never_available_extension_osx_future_method() {} // expected-note@-5 3 {{has been explicitly marked unavailable here}}
 
   func never_available_extension_available_method(
     _: NeverAvailable,
@@ -242,19 +242,19 @@ extension ExtendMe {
 
 @available(OSX, unavailable)
 extension ExtendMe {
-  func osx_extension_available_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func osx_extension_available_method() {} // expected-note@-2 {{'osx_extension_available_method()' has been explicitly marked unavailable here}}
 
   @available(OSX 99, *)
-  func osx_extension_osx_future_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func osx_extension_osx_future_method() {} // expected-note@-5 {{'osx_extension_osx_future_method()' has been explicitly marked unavailable here}}
 
-  @available(*, unavailable)
-  func osx_extension_never_available_method() {} // expected-note 3 {{'osx_extension_never_available_method()' has been explicitly marked unavailable here}}
+  @available(*, unavailable) // expected-note 2 {{'osx_extension_never_available_method()' has been explicitly marked unavailable here}}
+  func osx_extension_never_available_method() {} // expected-note@-8 {{'osx_extension_never_available_method()' has been explicitly marked unavailable here}}
 
-  @available(OSX, unavailable)
-  func osx_extension_osx_method() {} // expected-note {{'osx_extension_osx_method()' has been explicitly marked unavailable here}}
+  @available(OSX, unavailable) // expected-note {{'osx_extension_osx_method()' has been explicitly marked unavailable here}}
+  func osx_extension_osx_method() {}
 
-  @available(OSXApplicationExtension, unavailable)
-  func osx_extension_osx_app_extension_method() {} // expected-note {{'osx_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
+  @available(OSXApplicationExtension, unavailable) // expected-note {{'osx_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
+  func osx_extension_osx_app_extension_method() {}
 
   func osx_extension_available_method(
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
@@ -302,19 +302,19 @@ extension ExtendMe {
 
 @available(OSXApplicationExtension, unavailable)
 extension ExtendMe {
-  func osx_app_extension_extension_available_method() {} // expected-note {{'osx_app_extension_extension_available_method()' has been explicitly marked unavailable here}}
+  func osx_app_extension_extension_available_method() {} // expected-note@-2 {{'osx_app_extension_extension_available_method()' has been explicitly marked unavailable here}}
 
   @available(OSX 99, *)
-  func osx_app_extension_extension_osx_future_method() {} // expected-note {{'osx_app_extension_extension_osx_future_method()'}}
+  func osx_app_extension_extension_osx_future_method() {} // expected-note@-5 {{'osx_app_extension_extension_osx_future_method()'}}
 
-  @available(*, unavailable)
-  func osx_app_extension_extension_never_available_method() {} // expected-note 3 {{'osx_app_extension_extension_never_available_method()' has been explicitly marked unavailable here}}
+  @available(*, unavailable) // expected-note 2 {{'osx_app_extension_extension_never_available_method()' has been explicitly marked unavailable here}}
+  func osx_app_extension_extension_never_available_method() {} // expected-note@-8 {{'osx_app_extension_extension_never_available_method()' has been explicitly marked unavailable here}}
 
   @available(OSX, unavailable)
-  func osx_app_extension_extension_osx_method() {} // expected-note {{'osx_app_extension_extension_osx_method()' has been explicitly marked unavailable here}}
+  func osx_app_extension_extension_osx_method() {} // expected-note@-11 {{'osx_app_extension_extension_osx_method()' has been explicitly marked unavailable here}}
 
-  @available(OSXApplicationExtension, unavailable)
-  func osx_app_extension_extension_osx_app_extension_method() {} // expected-note {{'osx_app_extension_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
+  @available(OSXApplicationExtension, unavailable) // expected-note {{'osx_app_extension_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
+  func osx_app_extension_extension_osx_app_extension_method() {}
 
   func osx_app_extension_extension_available_method(
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}

--- a/test/attr/attr_availability_tvos.swift
+++ b/test/attr/attr_availability_tvos.swift
@@ -3,21 +3,21 @@
 @available(tvOS, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
               message: "you don't want to do that anyway")
 func doSomething() { }
-// expected-note @-1{{'doSomething()' was obsoleted in tvOS 9.0}}
+// expected-note @-3{{'doSomething()' was obsoleted in tvOS 9.0}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable in tvOS: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
 @available(tvOS, introduced: 1.0, deprecated: 2.0, obsoleted: 8.0)
 func doSomethingElse() { }
-// expected-note @-1{{'doSomethingElse()' was obsoleted in tvOS 8.0}}
+// expected-note @-2{{'doSomethingElse()' was obsoleted in tvOS 8.0}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in tvOS}}
 
 // Preservation of minor-only version
 @available(tvOS, introduced: 1.0, deprecated: 1.5, obsoleted: 9)
 func doSomethingReallyOld() { }
-// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in tvOS 9}}
+// expected-note @-2{{'doSomethingReallyOld()' was obsoleted in tvOS 9}}
 
 doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable in tvOS}}
 

--- a/test/attr/attr_availability_vision.swift
+++ b/test/attr/attr_availability_vision.swift
@@ -3,21 +3,21 @@
 @available(visionOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2.0,
            message: "you don't want to do that anyway")
 public func doSomething() { }
-// expected-note @-1{{'doSomething()' was obsoleted in visionOS 2.0}}
+// expected-note @-3{{'doSomething()' was obsoleted in visionOS 2.0}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable in visionOS: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
 @available(visionOS, introduced: 1.0, deprecated: 1.5, obsoleted: 1.5.3)
 func doSomethingElse() { }
-// expected-note @-1{{'doSomethingElse()' was obsoleted in visionOS 1.5.3}}
+// expected-note @-2{{'doSomethingElse()' was obsoleted in visionOS 1.5.3}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in visionOS}}
 
 // Preservation of minor-only version
 @available(visionOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2)
 func doSomethingReallyOld() { }
-// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in visionOS 2}}
+// expected-note @-2{{'doSomethingReallyOld()' was obsoleted in visionOS 2}}
 
 doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable in visionOS}}
 

--- a/test/attr/attr_availability_watchos.swift
+++ b/test/attr/attr_availability_watchos.swift
@@ -3,21 +3,21 @@
 @available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2.0,
               message: "you don't want to do that anyway")
 func doSomething() { }
-// expected-note @-1{{'doSomething()' was obsoleted in watchOS 2.0}}
+// expected-note @-3{{'doSomething()' was obsoleted in watchOS 2.0}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable in watchOS: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
 @available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 1.5.3)
 func doSomethingElse() { }
-// expected-note @-1{{'doSomethingElse()' was obsoleted in watchOS 1.5.3}}
+// expected-note @-2{{'doSomethingElse()' was obsoleted in watchOS 1.5.3}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in watchOS}}
 
 // Preservation of minor-only version
 @available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2)
 func doSomethingReallyOld() { }
-// expected-note @-1{{'doSomethingReallyOld()' was obsoleted in watchOS 2}}
+// expected-note @-2{{'doSomethingReallyOld()' was obsoleted in watchOS 2}}
 
 doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailable in watchOS}}
 

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -227,8 +227,8 @@ struct S7 : P7 {
 protocol P8 {
   associatedtype B
 
-  @available(*, unavailable, renamed: "B")
-  typealias A = B // expected-note{{'A' has been explicitly marked unavailable here}}
+  @available(*, unavailable, renamed: "B") // expected-note{{'A' has been explicitly marked unavailable here}}
+  typealias A = B
 }
 
 func testP8<T: P8>(_: T) where T.A == Int { } // expected-error{{'A' has been renamed to 'B'}}{{34-35=B}}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -960,8 +960,8 @@ struct Observable<Value> {
     self.stored = wrappedValue
   }
 
-  @available(*, unavailable, message: "must be in a class")
-  var wrappedValue: Value { // expected-note 2{{'wrappedValue' has been explicitly marked unavailable here}}
+  @available(*, unavailable, message: "must be in a class") // expected-note 2{{'wrappedValue' has been explicitly marked unavailable here}}
+  var wrappedValue: Value {
     get { fatalError("called wrappedValue getter") }
     set { fatalError("called wrappedValue setter") }
   }

--- a/test/decl/var/result_builders_availability.swift
+++ b/test/decl/var/result_builders_availability.swift
@@ -85,8 +85,8 @@ tuplify(true) { x in
   // expected-note@-1{{add 'if #available' version check}}
 }
 
-@available(*, unavailable)
-func unavailableFunc(_ x: Bool) -> Bool {} // expected-note {{'unavailableFunc' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note {{'unavailableFunc' has been explicitly marked unavailable here}}
+func unavailableFunc(_ x: Bool) -> Bool {}
 
 // https://github.com/apple/swift/issues/55700
 // Availability checking not working in the 'where' clause of a 'for' loop

--- a/test/diagnostics/highlights.swift
+++ b/test/diagnostics/highlights.swift
@@ -35,24 +35,34 @@ func outOfOrderArguments() { labeled(b: 1, a: 2) }
 
 @unsafe @safe func safeAndUnsafe() {}
 
-@available(*, unavailable) func unavailableFn() {}
+@available(*, unavailable)
+func unavailableFn() {}
+
 func useUnavailable() { unavailableFn() }
 
-@available(swift, obsoleted: 3.0) func obsoletedFn() {}
+@available(swift, obsoleted: 3.0)
+func obsoletedFn() {}
+
 func useObsoleted() { obsoletedFn() }
 
-@available(swift, introduced: 99) func unintroducedFn() {}
+@available(swift, introduced: 99)
+func unintroducedFn() {}
+
 func useUnintroduced() { unintroducedFn() }
 
 protocol P {}
 func requiresP<T: P>(_ t: T) {}
 
 struct Unavail {}
-@available(*, unavailable) extension Unavail: P {}
+@available(*, unavailable)
+extension Unavail: P {}
+
 func useUnavailableConformance(v: Unavail) { requiresP(v) }
 
 struct Obs {}
-@available(swift, obsoleted: 3.0) extension Obs: P {}
+@available(swift, obsoleted: 3.0)
+extension Obs: P {}
+
 func useObsoletedConformance(v: Obs) { requiresP(v) }
 
 // CHECK:      error: result builder attributes cannot have arguments
@@ -108,37 +118,37 @@ func useObsoletedConformance(v: Obs) { requiresP(v) }
 // CHECK-NEXT: {{^}}                        ^~~~~~~~~~~~~{{$}}
 
 // CHECK:      note: 'unavailableFn()' has been explicitly marked unavailable here
-// CHECK-NEXT: {{^}}@available(*, unavailable) func unavailableFn() {}
-// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~      ^{{$}}
+// CHECK-NEXT: {{^}}@available(*, unavailable)
+// CHECK-NEXT: {{^}}^~~~~~~~~~~~~~~~~~~~~~~~~~{{$}}
 
 // CHECK:      error: 'obsoletedFn()' is unavailable
 // CHECK-NEXT: {{^}}func useObsoleted() { obsoletedFn() }
 // CHECK-NEXT: {{^}}                      ^~~~~~~~~~~{{$}}
 
 // CHECK:      note: 'obsoletedFn()' was obsoleted in Swift 3.0
-// CHECK-NEXT: {{^}}@available(swift, obsoleted: 3.0) func obsoletedFn() {}
-// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      ^{{$}}
+// CHECK-NEXT: {{^}}@available(swift, obsoleted: 3.0)
+// CHECK-NEXT: {{^}}^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{{$}}
 
 // CHECK:      error: 'unintroducedFn()' is unavailable in Swift
 // CHECK-NEXT: {{^}}func useUnintroduced() { unintroducedFn() }
 // CHECK-NEXT: {{^}}                         ^~~~~~~~~~~~~~{{$}}
 
 // CHECK:      note: 'unintroducedFn()' was introduced in Swift 99
-// CHECK-NEXT: {{^}}@available(swift, introduced: 99) func unintroducedFn() {}
-// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      ^{{$}}
+// CHECK-NEXT: {{^}}@available(swift, introduced: 99)
+// CHECK-NEXT: {{^}}^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{{$}}
 
 // CHECK:      error: conformance of 'Unavail' to 'P' is unavailable
 // CHECK-NEXT: {{^}}func useUnavailableConformance(v: Unavail) { requiresP(v) }
 // CHECK-NEXT: {{^}}                                             ^{{$}}
 
 // CHECK:      note: conformance of 'Unavail' to 'P' has been explicitly marked unavailable here
-// CHECK-NEXT: {{^}}@available(*, unavailable) extension Unavail: P {}
-// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~ ^{{$}}
+// CHECK-NEXT: {{^}}@available(*, unavailable)
+// CHECK-NEXT: {{^}}^~~~~~~~~~~~~~~~~~~~~~~~~~{{$}}
 
 // CHECK:      error: conformance of 'Obs' to 'P' is unavailable
 // CHECK-NEXT: {{^}}func useObsoletedConformance(v: Obs) { requiresP(v) }
 // CHECK-NEXT: {{^}}                                       ^{{$}}
 
 // CHECK:      note: conformance of 'Obs' to 'P' was obsoleted in Swift 3.0
-// CHECK-NEXT: {{^}}@available(swift, obsoleted: 3.0) extension Obs: P {}
-// CHECK-NEXT: {{^}}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^{{$}}
+// CHECK-NEXT: {{^}}@available(swift, obsoleted: 3.0)
+// CHECK-NEXT: {{^}}^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{{$}}

--- a/test/embedded/availability.swift
+++ b/test/embedded/availability.swift
@@ -4,19 +4,19 @@
 
 @_unavailableInEmbedded
 public struct UnavailableInEmbedded {}
-// expected-note@-1 {{'UnavailableInEmbedded' has been explicitly marked unavailable here}}
+// expected-note@-2 {{'UnavailableInEmbedded' has been explicitly marked unavailable here}}
 
 @available(*, unavailable, message: "always unavailable")
 public struct UniverallyUnavailable {}
-// expected-note@-1 3 {{'UniverallyUnavailable' has been explicitly marked unavailable here}}
+// expected-note@-2 3 {{'UniverallyUnavailable' has been explicitly marked unavailable here}}
 
 @_unavailableInEmbedded
 public func unavailable_in_embedded() { }
-// expected-note@-1 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
+// expected-note@-2 {{'unavailable_in_embedded()' has been explicitly marked unavailable here}}
 
 @available(*, unavailable, message: "always unavailable")
 public func universally_unavailable() { }
-// expected-note@-1 4 {{'universally_unavailable()' has been explicitly marked unavailable here}}
+// expected-note@-2 4 {{'universally_unavailable()' has been explicitly marked unavailable here}}
 
 @_unavailableInEmbedded
 public func unused() { } // no error
@@ -36,9 +36,9 @@ public func has_universally_unavailable_overload(_ s2: S2) { }
 
 public struct Available {}
 
-@_unavailableInEmbedded
+@_unavailableInEmbedded // expected-note {{'unavailable_in_embedded_method' has been explicitly marked unavailable here}}
 extension Available {
-  public func unavailable_in_embedded_method( // expected-note {{'unavailable_in_embedded_method' has been explicitly marked unavailable here}}
+  public func unavailable_in_embedded_method(
     _ uie: UnavailableInEmbedded,
     _ uu: UniverallyUnavailable, // expected-error {{'UniverallyUnavailable' is unavailable: always unavailable}}
     _ a: Available,

--- a/test/expr/unary/keypath/keypath-availability.swift
+++ b/test/expr/unary/keypath/keypath-availability.swift
@@ -19,8 +19,8 @@ struct Butt {
   var setter_universally_unavailable: Int {
     get { fatalError() }
 
-    @available(*, unavailable)
-    set { fatalError() } // expected-note 2 {{setter for 'setter_universally_unavailable' has been explicitly marked unavailable here}}
+    @available(*, unavailable) // expected-note 2 {{setter for 'setter_universally_unavailable' has been explicitly marked unavailable here}}
+    set { fatalError() }
   }
 }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -50,11 +50,11 @@ struct C<T> { // expected-note 4 {{'T' declared as parameter to type 'C'}}
 struct Unavailable {
   @available(*, unavailable)
   var unavailableProperty: Int { 0 }
-  // expected-note@-1 {{'unavailableProperty' has been explicitly marked unavailable here}}
+  // expected-note@-2 {{'unavailableProperty' has been explicitly marked unavailable here}}
 
   @available(*, unavailable)
   subscript(x: Sub) -> Int { get { } set { } }
-  // expected-note@-1 {{'subscript(_:)' has been explicitly marked unavailable here}}
+  // expected-note@-2 {{'subscript(_:)' has been explicitly marked unavailable here}}
 }
 
 struct Deprecated {
@@ -598,8 +598,8 @@ func useUnambiguousSubscript(_ sub: Sub) {
 }
 
 struct BothUnavailableSubscript {
-  @available(*, unavailable)
-  subscript(sub: Sub) -> Int { get { } set { } } // expected-note {{'subscript(_:)' has been explicitly marked unavailable here}}
+  @available(*, unavailable) // expected-note {{'subscript(_:)' has been explicitly marked unavailable here}}
+  subscript(sub: Sub) -> Int { get { } set { } }
 
   @available(*, unavailable)
   subscript(y y: Sub) -> Int { get { } set { } }

--- a/test/type/opaque_availability.swift
+++ b/test/type/opaque_availability.swift
@@ -12,8 +12,8 @@ func sometimesOpaque() -> some P { return X() }
 
 struct NeverConformsToP {}
 
-@available(*, unavailable)
-extension NeverConformsToP: P {} // expected-note 2 {{conformance of 'NeverConformsToP' to 'P' has been explicitly marked unavailable here}}
+@available(*, unavailable) // expected-note 2 {{conformance of 'NeverConformsToP' to 'P' has been explicitly marked unavailable here}}
+extension NeverConformsToP: P {}
 
 @available(SwiftStdlib 5.1, *)
 struct Outer {
@@ -34,8 +34,8 @@ struct Outer {
 
 struct ConformsToPExeceptOnMacOS {}
 
-@available(macOS, unavailable)
-extension ConformsToPExeceptOnMacOS: P {} // expected-note {{conformance of 'ConformsToPExeceptOnMacOS' to 'P' has been explicitly marked unavailable here}}
+@available(macOS, unavailable) // expected-note {{conformance of 'ConformsToPExeceptOnMacOS' to 'P' has been explicitly marked unavailable here}}
+extension ConformsToPExeceptOnMacOS: P {}
 
 @available(SwiftStdlib 5.1, *)
 extension Outer {


### PR DESCRIPTION
Previously, the compiler would emit a note pointing to the unavailable declaration and highlight the range of the attribute that makes the decl unavailable. Unfortunately the highlight is rarely rendered because most frontends only show highlights that are on the same line as the location pointed to by the diagnostic and `@available` is not usually written on the same line as the declaration it is attached to. Switch to pointing to the attribute itself so that this crucial information is always rendered.