### PR TITLE
[SILOptimizer] Preserve the debug scope when specializing witness/class methods

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2618,7 +2618,7 @@ bool swift::specializeClassMethodInst(ClassMethodInst *cm) {
   CanSILFunctionType finalFuncTy = reInfo.getSpecializedType();
   SILType finalSILTy = SILType::getPrimitiveObjectType(finalFuncTy);
 
-  SILBuilder builder(cm);
+  SILBuilder builder(cm, cm->getDebugScope());
   auto *newCM = builder.createClassMethod(cm->getLoc(), cm->getOperand(),
                                           cm->getMember(), finalSILTy);
 
@@ -2671,7 +2671,7 @@ bool swift::specializeWitnessMethodInst(WitnessMethodInst *wm) {
   CanSILFunctionType finalFuncTy = reInfo.getSpecializedType();
   SILType finalSILTy = SILType::getPrimitiveObjectType(finalFuncTy);
 
-  SILBuilder builder(wm);
+  SILBuilder builder(wm, wm->getDebugScope());
   auto *newWM = builder.createWitnessMethod(wm->getLoc(), wm->getLookupType(),
                                             wm->getConformance(), wm->getMember(), finalSILTy);
 

--- a/test/DebugInfo/embedded-witness-method-scope.swift
+++ b/test/DebugInfo/embedded-witness-method-scope.swift
@@ -1,0 +1,34 @@
+// Specializing a witness_method for embedded Swift must preserve the
+// instruction's lexical debug scope. 
+//
+// RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil \
+// RUN:   -Xllvm -sil-print-debuginfo -target %target-cpu-apple-macos14 \
+// RUN:   -enable-experimental-feature Embedded -parse-as-library -wmo -Onone -g \
+// RUN:   -module-name main %s -o - | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
+// REQUIRES: swift_feature_Embedded
+
+protocol P {
+  mutating func f() -> Int
+}
+
+final class C: P {
+  func f() -> Int { return 42 }
+}
+
+public func test() {
+  var p: P = C()
+  _ = p.f()
+}
+
+// The body of test() opens a lexical block for `p`, whose scope has the
+// function's scope as its parent.
+// CHECK: sil_scope [[FUNC:[0-9]+]] { {{.*}} parent @$e4main4testyyF
+// CHECK: sil_scope [[BLOCK:[0-9]+]] { {{.*}} parent [[FUNC]] }
+
+// The specialized witness_method and the apply that consumes it must both sit
+// in that lexical block, not in the function scope.
+// CHECK: witness_method {{.*}}#P.f{{.*}}, scope [[BLOCK]]
+// CHECK: apply {{.*}}$@convention(witness_method: P){{.*}}, scope [[BLOCK]]


### PR DESCRIPTION
In embedded Swift, MandatoryPerformanceOptimizations rewrites every
`witness_method` and `class_method` whose lookup type is fully concrete,
erasing the generic signature. Both rewrites built the replacement with

  SILBuilder builder(wm);

The one-argument `SILBuilder(SILInstruction *)` constructor leaves
`CurDebugScope` null, and `SILBuilder::getSILDebugLocation` then silently
substitutes the enclosing *function*'s scope:

  else if (!Scope && F)
    Scope = F->getDebugScope();

So the location survived but the lexical scope did not. For

  func testClassWithExtension() {
    var classWithExtension: P = ClassWithExtension()
    classWithExtension.definedInExtension()   // one statement
  }

the specialized `witness_method` came out on the function scope while the
`apply` consuming it stayed on the enclosing lexical block, giving a scope
sequence of 3 -> 1 -> 2 in the middle of a single source statement.

Assisted-by: Claude

rdar://184637983
