### PR TITLE
Revert "[rebranch] Adjust to "[FunctionAttrs] Add support for nofree argument inference""

### DIFF
--- a/test/IRGen/builtin_pack_length.swift
+++ b/test/IRGen/builtin_pack_length.swift
@@ -31,7 +31,7 @@ func weirdPackCountUse1<each T>(_ x: repeat each T) -> Builtin.Word {
 }
 
 struct Pack<each T> {
-// CHECK: define {{.*}} @"$s8builtins4PackV5countBwvgZ"(i64 returned [[PACK_COUNT:%.*]], ptr nofree readnone captures(none) %"each T")
+// CHECK: define {{.*}} @"$s8builtins4PackV5countBwvgZ"(i64 returned [[PACK_COUNT:%.*]], ptr readnone captures(none) %"each T")
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i64 [[PACK_COUNT]]
   static var count: Builtin.Word {

--- a/test/IRGen/class_field_other_module.swift
+++ b/test/IRGen/class_field_other_module.swift
@@ -7,7 +7,7 @@
 
 import other_class
 
-// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassXys5Int32V0c1_A00F0CF"(ptr nofree readonly captures(none) %0)
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassXys5Int32V0c1_A00F0CF"(ptr readonly captures(none) %0)
 // CHECK-NEXT: entry:
 // An Int32 after the heap object header
 // CHECK-NEXT: [[GEP:%.*]] = getelementptr inbounds{{.*}} i8, ptr %0, i64 16
@@ -17,7 +17,7 @@ public func getSubclassX(_ o: Subclass) -> Int32 {
   return o.x
 }
 
-// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassYys5Int32V0c1_A00F0CF"(ptr nofree readonly captures(none) %0)
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$s24class_field_other_module12getSubclassYys5Int32V0c1_A00F0CF"(ptr readonly captures(none) %0)
 // CHECK-NEXT: entry:
 // An Int32 after an Int32 after the heap object header
 // CHECK-NEXT: [[GEP:%.*]] = getelementptr inbounds{{.*}} i8, ptr %0, i64 20

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -48,8 +48,8 @@ extension def_enum.TrafficLight : Error {}
 
 extension def_enum.Term : Error {}
 
-// CHECK-NORMAL-LABEL: define hidden {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr nofree readnone captures(none) %T) local_unnamed_addr
-// CHECK-TESTABLE-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr nofree readnone captures(none) %T)
+// CHECK-NORMAL-LABEL: define hidden {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr readnone captures(none) %T) local_unnamed_addr
+// CHECK-TESTABLE-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}i64 @"$s12enum_derived7PhantomO8rawValues5Int64Vvg"(i8 %0, ptr readnone captures(none) %T)
 
 enum Phantom<T> : Int64 {
   case Up

--- a/test/IRGen/inline_array_enum_tags.swift
+++ b/test/IRGen/inline_array_enum_tags.swift
@@ -10,7 +10,7 @@ public struct Bar {
     let y: [UInt64]
 }
 
-// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags3BazOwug"(ptr noalias nofree readonly captures(none) %value, ptr nofree readnone captures(none) %Baz)
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags3BazOwug"(ptr noalias readonly captures(none) %value, ptr readnone captures(none) %Baz)
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds{{.*}} i8, ptr %value, {{i64|i32}} 24
 // CHECK:   [[TAG_VAL:%.*]] = load i8, ptr [[TAG_ADDR]], align 8
 // CHECK:   [[TAG_EXT:%.*]] = zext i8 [[TAG_VAL]] to i32
@@ -27,7 +27,7 @@ public struct Padded {
 }
 
 
-// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags17WithPaddedPayloadOwug"(ptr noalias nofree readonly captures(none) %value, ptr nofree readnone captures(none) %WithPaddedPayload)
+// CHECK: define {{.*}} i32 @"$s22inline_array_enum_tags17WithPaddedPayloadOwug"(ptr noalias readonly captures(none) %value, ptr readnone captures(none) %WithPaddedPayload)
 // CHECK: entry:
 // CHECK:   [[ADDR:%.*]] = getelementptr inbounds{{.*}} i8, ptr %value, {{i64|i32}} 8
 // CHECK:   [[VAL:%.*]] = load {{i64|i32}}, ptr [[ADDR]], align 8

--- a/test/IRGen/noncopyable_struct_deinit_value_witness.swift
+++ b/test/IRGen/noncopyable_struct_deinit_value_witness.swift
@@ -1,6 +1,6 @@
 // RUN: %swift-frontend -O -emit-ir -module-name foo %s -o - | %FileCheck %s
 
-// CHECK-LABEL: define internal void @"$s3foo3FooVwxx"(ptr noalias %object, ptr nofree readonly captures(none) %"Foo<T>")
+// CHECK-LABEL: define internal void @"$s3foo3FooVwxx"(ptr noalias %object, ptr readonly captures(none) %"Foo<T>")
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   tail call swiftcc void @"$s3foo3FooVfD"(ptr %"Foo<T>", ptr noalias swiftself %object)
 // CHECK-NEXT:   ret void

--- a/test/IRGen/package_bypass_resilience_class.swift
+++ b/test/IRGen/package_bypass_resilience_class.swift
@@ -46,7 +46,7 @@ final public class Pub {
   // method lookup function for Core.Pub
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3PubCMu"(ptr %0, ptr %1)
 
-  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3PubCfd"(ptr nofree readnone returned swiftself{{.*}} %0)
+  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3PubCfd"(ptr readnone returned swiftself{{.*}} %0)
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3PubCfD"(ptr swiftself %0)
 }
 
@@ -97,7 +97,7 @@ package class Foo {
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc { ptr, ptr } @"$s4Core3FooC02myB0AA3PubCSgvMTj"
 
   // Core.Foo.deinit
-  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3FooCfd"(ptr nofree readonly returned swiftself{{.*}} %0)
+  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3FooCfd"(ptr readonly returned swiftself{{.*}} %0)
 
   // Core.Foo.__deallocating_deinit
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3FooCfD"(ptr swiftself %0)
@@ -119,7 +119,7 @@ final package class Bar {
   // method lookup function for Core.Bar
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3BarCMu"(ptr %0, ptr %1)
 
-  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3BarCfd"(ptr nofree readonly returned swiftself{{.*}} %0)
+  // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc ptr @"$s4Core3BarCfd"(ptr readonly returned swiftself{{.*}} %0)
   // CHECK-COMMON-DAG: define {{(dllexport |protected )?}}swiftcc void @"$s4Core3BarCfD"(ptr swiftself %0)
 
   package var myBar: Pub?

--- a/test/IRGen/pre_specialize.swift
+++ b/test/IRGen/pre_specialize.swift
@@ -42,11 +42,11 @@
 // specialized InternalThing.computedX.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingV9computedXxvgSi_Ts5"([[INT]]{{( returned)?}} %0)
 // specialized InternalThing.computedX.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr {{(nofree )?}}swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %1)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvsSi_Ts5"([[INT]] %0, ptr swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %1)
 // specialized InternalThing.subscript.getter
 // CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT]] @"$s1A13InternalThingVyxSicigSi_Ts5"([[INT]] %0, [[INT]]{{( returned)?}} %1)
 // specialized InternalThing.subscript.setter
-// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr {{(nofree )?}}swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %2)
+// CHECK-A-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicisSi_Ts5"([[INT]] %0, [[INT]] %1, ptr swiftself {{(writeonly )?}}captures(none) dereferenceable({{(4|8)}}){{.*}} %2)
 
 // specialized InternalRef.compute()
 // CHECK-A-FRAG-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc [[INT:(i64|i32)]] @"$s1A11InternalRefC7computexyFAA09ResilientA10BoxedThingVySiG_Ts5"
@@ -75,13 +75,13 @@
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingV9computedXxvg1B07AnotherB0C_Ts5"(ptr{{( returned)?}} %0)
 
 // specialized InternalThing.computedX.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr {{(nofree )?}}swiftself captures(none) dereferenceable({{(4|8)}}) %1)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr swiftself captures(none) dereferenceable({{(4|8)}}) %1)
 
 // specialized InternalThing.subscript.getter
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingVyxSicig1B07AnotherB0C_Ts5"([[INT:(i64|i32)]] %0, ptr{{( returned)?}} %1)
 
 // specialized InternalThing.subscript.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr {{(nofree )?}}swiftself captures(none) dereferenceable({{(4|8)}}) %2)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr swiftself captures(none) dereferenceable({{(4|8)}}) %2)
 
 // specialized InternalRef.compute()
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A11InternalRefC7computexyF1B12AnotherThingC_Ts5

--- a/test/IRGen/runtime_calling_conventions.swift
+++ b/test/IRGen/runtime_calling_conventions.swift
@@ -11,7 +11,7 @@ public class C {
 // Check that runtime functions use a proper calling convention.
 // CHECK-NOT: call void {{.*}} @swift_release
 
-// OPT-CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s{{(27|28)}}runtime_calling_conventions3fooyyAA1CCF"(ptr nofree readnone captures(none) %0)
+// OPT-CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s{{(27|28)}}runtime_calling_conventions3fooyyAA1CCF"(ptr readnone captures(none) %0)
 // Check that runtime functions use a proper calling convention.
 // OPT-CHECK-NOT: tail call void @swift_release
 

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -67,7 +67,7 @@ where Self : CodingType,
   print(Self.ValueType.self)
 }
 
-// OSIZE: define internal swiftcc ptr @"$s21same_type_constraints12GenericKlazzCyxq_GAA1EAA4DataAaEP_AA0F4TypePWT"(ptr nofree readnone %"GenericKlazz<T, R>.Data", ptr nofree readonly captures(none) %"GenericKlazz<T, R>", ptr nofree readnone captures(none) %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
+// OSIZE: define internal swiftcc ptr @"$s21same_type_constraints12GenericKlazzCyxq_GAA1EAA4DataAaEP_AA0F4TypePWT"(ptr readnone %"GenericKlazz<T, R>.Data", ptr readonly captures(none) %"GenericKlazz<T, R>", ptr readnone captures(none) %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
 // OSIZE: [[ATTRS]] = {{{.*}}noinline
 
 // Check that same-typing two generic parameters together lowers correctly.

--- a/test/IRGen/typelayout_based_value_witness.swift
+++ b/test/IRGen/typelayout_based_value_witness.swift
@@ -81,7 +81,7 @@ public enum ForwardEnum<T> {
 // CHECK: }
 
 
-// OPT: define{{.*}} void @"$s30typelayout_based_value_witness1AVwxx"(ptr noalias %object, ptr nofree readonly captures(none) %"A<T>")
+// OPT: define{{.*}} void @"$s30typelayout_based_value_witness1AVwxx"(ptr noalias %object, ptr readonly captures(none) %"A<T>")
 // OPT:   [[T_PARAM:%.*]] = getelementptr inbounds{{.*}} i8, ptr %"A<T>", i64 16
 // OPT:   [[T:%.*]] = load ptr, ptr [[T_PARAM]]
 // OPT:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8, ptr [[T]], {{(i64|i32)}} -8
@@ -127,7 +127,7 @@ public enum ForwardEnum<T> {
 // OPT:   ret void
 // CHECK: }
 
-// OPT: define internal void @"$s30typelayout_based_value_witness2E3Owui"(ptr noalias nofree writeonly captures(none) %value, i32 %tag, ptr nofree readonly captures(none) %"E3<T>")
+// OPT: define internal void @"$s30typelayout_based_value_witness2E3Owui"(ptr noalias writeonly captures(none) %value, i32 %tag, ptr readonly captures(none) %"E3<T>")
 // OPT:  [[IS_EMPTY:%.*]] = icmp eq i32 {{%.*}}, 0
 // OPT:  br i1 [[IS_EMPTY]], label %empty-payload, label %non-empty-payload
 // OPT: }

--- a/validation-test/IRGen/rdar149985633.swift
+++ b/validation-test/IRGen/rdar149985633.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: PTRSIZE=64
 
-// CHECK: define {{.*}}swiftcc void @"$s13rdar1499856334DateV1a1b1c1d1e1fACSiSg_A5JtcfC"(ptr noalias nofree writeonly sret(%T13rdar1499856334DateV) captures(none){{.*}} %0, i64 %1, i8 %2, i64 %3, i8 %4, i64 %5, i8 %6, i64 %7, i8 %8, i64 %9, i8 %10, i64 %11, i8 %12)
+// CHECK: define {{.*}}swiftcc void @"$s13rdar1499856334DateV1a1b1c1d1e1fACSiSg_A5JtcfC"(ptr noalias writeonly sret(%T13rdar1499856334DateV) captures(none){{.*}} %0, i64 %1, i8 %2, i64 %3, i8 %4, i64 %5, i8 %6, i64 %7, i8 %8, i64 %9, i8 %10, i64 %11, i8 %12)
 // CHECK: entry:
 // CHECK:   store i64 %1
 // CHECK:   getelementptr inbounds{{.*}} i8, ptr %0, i64 8


### PR DESCRIPTION
This reverts a rebranch change to make way for
5b6230da5ff5025d1bc43b84ba85727d7a87195f, an equivalent main branch change that was adapted to work on both branches.