### PR TITLE
[Test] Add a stdlib_5_8_runtime lit feature and gate the inverted protocol tests on it.

### DIFF
--- a/test/Interpreter/moveonly_reflection.swift
+++ b/test/Interpreter/moveonly_reflection.swift
@@ -6,6 +6,7 @@
 // RUN: %FileCheck %s < %t/output.txt
 
 // REQUIRES: executable_test
+// REQUIRES: stdlib_5_8_runtime
 
 enum Maybe<Wrapped: ~Copyable>: ~Copyable {
   case some(Wrapped)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2882,6 +2882,33 @@ if 'concurrency' in config.available_features:
     else:
         config.available_features.add('concurrency_runtime')
 
+# Determine whether the runtime we test against is Swift 5.8 or newer. IRGen
+# omits inverted protocol metadata when targeting earlier runtimes, so tests
+# that need that metadata cannot run against them.
+if 'use_os_stdlib' not in lit_config.params:
+    config.available_features.add('stdlib_5_8_runtime')
+elif run_vendor == 'apple':
+    # OS version corresponding to SwiftStdlib 5.8, per
+    # utils/availability-macros.def.
+    STDLIB_5_8_OS_VERSION = {
+        'macosx': '13.3',
+        'ios': '16.4',
+        'maccatalyst': '16.4',
+        'tvos': '16.4',
+        'watchos': '9.4',
+        'xros': '1.0'
+    }
+    stdlib_5_8_os_version = STDLIB_5_8_OS_VERSION.get(run_os, '')
+
+    if stdlib_5_8_os_version and not version_gt(stdlib_5_8_os_version, run_vers):
+        config.available_features.add('stdlib_5_8_runtime')
+    else:
+        lit_config.note(
+            'Disabled Swift 5.8 runtime tests because run version %s < %s'
+            % (run_vers, stdlib_5_8_os_version))
+else:
+    config.available_features.add('stdlib_5_8_runtime')
+
 # Set up testing with the standard libraries coming from either the OS, the back
 # deployment runtime or the just-built libraries. By default, we run tests with
 # the just-built libraries.

--- a/test/stdlib/NoncopyableComparable.swift
+++ b/test/stdlib/NoncopyableComparable.swift
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 // The emission of runtime metadata for inverted requirements needs a 5.8+
-// target, so build the test targeting 5.8 and mark the tests as requiring 5.8.
+// target, so build the test targeting 5.8 and only run it against a 5.8+
+// runtime.
 // RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
+// REQUIRES: stdlib_5_8_runtime
 // REQUIRES: swift_feature_Lifetimes
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
@@ -67,7 +69,7 @@ extension InlineArray where Element: Comparable & ~Copyable {
 	}
 }
 
-NoncopyableComparableTests.test("comparing noncopyables").require(.stdlib_5_8).code {
+NoncopyableComparableTests.test("comparing noncopyables") {
   let a = Noncopyable(wrapped: 0)
   let b = Noncopyable(wrapped: 1)
   let c = Noncopyable(wrapped: 2)
@@ -99,7 +101,7 @@ NoncopyableComparableTests.test("comparing noncopyables").require(.stdlib_5_8).c
   expectFalse(array.inReverseOrder())
 }
 
-NoncopyableComparableTests.test("comparing nonescapables").require(.stdlib_5_8).code {
+NoncopyableComparableTests.test("comparing nonescapables") {
   let a = Noncopyable<Nonescapable>(wrapped: .init(wrapped: 0))
   let b = Noncopyable<Nonescapable>(wrapped: .init(wrapped: 1))
   let c = Noncopyable<Nonescapable>(wrapped: .init(wrapped: 2))

--- a/test/stdlib/NoncopyableEquatable.swift
+++ b/test/stdlib/NoncopyableEquatable.swift
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 // The emission of runtime metadata for inverted requirements needs a 5.8+
-// target, so build the test targeting 5.8 and mark the tests as requiring 5.8.
+// target, so build the test targeting 5.8 and only run it against a 5.8+
+// runtime.
 // RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
+// REQUIRES: stdlib_5_8_runtime
 // REQUIRES: swift_feature_Lifetimes
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
@@ -60,7 +62,7 @@ extension InlineArray where Element: Equatable & ~Copyable {
   }
 }
 
-NoncopyableEquatableTests.test("equating noncopyables").require(.stdlib_5_8).code {
+NoncopyableEquatableTests.test("equating noncopyables") {
   // TODO: update StdLibUnitTest to work with ~Copyable Equtable
   
   let a = Noncopyable(wrapping: 1)
@@ -99,7 +101,7 @@ NoncopyableEquatableTests.test("equating noncopyables").require(.stdlib_5_8).cod
   expectNil(array.firstIndex(of: .init(wrapping: 3)))
 }
 
-NoncopyableEquatableTests.test("equating nonescapables").require(.stdlib_5_8).code {
+NoncopyableEquatableTests.test("equating nonescapables") {
   let nc1 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc2 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc3 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 2))

--- a/test/stdlib/NoncopyableHashable.swift
+++ b/test/stdlib/NoncopyableHashable.swift
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 // The emission of runtime metadata for inverted requirements needs a 5.8+
-// target, so build the test targeting 5.8 and mark the tests as requiring 5.8.
+// target, so build the test targeting 5.8 and only run it against a 5.8+
+// runtime.
 // RUN: %target-run-simple-swift(-target %target-swift-5.8-abi-triple -enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
+// REQUIRES: stdlib_5_8_runtime
 // REQUIRES: swift_feature_Lifetimes
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
@@ -64,7 +66,7 @@ extension InlineArray where Element: Hashable & ~Copyable {
   }
 }
 
-NoncopyableHashableTests.test("hashing noncopyables").require(.stdlib_5_8).code {
+NoncopyableHashableTests.test("hashing noncopyables") {
   let a = Noncopyable(wrapping: 1)
   let b = Noncopyable(wrapping: 2)
   let c = Noncopyable(wrapping: 1)
@@ -90,7 +92,7 @@ NoncopyableHashableTests.test("hashing noncopyables").require(.stdlib_5_8).code 
   
 }
 
-NoncopyableHashableTests.test("hashing nonescapables").require(.stdlib_5_8).code {
+NoncopyableHashableTests.test("hashing nonescapables") {
   let nc1 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc2 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 1))
   let nc3 = Noncopyable<Nonescapable>(wrapping: .init(wrapped: 2))


### PR DESCRIPTION
These tests can't run against runtimes older than 5.8, and they can't even launch when using an old version, so using version gating in the test code isn't enough. We still want to test them against older runtimes that are at least 5.8, so the usual UNSUPPORTED: use_os_stdlib / back_deployment_runtime isn't what we want here.

rdar://184418144