### PR TITLE
[cxx-interop] Name unnamed parameters in synthesized forwarding thunks

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6007,6 +6007,17 @@ static FuncDecl *synthesizeBaseFunctionDeclCall(ClangImporter &impl,
       ctx.getClangModuleLoader()->importDeclDirectly(newClangMethod));
 }
 
+/// C++ parameters may be unnamed, in which case the imported ParamDecl has an
+/// empty body name. Give such parameters a body name so that SILGen produces a
+/// value for them while being lowered.
+static void giveParameterNamesForThunk(ASTContext &ctx,
+                                       ArrayRef<ParamDecl *> params) {
+  for (auto [i, param] : llvm::enumerate(params)) {
+    if (param->getParameterName().empty())
+      param->setName(ctx.getIdentifier("__argument" + std::to_string(i)));
+  }
+}
+
 // Generates the body of a derived method, that invokes the base
 // method.
 // The method's body takes the following form:
@@ -6628,6 +6639,10 @@ static ValueDecl *cloneBaseMemberDecl(ClangImporter::Implementation &Impl,
       if (cxxMethod->getRefQualifier() == clang::RefQualifierKind::RQ_RValue)
         return nullptr;
     }
+
+    // The synthesized body refers to the parameters by DeclRefExpr, so any
+    // unnamed C++ parameter needs a body name for SILGen to bind it.
+    giveParameterNamesForThunk(context, fn->getParameters()->getArray());
 
     auto out = FuncDecl::createImplicit(
         context, fn->getStaticSpelling(), fn->getName(), fn->getNameLoc(),
@@ -7775,6 +7790,10 @@ static ValueDecl *addThunkForDependentTypes(FuncDecl *oldDecl,
   auto fixedParams =
       ParameterList::create(newDecl->getASTContext(), fixedParameters);
 
+  // The synthesized body refers to the parameters by DeclRefExpr, so any
+  // unnamed C++ parameter needs a body name for SILGen to bind it.
+  giveParameterNamesForThunk(newDecl->getASTContext(), fixedParameters);
+
   Type fixedResultType;
   if (oldDecl->getResultInterfaceType()->isEqual(
           oldDecl->getASTContext().getAnyExistentialType()))
@@ -7877,6 +7896,10 @@ static ValueDecl *generateThunkForExtraMetatypes(SubstitutionMap subst,
     auto *newParamDecl = ParamDecl::clone(newDecl->getASTContext(), param);
     newParams.push_back(newParamDecl);
   }
+
+  // The synthesized body refers to the parameters by DeclRefExpr, so any
+  // unnamed C++ parameter needs a body name for SILGen to bind it.
+  giveParameterNamesForThunk(newDecl->getASTContext(), newParams);
 
   auto originalFnSubst = cast<AbstractFunctionDecl>(oldDecl)
                              ->getInterfaceType()

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -137,6 +137,19 @@ public:
     int getXMut() {
         return x;
     }
+
+    int unnamedParam(int) const {
+        return x;
+    }
+    int unnamedParamMut(int) {
+        return x;
+    }
+    int mixedNamedParams(int, int y) const {
+        return x + y;
+    }
+    int unnamedRefParam(int &) const {
+        return x;
+    }
 private:
     int x;
 };

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -151,6 +151,14 @@
 // CHECK-NEXT:   public func getX() -> CInt
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func unnamedParam(_: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func unnamedParamMut(_: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func mixedNamedParams(_: CInt, _ y: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func unnamedRefParam(_: inout CInt) -> CInt
 // CHECK-NOT:    public
 // CHECK:      }
 
@@ -161,6 +169,14 @@
 // CHECK-NEXT:   public func getX() -> CInt
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func unnamedParam(_: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func unnamedParamMut(_: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func mixedNamedParams(_: CInt, _ y: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func unnamedRefParam(_: inout CInt) -> CInt
 // CHECK-NEXT:   public init(_ x: CInt)
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getDerivedX() -> CInt
@@ -181,6 +197,14 @@
 // CHECK-NEXT:   public func getX() -> CInt
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func getXMut() -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func unnamedParam(_: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public mutating func unnamedParamMut(_: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func mixedNamedParams(_: CInt, _ y: CInt) -> CInt
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   public func unnamedRefParam(_: inout CInt) -> CInt
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func getDerivedX() -> CInt
 // CHECK-NEXT:   @discardableResult

--- a/test/Interop/Cxx/class/inheritance/functions-silgen.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-silgen.swift
@@ -13,3 +13,27 @@ let _ = testGetX()
 // CHECK: {{.*}}(%[[SELF_VAL:.*]] : $*CopyTrackedDerivedClass):
 // CHECK: function_ref @{{.*}}__synthesizedBaseCall_{{.*}} : $@convention(cxx_method) (@in_guaranteed CopyTrackedDerivedClass) -> Int32
 // CHECK-NEXT: apply %{{.*}}(%[[SELF_VAL]])
+
+func testUnnamedParam() -> CInt {
+    let derived = CopyTrackedDerivedClass(42)
+    return derived.unnamedParam(1)
+}
+
+let _ = testUnnamedParam()
+
+// CHECK: sil shared @$sSo23CopyTrackedDerivedClassV12unnamedParamys5Int32VAEF : $@convention(method) (Int32, @in_guaranteed CopyTrackedDerivedClass) -> Int32
+// CHECK: bb0(%[[ARG:.*]] : $Int32, %[[SELF:.*]] : $*CopyTrackedDerivedClass):
+// CHECK: function_ref @{{.*}}__synthesizedBaseCall_{{.*}} : $@convention(cxx_method) (Int32, @in_guaranteed CopyTrackedDerivedClass) -> Int32
+// CHECK-NEXT: apply %{{.*}}(%[[ARG]], %{{.*}})
+
+func testMixedNamedParams() -> CInt {
+    let derived = CopyTrackedDerivedClass(42)
+    return derived.mixedNamedParams(1, 2)
+}
+
+let _ = testMixedNamedParams()
+
+// CHECK: sil shared @$sSo23CopyTrackedDerivedClassV16mixedNamedParamsys5Int32VAE_AEtF : $@convention(method) (Int32, Int32, @in_guaranteed CopyTrackedDerivedClass) -> Int32
+// CHECK: bb0(%[[UNNAMED:.*]] : $Int32, %[[Y:.*]] : $Int32, %{{.*}} : $*CopyTrackedDerivedClass):
+// CHECK: function_ref @{{.*}}__synthesizedBaseCall_{{.*}} : $@convention(cxx_method) (Int32, Int32, @in_guaranteed CopyTrackedDerivedClass) -> Int32
+// CHECK-NEXT: apply %{{.*}}(%[[UNNAMED]], %[[Y]], %{{.*}})

--- a/test/Interop/Cxx/class/inheritance/functions.swift
+++ b/test/Interop/Cxx/class/inheritance/functions.swift
@@ -108,4 +108,19 @@ FunctionsTestSuite.test("non-initializer function renamed to init()") {
   expectEqual(freeFuncRenamedToInit(), 42)
 }
 
+FunctionsTestSuite.test("base members with unnamed parameters") {
+  let derived = CopyTrackedDerivedClass(42)
+  expectEqual(derived.unnamedParam(1), 42)
+  expectEqual(derived.mixedNamedParams(1, 2), 44)
+
+  var mutDerived = CopyTrackedDerivedClass(7)
+  expectEqual(mutDerived.unnamedParamMut(1), 7)
+
+  var r: CInt = 5
+  expectEqual(derived.unnamedRefParam(&r), 42)
+
+  let derivedDerived = CopyTrackedDerivedDerivedClass(-5)
+  expectEqual(derivedDerived.unnamedParam(1), -5)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/templates/Inputs/dependent-types-unnamed-param.h
+++ b/test/Interop/Cxx/templates/Inputs/dependent-types-unnamed-param.h
@@ -1,0 +1,23 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_TYPES_UNNAMED_PARAM_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_TYPES_UNNAMED_PARAM_H
+
+template <typename T>
+struct Dependent {
+  using type = T;
+};
+
+// A dependent parameter type is imported as "Any", so calls go through a
+// forwarding thunk that casts the arguments. The unnamed C++ parameter still
+// has to be forwarded to the C++ function.
+template <typename T>
+T dependentUnnamedParam(T a, typename Dependent<T>::type) {
+  return a;
+}
+
+// A dependent result type builds a thunk too.
+template <typename T>
+typename Dependent<T>::type dependentResultUnnamedParam(T, T b) {
+  return b;
+}
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_TYPES_UNNAMED_PARAM_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -168,6 +168,11 @@ module DependentTypes {
   requires cplusplus
 }
 
+module DependentTypesUnnamedParam {
+  header "dependent-types-unnamed-param.h"
+  requires cplusplus
+}
+
 module UnevaluatedContext {
   header "unevaluated-context.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
+++ b/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
@@ -13,6 +13,16 @@ struct Struct {
 
   template <typename T>
   static void templateTypeParamNotUsedInSignatureStatic() {}
+
+  template <typename T>
+  int unnamedParamNotUsedInSignature(int) const {
+    return 42;
+  }
+
+  template <typename T>
+  static int unnamedParamNotUsedInSignatureStatic(int) {
+    return 42;
+  }
 };
 
 template <typename T>
@@ -56,5 +66,18 @@ void templateTypeParamNotUsedInSignatureWithVarargsAndUnrelatedParam(int x, ...)
 
 template <typename T, int N>
 void templateTypeParamNotUsedInSignatureWithNonTypeParam() {}
+
+template <typename T>
+int unnamedParamNotUsedInSignature(int) { return 42; }
+
+template <typename T>
+int mixedNamedParamsNotUsedInSignature(int x, int) {
+  return x;
+}
+
+template <typename T, typename U>
+U unnamedAndDeducedParamsNotUsedInSignature(int, U u) {
+  return u;
+}
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_TEMPLATE_TYPE_PARAMETER_NOT_IN_SIGNATURE_H

--- a/test/Interop/Cxx/templates/dependent-types-unnamed-param.swift
+++ b/test/Interop/Cxx/templates/dependent-types-unnamed-param.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+//
+// REQUIRES: executable_test
+
+// A dependent parameter or result type is imported as "Any", so the call goes
+// through a forwarding thunk that casts the arguments. SILGen only creates a
+// binding for a parameter that has a body name, so the thunk gives unnamed C++
+// parameters one instead of crashing while lowering the synthesized body.
+
+import StdlibUnittest
+import DependentTypesUnnamedParam
+
+var DependentTypesTestSuite = TestSuite("Thunks for dependent types with unnamed parameters")
+
+DependentTypesTestSuite.test("dependent parameter type") {
+  expectEqual(dependentUnnamedParam(7 as CInt, (9 as CInt) as Any), 7)
+}
+
+DependentTypesTestSuite.test("dependent result type") {
+  expectEqual(dependentResultUnnamedParam(1 as CInt, 42 as CInt) as! CInt, 42)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
@@ -22,3 +22,44 @@ _ = templateTypeParamNotUsedInSignature(T: Bool.self)
 // CHECK: bb0(%0 : $@thin Bool.Type):
 // CHECK:   {{.*}} = function_ref @$sSo69__swift_specializedThunk__Z35templateTypeParamNotUsedInSignatureIbEbvSbyFTo : $@convention(c) () -> Bool
 // CHECK: } // end sil function '$sSC35templateTypeParamNotUsedInSignatureyS2bmF'
+
+_ = unnamedParamNotUsedInSignature(4, T: Int.self)
+
+// CHECK: sil [transparent] [serialized] [ossa] @$sSC30unnamedParamNotUsedInSignatureys5Int32VAC_SimtF : $@convention(thin) (Int32, @thin Int.Type) -> Int32 {
+// CHECK: bb0([[ARG:%.*]] : $Int32, %{{.*}} : $@thin Int.Type):
+// CHECK:   debug_value [[ARG]], let, name "__argument0"
+// CHECK:   [[FN:%.*]] = function_ref @$sSo{{.*}}__swift_specializedThunk{{.*}} : $@convention(c) (Int32) -> Int32
+// CHECK:   {{.*}} = apply [[FN]]([[ARG]])
+// CHECK: } // end sil function '$sSC30unnamedParamNotUsedInSignatureys5Int32VAC_SimtF'
+
+_ = mixedNamedParamsNotUsedInSignature(1, 2, T: Int.self)
+
+// CHECK: sil [transparent] [serialized] [ossa] @$sSC34mixedNamedParamsNotUsedInSignatureys5Int32VAC_ACSimtF : $@convention(thin) (Int32, Int32, @thin Int.Type) -> Int32 {
+// CHECK: bb0([[X:%.*]] : $Int32, [[UNNAMED:%.*]] : $Int32, %{{.*}} : $@thin Int.Type):
+// CHECK-DAG:   debug_value [[X]], let, name "x"
+// CHECK-DAG:   debug_value [[UNNAMED]], let, name "__argument1"
+// CHECK:   [[FN2:%.*]] = function_ref @$sSo{{.*}}__swift_specializedThunk{{.*}} : $@convention(c) (Int32, Int32) -> Int32
+// CHECK:   {{.*}} = apply [[FN2]]([[X]], [[UNNAMED]])
+// CHECK: } // end sil function '$sSC34mixedNamedParamsNotUsedInSignatureys5Int32VAC_ACSimtF'
+
+_ = unnamedAndDeducedParamsNotUsedInSignature(1, 2 as CInt, T: Int.self)
+
+// CHECK: sil [transparent] [serialized] [ossa] @$sSC41unnamedAndDeducedParamsNotUsedInSignatureys5Int32VAC_ACSimtF : $@convention(thin) (Int32, Int32, @thin Int.Type) -> Int32 {
+// CHECK: bb0([[U0:%.*]] : $Int32, [[U1:%.*]] : $Int32, %{{.*}} : $@thin Int.Type):
+// CHECK-DAG:   debug_value [[U0]], let, name "__argument0"
+// CHECK-DAG:   debug_value [[U1]], let, name "u"
+// CHECK: } // end sil function '$sSC41unnamedAndDeducedParamsNotUsedInSignatureys5Int32VAC_ACSimtF'
+
+let s = Struct()
+_ = s.unnamedParamNotUsedInSignature(4, T: Int.self)
+_ = Struct.unnamedParamNotUsedInSignatureStatic(4, T: Int.self)
+
+// CHECK: sil shared [transparent] [serialized] [ossa] @$sSo6StructV30unnamedParamNotUsedInSignatureys5Int32VAE_SimtF : $@convention(method) (Int32, @thin Int.Type, Struct) -> Int32 {
+// CHECK: bb0([[MARG:%.*]] : $Int32, %{{.*}} : $@thin Int.Type, %{{.*}} : $Struct):
+// CHECK:   debug_value [[MARG]], let, name "__argument0"
+// CHECK: } // end sil function '$sSo6StructV30unnamedParamNotUsedInSignatureys5Int32VAE_SimtF'
+
+// CHECK: sil shared [transparent] [serialized] [ossa] @$sSo6StructV36unnamedParamNotUsedInSignatureStaticys5Int32VAE_SimtFZ : $@convention(method) (Int32, @thin Int.Type, @thin Struct.Type) -> Int32 {
+// CHECK: bb0([[SARG:%.*]] : $Int32, %{{.*}} : $@thin Int.Type, %{{.*}} : $@thin Struct.Type):
+// CHECK:   debug_value [[SARG]], let, name "__argument0"
+// CHECK: } // end sil function '$sSo6StructV36unnamedParamNotUsedInSignatureStaticys5Int32VAE_SimtFZ'


### PR DESCRIPTION
C++ parameters may be unnamed, in which case the imported ParamDecl has an empty body name. SILGen does not create a binding for an anonymous parameter, so a synthesized body that refers to one via a DeclRefExpr would crash while being lowered. Give such parameters a body name so that SILGen produces a value for them.

rdar://184645956