### PR TITLE
[test] Fix xrsimulator-arm64 lit failures (#90350)

### DIFF
--- a/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
@@ -12,6 +12,10 @@
 
 // UNSUPPORTED: freestanding
 
+// Bare `dispatch_assert_queue` symbol is hidden on visionOS 1.0
+// (only `$V2` is exported).
+// UNSUPPORTED: OS=xros
+
 import StdlibUnittest
 
 ////////////////////////

--- a/test/Concurrency/Runtime/unspecified_is_main_actor.swift
+++ b/test/Concurrency/Runtime/unspecified_is_main_actor.swift
@@ -14,6 +14,10 @@
 // UNSUPPORTED: back_deployment_concurrency
 // UNSUPPORTED: use_os_stdlib
 
+// Bare `dispatch_assert_queue` symbol is hidden on visionOS 1.0
+// (only `$V2` is exported).
+// UNSUPPORTED: OS=xros
+
 // Just a runtime test as a sanity check.
 
 import StdlibUnittest

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -470,6 +470,7 @@ func ffpo(_ value: ForPattern?) {
 func oldThing() {}
 
 @available(iOS, introduced: 14.0)
+@available(visionOS, introduced: 1.0)
 func newThing() {}
 
 func newThingClient() {

--- a/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
+++ b/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
@@ -12,6 +12,8 @@
 // REQUIRES: concurrency_runtime
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
 // CHECK-LABEL: %swift.back_deploy.task.pre_57 = type {
 //                  object header
 // CHECK-SAME:      %swift.refcounted

--- a/test/ModuleInterface/assoc_type_inference_tvos.swift
+++ b/test/ModuleInterface/assoc_type_inference_tvos.swift
@@ -11,6 +11,9 @@
 
 // REQUIRES: objc_interop
 
+// FIXME: rdar://180495612
+// UNSUPPORTED: OS=xros
+
 import CAssoc
 
 extension TheColor {

--- a/test/TBD/multimodule-implied-objc.swift
+++ b/test/TBD/multimodule-implied-objc.swift
@@ -1,5 +1,4 @@
 // REQUIRES: VENDOR=apple
-// XFAIL: OS=xros
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
 // RUN: split-file %s %t

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1140,7 +1140,8 @@ if run_vendor == 'apple':
             'ios': '99.99',
             'maccatalyst': '99.99',
             'tvos': '99.99',
-            'watchos': '99.99'
+            'watchos': '99.99',
+            'xros': '99.99'
         }
         future_version = FUTURE_VERSION.get(run_os, '')
         config.future_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -26,7 +26,7 @@
 # 9999 is the generic unknown future Swift release. It always needs to resolve
 # to the special placeholder version numbers 9999.
 
-SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
 
 # The last entry in this list corresponds to the Swift version currently under
 # development. This usually resolves to placeholder version numbers (9999) until


### PR DESCRIPTION
- **Explanation**:
This PR fixes a few xrsimulator-arm64 lit failures:
  * `test/lit.cfg`: The `FUTURE_VERSION` dict was missing `'xros'`, so `%target-future-triple` collapsed to a versionless `arm64-apple-xros-simulator` (pinned to the visionOS 1.0 deployment floor) instead of the intended `...99.99...`.
  * `utils/availability-macros.def`: the `SwiftStdlib 9999` entries had no visionOS row, so the compiler derived visionOS availability from iOS (`iOS 13.0 → visionOS 13.0`, etc.), producing unreachable version requirements at the visionOS 1.0 deployment target.
  * `Frontend/ast-dump-json-no-crash.swift` — the hand-authored `@available(iOS, introduced: 14.0)` was flagged unavailable on visionOS via iOS-derivation. Add an explicit visionOS 1.0 introduction.
  * `IRGen/coroutine_accessors_backdeploy_async_56.swift` — visionOS enters `RuntimeVersions.def` at 5.10/1.0, so Swift 5.7 is always-available and the pre-5.7 back-deploy layout is never emitted. `UNSUPPORTED: OS=xros`.
  * `ModuleInterface/assoc_type_inference_tvos.swift` — the clang-importer SDK does not contain SDKSettings.json, which is required for availability derivation for visionOS. Marking as unsupported until that is fixed.
  *
  `Concurrency/Runtime/{nonisolated_inherits_isolation,unspecified_is_main_actor}.swift` — both `@_silgen_name("dispatch_assert_queue")` against a bare C symbol that is hidden on visionOS 1.0 (only `$V2` is exported). `UNSUPPORTED: OS=xros`.
  * `TBD/multimodule-implied-objc.swift` — drop stale `XFAIL: OS=xros` from the original "Introduce VisionOS Platform" bootstrap; the test now passes.
- **Scope**: 
Added availability macro for visionOS, plus test changes and lit config changes.
- **Issues**:
rdar://183989140
- **Original PRs**:
https://github.com/swiftlang/swift/pull/90350
- **Risk**:
Low. This PR is predominantly test changes. The availability macro change affects only version 9999.
- **Testing**:
Ran affected tests across all platforms.

- **Reviewers**:
@tshortli 