### PR TITLE
AST: Fix availability scope for a macro expansion in an `if #available` region

### DIFF
--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -73,21 +73,24 @@ AvailabilityScope::createForSourceFile(SourceFile *SF,
       auto charRange = Ctx.SourceMgr.getRangeForBuffer(SF->getBufferID());
       range = SourceRange(charRange.getStart(), charRange.getEnd());
 
+      auto originalNode = SF->getNodeInEnclosingSourceFile();
+      SourceLoc lookupLoc = originalNode.getStartLoc();
+
       // For peer, conformance, and extension macros, the expansion is a
       // sibling of the attached declaration rather than nested inside it.
       // The expansion should therefore inherit availability from the
-      // enclosing context, not from the attached declaration. Locate the
-      // parent scope using the buffer's logical declaration context instead
-      // of the attached node's source location.
-      SourceLoc lookupLoc;
+      // enclosing context, not from the attached declaration, so ignore the
+      // scopes that the attached declaration introduces when looking up the
+      // parent scope.
+      ASTNode stopAtNode;
       if (auto role = SF->getFulfilledMacroRole()) {
         switch (*role) {
         case MacroRole::Peer:
         case MacroRole::Conformance:
         case MacroRole::Extension:
-          if (auto *dcDecl =
-                  SF->getGeneratedSourceFileInfo()->declContext->getAsDecl())
-            lookupLoc = dcDecl->getStartLoc();
+          if (auto *attachedDecl = originalNode.dyn_cast<Decl *>())
+            stopAtNode = const_cast<Decl *>(
+                attachedDecl->getConcreteSyntaxDeclForAttributes());
           break;
         case MacroRole::Expression:
         case MacroRole::Declaration:
@@ -97,17 +100,14 @@ AvailabilityScope::createForSourceFile(SourceFile *SF,
         case MacroRole::Member:
         case MacroRole::Body:
         case MacroRole::Preamble:
-          lookupLoc = SF->getNodeInEnclosingSourceFile().getStartLoc();
           break;
         }
-      } else {
-        lookupLoc = SF->getNodeInEnclosingSourceFile().getStartLoc();
       }
 
-      parentContext =
-          lookupLoc.isValid()
-              ? parentScope->findMostRefinedSubContext(lookupLoc, Ctx)
-              : parentScope;
+      parentContext = lookupLoc.isValid()
+                          ? parentScope->findMostRefinedSubContext(
+                                lookupLoc, Ctx, stopAtNode)
+                          : parentScope;
     }
     break;
   }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -821,6 +821,26 @@ public struct PeerMethodThatCallsCodeMacro: PeerMacro {
   }
 }
 
+public struct PeerFuncThatCallsCodeMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard case let .argumentList(arguments) = node.arguments else {
+      throw CustomError.message("Macro requires a string literal")
+    }
+    let codeString = try extractCodeStringArgument(arguments)
+    return [
+      """
+      func synthesizedPeerFunc() {
+        \(raw: codeString)
+      }
+      """,
+    ]
+  }
+}
+
 public struct GetterThatCallsCodeMacro: AccessorMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_availability_macosx.swift
+++ b/test/Macros/macro_availability_macosx.swift
@@ -24,6 +24,9 @@ macro MemberThatCallsCode(_ codeString: String) = #externalMacro(module: "MacroD
 @attached(peer, names: arbitrary)
 macro PeerMethodThatCallsCode(_ codeString: String) = #externalMacro(module: "MacroDefinition", type: "PeerMethodThatCallsCodeMacro")
 
+@attached(peer, names: arbitrary)
+macro PeerFuncThatCallsCode(_ codeString: String) = #externalMacro(module: "MacroDefinition", type: "PeerFuncThatCallsCodeMacro")
+
 @attached(accessor)
 macro GetterThatCallsCode(_ codeString: String) = #externalMacro(module: "MacroDefinition", type: "GetterThatCallsCodeMacro")
 
@@ -160,3 +163,30 @@ expected-expansion@-2:32{{
   expected-note@3:5 {{add 'if #available' version check}}
 }}
 */
+
+func hasLocalDeclsWithPeers() {
+  // expected-note@-1 {{add '@available' attribute to enclosing global function}}
+  if #available(macOS 12.0, *) {
+    @PeerFuncThatCallsCode("onlyInMacOS12()")
+    func gatedLocalFunc() {}
+    gatedLocalFunc()
+  }
+
+  @PeerFuncThatCallsCode("onlyInMacOS12()")
+  // expected-note@-1 2{{in expansion of macro 'PeerFuncThatCallsCode' on local function 'ungatedLocalFunc()' here}}
+  func ungatedLocalFunc() {}
+  /*
+  expected-expansion@-2:29{{
+    expected-error@2:3 {{'onlyInMacOS12()' is only available in macOS 12.0 or newer}}
+    expected-note@2:3 {{add 'if #available' version check}}
+  }}
+  */
+  ungatedLocalFunc()
+}
+
+func hasLocalDeclWithPeerInGuardFallthrough() {
+  guard #available(macOS 12.0, *) else { return }
+  @PeerFuncThatCallsCode("onlyInMacOS12()")
+  func gatedLocalFunc() {}
+  gatedLocalFunc()
+}


### PR DESCRIPTION
When searching for the availability scope that contains the peer macro expansion, stop at the scope representing the decl that the peer macro is attached to. Previously, the availability scope for the expansion could be nested inside the scope for the decl with the macro attached.

Resolves rdar://184167341.
