### PR TITLE
Windows: add option to smoke test installer

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -116,9 +116,10 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -Summary || (exit /b 1)
 
 if not "%SMOKE_TEST%"=="" (
-  powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0windows-smoke-tests\RunSmokeTest.ps1 ^
+  powershell.exe -NonInteractive -ExecutionPolicy RemoteSigned -File %~dp0windows-smoke-tests\RunSmokeTest.ps1 ^
     -Installer "%PackageRoot%\installer.exe" ^
-    -SourceCache "%SourceRoot%" || (exit /b 1)
+    -SourceCache "%SourceRoot%" ^
+    -EntryPoint "%~dp0windows-smoke-tests\SmokeTest.ps1" || (exit /b 1)
 )
 
 :: Publish PDBs into a Microsoft-compatible symbol store and zip it so that

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -24,6 +24,7 @@ echo set SKIP_UPDATE_CHECKOUT=%SKIP_UPDATE_CHECKOUT%>> %TEMP%\call-build.cmd
 echo set REPO_SCHEME=%REPO_SCHEME%>> %TEMP%\call-build.cmd
 echo set WINDOWS_SDKS=%WINDOWS_SDKS%>> %TEMP%\call-build.cmd
 echo set HOST_ARCH_NAME=%HOST_ARCH_NAME%>> %TEMP%\call-build.cmd
+echo set SMOKE_TEST=%SMOKE_TEST%>> %TEMP%\call-build.cmd
 echo "%~f0">> %TEMP%\call-build.cmd
 start /i /b /wait cmd.exe /env=default /c "%TEMP%\call-build.cmd"
 set ec=%errorlevel%
@@ -91,6 +92,16 @@ if not "%DEBUG_INFO%"=="" set "DebugInfoArg=-DebugInfo"
 
 call :CloneRepositories || (exit /b 1)
 
+if not "%SMOKE_TEST%"=="" if "%INCLUDE_PACKAGING%"=="" (
+  echo SMOKE_TEST needs INCLUDE_PACKAGING
+  exit /b 1
+)
+
+if not "%SMOKE_TEST%"=="" if not exist "%SourceRoot%\swift-docker" (
+  echo SMOKE_TEST needs a swift-docker checkout at %SourceRoot%\swift-docker
+  exit /b 1
+)
+
 :: We only have write access to BuildRoot, so use that as the image root.
 powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   %HostArchNameArg% ^
@@ -103,6 +114,12 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -IncludeSBoM ^
   %DebugInfoArg% ^
   -Summary || (exit /b 1)
+
+if not "%SMOKE_TEST%"=="" (
+  powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0windows-smoke-tests\RunSmokeTest.ps1 ^
+    -Installer "%PackageRoot%\installer.exe" ^
+    -SourceCache "%SourceRoot%" || (exit /b 1)
+)
 
 :: Publish PDBs into a Microsoft-compatible symbol store and zip it so that
 :: CI can upload the archive to the Swift debug-symbols server.

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -92,13 +92,6 @@ if not "%DEBUG_INFO%"=="" set "DebugInfoArg=-DebugInfo"
 
 call :CloneRepositories || (exit /b 1)
 
