### PR TITLE
[Sema] Improve diagnostic message for nonisolated mutable stored properties

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6446,8 +6446,8 @@ GROUPED_ERROR(inverse_requires_any,ExistentialAny,none,
               "constraint that suppresses conformance requires 'any'", ())
 
 ERROR(nonisolated_mutable_storage,none,
-      "'nonisolated' cannot be applied to mutable stored properties",
-      ())
+      "'nonisolated' cannot be applied to mutable stored property %0",
+      (DeclName))
 NOTE(nonisolated_mutable_storage_note,none,
      "convert %0 to a 'let' constant or consider declaring it "
      "'nonisolated(unsafe)' if manually managing concurrency safety",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8413,17 +8413,17 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         // Otherwise, this stored property has to be qualified as 'unsafe'.
         if (var->supportsMutation() && !attr->isUnsafe() && !canBeNonisolated) {
           if (var->hasAttachedPropertyWrapper()) {
-            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage, var->getName())
                 .warnUntilLanguageModeIf(attr->isImplicit(), LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
-            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage, var->getName())
                 .warnUntilLanguageMode(LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else {
-            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage, var->getName())
               .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             if (var->hasStorage())
               var->diagnose(diag::nonisolated_mutable_storage_note, var);

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -817,29 +817,29 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l31'; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l32: Int = v
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l32'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l33'; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l34: Int = self.v
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l34'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l35'; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
     nonisolated lazy var l41: Int = { l }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l41'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l42: Int = l
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l42'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l43: Int = { self.l }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l43'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l44: Int = self.l
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l44'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l45: Int = { [unowned self] in self.l }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'l45'; this is an error in the Swift 6 language mode}}
 }
 
 // Infer global actors from context only for instance members.

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -65,7 +65,7 @@ actor Pumpkin: NSObject {}
 
 actor Bad {
   @objc nonisolated lazy var invalid = 0
-  // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored property 'invalid'; this is an error in the Swift 6 language mode}}
   // expected-error@-2 {{actor-isolated setter for property 'invalid' cannot be '@objc'}}
   // expected-error@-3 {{actor-isolated getter for property 'invalid' cannot be '@objc'}}
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -404,7 +404,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0 // expected-warning {{'nonisolated' cannot be applied to mutable stored properties}}
+  @WrapperActor var actorSynced: Int = 0 // expected-warning {{'nonisolated' cannot be applied to mutable stored property 'actorSynced'}}
   func testActorSynced() {
     _ = actorSynced
     _ = $actorSynced

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -114,7 +114,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  @WrapperActor var actorSynced: Int = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored property 'actorSynced'}}
 
   func testActorSynced() {
     _ = actorSynced

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -37,8 +37,8 @@ struct ImplicitlySendable {
   nonisolated var d = 0
 
   // never okay
-  nonisolated lazy var e = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  nonisolated lazy var e = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored property 'e'}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored property 'f'}}
 }
 
 struct ImplicitlyNonSendable {
@@ -61,8 +61,8 @@ public struct PublicSendable: Sendable {
   nonisolated var d = 0
 
   // never okay
-  nonisolated lazy var e = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  nonisolated lazy var e = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored property 'e'}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored property 'f'}}
 }
 
 public struct PublicNonSendable {
@@ -95,8 +95,8 @@ nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
 
 @MainActor struct S {
   var value: NonSendable // globally-isolated
-  @P nonisolated var x = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
-  nonisolated lazy var y = 1 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  @P nonisolated var x = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored property 'x'}}
+  nonisolated lazy var y = 1 // expected-error {{'nonisolated' cannot be applied to mutable stored property 'y'}}
   struct Nested {} // 'Nested' is not @MainActor-isolated
 }
 
@@ -305,7 +305,7 @@ struct B: Sendable {
 
 final class KlassB: Sendable {
   // expected-note@+2 {{convert 'test' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
-  // expected-error@+1 {{'nonisolated' cannot be applied to mutable stored properties}}
+  // expected-error@+1 {{'nonisolated' cannot be applied to mutable stored property 'test'}}
   nonisolated var test: Int = 1
 }
 

--- a/test/Concurrency/toplevel/file_default_globals.swift
+++ b/test/Concurrency/toplevel/file_default_globals.swift
@@ -59,7 +59,7 @@ var storedVarGlobal = 0
 // expected-swift6-note@-6 {{convert 'storedVarGlobal' to a 'let' constant to make 'Sendable' shared state immutable}}
 // expected-swift6-note@-7 {{add '@MainActor' to make var 'storedVarGlobal' part of global actor 'MainActor'}}
 // expected-swift6-note@-8 {{disable concurrency-safety checks if accesses are protected by an external synchronization mechanism}}
-// expected-error@-9 {{'nonisolated' cannot be applied to mutable stored properties}}
+// expected-error@-9 {{'nonisolated' cannot be applied to mutable stored property 'storedVarGlobal'}}
 // expected-note@-10 {{convert 'storedVarGlobal' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
 
 // MAIN: @MainActor {{.*}}let storedLetGlobal: Int


### PR DESCRIPTION
### Description
This PR improves the diagnostic error message emitted when `nonisolated` is incorrectly applied to a mutable stored property, as reported in #88709.

Previously, the compiler emitted a generic error: 
`'nonisolated' cannot be applied to mutable stored properties`

The compiler now specifies the exact property name that caused the error:
`'nonisolated' cannot be applied to mutable stored property 'myVariable'`

### Changes Made
* Updated `DiagnosticsSema.def` to accept a `DeclName` parameter for the `nonisolated_mutable_storage` diagnostic.
* Modified `AttributeChecker::visitNonisolatedAttr` in `lib/Sema/TypeCheckAttr.cpp` to pass the `VarDecl`'s name when emitting the diagnostic.
* Updated all associated tests in `test/Concurrency/` to match the new interpolated error message expectations.

Fixes #88709 

### Testing
* Verified all `test/Concurrency/` diagnostic tests pass with the updated error message.
