### PR TITLE
[DebugInfo] Fix passes assuming single operand in debug_value instructions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -572,14 +572,14 @@ private extension DebugValueInst {
     // Strip deref: removes the enum load it becomes an object type.
     self.stripDeref(index: index)
 
-    let debugBB = self.getOrCreateDebugReconstructionBlock()
-    guard debugBB.arguments.count > 0 else {
+    guard index < operands.count, !(operands[index].value is Undef) else {
       // The debug_value was killed if it relied on the address itself.
       // No salvaging possible.
       return
     }
 
-    let oldArg = debugBB.arguments[0]
+    let debugBB = self.getOrCreateDebugReconstructionBlock()
+    let oldArg = debugBB.arguments[index]
 
     // Load from the new alloc_stack (undef placeholder) and wrap it in an enum.
     let bbBuilder = Builder(atBeginOf: debugBB, location: self.location, context)
@@ -590,9 +590,9 @@ private extension DebugValueInst {
     oldArg.uses.replaceAll(with: enumVal, context)
 
     // Replace the phi arg with correct type, and wire the load's operand.
-    debugBB.eraseArgument(at: 0, context)
+    debugBB.eraseArgument(at: index, context)
     let newArg = debugBB.insertPhiArgument(
-      atPosition: 0, type: operandType, ownership: .none, context)
+      atPosition: index, type: operandType, ownership: .none, context)
     loadVal.operand.set(to: newArg, context)
   }
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1807,6 +1807,21 @@ public:
     return sharedUInt32().InstructionBaseWithTrailingOperands.numOperands;
   }
 