-:: XXX: TEMPORARY FOR TESTING DO NOT MERGE
-set SMOKE_TEST=true
-:: XXX: TEMPORARY FOR TESTING DO NOT MERGE
-if not exist "%SourceRoot%\swift-docker" (
-  git clone --depth 1 https://github.com/swiftlang/swift-docker "%SourceRoot%\swift-docker" || (exit /b 1)
-)
-
 if not "%SMOKE_TEST%"=="" if "%INCLUDE_PACKAGING%"=="" (
   echo SMOKE_TEST needs INCLUDE_PACKAGING
   exit /b 1

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -92,6 +92,13 @@ if not "%DEBUG_INFO%"=="" set "DebugInfoArg=-DebugInfo"
 
 call :CloneRepositories || (exit /b 1)
 
+:: XXX: TEMPORARY FOR TESTING DO NOT MERGE
+set SMOKE_TEST=true
+:: XXX: TEMPORARY FOR TESTING DO NOT MERGE
+if not exist "%SourceRoot%\swift-docker" (
+  git clone --depth 1 https://github.com/swiftlang/swift-docker "%SourceRoot%\swift-docker" || (exit /b 1)
+)
+
 if not "%SMOKE_TEST%"=="" if "%INCLUDE_PACKAGING%"=="" (
   echo SMOKE_TEST needs INCLUDE_PACKAGING
   exit /b 1

--- a/utils/windows-smoke-tests/RunSmokeTest.ps1
+++ b/utils/windows-smoke-tests/RunSmokeTest.ps1
@@ -15,41 +15,30 @@ Path to the installer to test.
 
 .PARAMETER SourceCache
 Path to the directory containing the swift-docker checkout.
-Defaults to the directory containing this checkout of swift.
 
 .PARAMETER EntryPoint
 PowerShell script containing the tests to run inside the container.
-Defaults to `SmokeTest.ps1` in this script's directory.
 #>
 [CmdletBinding()]
 param
 (
+  [Parameter(Mandatory)]
   [string] $Installer,
+  [Parameter(Mandatory)]
   [string] $SourceCache,
-  [string] $EntryPoint = "SmokeTest.ps1"
+  [Parameter(Mandatory)]
+  [string] $EntryPoint
 )
 
 $ErrorActionPreference = "Stop"
 
-if (-not $SourceCache) {
-  $SourceCache = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
-}
-
-if (-not [IO.Path]::IsPathRooted($EntryPoint)) {
-  $EntryPoint = Join-Path $PSScriptRoot $EntryPoint
-}
 if (-not (Test-Path $EntryPoint)) {
   throw "Entry point not found at '$EntryPoint'."
 }
-$EntryPoint = (Resolve-Path $EntryPoint).Path
 
-if (-not $Installer) {
-  throw "-Installer is required."
-}
 if (-not (Test-Path $Installer)) {
   throw "Installer not found at '$Installer'."
 }
-$Installer = (Resolve-Path $Installer).Path
 
 $WindowsBuild = [int](Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").CurrentBuildNumber
 if ($WindowsBuild -ge 20348) {

--- a/utils/windows-smoke-tests/RunSmokeTest.ps1
+++ b/utils/windows-smoke-tests/RunSmokeTest.ps1
@@ -40,13 +40,13 @@ if (-not (Test-Path $Installer)) {
   throw "Installer not found at '$Installer'."
 }
 
-$WindowsBuild = [int](Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").CurrentBuildNumber
-if ($WindowsBuild -ge 20348) {
-  $Variant = "ltsc2022-full"
-} elseif ($WindowsBuild -ge 17763) {
-  $Variant = "1809-full"
+$Build = [System.Environment]::OSVersion.Version.Build
+$Variant = if ($Build -ge 20348) {
+  "ltsc2022-full"
+} elseif ($Build -ge 17763) {
+  "1809-full"
 } else {
-  throw "Smoke tests are not supported on this Windows version (build $WindowsBuild)."
+  throw "Swift is not supported on this Windows Version (Build $Build)"
 }
 
 $Dockerfile = Join-Path $SourceCache "swift-docker\swift-ci\main\windows\smoketest\$Variant\Dockerfile"

--- a/utils/windows-smoke-tests/RunSmokeTest.ps1
+++ b/utils/windows-smoke-tests/RunSmokeTest.ps1
@@ -1,0 +1,116 @@
+<#
+.SYNOPSIS
+Smoke-tests a Swift installer in a Windows container.
+
+.DESCRIPTION
+Builds a container image from the swift-docker smoke-test Dockerfile, installing
+the given installer into it, then runs `EntryPoint` inside the resulting
+container.
+
+Requires a swift-docker checkout and a Docker installation configured for
+Windows containers.
+
+.PARAMETER Installer
+Path to the installer to test.
+
+.PARAMETER SourceCache
+Path to the directory containing the swift-docker checkout.
+Defaults to the directory containing this checkout of swift.
+
+.PARAMETER EntryPoint
+PowerShell script containing the tests to run inside the container.
+Defaults to `SmokeTest.ps1` in this script's directory.
+#>
+[CmdletBinding()]
+param
+(
+  [string] $Installer,
+  [string] $SourceCache,
+  [string] $EntryPoint = "SmokeTest.ps1"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $SourceCache) {
+  $SourceCache = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+}
+
+if (-not [IO.Path]::IsPathRooted($EntryPoint)) {
+  $EntryPoint = Join-Path $PSScriptRoot $EntryPoint
+}
+if (-not (Test-Path $EntryPoint)) {
+  throw "Entry point not found at '$EntryPoint'."
+}
+$EntryPoint = (Resolve-Path $EntryPoint).Path
+
+if (-not $Installer) {
+  throw "-Installer is required."
+}
+if (-not (Test-Path $Installer)) {
+  throw "Installer not found at '$Installer'."
+}
+$Installer = (Resolve-Path $Installer).Path
+
+$WindowsBuild = [int](Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").CurrentBuildNumber
+if ($WindowsBuild -ge 20348) {
+  $Variant = "ltsc2022-full"
+} elseif ($WindowsBuild -ge 17763) {
+  $Variant = "1809-full"
+} else {
+  throw "Smoke tests are not supported on this Windows version (build $WindowsBuild)."
+}
+
+$Dockerfile = Join-Path $SourceCache "swift-docker\swift-ci\main\windows\smoketest\$Variant\Dockerfile"
+if (-not (Test-Path $Dockerfile)) {
+  throw "Smoke tests require a swift-docker checkout at '$(Join-Path $SourceCache "swift-docker")' (expected a Dockerfile at '$Dockerfile')."
+}
+
+if (-not (Get-Command docker -ErrorAction Ignore)) {
+  throw "Docker was not found on the path."
+}
+docker version | Out-Null
+if ($LASTEXITCODE -ne 0) {
+  throw "'docker version' failed; the Docker daemon may not be running."
+}
+$DockerInfo = docker info
+if ($LASTEXITCODE -ne 0) {
+  throw "'docker info' failed; the Docker daemon may not be running."
+}
+if (-not ($DockerInfo -match "OSType:\s*windows")) {
+  throw "Docker is not configured for Windows containers."
+}
+
+$WorkingDir = Join-Path $env:TEMP "swift-smoke-test-$([Guid]::NewGuid().ToString("n"))"
+New-Item -ItemType Directory -Path $WorkingDir | Out-Null
+try {
+  Copy-Item $Dockerfile (Join-Path $WorkingDir "Dockerfile")
+
+  Copy-Item $Installer (Join-Path $WorkingDir (Split-Path $Installer -Leaf))
+  Copy-Item $EntryPoint (Join-Path $WorkingDir (Split-Path $EntryPoint -Leaf))
+
+  Write-Host "[smoke-test] docker build ..."
+  $Start = [DateTime]::Now
+  docker build `
+    --file (Join-Path $WorkingDir "Dockerfile") `
+    --build-arg SWIFT_INSTALLER_PATH=$(Split-Path $Installer -Leaf) `
+    --build-arg ENTRY_POINT=$(Split-Path $EntryPoint -Leaf) `
+    --tag swift-smoke-test `
+    $WorkingDir
+  if ($LASTEXITCODE -ne 0) { throw "docker build failed with exit code $LASTEXITCODE." }
+  Write-Host "[smoke-test] docker build took $(([DateTime]::Now - $Start).ToString("hh\:mm\:ss"))"
+
+  Write-Host "[smoke-test] docker run ..."
+  $Start = [DateTime]::Now
+  docker run --rm swift-smoke-test
+  if ($LASTEXITCODE -ne 0) { throw "Smoke test failed with exit code $LASTEXITCODE." }
+  Write-Host "[smoke-test] docker run took $(([DateTime]::Now - $Start).ToString("hh\:mm\:ss"))"
+
+  Write-Host -ForegroundColor Green "[smoke-test] passed"
+} finally {
+  Remove-Item -Recurse -Force $WorkingDir -ErrorAction Ignore
+  if (docker images --quiet swift-smoke-test) {
+    docker rmi swift-smoke-test | Out-Null
+  }
+}
+
+exit 0

--- a/utils/windows-smoke-tests/SmokeTest.ps1
+++ b/utils/windows-smoke-tests/SmokeTest.ps1
@@ -1,0 +1,8 @@
+# Smoke-tests the installed Swift toolchain.
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Starting smoke test"
+Write-Host ""
+
+swift --version
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
This adds a new option, `SMOKE_TEST`, to `build-windows-toolchain.bat` which:
- Brings up a Windows Docker container
- Installs the just-built installer to it
- Runs an arbitrary smoke test on it

Right now the smoke test just consists of `swift --version`, but this is enough to catch many of the practical "broken installer" issues we've seen. Adding https://github.com/swiftlang/swift-integration-tests is planned in a future change.

`RunSmokeTests.ps1` is runnable locally independent of a full build to allow smoke-testing already built installers.
Requirements:
- `swift-docker` checkout
- Docker installed and set up for Windows containers (NB: this is not the default)

Scheduled CI currently checks out `swift-docker`, but PR CI does *not*, so it is not currently possible to test this in PR CI without modification (checking out `swift-docker` explicitly). Successful run which defaults `SMOKE_TEST` to true and checks out `swift-docker`: https://ci-external.swift.org/job/swift-PR-build-toolchain-windows/6729/

This supersedes https://github.com/swiftlang/swift/pull/84770 which embedded the same approach in build.ps1