### PR TITLE
[cxx-interop] Consider SWIFT_SHARED_REFERENCE and co Escapable

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -308,6 +308,11 @@ ERROR(nonescapable_foreign_reference_type, none,
       "escapable",
       (const clang::NamedDecl *))
 
+GROUPED_WARNING(escapable_foreign_reference_type, ForeignReferenceType, none,
+      "%0 has no effect on %1; foreign reference types are imported as Swift "
+      "classes, which are always escapable",
+      (StringRef, const clang::NamedDecl *))
+
 GROUPED_WARNING(unannotated_cxx_func_returning_frt, ForeignReferenceType, none,
         "cannot infer ownership of foreign reference value returned by %0",
         (const ValueDecl *))

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5440,12 +5440,14 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
 
 void ClangImporter::Implementation::diagnoseTopLevelValue(
     const DeclName &name) {
+  llvm::SmallPtrSet<const clang::Decl *, 4> visited;
   forEachLookupTable([&](SwiftLookupTable &table) -> bool {
     for (const auto &entry :
          table.lookup(name.getBaseName(),
                       EffectiveClangContext(
                           getClangASTContext().getTranslationUnitDecl()))) {
-      diagnoseTargetDirectly(importDiagnosticTargetFromLookupTableEntry(entry));
+      diagnoseTargetDirectly(importDiagnosticTargetFromLookupTableEntry(entry),
+                             visited);
     }
     return false;
   });
@@ -5453,6 +5455,7 @@ void ClangImporter::Implementation::diagnoseTopLevelValue(
 
 void ClangImporter::Implementation::diagnoseMemberValue(
     const DeclName &name, const clang::DeclContext *container) {
+  llvm::SmallPtrSet<const clang::Decl *, 4> visited;
   forEachLookupTable([&](SwiftLookupTable &table) -> bool {
     for (const auto &entry :
          table.lookup(name.getBaseName(), EffectiveClangContext(container))) {
@@ -5465,16 +5468,30 @@ void ClangImporter::Implementation::diagnoseMemberValue(
       if (nd->getDeclContext() != container)
         continue;
 
-      diagnoseTargetDirectly(importDiagnosticTargetFromLookupTableEntry(entry));
+      diagnoseTargetDirectly(importDiagnosticTargetFromLookupTableEntry(entry),
+                             visited);
     }
     return false;
   });
 }
 
 void ClangImporter::Implementation::diagnoseTargetDirectly(
-    ImportDiagnosticTarget target) {
+    ImportDiagnosticTarget target,
+    llvm::SmallPtrSetImpl<const clang::Decl *> &visited) {
   if (const clang::Decl *decl = target.dyn_cast<const clang::Decl *>()) {
-    Walker.TraverseDecl(const_cast<clang::Decl *>(decl));
+    if (visited.insert(decl).second)
+      Walker.TraverseDecl(const_cast<clang::Decl *>(decl));
+
+    // Import diagnostics are queued against a tag's definition, but a lookup
+    // entry is often a forward declaration or a typedef, and several entries for
+    // one name can reach the same definition, hence the visited set.
+    if (const auto *typedefDecl = dyn_cast<clang::TypedefNameDecl>(decl))
+      if (const auto *tagDecl =
+              typedefDecl->getUnderlyingType()->getAsTagDecl())
+        decl = tagDecl;
+    if (auto definition = importer::getDefinitionForClangTypeDecl(decl))
+      if (*definition && visited.insert(*definition).second)
+        Walker.TraverseDecl(const_cast<clang::Decl *>(*definition));
   } else if (const clang::MacroInfo *macro =
                  target.dyn_cast<const clang::MacroInfo *>()) {
     Walker.VisitMacro(macro);
@@ -5738,6 +5755,25 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
         return CxxEscapability::NonEscapable;
       if (hasEscapableAttr(recordDecl))
         continue;
+      // A foreign reference type is imported as a Swift class, which is always
+      // escapable, including a SWIFT_UNSAFE_REFERENCE, whose unsafety is a
+      // separate axis. Non-escapable fields and bases are rejected separately,
+      // where the type is imported.
+      if (auto *definition = recordDecl->getDefinition()) {
+        if (evaluateOrDefault(evaluator,
+                              ForeignReferenceTypeInfoRequest({definition}), {})
+                .isReference())
+          continue;
+      } else if (llvm::any_of(recordDecl->redecls(), [](const auto *redecl) {
+                   return hasImportReferenceAttr(
+                       cast<clang::RecordDecl>(redecl));
+                 })) {
+        // Inherited reference-ness needs a definition, but a direct annotation
+        // is enough. Ask the attribute, not the request: the request is cached
+        // per decl, so an uninstantiated class template would cache
+        // "not a reference" for good.
+        continue;
+      }
       if (hasSwiftAttribute(recordDecl, {"unsafe", "unsafe(always)"}))
         return CxxEscapability::Unknown;
       llvm::ArrayRef<int> STLParams;
@@ -9220,6 +9256,16 @@ static const std::vector<std::vector<std::pair<StringRef, StringRef>>>
 
 static bool isConditionalAttr(StringRef attrName) {
   return attrName == "escapable_if:" || attrName == "copyable_if:";
+}
+
+StringRef
+importer::getPrettySwiftAttributeName(const clang::SwiftAttrAttr *attr) {
+  for (const auto &groupOfAttrs : ConflictingSwiftAttrs)
+    for (auto [attrName, annotationName] : groupOfAttrs)
+      if (attr->getAttribute().starts_with(attrName))
+        return annotationName;
+
+  return attr->getAttribute();
 }
 
 void ClangImporter::Implementation::validateSwiftAttributes(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2480,6 +2480,16 @@ namespace {
           return nullptr;
         }
 
+        // Escapability annotations have no effect on a foreign reference type.
+        for (auto *swiftAttr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
+          if (swiftAttr->getAttribute() == "Escapable" ||
+              swiftAttr->getAttribute().starts_with("escapable_if:"))
+            Impl.diagnose(HeaderLoc(decl->getLocation()),
+                          diag::escapable_foreign_reference_type,
+                          importer::getPrettySwiftAttributeName(swiftAttr),
+                          decl);
+        }
+
         result = Impl.createDeclWithClangNode<ClassDecl>(
             decl, importer::convertClangAccess(decl->getAccess()), loc, name,
             loc, ArrayRef<InheritedEntry>{}, nullptr, dc, false);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2029,7 +2029,18 @@ public:
                            const clang::DeclContext *container);
 
   /// Emit any import diagnostics associated with the given Clang node.
-  void diagnoseTargetDirectly(ImportDiagnosticTarget target);
+  ///
+  /// \param visited Declarations already traversed for the current lookup, so
+  /// that a definition reachable from several entries is diagnosed once.
+  void diagnoseTargetDirectly(
+      ImportDiagnosticTarget target,
+      llvm::SmallPtrSetImpl<const clang::Decl *> &visited);
+
+  /// Emit any import diagnostics associated with the given Clang node.
+  void diagnoseTargetDirectly(ImportDiagnosticTarget target) {
+    llvm::SmallPtrSet<const clang::Decl *, 4> visited;
+    diagnoseTargetDirectly(target, visited);
+  }
 
 private:
   static ImportDiagnosticTarget importDiagnosticTargetFromLookupTableEntry(
@@ -2324,6 +2335,11 @@ bool hasEscapableAttr(const clang::RecordDecl *decl);
 /// The \c @_refCountedPtr attribute marking \p decl as a reference counting
 /// smart pointer, or null if it does not have one.
 CustomAttr *getRefCountedPtrAttr(Decl *decl);
+
+/// The macro that spells \p attr in a header, e.g. \c SWIFT_ESCAPABLE for
+/// \c swift_attr("Escapable"), for use in diagnostics. Falls back to the
+/// attribute string itself when it has no documented macro.
+StringRef getPrettySwiftAttributeName(const clang::SwiftAttrAttr *attr);
 
 CxxValueSemanticsKind
 getCxxValueSemanticsKind(const clang::Type *type,

--- a/test/Interop/Cxx/foreign-reference/escapable-frt.swift
+++ b/test/Interop/Cxx/foreign-reference/escapable-frt.swift
@@ -1,0 +1,94 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}test.swift \
+// RUN:   -I %t%{fs-sep}Inputs \
+// RUN:   -Xcc -iapinotes-modules -Xcc %swift_src_root/stdlib/public/Cxx/std \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking \
+// RUN:   -strict-memory-safety
+
+// UNSUPPORTED: OS=windows-msvc
+
+// Foreign reference types are always escapable, so member-based inference must
+// not report unknown escapability for them, which would make containers such as
+// std::shared_ptr unsafe under strict memory safety.
+
+//--- Inputs/module.modulemap
+module Test {
+    header "escapable.h"
+    requires cplusplus
+}
+
+//--- Inputs/escapable.h
+#include "swift/bridging"
+#include <memory>
+
+// A typical foreign reference base: polymorphic and non-copyable, so
+// escapability cannot be derived from its members.
+struct SWIFT_IMMORTAL_REFERENCE Base {
+  virtual ~Base() {}
+  Base(const Base &) = delete;
+  Base &operator=(const Base &) = delete;
+
+protected:
+  Base() {}
+};
+
+// Reference-ness is inherited from Base, so Derived is escapable as well.
+struct Derived : Base {
+  int value;
+};
+
+// A foreign reference type annotated directly.
+struct SWIFT_IMMORTAL_REFERENCE Immortal {
+  virtual ~Immortal() {}
+  int value;
+};
+
+// Same shape, but not a reference type: escapability stays unknown, so this one
+// is still unsafe. Keeps the test honest about -strict-memory-safety being on.
+struct Polymorphic {
+  virtual ~Polymorphic() {}
+  Polymorphic(const Polymorphic &) = delete;
+  Polymorphic &operator=(const Polymorphic &) = delete;
+  Polymorphic() {}
+};
+
+inline std::shared_ptr<Derived> makeDerived() { return nullptr; }
+inline std::shared_ptr<Immortal> makeImmortal() { return nullptr; }
+inline std::unique_ptr<Derived> makeUniqueDerived() { return nullptr; }
+inline std::shared_ptr<Polymorphic> makePolymorphic() { return nullptr; }
+
+//--- test.swift
+import Test
+import CxxStdlib
+
+// A smart pointer to a foreign reference type is escapable, so using it does
+// not require 'unsafe'.
+public func useSharedDerived() {
+  let ptr = makeDerived()
+  _ = ptr
+}
+
+public func useSharedImmortal() {
+  let ptr = makeImmortal()
+  _ = ptr
+}
+
+public func useUniqueDerived() {
+  let ptr = makeUniqueDerived()
+  _ = ptr
+}
+
+// The foreign reference types themselves are imported as classes.
+public func useDerived(_ x: Derived) -> Int32 { x.value }
+public func useImmortal(_ x: Immortal) -> Int32 { x.value }
+
+// A non-reference type of the same shape is still unsafe, which confirms
+// -strict-memory-safety is in effect above.
+public func usePolymorphic() {
+  let ptr = makePolymorphic() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1 {{involves unsafe type}}
+  _ = ptr // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1 {{involves unsafe type}}
+}

--- a/test/Interop/Cxx/foreign-reference/nonescapable-frt-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/nonescapable-frt-errors.swift
@@ -53,7 +53,7 @@ struct SWIFT_SHARED_REFERENCE(retainShared, releaseShared) SWIFT_NONESCAPABLE
 };
 
 // Non-escapability inherited from a non-escapable foreign reference base.
-// expected-error@+1 {{'DerivedFromNonEscapable' cannot be both a foreign reference type and non-escapable}}
+// expected-note@+2 {{escapable record 'DerivedFromNonEscapable' cannot have non-escapable base 'ImmortalNonEscapable'}}
 struct SWIFT_IMMORTAL_REFERENCE DerivedFromNonEscapable
     : ImmortalNonEscapable {};
 
@@ -65,7 +65,7 @@ struct SWIFT_NONESCAPABLE View {
 void retainWithField(class FRTWithNonEscapableField *);
 void releaseWithField(class FRTWithNonEscapableField *);
 
-// expected-error@+1 {{'FRTWithNonEscapableField' cannot be both a foreign reference type and non-escapable}}
+// expected-note@+1 {{escapable record 'FRTWithNonEscapableField' cannot have non-escapable field 'view'}}
 class FRTWithNonEscapableField {
 public:
   View view;
@@ -78,10 +78,51 @@ struct SWIFT_IMMORTAL_REFERENCE ComplexFRTWithNonEscapableField {
   ComplexFRTWithNonEscapableField(const ComplexFRTWithNonEscapableField &);
 };
 
+// A templated foreign reference type that stores a non-escapable template
+// argument is rejected, whether or not it spells SWIFT_ESCAPABLE_IF. A
+// non-escapable argument that is not stored is fine, since nothing that cannot
+// escape ends up inside the class.
+// expected-warning@+3 2 {{SWIFT_ESCAPABLE_IF has no effect on}}
+// expected-note@+2 {{escapable record 'StoresArgument<View>' cannot have non-escapable field 'value'}}
+template <class T> struct SWIFT_IMMORTAL_REFERENCE SWIFT_ESCAPABLE_IF(T)
+    StoresArgument {
+  T value;
+};
+using StoresNonEscapable = StoresArgument<View>;
+using StoresEscapable = StoresArgument<int>;
+
+// expected-note@+1 {{escapable record 'UnannotatedTemplate<View>' cannot have non-escapable field 'value'}}
+template <class T> struct SWIFT_IMMORTAL_REFERENCE UnannotatedTemplate {
+  T value;
+};
+using UnannotatedNonEscapable = UnannotatedTemplate<View>;
+
+template <class T> struct SWIFT_IMMORTAL_REFERENCE DoesNotStoreArgument {
+  int value;
+};
+using DoesNotStoreNonEscapable = DoesNotStoreArgument<View>;
+
 // A foreign reference type with no escapability annotation is imported as usual.
 struct SWIFT_IMMORTAL_REFERENCE Immortal {
   int value;
 };
+
+// Escapability annotations are redundant on a foreign reference type, whether
+// it is annotated directly or inherits its reference-ness from a base.
+// expected-warning@+1 {{SWIFT_ESCAPABLE has no effect on 'ImmortalEscapable'}}
+struct SWIFT_IMMORTAL_REFERENCE SWIFT_ESCAPABLE ImmortalEscapable {
+  int value;
+};
+
+// expected-warning@+1 {{SWIFT_ESCAPABLE has no effect on 'DerivedEscapable'}}
+struct SWIFT_ESCAPABLE DerivedEscapable : Immortal {};
+
+// expected-warning@+2 {{SWIFT_ESCAPABLE_IF has no effect on 'ConditionallyEscapable<int>'}}
+template <class T> struct SWIFT_IMMORTAL_REFERENCE SWIFT_ESCAPABLE_IF(T)
+    ConditionallyEscapable {
+  T value;
+};
+using ConditionallyEscapableInt = ConditionallyEscapable<int>;
 
 struct HoldsNonEscapableFRT {
   // expected-note@+2 {{field 'field' unavailable (cannot import)}}
@@ -103,11 +144,19 @@ struct SWIFT_IMMORTAL_REFERENCE AnnotatedViaAPINotes {
   int value;
 };
 
+// An escapability annotation applied via API notes is redundant too.
+// expected-warning@+1 {{SWIFT_ESCAPABLE has no effect on 'EscapableViaAPINotes'}}
+struct SWIFT_IMMORTAL_REFERENCE EscapableViaAPINotes {
+  int value;
+};
+
 //--- Inputs/APINotes.apinotes
 Name: APINotes
 Tags:
 - Name: AnnotatedViaAPINotes
   SwiftEscapable: false
+- Name: EscapableViaAPINotes
+  SwiftEscapable: true
 
 //--- direct.swift
 import Direct
@@ -119,8 +168,17 @@ public func useShared(_ x: SharedNonEscapable) {} // expected-error {{cannot fin
 public func useDerived(_ x: DerivedFromNonEscapable) {} // expected-error {{cannot find type 'DerivedFromNonEscapable' in scope}}
 public func useFRTWithNEField(_ x: FRTWithNonEscapableField) {} // expected-error {{cannot find type 'FRTWithNonEscapableField' in scope}}
 public func useComplexFRTWithNEField(_ x: ComplexFRTWithNonEscapableField) {} // expected-error {{cannot find type 'ComplexFRTWithNonEscapableField' in scope}}
+public func useStoresNE(_ x: StoresNonEscapable) {} // expected-error {{cannot find type 'StoresNonEscapable' in scope}}
+public func useUnannotatedNE(_ x: UnannotatedNonEscapable) {} // expected-error {{cannot find type 'UnannotatedNonEscapable' in scope}}
+
+// A non-escapable template argument that is never stored is not a problem.
+public func useStoresEscapable(_ x: StoresEscapable) -> Int32 { x.value }
+public func useDoesNotStoreNE(_ x: DoesNotStoreNonEscapable) -> Int32 { x.value }
 
 public func useEscapable(_ x: Immortal) -> Int32 { x.value }
+public func useImmortalEscapable(_ x: ImmortalEscapable) -> Int32 { x.value }
+public func useDerivedEscapable(_ x: DerivedEscapable) {}
+public func useConditional(_ x: ConditionallyEscapableInt) -> Int32 { x.value }
 
 // Records with a non-escapable foreign reference field are imported without
 // that field.
@@ -136,3 +194,4 @@ public func useImmortalHolder(_ x: ImmortalHoldsNonEscapableFRT) {
 import APINotes
 
 public func useAnnotated(_ x: AnnotatedViaAPINotes) {} // expected-error {{cannot find type 'AnnotatedViaAPINotes' in scope}}
+public func useEscapableViaAPINotes(_ x: EscapableViaAPINotes) -> Int32 { x.value }

--- a/test/Interop/Cxx/stdlib/use-std-enable-shared-from-this-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-enable-shared-from-this-typechecker.swift
@@ -1,7 +1,9 @@
-// RUN: %target-swift-frontend %s -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-swift-frontend %s -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -verify-ignore-unrelated
 
 import StdEnableSharedFromThis
 
 func s(_ _: SharableFromThis) {}
+// The notes explaining why these are not importable land in the C++ standard
+// library headers, so they are ignored above rather than matched here.
 func f(_ _: MalformedFoo) {} // expected-error {{cannot find type 'MalformedFoo' in scope}}
 func i(_ _: MalformedInt) {} // expected-error {{cannot find type 'MalformedInt' in scope}}


### PR DESCRIPTION
This PR makes sure FRTs always considered as escapable. So conflicting or redundant attributes are diagnosed. Also, this adds some fixes where some diagnostics were not emitted for forward declarations or type aliases. A templated shared reference with a non-escapable template argument now should trigger an error.

rdar://179532898
