### PR TITLE
[build-script] Ignore /opt/homebrew/lib when configuring Darwin builds (#91331)

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -364,7 +364,8 @@ class BuildScriptInvocation(object):
             # For additional isolation, disable pkg-config. Homebrew's pkg-config
             # prioritizes CommandLineTools paths, resulting in compile errors.
             args.extra_cmake_options += [
-                '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib',
+                '-DCMAKE_IGNORE_PATH=/usr/lib;/usr/local/lib;/lib;'
+                '/opt/homebrew/lib',
                 '-DPKG_CONFIG_EXECUTABLE=/usr/bin/false',
             ]
 


### PR DESCRIPTION
- **Explanation**:
Add `/opt/homebrew/lib` to the existing CMAKE_IGNORE_PATH isolation list, which only covered the Intel Homebrew prefix.
- **Scope**:
Changes the CMake config so the build system finds the correct binary tools to use.
- **Issues**:
rdar://184231214
- **Original PRs**:
https://github.com/swiftlang/swift/pull/91331
- **Risk**:
Low. This guards the build system against an issue which only happens on newer systems. It does not affect any of the existing CI pipelines.
- **Testing**:
Tested in the new CI job being brought up.
- **Reviewers**:
@shahmishal 