+protected:
+  /// Removes the last operand, shrinking the tail allocated operand list.
+  /// The other, previous, operands, remain fully valid.
+  /// If there are any OtherTrailingTypes, they need to be moved separately by
+  /// the callee.
+  void eraseLastOperandInPlace() {
+    auto operands = getAllOperands();
+    ASSERT(!operands.empty() && "no operand to erase");
+
+    operands.back().~Operand();
+    sharedUInt32().InstructionBaseWithTrailingOperands.numOperands =
+        operands.size() - 1;
+  }
+
+public:
   ArrayRef<Operand> getAllOperands() const {
     return this->template getTrailingObjectsNonStrict<Operand>(
         sharedUInt32().InstructionBaseWithTrailingOperands.numOperands);
@@ -5777,12 +5792,12 @@ class DebugValueInst final
   using InstructionBaseWithTrailingOperands::numTrailingObjects;
   SIL_DEBUG_VAR_SUPPLEMENT_TRAILING_OBJS_IMPL()
 
-public:
-  // FIXME: These following 2 functions are temporary, while debug_value
-  // transitions to being a multi-operand instruction.
-  SILValue getOperand() const { return getAllOperands()[0].get(); }
-  void setOperand(SILValue V) { getAllOperands()[0].set(V); }
+  /// Removes the last operand, shrinking the tail allocated operand list.
+  /// Only the last operand can be removed, to avoid invalidating other
+  /// existing Operand pointers. Pointers to this last operand are invalidated.
+  void eraseLastOperand();
 
+public:
   /// Returns the single operand, asserting that there is exactly one.
   /// Should only be used in contexts where it is known that there is no
   /// debug reconstruction block.
@@ -5952,15 +5967,16 @@ public:
   /// The newly created basic block will be well-formed, returning the SSA
   /// value of this debug_value directly.
   /// If this debug_value has an undef operand, the reconstruction block
-  /// has no arguments and returns undef directly.
+  /// has no arguments and returns undef directly, and the operand is dropped.
   SILBasicBlock *getOrCreateDebugReconstructionBlock();
 
-  /// Drops the operand from this debug value.
+  /// Kills the operand from this debug value.
   /// This function must be called by passes whenever the operand of this debug
   /// value is no longer valid and cannot be salvaged.
-  /// This will replace the operand with an undef, and clear any DIExpr or debug
-  /// reconstruction block.
-  /// If \p varType is specified, the undef will use that type (in the
+  /// Uses inside a debug reconstruction block are replaced with undef. If this
+  /// is the last operand, the operand list is shrunk.
+  /// Any pointers to the killed Operand are invalidated.
+  /// If \p operandType is specified, that undef will use that type (in the
   /// appropriate address/object form) instead of the current operand's type.
   void killOperand(unsigned operandIdx, SILType operandType = SILType());
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6198,11 +6198,9 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
     ConditionalDominanceScope condScope(*this);
 
     // Bind each block argument to its operand.
-    // There can be less arguments than operands because constant values are
-    // currently represented with one undef operand and zero bb arguments.
     auto Operands = i->getAllOperands();
-    assert(DebugBB->getNumArguments() <= Operands.size() &&
-           "debug block has more arguments than operands");
+    assert(DebugBB->getNumArguments() == Operands.size() &&
+           "debug block arguments must match the operands");
     for (auto Idx : indices(DebugBB->getArguments())) {
       SILValue operand = Operands[Idx].get();
       SILArgument *blockArg = DebugBB->getArgument(Idx);

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -155,16 +155,28 @@ collectTypeDependentOperands(SmallVectorImpl<SILValue> &typeDependentOperands,
 // SILInstruction Subclasses
 //===----------------------------------------------------------------------===//
 
+/// Returns the size of the debug variable data that is tail allocated after an
+/// instruction's operands.
+static size_t getDebugVarTrailingDataSize(size_t nameLength, bool hasType,
+                                       bool hasLoc, bool hasScope,
+                                       size_t numDIExprElements) {
+  return nameLength + (hasType ? sizeof(SILType) : 0) +
+         (hasLoc ? sizeof(SILLocation) : 0) +
+         (hasScope ? sizeof(const SILDebugScope *) : 0) +
+         sizeof(SILDIExprElement) * numDIExprElements;
+}
+
 template <typename INST>
 static void *allocateDebugVarCarryingInst(SILModule &M,
                                           std::optional<SILDebugVariable> Var,
                                           ArrayRef<SILValue> Operands = {}) {
   return M.allocateInst(
-      sizeof(INST) + (Var ? Var->Name.size() : 0) +
-          (Var && Var->Type ? sizeof(SILType) : 0) +
-          (Var && Var->Loc ? sizeof(SILLocation) : 0) +
-          (Var && Var->Scope ? sizeof(const SILDebugScope *) : 0) +
-          sizeof(SILDIExprElement) * (Var ? Var->DIExpr.getNumElements() : 0) +
+      sizeof(INST) +
+          (Var ? getDebugVarTrailingDataSize(
+                     Var->Name.size(), Var->Type.has_value(),
+                     Var->Loc.has_value(), Var->Scope != nullptr,
+                     Var->DIExpr.getNumElements())
+               : 0) +
           sizeof(Operand) * Operands.size(),
       alignof(INST));
 }
@@ -455,7 +467,7 @@ DebugValueInst::DebugValueInst(
     setUsesMoveableValueDebugInfo();
   setTrace(trace);
   if (prependDeref)
-    this->prependDeref(0);
+    sharedUInt8().DebugValueInst.prependDeref = true;
 }
 
 DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
@@ -586,6 +598,8 @@ SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
     // Clear the op_deref, unless we have an address-only type.
     if (!addressOnly)
       sharedUInt8().DebugValueInst.prependDeref = false;
+    // As the block has no argument, drop the operand.
+    eraseLastOperand();
   } else if (hasDeref()) {
     SILArgument *arg = block->createPhiArgument(
         operand->getType().getAddressType(), OwnershipKind::None);
@@ -627,7 +641,43 @@ void DebugValueInst::cloneReconstructionBlockFrom(DebugValueInst *src) {
     .cloneDebugReconstructionBlockContent(srcBB, newBB);
 }
 
+void DebugValueInst::eraseLastOperand() {
+  // The variable data is tail allocated after the operands, so shrinking the
+  // operand list moves it by one operand. It is all trivially copyable, so
+  // using memmove is safe. Nothing keeps pointers on the varinfo.
+  size_t varinfoSize = getDebugVarTrailingDataSize(
+      VarInfo.getName(getTrailingObjects<char>()).size(),
+      HasAuxDebugVariableType, hasAuxDebugLocation(), hasAuxDebugScope(),
+      NumDIExprOperands);
+  char *varinfoBegin = reinterpret_cast<char *>(getAllOperands().end());
+
+  eraseLastOperandInPlace();
+  std::memmove(varinfoBegin - sizeof(Operand), varinfoBegin, varinfoSize);
+}
+
 void DebugValueInst::killOperand(unsigned operandIdx, SILType operandType) {
+  // If there is a debug reconstruction block, the operand doesn't describe the
+  // variable directly, the block does. Drop the operand, keeping the rest of
+  // the block, as a part of the variable might be constant and still recoverable.
+  if (auto *bb = getDebugReconstructionBlock()) {
+    ASSERT(bb->getNumArguments() == getAllOperands().size() &&
+           "debug reconstruction block arguments must match the operands");
+    ASSERT(operandIdx < bb->getNumArguments());
+    auto *argument = bb->getArgument(operandIdx);
+    argument->replaceAllUsesWithUndef();
+
+    // Only a trailing operand can be removed: erasing one in the middle would
+    // shift the following operands, invalidating existing Operand pointers.
+    if (operandIdx == getAllOperands().size() - 1) {
+      bb->eraseArgument(operandIdx);
+      eraseLastOperand();
+    } else {
+      // Keep an undef operand and its now unused block argument.
+      getAllOperands()[operandIdx].set(SILUndef::get(argument));
+    }
+    return;
+  }
+
   Operand &operandRef = getAllOperands()[operandIdx];
   SILValue operand = operandRef.get();
   if (isa<SILUndef>(operand)) {
@@ -657,19 +707,6 @@ void DebugValueInst::killOperand(unsigned operandIdx, SILType operandType) {
   // The stored DIExpr only contains fragments, which we want to keep.
   if (!addressOnly)
     sharedUInt8().DebugValueInst.prependDeref = false;
-
-  // Rather than completely removing the debug reconstruction block, remove its
-  // argument, as a part of the variable might be constant and recoverable.
-  if (auto bb = getDebugReconstructionBlock()) {
-    ASSERT(operandIdx < bb->getNumArguments());
-    ASSERT(bb->getNumArguments() == 1 && "Multi operand support not ready");
-    auto argument = bb->getArgument(operandIdx);
-    argument->replaceAllUsesWithUndef();
-    // FIXME: For correct multi operand support, the operand must also be
-    // removed from the debug_value instruction's operand list, or the
-    // indices will not match.
-    bb->eraseArgument(operandIdx);
-  }
 }
 
 SILType DebugValueInst::getVarType() const {
@@ -682,12 +719,6 @@ SILType DebugValueInst::getVarType() const {
 }
 
 bool DebugValueInst::isExprTypeValid() const {
-  auto varInfo = getCompleteVarInfo();
-
-  // TODO: Multiple operands are not yet supported.
-  if (getAllOperands().size() != 1)
-    return false;
-
   // Ignore trace debug values.
   if (hasTrace())
     return true;
@@ -696,23 +727,36 @@ bool DebugValueInst::isExprTypeValid() const {
   if (!F)
     return false;
 
-  SILValue operand = getSingleOperand();
-  SILType valueType = operand->getType();
+  // A debug_value with no operands need a debug reconstruction block.
+  if (getAllOperands().empty() && !getDebugReconstructionBlock())
+    return false;
 
-  // Special case: a DebugValueInst with an alloc_box operand is equivalent to
-  // the alloc_box.
-  if (auto *box = dyn_cast<AllocBoxInst>(operand))
-    if (varInfo.DIExpr.elements().empty() &&
-        getDebugReconstructionBlock() == nullptr &&
-        varInfo.Type == box->getAddressType().getObjectType())
-      return true;
+  auto varInfo = getCompleteVarInfo();
 
-  // Transform: debug BB transforms the SSA value to its return type.
-  if (auto *debugBB = getDebugReconstructionBlock()) {
-    if (debugBB->getNumArguments() > 0) {
-      if (debugBB->getNumArguments() > 1)
-        return false;
-      if (debugBB->getArgument(0)->getType() != valueType)
+  auto operands = getAllOperands();
+  auto *debugBB = getDebugReconstructionBlock();
+  SILType valueType;
+
+  if (!debugBB) {
+    // Without a debug reconstruction block, there must be exactly one operand.
+    if (operands.size() != 1)
+      return false;
+
+    SILValue operand = getSingleOperand();
+    valueType = operand->getType();
+
+    // Special case: a DebugValueInst with an alloc_box operand is equivalent to
+    // the alloc_box.
+    if (auto *box = dyn_cast<AllocBoxInst>(operand))
+      if (varInfo.DIExpr.elements().empty() &&
+          varInfo.Type == box->getAddressType().getObjectType())
+        return true;
+  } else {
+    // Transform: debug BB transforms the SSA values to its return type.
+    if (debugBB->getNumArguments() != operands.size())
+      return false;
+    for (unsigned idx : indices(operands)) {
+      if (debugBB->getArgument(idx)->getType() != operands[idx].get()->getType())
         return false;
     }
     auto *terminator = cast<ReturnInst>(debugBB->getTerminator());

--- a/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
+++ b/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
@@ -382,15 +382,15 @@ bool PhiExpansionPass::optimizeArg(SILPhiArgument *initialArg) {
     SILArgument *newArg = block->replacePhiArgumentAndReplaceAllUses(
                              arg->getIndex(), newType, arg->getOwnershipKind());
 
-    // First collect all users, then do the transformation.
+    // First collect all uses, then do the transformation.
     // We don't want to modify the use list while iterating over it.
-    llvm::SmallVector<DebugValueInst *, 8> debugValueUsers;
+    llvm::SmallVector<Operand *, 8> debugValueUses;
     llvm::SmallVector<StructExtractInst *, 8> structExtractUsers;
 
     for (Operand *use : newArg->getUses()) {
       SILInstruction *user = use->getUser();
-      if (auto *dvi = dyn_cast<DebugValueInst>(user)) {
-        debugValueUsers.push_back(dvi);
+      if (isa<DebugValueInst>(user)) {
+        debugValueUses.push_back(use);
         continue;
       }
       if (auto *sei = dyn_cast<StructExtractInst>(user)) {
@@ -400,8 +400,10 @@ bool PhiExpansionPass::optimizeArg(SILPhiArgument *initialArg) {
       // Branches are handled below by handling incoming phi operands.
       assert(isa<BranchInst>(user) || isa<CondBranchInst>(user));
     }
-  
-    for (DebugValueInst *dvi : debugValueUsers) {
+
+    for (Operand *use : debugValueUses) {
+      auto *dvi = cast<DebugValueInst>(use->getUser());
+      unsigned operandIdx = use->getOperandNumber();
       // Build a debug reconstruction block that rebuilds the struct from
       // the single known field, using undef for the remaining fields.
       SILBasicBlock *debugBB = dvi->getOrCreateDebugReconstructionBlock();
@@ -424,10 +426,10 @@ bool PhiExpansionPass::optimizeArg(SILPhiArgument *initialArg) {
               .createStruct(dvi->getLoc(), structType, structFields);
 
       // Replace the known field operand with the new phi argument.
-      SILArgument *oldArg = debugBB->getArgument(0);
+      SILArgument *oldArg = debugBB->getArgument(operandIdx);
       oldArg->replaceAllUsesWith(structVal);
       SILPhiArgument *newArg = debugBB->replacePhiArgument(
-          0, newType, OwnershipKind::None);
+          operandIdx, newType, OwnershipKind::None);
       structVal->setOperand(fieldIdx, newArg);
     }
     for (StructExtractInst *sei : structExtractUsers) {

--- a/test/DebugInfo/allocbox_to_stack.sil
+++ b/test/DebugInfo/allocbox_to_stack.sil
@@ -14,7 +14,7 @@ enum Nat {
 // CHECK-LABEL: sil [ossa] @box_with_debug_reconstruction_block_indirect_enum
 // CHECK: alloc_stack
 // CHECK-NOT: alloc_box
-// CHECK: debug_value undef : {{.*}}, var, name "x", type $Nat, transform
+// CHECK: debug_value (), var, name "x", type $Nat, transform
 sil [ossa] @box_with_debug_reconstruction_block_indirect_enum : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_box ${ var Nat }

--- a/test/DebugInfo/dead-store-elimination.sil
+++ b/test/DebugInfo/dead-store-elimination.sil
@@ -56,7 +56,7 @@ bb0(%0 : $MyStruct):
 // When a debug_value has a reconstruction block with no load (e.g.
 // address_to_pointer), stripDeref cannot salvage and calls killOperand.
 // CHECK-LABEL: @dse_salvage_store_strip_deref_kill
-// CHECK: debug_value undef : {{.+}}, let, name "ptr", type $Builtin.RawPointer, transform {
+// CHECK: debug_value (), let, name "ptr", type $Builtin.RawPointer, transform {
 // CHECK:   bb0:
 // CHECK:     address_to_pointer undef : $*MyStruct to $Builtin.RawPointer
 // CHECK:     return

--- a/test/DebugInfo/debug_transform_block.sil
+++ b/test/DebugInfo/debug_transform_block.sil
@@ -22,7 +22,7 @@ sil @test_transform_const : $@convention(thin) () -> () {
 bb0:
 // The transform block produces a constant i64 42 that is used in #dbg_value.
 // CHECK: #dbg_value(i64 42, ![[VAR1:[0-9]+]]
-  debug_value undef : $Builtin.Int64, let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
+  debug_value (), let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
   bb0:
     %0 = integer_literal $Builtin.Int64, 42
     return %0 : $Builtin.Int64

--- a/test/DebugInfo/irgen_debug_reconstruction.sil
+++ b/test/DebugInfo/irgen_debug_reconstruction.sil
@@ -1,5 +1,4 @@
-// RUN: %target-swiftc_driver -Xfrontend -disable-debugger-shadow-copies -Xfrontend -sil-verify-none -O -g -emit-ir %s | %FileCheck %s
-// TODO: Remove -sil-verify-none once isExprTypeValid() accepts multiple operands.
+// RUN: %target-swiftc_driver -Xfrontend -disable-debugger-shadow-copies -O -g -emit-ir %s | %FileCheck %s
 sil_stage canonical
 
 import Swift

--- a/test/DebugInfo/irgen_undef.sil
+++ b/test/DebugInfo/irgen_undef.sil
@@ -38,19 +38,19 @@ return %0 : $Builtin.Int64
 sil @constant : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
 bb0(%0 : $Builtin.Int64):
 // CHECK: #dbg_value(i64 42, ![[CONST_VAR:[0-9]+]], !DIExpression()
-debug_value undef : $Builtin.Int64, var, name "const", transform {
+debug_value (), var, name "const", transform {
 bb0:
   %1 = integer_literal $Builtin.Int64, 42
   return %1 : $Builtin.Int64
 }
 // CHECK: #dbg_value(i64 3645, ![[CONSTINT_VAR:[0-9]+]], !DIExpression()
-debug_value undef : $Builtin.Int64, var, name "constint", type $Int64, expr op_fragment:#Int64._value, transform {
+debug_value (), var, name "constint", type $Int64, expr op_fragment:#Int64._value, transform {
 bb0:
   %1 = integer_literal $Builtin.Int64, 3645
   return %1 : $Builtin.Int64
 }
 // CHECK: #dbg_value(i64 6, ![[CONSTUPLE_VAR:[0-9]+]], !DIExpression(DW_OP_LLVM_fragment, 0, 64)
-debug_value undef : $Builtin.Int64, var, name "constuple", type $(Int64, Int64), expr op_tuple_fragment:$(Int64, Int64):0:op_fragment:#Int64._value, transform {
+debug_value (), var, name "constuple", type $(Int64, Int64), expr op_tuple_fragment:$(Int64, Int64):0:op_fragment:#Int64._value, transform {
 bb0:
   %1 = integer_literal $Builtin.Int64, 6
   return %1 : $Builtin.Int64
@@ -62,7 +62,7 @@ return %0 : $Builtin.Int64
 sil @float_constant : $@convention(thin) (Builtin.FPIEEE64) -> (Builtin.FPIEEE64) {
 bb0(%0 : $Builtin.FPIEEE64):
   // CHECK: #dbg_value(double 2.000000e+00, ![[FCONST_VAR:[0-9]+]], !DIExpression()
-  debug_value undef : $Builtin.FPIEEE64, var, name "fconst", transform {
+  debug_value (), var, name "fconst", transform {
   bb0:
     %1 = float_literal $Builtin.FPIEEE64, 0x4000000000000000 // 2.0
     return %1 : $Builtin.FPIEEE64

--- a/test/DebugInfo/phi-expansion.sil
+++ b/test/DebugInfo/phi-expansion.sil
@@ -34,3 +34,35 @@ bb3(%5 : $Mystruct):
   %6 = struct_extract %5 : $Mystruct, #Mystruct.i
   return %6 : $Int
 }
+
+// CHECK-LABEL: sil @test_multi_operand
+// CHECK: bb3(%[[PHI:[0-9]*]] : $Int):
+// CHECK:   debug_value (%2 : $Int, %[[PHI]] : $Int), let, name "pos", type $Mystruct, transform {
+// CHECK:     bb0(%0 : $Int, %1 : $Int):
+// CHECK:       %2 = struct $Mystruct (%1 : $Int, undef : $Int)
+// CHECK:       %3 = struct_extract %2 : $Mystruct, #Mystruct.j
+// CHECK:       %4 = struct $Mystruct (%0 : $Int, %3 : $Int)
+// CHECK:       return %4 : $Mystruct
+// CHECK:   }
+// CHECK: } // end sil function 'test_multi_operand'
+
+sil @test_multi_operand : $@convention(thin) (Mystruct, Mystruct, Int) -> Int {
+bb0(%0 : $Mystruct, %1 : $Mystruct, %2 : $Int):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Mystruct)
+
+bb2:
+  br bb3(%1 : $Mystruct)
+
+bb3(%5 : $Mystruct):
+  debug_value (%2 : $Int, %5 : $Mystruct), let, name "pos", type $Mystruct, transform {
+  bb0(%0 : $Int, %1 : $Mystruct):
+    %2 = struct_extract %1 : $Mystruct, #Mystruct.j
+    %3 = struct $Mystruct (%0 : $Int, %2 : $Int)
+    return %3 : $Mystruct
+  }
+  %6 = struct_extract %5 : $Mystruct, #Mystruct.i
+  return %6 : $Int
+}

--- a/test/DebugInfo/salvage-literal.swift
+++ b/test/DebugInfo/salvage-literal.swift
@@ -7,11 +7,11 @@
 public func f() -> Int {
   let a = 2
   let b = 3
-  // CHECK: debug_value undef : $Builtin.Int{{32|64}}, let, name "a", type $Int, expr op_fragment:#Int._value, transform {
+  // CHECK: debug_value (), let, name "a", type $Int, expr op_fragment:#Int._value, transform {
   // CHECK:   %0 = integer_literal $Builtin.Int{{32|64}}, 2
   // CHECK:   return %0
   // CHECK: }
-  // CHECK: debug_value undef : $Builtin.Int{{32|64}}, let, name "b", type $Int, expr op_fragment:#Int._value, transform {
+  // CHECK: debug_value (), let, name "b", type $Int, expr op_fragment:#Int._value, transform {
   // CHECK:   %0 = integer_literal $Builtin.Int{{32|64}}, 3
   // CHECK:   return %0
   // CHECK: }
@@ -22,11 +22,11 @@ public func f() -> Int {
 public func g() -> Double {
   let a = 2.0
   let b = 3.0
-  // CHECK: debug_value undef : $Builtin.FPIEEE64, let, name "a", type $Double, expr op_fragment:#Double._value, transform {
+  // CHECK: debug_value (), let, name "a", type $Double, expr op_fragment:#Double._value, transform {
   // CHECK:   %0 = float_literal $Builtin.FPIEEE64, 0x4000000000000000
   // CHECK:   return %0
   // CHECK: }
-  // CHECK: debug_value undef : $Builtin.FPIEEE64, let, name "b", type $Double, expr op_fragment:#Double._value, transform {
+  // CHECK: debug_value (), let, name "b", type $Double, expr op_fragment:#Double._value, transform {
   // CHECK:   %0 = float_literal $Builtin.FPIEEE64, 0x4008000000000000
   // CHECK:   return %0
   // CHECK: }

--- a/test/DebugInfo/salvage_builtin.sil
+++ b/test/DebugInfo/salvage_builtin.sil
@@ -10,7 +10,7 @@ import Swift
 // Nullary builtin (zeroInitializer): salvaged by cloning into debug BB.
 
 // CHECK-LABEL: sil @test_nullary_builtin
-// CHECK:         debug_value undef : $Builtin.Int64, let, name "zero", {{.*}}transform {
+// CHECK:         debug_value (), let, name "zero", {{.*}}transform {
 // CHECK:           %0 = builtin "zeroInitializer"() : $Builtin.Int64
 // CHECK:           return %0 : $Builtin.Int64
 // CHECK:         }
@@ -124,7 +124,7 @@ bb0(%0 : $Builtin.Int64):
 // pattern after prior cascading salvage of the tuple_extract).
 
 // CHECK-LABEL: sil @test_checked_trunc_intliteral
-// CHECK:         debug_value undef : {{.*}}, let, name "truncated", {{.*}}transform {
+// CHECK:         debug_value (), let, name "truncated", {{.*}}transform {
 // CHECK:           %0 = integer_literal $Builtin.Int1, 0
 // CHECK:           %1 = integer_literal $Builtin.Int64, 42
 // CHECK:           %2 = tuple (%1 : $Builtin.Int64, %0 : $Builtin.Int1)

--- a/test/DebugInfo/salvage_enum.sil
+++ b/test/DebugInfo/salvage_enum.sil
@@ -35,7 +35,7 @@ bb0(%0 : $Builtin.Int64):
 
 // CHECK-LABEL: sil @test_salvage_enum_no_payload
 // CHECK:       bb0:
-// CHECK:         debug_value undef : $Optional<Int64>, let, name "empty", transform {
+// CHECK:         debug_value (), let, name "empty", transform {
 // CHECK:           bb0:
 // CHECK:             [[NONE:%[0-9]+]] = enum $Optional<Int64>, #Optional.none!enumelt
 // CHECK:             return [[NONE]] : $Optional<Int64>

--- a/test/DebugInfo/salvage_struct_extract_lifetime.sil
+++ b/test/DebugInfo/salvage_struct_extract_lifetime.sil
@@ -20,7 +20,7 @@ struct Job: ~Copyable {
 // CHECK:             return %1 : $Builtin.Int64
 // CHECK:         }
 // CHECK:         release_value %0
-// CHECK:         debug_value undef : $Job, let, name "after_destroy", {{.*}}transform
+// CHECK:         debug_value (), let, name "after_destroy", {{.*}}transform
 // CHECK-LABEL: } // end sil function 'test_destroy_kills_debug_value'
 sil [ossa] @test_destroy_kills_debug_value : $@convention(thin) (@owned Job) -> () {
 bb0(%0 : @owned $Job):

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -100,7 +100,7 @@ public struct Empty {}
 // When an empty struct is removed, the debug_value should be fully salvaged
 // into a debug BB by cloning the struct construction.
 // CHECK-LABEL: sil @salvage_empty_struct
-// CHECK: debug_value undef : $Empty, let, name "e", transform {
+// CHECK: debug_value (), let, name "e", transform {
 // CHECK:   bb0:
 // CHECK:     %[[S:[0-9]+]] = struct $Empty ()
 // CHECK:     return %[[S]] : $Empty
@@ -139,7 +139,7 @@ bb0(%0 : $Int64, %1 : $Int64):
 // When an empty tuple is removed, the debug_value should be fully salvaged
 // into a debug BB by cloning the tuple construction.
 // CHECK-LABEL: sil @salvage_empty_tuple
-// CHECK: debug_value undef : $(), let, name "e", transform {
+// CHECK: debug_value (), let, name "e", transform {
 // CHECK:   bb0:
 // CHECK:     %[[T:[0-9]+]] = tuple ()
 // CHECK:     return %[[T]] : $()

--- a/test/DebugInfo/simplify_alloc_stack.sil
+++ b/test/DebugInfo/simplify_alloc_stack.sil
@@ -49,6 +49,42 @@ bb0(%0 : $*any P):
   return %r : $()
 }
 
+struct Pair {
+  @_hasStorage var i: Int { get set }
+  @_hasStorage var o: Optional<Int> { get set }
+  init(i: Int, o: Optional<Int>)
+}
+
+// Test that multi-operand debug values are rewritten correctly.
+// CHECK-LABEL: sil [ossa] @expand_enum_multi_operand :
+// CHECK:         [[A:%[0-9]+]] = alloc_stack $Int
+// CHECK:         debug_value (%0, [[A]]), var, name "x", type $Pair, transform {
+// CHECK:         bb0(%0 : $Int, %1 : $*Int):
+// CHECK:           %2 = load %1
+// CHECK:           %3 = enum $Optional<Int>, #Optional.some!enumelt, %2
+// CHECK:           %4 = struct $Pair (%0, %3)
+// CHECK:           return %4
+// CHECK:         }
+// CHECK:       } // end sil function 'expand_enum_multi_operand'
+sil [ossa] @expand_enum_multi_operand : $@convention(thin) (Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int):
+  %2 = alloc_stack $Optional<Int>
+  %3 = init_enum_data_addr %2, #Optional.some!enumelt
+  store %1 to [trivial] %3 : $*Int
+  inject_enum_addr %2, #Optional.some!enumelt
+  debug_value (%0 : $Int, %2 : $*Optional<Int>), var, name "x", type $Pair, transform {
+  bb0(%0 : $Int, %1 : $*Optional<Int>):
+    %2 = load %1 : $*Optional<Int>
+    %3 = struct $Pair (%0 : $Int, %2 : $Optional<Int>)
+    return %3 : $Pair
+  }
+  %5 = unchecked_take_enum_data_addr %2, #Optional.some!enumelt
+  destroy_addr %5
+  dealloc_stack %2
+  %r = tuple ()
+  return %r : $()
+}
+
 enum TwoCase {
   case a(Int)
   case b(Int)

--- a/test/DebugInfo/simplify_builtin.sil
+++ b/test/DebugInfo/simplify_builtin.sil
@@ -9,11 +9,11 @@ import Builtin
 //
 // CHECK-LABEL: sil @preserve_bitwise_operands : $@convention(thin) () -> Builtin.Int32 {
 // CHECK:       bb0:
-// CHECK-NEXT:    debug_value undef : $Builtin.Int32, let, name "x", transform {
+// CHECK-NEXT:    debug_value (), let, name "x", transform {
 // CHECK:           %0 = integer_literal $Builtin.Int32, 1
 // CHECK:           return %0 : $Builtin.Int32
 // CHECK:         }
-// CHECK:         debug_value undef : $Builtin.Int32, let, name "y", transform {
+// CHECK:         debug_value (), let, name "y", transform {
 // CHECK:           %0 = integer_literal $Builtin.Int32, 2
 // CHECK:           return %0 : $Builtin.Int32
 // CHECK:         }
@@ -32,11 +32,11 @@ bb0:
 
 // CHECK-LABEL: sil @preserve_add_operands : $@convention(thin) () -> Builtin.Int32 {
 // CHECK:       bb0:
-// CHECK-NEXT:    debug_value undef : $Builtin.Int32, let, name "x", transform {
+// CHECK-NEXT:    debug_value (), let, name "x", transform {
 // CHECK:           %0 = integer_literal $Builtin.Int32, -1
 // CHECK:           return %0 : $Builtin.Int32
 // CHECK:         }
-// CHECK:         debug_value undef : $Builtin.Int32, let, name "y", transform {
+// CHECK:         debug_value (), let, name "y", transform {
 // CHECK:           %0 = integer_literal $Builtin.Int32, 2
 // CHECK:           return %0 : $Builtin.Int32
 // CHECK:         }

--- a/test/DebugInfo/sroa_debug_value.sil
+++ b/test/DebugInfo/sroa_debug_value.sil
@@ -71,7 +71,7 @@ sil_scope 3 { loc "sroa.swift":20:6 parent @sroa_kills_debug_reconstruction_bloc
 // CHECK-SROA-LABEL: sil {{.+}} @sroa_kills_debug_reconstruction_block
 // When a debug_value has a reconstruction block, SROA cannot append fragments.
 // Instead it kills the operand (replaces with undef) and preserves the block.
-// CHECK-SROA: debug_value undef : {{.+}}, let, name "ptr", type $Builtin.RawPointer, transform {
+// CHECK-SROA: debug_value (), let, name "ptr", type $Builtin.RawPointer, transform {
 // CHECK-SROA:   bb0:
 // CHECK-SROA:     address_to_pointer undef : $*MyStruct to $Builtin.RawPointer
 // CHECK-SROA:     return

--- a/test/SIL/Parser/debug_transform_block.sil
+++ b/test/SIL/Parser/debug_transform_block.sil
@@ -9,12 +9,12 @@ sil_scope 1 { parent @test_transform_const : $@convention(thin) () -> () }
 // CHECK-LABEL: sil @test_transform_const :
 sil @test_transform_const : $@convention(thin) () -> () {
 bb0:
-  // CHECK: debug_value undef : $Builtin.Int64, let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
+  // CHECK: debug_value (), let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
   // CHECK:   bb0:
   // CHECK:     %0 = integer_literal $Builtin.Int64, 42
   // CHECK:     return %0 : $Builtin.Int64
   // CHECK:   }
-  debug_value undef : $Builtin.Int64, let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
+  debug_value (), let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
   bb0:
     %0 = integer_literal $Builtin.Int64, 42
     return %0 : $Builtin.Int64

--- a/test/SIL/Parser/debug_value_multi_operand.sil
+++ b/test/SIL/Parser/debug_value_multi_operand.sil
@@ -1,5 +1,4 @@
-// RUN: %target-sil-opt -sil-verify-none -sil-print-types %s | %target-sil-opt -sil-verify-none -sil-print-types | %FileCheck %s
-// TODO: Remove -sil-verify-none when multi-operand debug_value is supported
+// RUN: %target-sil-opt -sil-print-types %s | %target-sil-opt -sil-print-types | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SIL/Parser/debug_value_multi_operand.sil
+++ b/test/SIL/Parser/debug_value_multi_operand.sil
@@ -20,21 +20,3 @@ bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int32):
   return %r : $()
 }
 // CHECK: } // end sil function 'test_multi_operand_transform'
-
-// CHECK-LABEL: sil @test_zero_operand_transform :
-sil @test_zero_operand_transform : $@convention(thin) () -> () {
-bb0:
-  // CHECK: debug_value (), let, name "const", transform {
-  // CHECK:   bb0:
-  // CHECK:     %0 = integer_literal $Builtin.Int64, 42
-  // CHECK:     return %0 : $Builtin.Int64
-  // CHECK:   }
-  debug_value (), let, name "const", transform {
-  bb0:
-    %0 = integer_literal $Builtin.Int64, 42
-    return %0 : $Builtin.Int64
-  }
-  %r = tuple ()
-  return %r : $()
-}
-// CHECK: } // end sil function 'test_zero_operand_transform'

--- a/test/SIL/Parser/debug_value_zero_operand.sil
+++ b/test/SIL/Parser/debug_value_zero_operand.sil
@@ -1,0 +1,65 @@
+// RUN: %target-sil-opt -sil-print-types %s | %target-sil-opt -sil-print-types | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+
+protocol P {}
+
+// A debug_value with no operand describes a variable whose value is entirely
+// reconstructed by its transform block.
+
+// CHECK-LABEL: sil @test_zero_operand_transform :
+sil @test_zero_operand_transform : $@convention(thin) () -> () {
+bb0:
+  // CHECK: debug_value (), let, name "const", transform {
+  // CHECK:   bb0:
+  // CHECK:     %0 = integer_literal $Builtin.Int64, 42
+  // CHECK:     return %0 : $Builtin.Int64
+  // CHECK:   }
+  debug_value (), let, name "const", transform {
+  bb0:
+    %0 = integer_literal $Builtin.Int64, 42
+    return %0 : $Builtin.Int64
+  }
+  %r = tuple ()
+  return %r : $()
+}
+// CHECK: } // end sil function 'test_zero_operand_transform'
+
+// The variable type can also be stored explicitly, along with a fragment.
+// CHECK-LABEL: sil @test_zero_operand_fragment :
+sil @test_zero_operand_fragment : $@convention(thin) () -> () {
+bb0:
+  // CHECK: debug_value (), let, name "const", type $Int64, expr op_fragment:#Int64._value, transform {
+  // CHECK:   bb0:
+  // CHECK:     %0 = integer_literal $Builtin.Int64, 42
+  // CHECK:     return %0 : $Builtin.Int64
+  // CHECK:   }
+  debug_value (), let, name "const", type $Int64, expr op_fragment:#Int64._value, transform {
+  bb0:
+    %0 = integer_literal $Builtin.Int64, 42
+    return %0 : $Builtin.Int64
+  }
+  %r = tuple ()
+  return %r : $()
+}
+// CHECK: } // end sil function 'test_zero_operand_fragment'
+
+// With no operand, an op_deref applies to the transform block's return value,
+// which must then be address-only.
+// CHECK-LABEL: sil @test_zero_operand_deref :
+sil @test_zero_operand_deref : $@convention(thin) () -> () {
+bb0:
+  // CHECK: debug_value (), let, name "x", type $any P, expr op_deref, transform {
+  // CHECK:   bb0:
+  // CHECK:     return undef : $*any P
+  // CHECK:   }
+  debug_value (), let, name "x", type $any P, expr op_deref, transform {
+  bb0:
+    return undef : $*any P
+  }
+  %r = tuple ()
+  return %r : $()
+}
+// CHECK: } // end sil function 'test_zero_operand_deref'

--- a/test/SIL/verifier_failures_debug_transform.sil
+++ b/test/SIL/verifier_failures_debug_transform.sil
@@ -9,10 +9,12 @@ import Swift
 
 sil_scope 1 { parent @test_type_mismatch : $@convention(thin) () -> () }
 sil_scope 2 { parent @test_arg_type_mismatch : $@convention(thin) (Builtin.Int64) -> () }
-sil_scope 3 { parent @test_deref_mismatch : $@convention(thin) () -> () }
+sil_scope 3 { parent @test_deref_mismatch : $@convention(thin) (Builtin.Int64) -> () }
 sil_scope 4 { parent @test_no_transform_type_mismatch : $@convention(thin) (Builtin.Int32) -> () }
 sil_scope 5 { parent @test_fragment_wrong_parent : $@convention(thin) (Builtin.Int64) -> () }
 sil_scope 6 { parent @test_tuple_fragment_type_mismatch : $@convention(thin) (Builtin.Int64) -> () }
+sil_scope 7 { parent @test_arg_count_mismatch : $@convention(thin) (Builtin.Int64) -> () }
+sil_scope 8 { parent @test_no_operand_without_transform : $@convention(thin) () -> () }
 
 // The transform block returns Builtin.Int32 but the fragment narrows to
 // Builtin.Int64.
@@ -21,7 +23,7 @@ sil_scope 6 { parent @test_tuple_fragment_type_mismatch : $@convention(thin) (Bu
 // CHECK-LABEL: End Error in function test_type_mismatch
 sil @test_type_mismatch : $@convention(thin) () -> () {
 bb0:
-  debug_value undef : $Builtin.Int32, let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
+  debug_value (), let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
   bb0:
     %0 = integer_literal $Builtin.Int32, 42
     return %0 : $Builtin.Int32
@@ -49,11 +51,10 @@ bb0(%arg : $Builtin.Int64):
 // CHECK-LABEL: Begin Error in function test_deref_mismatch
 // CHECK:       SIL verification failed: debug_value type chain should hold
 // CHECK-LABEL: End Error in function test_deref_mismatch
-sil @test_deref_mismatch : $@convention(thin) () -> () {
-bb0:
-  debug_value undef : $Builtin.Int64, let, name "x", type $Int64, expr op_deref:op_fragment:#Int64._value, transform {
-  bb0:
-    %0 = integer_literal $Builtin.Int64, 42
+sil @test_deref_mismatch : $@convention(thin) (Builtin.Int64) -> () {
+bb0(%arg : $Builtin.Int64):
+  debug_value %arg : $Builtin.Int64, let, name "x", type $Int64, expr op_deref:op_fragment:#Int64._value, transform {
+  bb0(%0 : $Builtin.Int64):
     return %0 : $Builtin.Int64
   }
   %r = tuple ()
@@ -89,6 +90,34 @@ bb0(%arg : $Builtin.Int64):
 sil @test_tuple_fragment_type_mismatch : $@convention(thin) (Builtin.Int64) -> () {
 bb0(%arg : $Builtin.Int64):
   debug_value %arg : $Builtin.Int64, let, name "x", type $(Int64, Int64), expr op_tuple_fragment:$(Int32, Int32):0:op_fragment:#Int64._value
+  %r = tuple ()
+  return %r : $()
+}
+
+// The transform block must have one argument per operand: here it has no args,
+// while the debug_value has an operand.
+// CHECK-LABEL: Begin Error in function test_arg_count_mismatch
+// CHECK:       SIL verification failed: debug_value type chain should hold
+// CHECK-LABEL: End Error in function test_arg_count_mismatch
+sil @test_arg_count_mismatch : $@convention(thin) (Builtin.Int64) -> () {
+bb0(%arg : $Builtin.Int64):
+  debug_value %arg : $Builtin.Int64, let, name "x", type $Int64, expr op_fragment:#Int64._value, transform {
+  bb0:
+    %0 = integer_literal $Builtin.Int64, 42
+    return %0 : $Builtin.Int64
+  }
+  %r = tuple ()
+  return %r : $()
+}
+
+// A debug_value without operands can only describe its variable through a
+// transform block.
+// CHECK-LABEL: Begin Error in function test_no_operand_without_transform
+// CHECK:       SIL verification failed: debug_value type chain should hold
+// CHECK-LABEL: End Error in function test_no_operand_without_transform
+sil @test_no_operand_without_transform : $@convention(thin) () -> () {
+bb0:
+  debug_value (), let, name "x", type $Int64
   %r = tuple ()
   return %r : $()
 }

--- a/test/Serialization/debug-value.swift
+++ b/test/Serialization/debug-value.swift
@@ -49,12 +49,12 @@ let _ = fooCaller(1, 2)
 
 let _ = constantFolded()
 // CHECK-LABEL: sil {{.*}} @$s8MyModule14constantFoldedSiyF
-// CHECK: debug_value undef : $Builtin.Int{{[0-9]+}}, let, name "a"
+// CHECK: debug_value (), let, name "a", type $Int
 // CHECK-SAME: transform {
 // CHECK:   [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int{{[0-9]+}}, 2
 // CHECK:   return [[LIT1]]
 // CHECK: }
-// CHECK: debug_value undef : $Builtin.Int{{[0-9]+}}, let, name "b"
+// CHECK: debug_value (), let, name "b", type $Int
 // CHECK-SAME: transform {
 // CHECK:   [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int{{[0-9]+}}, 3
 // CHECK:   return [[LIT2]]


### PR DESCRIPTION
Based on #91281 - Last 2 commits are new

Fix two passes/simplifications that depended on debug_value instructions having one operand: SimplifyAllocStack and PhiExpansion.