### PR TITLE
Create source compatibility presets for Apple Silicon (arm64) builds (#91275)

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3174,6 +3174,26 @@ debug
 no-assertions
 cross-compile-hosts=macosx-arm64
 
+[preset: source_compat_suite_macos_arm64_DA]
+mixin-preset=source_compat_suite_macos_base
+debug
+assertions
+
+[preset: source_compat_suite_macos_arm64_RA]
+mixin-preset=source_compat_suite_macos_base
+release
+assertions
+
+[preset: source_compat_suite_macos_arm64_R]
+mixin-preset=source_compat_suite_macos_base
+release
+no-assertions
+
+[preset: source_compat_suite_macos_arm64_D]
+mixin-preset=source_compat_suite_macos_base
+debug
+no-assertions
+
 [preset: source_compat_suite_linux_DA]
 mixin-preset=source_compat_suite_linux_base
 debug
@@ -3217,6 +3237,26 @@ mixin-preset=
 [preset: sourcekit_stress_test_macos_RA]
 mixin-preset=
     source_compat_suite_macos_RA
+    sourcekit_stress_test_mixin
+
+[preset: sourcekit_stress_test_macos_arm64_D]
+mixin-preset=
+    source_compat_suite_macos_arm64_D
+    sourcekit_stress_test_mixin
+
+[preset: sourcekit_stress_test_macos_arm64_DA]
+mixin-preset=
+    source_compat_suite_macos_arm64_DA
+    sourcekit_stress_test_mixin
+
+[preset: sourcekit_stress_test_macos_arm64_R]
+mixin-preset=
+    source_compat_suite_macos_arm64_R
+    sourcekit_stress_test_mixin
+
+[preset: sourcekit_stress_test_macos_arm64_RA]
+mixin-preset=
+    source_compat_suite_macos_arm64_RA
     sourcekit_stress_test_mixin
 
 [preset: linux_lldb]


### PR DESCRIPTION
- **Explanation**:
Create source compatibility presets for Apple Silicon (arm64) builds. The existing presets specify `cross-compile-hosts=macosx-arm64`, which does not work on Apple Silicon.
- **Scope**:
This creates new build presets which are only used for source compatibility tests.
- **Issues**:
Build issue in the new source compatibility jobs being set up.
- **Original PRs**:
https://github.com/swiftlang/swift/pull/91275
- **Risk**:
Low. This does not affect the shipped compiler.
- **Testing**:
Tested in the new source compatibility jobs.
- **Reviewers**:
 @shahmishal 