### PR TITLE
[build-script] Skip libLTO in sanitizer presets (#91274)

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -486,6 +486,8 @@ skip-test-xros
 
 enable-asan
 
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
+
 [preset: buildbot_incremental_tsan,tools=RDA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms
 
@@ -506,6 +508,8 @@ skip-build-watchos
 skip-test-watchos
 skip-build-xros
 skip-test-xros
+
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
 
 [preset: buildbot_incremental_asan_ubsan,tools=RDA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms
@@ -540,6 +544,8 @@ skip-test-xros
 
 enable-asan
 enable-ubsan
+
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
 
 [preset: buildbot_incremental,lldb_asan_ubsan]
 mixin-preset=buildbot_incremental_base
@@ -608,6 +614,8 @@ skip-test-xros
 enable-asan
 
 swift-stdlib-build-type=RelWithDebInfo
+
+extra-llvm-cmake-options=-DLLVM_TOOL_LTO_BUILD=OFF
 
 # Don't do bootstrapping to speed up the build
 # TODO: use bootstrapping=hosttools


### PR DESCRIPTION
- **Explanation**:
On macOS, ld dlopens libLTO.dylib eagerly at startup to probe LTO capabilities. When the swift-built libLTO is sanitized, dyld pulls the sanitizer runtime into ld's process, and AMFI's sanitizer-load platform policy on recent macOS versions rejects it, aborting the link. Skip building libLTO in the sanitizer presets so ld falls back to Xcode's unsanitized copy; these presets don't exercise LTO codegen.
- **Scope**:
This only affects the ASAN CI jobs.
- **Issues**:
Build failure in the new ASAN CI job being brought up.
- **Original PRs**:
https://github.com/swiftlang/swift/pull/91274
- **Risk**:
Low. The ASAN preset does not exercise LTO so we lose little to no test coverage.
- **Testing**:
Tested in the new ASAN CI job being brought up.
- **Reviewers**:
@ndrewh 