### PR TITLE
[SILGen] Support thunking/reabstraction of `@called(once)` values

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -896,6 +896,9 @@ public:
   /// Returns true if this SILType is a differentiable type.
   bool isDifferentiable(SILModule &M) const;
 
+  /// Returns true if this SILType is a `@called(once)` function type.
+  bool isCalledOnce() const;
+
   /// Returns the @_rawLayout attribute on this type if it has one.
   RawLayoutAttr *getRawLayout() const {
     auto sd = getStructOrBoundGenericStruct();

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3804,10 +3804,15 @@ CanSILFunctionType swift::buildSILFunctionThunkType(
       extInfoBuilder = extInfoBuilder.withIsPseudogeneric();
 
   // Add the formal parameters of the expected type to the thunk.
-  auto contextConvention =
-      fn->getTypeProperties(sourceType).isTrivial()
-          ? ParameterConvention::Direct_Unowned
-          : ParameterConvention::Direct_Guaranteed;
+  //
+  // A `@called(once)` source function is applied inside the thunk body,
+  // which is itself the consuming use that enforces call-at-most-once, so
+  // it must be captured as `Direct_Owned`.
+  auto contextConvention = fn->getTypeProperties(sourceType).isTrivial()
+                               ? ParameterConvention::Direct_Unowned
+                           : sourceType->isCalledOnce()
+                               ? ParameterConvention::Direct_Owned
+                               : ParameterConvention::Direct_Guaranteed;
   SmallVector<SILParameterInfo, 4> params;
   params.append(expectedType->getParameters().begin(),
                 expectedType->getParameters().end());

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3719,6 +3719,12 @@ CanSILFunctionType swift::buildSILFunctionThunkType(
   if (withoutActuallyEscaping)
     extInfoBuilder = extInfoBuilder.withNoEscape(false);
 
+  // The thunk itself cannot be `@called(once)` just like a closure cannot
+  // be since the constraint is about the value and is expressed on
+  // `partial_apply` instruction that forms the value of the thunk.
+  if (extInfoBuilder.isCalledOnce())
+    extInfoBuilder = extInfoBuilder.withCalledOnce(false);
+
   // Does the thunk type involve a local archetype type?
   SmallVector<GenericEnvironment *, 2> capturedEnvs;
   auto archetypeVisitor = [&](CanType t) {

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -920,6 +920,12 @@ bool SILType::isDifferentiable(SILModule &M) const {
       .has_value();
 }
 
+bool SILType::isCalledOnce() const {
+  if (auto F = dyn_cast<SILFunctionType>(getASTType()))
+    return F->isCalledOnce();
+  return false;
+}
+
 Type
 TypeBase::replaceSubstitutedSILFunctionTypesWithUnsubstituted(SILModule &M) const {
   return Type(const_cast<TypeBase *>(this)).transformRec([&](TypeBase *t) -> std::optional<Type> {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -429,6 +429,16 @@ ManagedValue LogicalPathComponent::project(SILGenFunction &SGF,
   if (isReadAccess(accessKind))
     return std::move(*this).projectForRead(SGF, loc, base, accessKind);
 
+  // A consuming access reads the component exactly once to produce an
+  // owned result; unlike Write/ReadWrite, there's no new value to write
+  // back afterward.
+  if (isConsumeAccess(accessKind))
+    return std::move(*this).projectForRead(
+        SGF, loc, base,
+        accessKind == SGFAccessKind::OwnedAddressConsume
+            ? SGFAccessKind::OwnedAddressRead
+            : SGFAccessKind::OwnedObjectRead);
+
   // AccessKind is Write or ReadWrite. We need to emit a get and set.
   assert(SGF.isInFormalEvaluationScope() &&
          "materializing l-value for modification without writeback scope");
@@ -1222,11 +1232,19 @@ namespace {
           // mark_unresolved_non_copyable_value to allow for DI to properly
           // handle delayed initialization of the boxes and convert those to
           // initable_but_not_consumable.
+          //
+          // `@called(once)` values are always consumed by whatever uses
+          // them, so a non-read access to one must permit consuming it,
+          // unlike an ordinary noncopyable var/let box, which only permits
+          // being fully reassigned.
           addr = SGF.B.createMarkUnresolvedNonCopyableValueInst(
               loc, addr,
               isReadAccess(getAccessKind())
                   ? MarkUnresolvedNonCopyableValueInst::CheckKind::
                         NoConsumeOrAssign
+              : Value.getType().isCalledOnce()
+                  ? MarkUnresolvedNonCopyableValueInst::CheckKind::
+                        ConsumableAndAssignable
                   : MarkUnresolvedNonCopyableValueInst::CheckKind::
                         AssignableButNotConsumable);
           return ManagedValue::forFormalAccessedAddress(addr, getAccessKind());

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5854,7 +5854,8 @@ static ManagedValue createPartialApplyOfThunk(SILGenFunction &SGF,
     SGF.B.createPartialApply(loc, thunkValue,
                              interfaceSubs, thunkArgs,
                              toType->getCalleeConvention(),
-                             toType->getIsolation());
+                             toType->getIsolation(),
+                             toType->isCalledOnce());
 }
 
 static ManagedValue createDifferentiableFunctionThunk(

--- a/test/IRGen/called_once_thunk.swift
+++ b/test/IRGen/called_once_thunk.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-emit-ir -module-name test -enable-experimental-feature CalledAttribute %s | %FileCheck %s
+
+// REQUIRES: swift_feature_CalledAttribute
+// REQUIRES: PTRSIZE=64
+
+public func identity<T>(_ f: @escaping (T) -> Void) -> (T) -> Void { f }
+
+public func makeCalledOnce(_ f: @escaping (Int) -> Void) -> @called(once) (Int) -> Void {
+  return identity(f)
+}
+
+public func callOnceThroughThunk(_ f: @called(once) (Int) -> ()) { f(1) }
+public func dontCallOnceThroughThunk(_ f: @called(once) (Int) -> ()) { /* never called */ }
+
+final class Tracker {
+  deinit { print("Tracker") }
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test33calledThroughThunkReleasesCaptureyyF"()
+// CHECK: [[TRACKER:%.*]] = call swiftcc ptr @"$s4test7TrackerCACycfC"
+// CHECK: call ptr @swift_retain(ptr returned [[TRACKER]])
+// CHECK: [[CLOSURE:%.*]] = call swiftcc { ptr, ptr } @"$s4test14makeCalledOnceyySiXOySicF"(ptr @"$s4test33calledThroughThunkReleasesCaptureyyFySicfU_TA", ptr [[TRACKER]])
+// CHECK: [[CLOSURE_FN:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 0
+// CHECK: [[CLOSURE_CTX:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 1
+// CHECK: call void @swift_release(ptr [[TRACKER]])
+// CHECK: call swiftcc void @"$s4test20callOnceThroughThunkyyySiXEnF"(ptr [[CLOSURE_FN]], ptr [[CLOSURE_CTX]])
+// CHECK: call void @swift_release(ptr [[TRACKER]])
+// CHECK: ret void
+public func calledThroughThunkReleasesCapture() {
+  let t = Tracker()
+  callOnceThroughThunk(makeCalledOnce { _ in _ = t })
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s4test38neverCalledThroughThunkReleasesCaptureyyF"()
+// CHECK: [[TRACKER:%.*]] = call swiftcc ptr @"$s4test7TrackerCACycfC"
+// CHECK: call ptr @swift_retain(ptr returned [[TRACKER]])
+// CHECK: [[CLOSURE:%.*]] = call swiftcc { ptr, ptr } @"$s4test14makeCalledOnceyySiXOySicF"(ptr @"$s4test38neverCalledThroughThunkReleasesCaptureyyFySicfU_TA", ptr [[TRACKER]])
+// CHECK: [[CLOSURE_FN:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 0
+// CHECK: [[CLOSURE_CTX:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 1
+// CHECK: call void @swift_release(ptr [[TRACKER]])
+// CHECK: call swiftcc void @"$s4test24dontCallOnceThroughThunkyyySiXEnF"(ptr [[CLOSURE_FN]], ptr [[CLOSURE_CTX]])
+// CHECK: call void @swift_release(ptr [[TRACKER]])
+// CHECK: ret void
+public func neverCalledThroughThunkReleasesCapture() {
+  let t = Tracker()
+  dontCallOnceThroughThunk(makeCalledOnce { _ in _ = t })
+}

--- a/test/Interpreter/called_once.swift
+++ b/test/Interpreter/called_once.swift
@@ -10,6 +10,22 @@ struct Resource: ~Copyable {
   consuming func use() { print("Resource(\(tag)) used") }
 }
 
+func identity<T>(_ f: @escaping (T) -> Void) -> (T) -> Void { f }
+
+struct Payload {
+  let tag: String
+}
+
+func consume(_ f: @called(once) (Payload) -> Void, _ value: Payload) {
+  f(value)
+}
+
+func consumeEscaping(_ f: @escaping @called(once) (Payload) -> Void, _ value: Payload) {
+  f(value)
+}
+
+func dontConsume(_ f: @called(once) (Payload) -> Void) { /* never called */ }
+
 func makeClosure(_ tag: String) -> @called(once) () -> Void {
   return { print("called \(tag)") }
 }
@@ -230,3 +246,72 @@ func testEmptyConsumingCaptureNeverCalledEscaping() {
 
 // CHECK-NEXT: EmptyResource deinit
 testEmptyConsumingCaptureNeverCalledEscaping()
+
+// Passing a concrete closure through a generic passthrough forces a
+// representation-changing reabstraction thunk before the final
+// `partial_apply [called_once]` can attach `@called(once)` to the result.
+func makeCalledOnce(_ f: @escaping (Payload) -> Void) -> @called(once) (Payload) -> Void {
+  return identity(f)
+}
+
+// A generic function's own body performs the escaping-to-`@called(once)`
+// conversion directly on its abstract parameter, sharing one thunk across
+// every instantiation of `T`.
+func genericMakeCalledOnce<T>(_ f: @escaping (T) -> Void) -> @called(once) (T) -> Void {
+  return f
+}
+
+// A thunked conversion landing in an (implicitly noescape) `@called(once)`
+// parameter still runs correctly.
+func testCalledThroughThunk() {
+  consume(makeCalledOnce { print("called \($0.tag)") }, Payload(tag: "direct"))
+}
+
+// CHECK: called direct
+testCalledThroughThunk()
+
+// The same conversion landing in an `@escaping @called(once)` parameter.
+func testCalledThroughThunkEscaping() {
+  consumeEscaping(makeCalledOnce { print("called \($0.tag)") }, Payload(tag: "escaping"))
+}
+
+// CHECK-NEXT: called escaping
+testCalledThroughThunkEscaping()
+
+// Calling a generically-produced `@called(once)` closure at a concrete type
+// forces a second thunk (bridging the concrete argument to the closure's
+// abstract calling convention) at the call site itself.
+func testGenericBodyConversion() {
+  let f = genericMakeCalledOnce { (s: String) in print("generic called \(s)") }
+  f("hello")
+}
+
+// CHECK-NEXT: generic called hello
+testGenericBodyConversion()
+
+// A capture carried through the thunked conversion is released exactly once
+// when the closure is called.
+func testCalledThroughThunkReleasesCapture() {
+  let t = Tracker("used")
+  let f = makeCalledOnce { (_: Payload) in
+    print("using \(t.tag)")
+  }
+  consume(f, Payload(tag: "x"))
+}
+
+// CHECK-NEXT: using used
+// CHECK-NEXT: Tracker(used) deinit
+testCalledThroughThunkReleasesCapture()
+
+// A capture carried through the thunked conversion is still released exactly
+// once even when the closure is never called.
+func testNeverCalledThroughThunkReleasesCapture() {
+  let t = Tracker("unused")
+  let f = makeCalledOnce { (_: Payload) in
+    print("using \(t.tag)")
+  }
+  dontConsume(f)
+}
+
+// CHECK-NEXT: Tracker(unused) deinit
+testNeverCalledThroughThunkReleasesCapture()

--- a/test/SIL/called_once_thunk.swift
+++ b/test/SIL/called_once_thunk.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend %s \
+// RUN: -emit-sil \
+// RUN: -enable-experimental-feature CalledAttribute \
+// RUN: -verify
+
+// REQUIRES: swift_feature_CalledAttribute
+
+struct Big {
+  var a, b, c, d: Int
+}
+
+func identity<T>(_ f: @escaping (T) -> Void) -> (T) -> Void { f }
+
+func genericMakeCalledOnce<T>(_ f: @escaping (T) -> Void) -> @called(once) (T) -> Void {
+  return f
+}
+
+func consumeCalledOnce(_ f: @called(once) (Int) -> Void) {
+  f(42)
+}
+
+func makeCalledOnce(_ f: @escaping (Int) -> Void) -> @called(once) (Int) -> Void {
+  return identity(f)
+}
+
+func testCallOnceThroughThunk() {
+  let f = makeCalledOnce { x in print(x) }
+  f(1) // Ok
+}
+
+func testNeverCalledThroughThunk() {
+  let f = makeCalledOnce { x in print(x) } // Ok (`@called(once)` has "at most" semantics)
+  _ = f
+}
+
+func testDoubleCallThroughThunk() {
+  let f = makeCalledOnce { x in print(x) } // expected-error {{'f' consumed more than once}}
+  f(1) // expected-note {{consumed here}}
+  f(2) // expected-note {{consumed again here}}
+}
+
+func testGenericBodyThunkDoubleCall() {
+  let f = genericMakeCalledOnce { (x: Int) in print(x) } // expected-error {{'f' consumed more than once}}
+  f(1) // expected-note {{consumed here}}
+  f(2) // expected-note {{consumed again here}}
+}
+
+func testCallOnceThroughThunkAtParameterBoundary(_ f: @escaping (Int) -> Void) {
+  consumeCalledOnce(identity(f)) // Ok
+}

--- a/test/SILGen/called_once.swift
+++ b/test/SILGen/called_once.swift
@@ -76,9 +76,10 @@ func testClosureWithCapture(f: @called(once) () -> Void) {
 
 // Captured `var`s go through the same "move at formation" path as `let`s:
 // forming `g` takes `f`'s current value out via [consumable_and_assignable]
-// + load [take]. Reassigning `f` afterward is ordinary box reinitialization,
-// via the pre-existing [assignable_but_not_consumable] + assign idiom, and
-// does not disturb the value already moved into `g`.
+// + load [take]. Reassigning `f` afterward also uses
+// [consumable_and_assignable] -- `@called(once)` values always have
+// consuming semantics, even for a plain overwrite -- and does not disturb
+// the value already moved into `g`.
 //
 // CHECK-LABEL: sil hidden [ossa] @$s11called_once25testClosureWithVarCaptureyyyyXEnF : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> () {
 // CHECK: bb0([[F_PARAM:%.*]] : @owned $@noescape @called(once) @callee_owned () -> ()):
@@ -100,7 +101,7 @@ func testClosureWithCapture(f: @called(once) () -> Void) {
 // CHECK:  [[NEW_VALUE:%.*]] = apply {{.*}}() : $@convention(thin) () -> @owned @called(once) @callee_owned () -> ()
 // CHECK:  [[NEW_VALUE_NOESCAPE:%.*]] = convert_escape_to_noescape [[NEW_VALUE]] : $@called(once) @callee_owned () -> () to $@noescape @called(once) @callee_owned () -> ()
 // CHECK:  [[F_ACCESS:%.*]] = begin_access [modify] [unknown] [[F_PROJ]] : $*@noescape @called(once) @callee_owned () -> ()
-// CHECK:  [[F_WRITE_ADDR:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[F_ACCESS]] : $*@noescape @called(once) @callee_owned () -> ()
+// CHECK:  [[F_WRITE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_ACCESS]] : $*@noescape @called(once) @callee_owned () -> ()
 // CHECK:  assign [[NEW_VALUE_NOESCAPE]] to [[F_WRITE_ADDR]] : $*@noescape @called(once) @callee_owned () -> ()
 // CHECK: } // end sil function '$s11called_once25testClosureWithVarCaptureyyyyXEnF'
 

--- a/test/SILGen/called_once_thunk.swift
+++ b/test/SILGen/called_once_thunk.swift
@@ -1,0 +1,74 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-feature CalledAttribute %s | %FileCheck %s
+
+// REQUIRES: swift_feature_CalledAttribute
+
+struct Big {
+  var a, b, c, d: Int
+}
+
+func identity<T>(_ f: @escaping (T) -> Void) -> (T) -> Void { f }
+
+func consumeCalledOnce(_ f: @called(once) (Big) -> Void, _ value: Big) {
+  f(value)
+}
+
+func acceptGenericCalledOnce<T>(_ f: @called(once) (T) -> Void, _ value: T) {
+  f(value)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s17called_once_thunk21genericMakeCalledOnceyyxXOyxclF : $@convention(thin) <T> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T> {
+// CHECK:      [[CONVERTED:%.*]] = convert_function {{%.*}} : $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T> to $@callee_guaranteed (@in_guaranteed T) -> ()
+// CHECK:      [[THUNK:%.*]] = function_ref @$sxIegn_xIeOxn_lTR : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @guaranteed @callee_guaranteed (@in_guaranteed τ_0_0) -> ()) -> ()
+// CHECK-NEXT: [[CLOSURE:%.*]] = partial_apply [called_once] [[THUNK]]<T>([[CONVERTED]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @guaranteed @callee_guaranteed (@in_guaranteed τ_0_0) -> ()) -> ()
+// CHECK:      return {{%.*}} : $@called(once) @callee_owned @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <T>
+// CHECK: } // end sil function '$s17called_once_thunk21genericMakeCalledOnceyyxXOyxclF'
+//
+// The thunk itself is a bare, uninstantiated forwarder -- `@called(once)`
+// only attaches once it's captured by the `partial_apply` above.
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sxIegn_xIeOxn_lTR : $@convention(thin) <T> (@in_guaranteed T, @guaranteed @callee_guaranteed (@in_guaranteed T) -> ()) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*T, [[FN:%.*]] : @guaranteed $@callee_guaranteed (@in_guaranteed T) -> ()):
+// CHECK-NEXT: apply [[FN]]([[ARG]]) : $@callee_guaranteed (@in_guaranteed T) -> ()
+// CHECK: } // end sil function '$sxIegn_xIeOxn_lTR'
+func genericMakeCalledOnce<T>(_ f: @escaping (T) -> Void) -> @called(once) (T) -> Void {
+  return f
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s17called_once_thunk22makeCalledOnceEscapingyyAA3BigVXOyADcF : $@convention(thin) (@guaranteed @callee_guaranteed (Big) -> ()) -> @owned @called(once) @callee_owned (Big) -> () {
+// CHECK: [[LAST_THUNK:%.*]] = function_ref @$s17called_once_thunk3BigVIegy_ACIeOxy_TR : $@convention(thin) (Big, @guaranteed @callee_guaranteed (Big) -> ()) -> ()
+// CHECK-NEXT: [[RESULT:%.*]] = partial_apply [called_once] [[LAST_THUNK]]({{%.*}}) : $@convention(thin) (Big, @guaranteed @callee_guaranteed (Big) -> ()) -> ()
+// CHECK-NEXT: return [[RESULT]] : $@called(once) @callee_owned (Big) -> ()
+// CHECK: } // end sil function '$s17called_once_thunk22makeCalledOnceEscapingyyAA3BigVXOyADcF'
+//
+// None of the generated reabstraction thunks themselves carry
+// `@called(once)` in their own declared type.
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$s17called_once_thunk3BigVIegy_ACIeOxy_TR : $@convention(thin) (Big, @guaranteed @callee_guaranteed (Big) -> ()) -> () {
+// CHECK-NOT: @called(once)
+// CHECK: } // end sil function '$s17called_once_thunk3BigVIegy_ACIeOxy_TR'
+func makeCalledOnceEscaping(_ f: @escaping (Big) -> Void) -> @called(once) (Big) -> Void {
+  return identity(f)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s17called_once_thunk34testNoEscapeConversionThroughThunkyyyAA3BigVc_ADtF : $@convention(thin) (@guaranteed @callee_guaranteed (Big) -> (), Big) -> () {
+// CHECK: [[THUNK:%.*]] = function_ref @$s17called_once_thunk3BigVIegy_ACIeOxy_TR : $@convention(thin) (Big, @guaranteed @callee_guaranteed (Big) -> ()) -> ()
+// CHECK-NEXT: [[ESCAPING:%.*]] = partial_apply [called_once] [[THUNK]]({{%.*}}) : $@convention(thin) (Big, @guaranteed @callee_guaranteed (Big) -> ()) -> ()
+// CHECK-NEXT: [[NOESCAPE:%.*]] = convert_escape_to_noescape [[ESCAPING]] : $@called(once) @callee_owned (Big) -> () to $@noescape @called(once) @callee_owned (Big) -> ()
+// CHECK: function_ref @$s17called_once_thunk17consumeCalledOnceyyyAA3BigVXEn_ADtF
+// CHECK-NEXT: apply {{%.*}}([[NOESCAPE]], {{%.*}}) : $@convention(thin) (@owned @noescape @called(once) @callee_owned (Big) -> (), Big) -> ()
+// CHECK: } // end sil function '$s17called_once_thunk34testNoEscapeConversionThroughThunkyyyAA3BigVc_ADtF'
+func testNoEscapeConversionThroughThunk(_ f: @escaping (Big) -> Void, _ big: Big) {
+  consumeCalledOnce(identity(f), big)
+}
+
+func testGenericCalledOnceParameter(_ f: @called(once) (Big) -> Void, _ big: Big) {
+  acceptGenericCalledOnce(f, big)
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$s17called_once_thunk3BigVIOxy_ACIeOxn_TR : $@convention(thin) (@in_guaranteed Big, @owned @noescape @called(once) @callee_owned (Big) -> ()) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*Big, [[FN:%.*]] : @owned $@noescape @called(once) @callee_owned (Big) -> ()):
+// CHECK: apply [[FN]]({{%.*}}) : $@noescape @called(once) @callee_owned (Big) -> ()
+// CHECK: } // end sil function '$s17called_once_thunk3BigVIOxy_ACIeOxn_TR'
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$s17called_once_thunk3BigVIOxn_ACIeOxy_TR : $@convention(thin) (Big, @owned @noescape @called(once) @callee_owned (@in_guaranteed Big) -> ()) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Big, [[FN:%.*]] : @owned $@noescape @called(once) @callee_owned (@in_guaranteed Big) -> ()):
+// CHECK: apply [[FN]]({{%.*}}) : $@noescape @called(once) @callee_owned (@in_guaranteed Big) -> ()
+// CHECK: } // end sil function '$s17called_once_thunk3BigVIOxn_ACIeOxy_TR'

--- a/test/SILGen/called_once_thunk.swift
+++ b/test/SILGen/called_once_thunk.swift
@@ -59,6 +59,16 @@ func testNoEscapeConversionThroughThunk(_ f: @escaping (Big) -> Void, _ big: Big
   consumeCalledOnce(identity(f), big)
 }
 
+// CHECK-LABEL: sil hidden [ossa] @$s17called_once_thunk30testGenericCalledOnceParameteryyyAA3BigVXEn_ADtF : $@convention(thin) (@owned @noescape @called(once) @callee_owned (Big) -> (), Big) -> () {
+// CHECK: [[F_PROJ:%.*]] = project_box {{.*}} : ${ var @noescape @called(once) @callee_owned (Big) -> () }, 0
+// CHECK: [[F_ACCESS:%.*]] = begin_access [deinit] [unknown] [[F_PROJ]] : $*@noescape @called(once) @callee_owned (Big) -> ()
+// CHECK: [[F_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[F_ACCESS]] : $*@noescape @called(once) @callee_owned (Big) -> ()
+// CHECK: [[F_VALUE:%.*]] = load [copy] [[F_ADDR]] : $*@noescape @called(once) @callee_owned (Big) -> ()
+// CHECK: [[THUNK:%.*]] = function_ref @$s17called_once_thunk3BigVIOxy_ACIeOxn_TR
+// CHECK: partial_apply [called_once] [[THUNK]]([[F_VALUE]]) : $@convention(thin) (@in_guaranteed Big, @owned @noescape @called(once) @callee_owned (Big) -> ()) -> ()
+// CHECK: function_ref @$s17called_once_thunk23acceptGenericCalledOnceyyyxXEn_xtlF
+// CHECK: end_access [[F_ACCESS]] : $*@noescape @called(once) @callee_owned (Big) -> ()
+// CHECK: } // end sil function '$s17called_once_thunk30testGenericCalledOnceParameteryyyAA3BigVXEn_ADtF'
 func testGenericCalledOnceParameter(_ f: @called(once) (Big) -> Void, _ big: Big) {
   acceptGenericCalledOnce(f, big)
 }
@@ -67,8 +77,3 @@ func testGenericCalledOnceParameter(_ f: @called(once) (Big) -> Void, _ big: Big
 // CHECK: bb0([[ARG:%.*]] : $*Big, [[FN:%.*]] : @owned $@noescape @called(once) @callee_owned (Big) -> ()):
 // CHECK: apply [[FN]]({{%.*}}) : $@noescape @called(once) @callee_owned (Big) -> ()
 // CHECK: } // end sil function '$s17called_once_thunk3BigVIOxy_ACIeOxn_TR'
-
-// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$s17called_once_thunk3BigVIOxn_ACIeOxy_TR : $@convention(thin) (Big, @owned @noescape @called(once) @callee_owned (@in_guaranteed Big) -> ()) -> () {
-// CHECK: bb0([[ARG:%.*]] : $Big, [[FN:%.*]] : @owned $@noescape @called(once) @callee_owned (@in_guaranteed Big) -> ()):
-// CHECK: apply [[FN]]({{%.*}}) : $@noescape @called(once) @callee_owned (@in_guaranteed Big) -> ()
-// CHECK: } // end sil function '$s17called_once_thunk3BigVIOxn_ACIeOxy_TR'


### PR DESCRIPTION
This change fixes thunking of conversions to `@called(once)` values and reabstraction
between `@called(once)` values. It makes sure that the parameter that takes `@called(once)`
is always `Direct_Owned`, the thunk itself never inherits `@called(once)` bit (the constraint is
expressed on the partial_apply that forms the value) and fixes a problem with l-value projection
when the access is consuming.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
