### PR TITLE
[cxx-interop] Fix extra destroy in thunks for @in_cxx parameters

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -613,6 +613,11 @@ static ManagedValue createInputFunctionArgument(
     return SGF.emitManagedPackWithCleanup(arg);
 
   case SILArgumentConvention::Indirect_In_CXX:
+    // An @in_cxx parameter is destroyed by the caller (this is the
+    // parameter-passing convention of the Itanium C++ ABI), so don't enter a
+    // cleanup for it here.
+    return ManagedValue::forOwnedRValue(arg, CleanupHandle::invalid());
+
   case SILArgumentConvention::Indirect_In:
     if (SGF.silConv.useLoweredAddresses())
       return SGF.emitManagedBufferWithCleanup(arg);

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -49,3 +49,9 @@ module CxxForeignRef {
   header "cxx-frt.h"
   requires cplusplus
 }
+
+module ObjCAsyncNonTrivialCxx {
+  header "objc-async-completion-handler-non-trivial.h"
+  requires objc
+  requires cplusplus
+}

--- a/test/Interop/Cxx/objc-correctness/Inputs/objc-async-completion-handler-non-trivial.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/objc-async-completion-handler-non-trivial.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+struct Tracked {
+  static int liveCount;
+
+  Tracked() { ++liveCount; }
+  Tracked(const Tracked &) { ++liveCount; }
+  Tracked(Tracked &&) = delete;
+  Tracked &operator=(const Tracked &) = delete;
+  Tracked &operator=(Tracked &&) = delete;
+  ~Tracked() { --liveCount; }
+};
+
+inline int getTrackedLiveCount() { return Tracked::liveCount; }
+
+NS_ASSUME_NONNULL_BEGIN
+@interface TrackedProducer : NSObject
+// Imported into Swift both as `produce(completionHandler:)` and as the async
+// `produce() async -> Tracked`.
+- (void)produceWithCompletionHandler:(void (^)(Tracked))completion;
+@end
+NS_ASSUME_NONNULL_END

--- a/test/Interop/Cxx/objc-correctness/Inputs/objc-async-completion-handler-non-trivial.mm
+++ b/test/Interop/Cxx/objc-correctness/Inputs/objc-async-completion-handler-non-trivial.mm
@@ -1,0 +1,10 @@
+#import "objc-async-completion-handler-non-trivial.h"
+
+int Tracked::liveCount = 0;
+
+@implementation TrackedProducer
+- (void)produceWithCompletionHandler:(void (^)(Tracked))completion {
+  Tracked t;
+  completion(t);
+}
+@end

--- a/test/Interop/Cxx/objc-correctness/objc-async-completion-handler-non-trivial-cxx-execution.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-async-completion-handler-non-trivial-cxx-execution.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t2)
+
+// RUN: %target-interop-build-clangxx -c %S/Inputs/objc-async-completion-handler-non-trivial.mm -o %t2/objc-async-impl.o -fobjc-arc
+
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -parse-as-library -Xlinker %t2/objc-async-impl.o) | %FileCheck %s
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -parse-as-library -O -Xlinker %t2/objc-async-impl.o) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// The ObjC async completion handler thunk builds the continuation's resume
+// argument in an alloc_stack, which is not valid with opaque values, where an
+// @in parameter is lowered to a direct value. This is unrelated to what is
+// tested here and reproduces without the @in_cxx fix as well.
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+// The argument of the completion handler block is passed with the Itanium C++
+// ABI convention: the caller destroys it.
+
+import Foundation
+import ObjCAsyncNonTrivialCxx
+
+func viaCompletionHandler() async {
+  await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+    TrackedProducer().produce(completionHandler: { t in
+      _ = t
+      c.resume()
+    })
+  }
+}
+
+func viaAsync() async {
+  let t = await TrackedProducer().produce()
+  _ = t
+}
+
+@main struct Main {
+  static func main() async {
+    await viaCompletionHandler()
+    // CHECK: live after completion handler: 0
+    print("live after completion handler: \(getTrackedLiveCount())")
+
+    await viaAsync()
+    // CHECK: live after async: 0
+    print("live after async: \(getTrackedLiveCount())")
+  }
+}

--- a/test/Interop/Cxx/objc-correctness/objc-async-completion-handler-non-trivial-cxx.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-async-completion-handler-non-trivial-cxx.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-silgen -I %t/Inputs -cxx-interoperability-mode=default %t/test.swift | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+//--- Inputs/header.h
+
+#import <Foundation/Foundation.h>
+
+struct NonTrivial {
+  NonTrivial();
+  NonTrivial(const NonTrivial &);
+  ~NonTrivial();
+};
+
+@interface Producer : NSObject
+- (void)produceWithCompletionHandler:(void (^_Nonnull)(struct NonTrivial))completion;
+@end
+
+//--- Inputs/module.modulemap
+
+module ObjCxxAsync {
+    header "header.h"
+    requires cplusplus
+    export *
+}
+
+//--- test.swift
+
+import ObjCxxAsync
+
+public func callIt(_ p: Producer) async {
+  let x = await p.produce()
+  _ = x
+}
+
+// CHECK-LABEL: sil {{.*}}@$sSo10NonTrivialVIeyBhX_ABT{{[zZ]}}_ : $@convention(c) @Sendable (@inout_aliasable @block_storage Any, @in_cxx NonTrivial) -> () {
+// CHECK: bb0(%0 : $*@block_storage Any, [[ARG:%.*]] : $*NonTrivial):
+// CHECK-NOT: destroy_addr [[ARG]]
+// CHECK: copy_addr [[ARG]] to [init]
+// CHECK-NOT: destroy_addr [[ARG]]
+// CHECK: return


### PR DESCRIPTION
@in_cxx parameters are destroyed by the caller but this convention was not followed by some thunks generated by the compiler resulting in double free errors.

rdar://184504484
