### PR TITLE
Sema: Emit deprecation diagnostics with re-mapped versions and domains

### DIFF
--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -86,8 +86,9 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
   // FIXME: Code completion doesn't offer accessors. It only emits 'VarDecl's.
   // So getter/setter specific availability doesn't work in code completion.
 
-  auto Domain = Attr.getDomain();
-  auto DeprecatedRange = Attr.getDeprecatedRange(Ctx).value();
+  auto DomainAndRange = Attr.getDeprecatedDomainAndRange(Ctx).value();
+  auto Domain = DomainAndRange.getDomain();
+  auto DeprecatedRange = DomainAndRange.getRange();
   auto Message = Attr.getMessage();
   auto NewName = Attr.getRename();
   if (!isSoftDeprecated) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1702,8 +1702,9 @@ static void diagnoseIfDeprecated(SourceRange referenceRange,
   auto &ctx = referenceDC->getASTContext();
 
   auto attr = restriction.getAttr();
-  auto domain = attr.getDomain();
-  auto deprecatedRange = attr.getDeprecatedRange(ctx).value();
+  auto domainAndRange = restriction.getDomainAndRange(ctx);
+  auto domain = domainAndRange.getDomain();
+  auto deprecatedRange = domainAndRange.getRange();
   auto message = attr.getMessage();
   auto rawRename = attr.getRename();
   if (message.empty() && rawRename.empty()) {
@@ -1766,8 +1767,9 @@ static bool diagnoseIfDeprecated(SourceLoc loc,
   auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
 
   auto attr = restriction.getAttr();
-  auto domain = attr.getDomain();
-  auto deprecatedRange = attr.getDeprecatedRange(ctx).value();
+  auto domainAndRange = restriction.getDomainAndRange(ctx);
+  auto domain = domainAndRange.getDomain();
+  auto deprecatedRange = domainAndRange.getRange();
   auto message = attr.getMessage();
   if (message.empty()) {
     ctx.Diags

--- a/test/Availability/availability_any_apple_os.swift
+++ b/test/Availability/availability_any_apple_os.swift
@@ -61,9 +61,12 @@ func availableAtDeploymentTarget() {
   // expected-visionos-error@-5 {{'availableInAnyAppleOS26_1()' is only available in visionOS 26.1 or newer}}
   // expected-apple-note@-6 {{add 'if #available' version check}}{{3-30=if #available(anyAppleOS 26.1, *) {\n      availableInAnyAppleOS26_1()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
 
-  // FIXME: [availability] Remap domain/version in deprecation diagnostics
   deprecatedInAnyAppleOS26()
-  // expected-apple-warning@-1 {{'deprecatedInAnyAppleOS26()' was deprecated in any Apple OS 26}}
+  // expected-macos-warning@-1 {{'deprecatedInAnyAppleOS26()' was deprecated in macOS 26}}
+  // expected-ios-warning@-2 {{'deprecatedInAnyAppleOS26()' was deprecated in iOS 26}}
+  // expected-watchos-warning@-3 {{'deprecatedInAnyAppleOS26()' was deprecated in watchOS 26}}
+  // expected-tvos-warning@-4 {{'deprecatedInAnyAppleOS26()' was deprecated in tvOS 26}}
+  // expected-visionos-warning@-5 {{'deprecatedInAnyAppleOS26()' was deprecated in visionOS 26}}
 
   obsoletedInAnyAppleOS26()
   // expected-macos-error@-1 {{'obsoletedInAnyAppleOS26()' is unavailable in macOS}}

--- a/test/ClangImporter/availability_any_apple_os.swift
+++ b/test/ClangImporter/availability_any_apple_os.swift
@@ -33,8 +33,8 @@ func test() {
 
 
   deprecated_in_26_0()
-  // expected-macosx-warning@-1 {{'deprecated_in_26_0()' was deprecated in any Apple OS 26.0}}
-  // expected-ios-warning@-2 {{'deprecated_in_26_0()' was deprecated in any Apple OS 26.0}}
+  // expected-macosx-warning@-1 {{'deprecated_in_26_0()' was deprecated in macOS 26.0}}
+  // expected-ios-warning@-2 {{'deprecated_in_26_0()' was deprecated in iOS 26.0}}
 
   obsoleted_in_26_0()
   // expected-macosx-error@-1 {{'obsoleted_in_26_0()' is unavailable in macOS}}

--- a/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
+++ b/test/attr/attr_availability_ios_to_visionos_decl_remap.swift
@@ -52,7 +52,7 @@ func testDeploymentTarget() {
   doSomethingFarFuture() // expected-error {{'doSomethingFarFuture()' is only available in visionOS 99.0 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}{{3-25=if #available(visionOS 99.0, *) {\n      doSomethingFarFuture()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
   doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in visionOS: you don't want to do that anyway}}
-  doSomethingInadvisable() // expected-warning {{'doSomethingInadvisable()' was deprecated in iOS 1.0: please don't}}
+  doSomethingInadvisable() // expected-warning {{'doSomethingInadvisable()' was deprecated in visionOS 1.0: please don't}}
   doSomethingGood()
   doSomethingOld()
 
@@ -60,7 +60,7 @@ func testDeploymentTarget() {
   // expected-note@-1 {{add 'if #available' version check}}{{3-45=if #available(visionOS 1.1, *) {\n      takesSomeProto(ConformsToProtoIniOS17_4())\n  \} else {\n      // Fallback on earlier versions\n  \}}}
   takesSomeProto(ConformsToProtoIniOS99()) // expected-warning {{conformance of 'ConformsToProtoIniOS99' to 'SomeProto' is only available in visionOS 99 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}{{3-43=if #available(visionOS 99, *) {\n      takesSomeProto(ConformsToProtoIniOS99())\n  \} else {\n      // Fallback on earlier versions\n  \}}}
-  takesSomeProto(ConformsToProtoDeprecatedIniOS17()) // expected-warning {{conformance of 'ConformsToProtoDeprecatedIniOS17' to 'SomeProto' was deprecated in iOS 1.0: please don't}}
+  takesSomeProto(ConformsToProtoDeprecatedIniOS17()) // expected-warning {{conformance of 'ConformsToProtoDeprecatedIniOS17' to 'SomeProto' was deprecated in visionOS 1.0: please don't}}
   takesSomeProto(ConformsToProtoObsoletedIniOS17()) // expected-error {{conformance of 'ConformsToProtoObsoletedIniOS17' to 'SomeProto' is unavailable in visionOS: you don't want to do that anyway}}
 
   if #available(iOS 17.4, *) {
@@ -85,7 +85,7 @@ func testAfterDeployment_iOS() {
   doSomethingElse() // expected-error {{'doSomethingElse()' is unavailable in visionOS: you don't want to do that anyway}}
   doSomethingFarFuture() // expected-error {{'doSomethingFarFuture()' is only available in visionOS 99.0 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
-  doSomethingInadvisable() // expected-warning {{'doSomethingInadvisable()' was deprecated in iOS 1.0: please don't}}
+  doSomethingInadvisable() // expected-warning {{'doSomethingInadvisable()' was deprecated in visionOS 1.0: please don't}}
   doSomethingGood()
   doSomethingOld()
 
@@ -96,7 +96,7 @@ func testAfterDeployment_iOS() {
 func testAfterDeployment_visionOS() {
   doSomething()
   doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable in visionOS: you don't want to do that anyway}}
-  doSomethingInadvisable() // expected-warning {{'doSomethingInadvisable()' was deprecated in iOS 1.0: please don't}}
+  doSomethingInadvisable() // expected-warning {{'doSomethingInadvisable()' was deprecated in visionOS 1.0: please don't}}
   doSomethingGood()
   doSomethingOld()
 


### PR DESCRIPTION
Render deprecation diagnostics with versions re-mapped to the target platform when the attribute imposing the restriction is for a different platform.

Resolves rdar://183284929.
