### PR TITLE
[Embedded] Mark ManagedBuffer.capacity as unavailable

### DIFF
--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -36,11 +36,6 @@ internal func _swift_bufferAllocate(
 ///   needed should be included in `Header`.
 @_fixed_layout
 open class ManagedBuffer<Header, Element: ~Copyable> {
-  #if $Embedded
-  @usableFromInline
-  final var _capacity: Int
-  #endif
-
   /// The stored `Header` instance.
   ///
   /// During instance creation, in particular during
@@ -95,15 +90,8 @@ extension ManagedBuffer where Element: ~Copyable {
          self,
          minimumCapacity._builtinWordValue, Element.self)
 
-    #if $Embedded
-    // Initialize the capacity before calling out to the factory because it may
-    // end up querying the capacity field of this ManagedBuffer.
-    unsafe p._capacityAddress.initialize(to: minimumCapacity)
-    #endif
-
     let initHeaderVal = try factory(p)
     unsafe p.headerAddress.initialize(to: initHeaderVal)
-
     // The _fixLifetime is not really needed, because p is used afterwards.
     // But let's be conservative and fix the lifetime after we use the
     // headerAddress.
@@ -119,16 +107,13 @@ extension ManagedBuffer where Element: ~Copyable {
   @_preInverseGenerics
   @inlinable
   @available(OpenBSD, unavailable, message: "malloc_size is unavailable.")
+  @_unavailableInEmbedded
   public final var capacity: Int {
-    #if $Embedded
-    return unsafe _capacityAddress.pointee
-    #else
     let storageAddr = UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(self))
     let endAddr = unsafe storageAddr + _swift_stdlib_malloc_size(storageAddr)
     let realCapacity = unsafe endAddr.assumingMemoryBound(to: Element.self) -
       firstElementAddress
     return realCapacity
-    #endif
   }
 
   @_preInverseGenerics
@@ -143,13 +128,6 @@ extension ManagedBuffer where Element: ~Copyable {
   internal final var headerAddress: UnsafeMutablePointer<Header> {
     return unsafe UnsafeMutablePointer<Header>(Builtin.addressof(&header))
   }
-
-  #if $Embedded
-  @inlinable
-  internal final var _capacityAddress: UnsafeMutablePointer<Int> {
-    unsafe UnsafeMutablePointer<Int>(Builtin.addressof(&_capacity))
-  }
-  #endif
 }
 
 extension ManagedBuffer where Element: ~Copyable {

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -36,6 +36,11 @@ internal func _swift_bufferAllocate(
 ///   needed should be included in `Header`.
 @_fixed_layout
 open class ManagedBuffer<Header, Element: ~Copyable> {
+  #if $Embedded
+  @usableFromInline
+  final var _capacity: Int
+  #endif
+
   /// The stored `Header` instance.
   ///
   /// During instance creation, in particular during
@@ -44,11 +49,6 @@ open class ManagedBuffer<Header, Element: ~Copyable> {
   /// reading the `header` property during `ManagedBuffer.create` is undefined.
   @_preInverseGenerics
   public final var header: Header
-
-  #if $Embedded
-  @usableFromInline
-  final var _capacity: Int
-  #endif
 
   #if $Embedded
   // In embedded mode this initializer has to be public, otherwise derived
@@ -95,12 +95,14 @@ extension ManagedBuffer where Element: ~Copyable {
          self,
          minimumCapacity._builtinWordValue, Element.self)
 
-    let initHeaderVal = try factory(p)
-    unsafe p.headerAddress.initialize(to: initHeaderVal)
-
     #if $Embedded
+    // Initialize the capacity before calling out to the factory because it may
+    // end up querying the capacity field of this ManagedBuffer.
     unsafe p._capacityAddress.initialize(to: minimumCapacity)
     #endif
+
+    let initHeaderVal = try factory(p)
+    unsafe p.headerAddress.initialize(to: initHeaderVal)
 
     // The _fixLifetime is not really needed, because p is used afterwards.
     // But let's be conservative and fix the lifetime after we use the

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -46,6 +46,11 @@ open class ManagedBuffer<Header, Element: ~Copyable> {
   public final var header: Header
 
   #if $Embedded
+  @usableFromInline
+  final var _capacity: Int
+  #endif
+
+  #if $Embedded
   // In embedded mode this initializer has to be public, otherwise derived
   // classes cannot be specialized.
   @_preInverseGenerics
@@ -92,6 +97,11 @@ extension ManagedBuffer where Element: ~Copyable {
 
     let initHeaderVal = try factory(p)
     unsafe p.headerAddress.initialize(to: initHeaderVal)
+
+    #if $Embedded
+    unsafe p._capacityAddress.initialize(to: minimumCapacity)
+    #endif
+
     // The _fixLifetime is not really needed, because p is used afterwards.
     // But let's be conservative and fix the lifetime after we use the
     // headerAddress.
@@ -108,11 +118,15 @@ extension ManagedBuffer where Element: ~Copyable {
   @inlinable
   @available(OpenBSD, unavailable, message: "malloc_size is unavailable.")
   public final var capacity: Int {
+    #if $Embedded
+    return unsafe _capacityAddress.pointee
+    #else
     let storageAddr = UnsafeMutableRawPointer(Builtin.bridgeToRawPointer(self))
     let endAddr = unsafe storageAddr + _swift_stdlib_malloc_size(storageAddr)
     let realCapacity = unsafe endAddr.assumingMemoryBound(to: Element.self) -
       firstElementAddress
     return realCapacity
+    #endif
   }
 
   @_preInverseGenerics
@@ -127,6 +141,13 @@ extension ManagedBuffer where Element: ~Copyable {
   internal final var headerAddress: UnsafeMutablePointer<Header> {
     return unsafe UnsafeMutablePointer<Header>(Builtin.addressof(&header))
   }
+
+  #if $Embedded
+  @inlinable
+  internal final var _capacityAddress: UnsafeMutablePointer<Int> {
+    unsafe UnsafeMutablePointer<Int>(Builtin.addressof(&_capacity))
+  }
+  #endif
 }
 
 extension ManagedBuffer where Element: ~Copyable {

--- a/test/embedded/managed-buffer.swift
+++ b/test/embedded/managed-buffer.swift
@@ -9,4 +9,8 @@
 // EXIST-NOT: @"$es13ManagedBufferCySis5UInt8VGN" = {{.*}}alias
 
 final public class MyBuffer: ManagedBuffer<Int, UInt8> {
+  // EXIST-NOT: _swift_stdlib_malloc_size
+  public final var cap: Int {
+    capacity
+  }
 }

--- a/test/embedded/managed-buffer.swift
+++ b/test/embedded/managed-buffer.swift
@@ -8,9 +8,4 @@
 // EXIST: @"$e4main8MyBufferCN" = {{.*}}alias
 // EXIST-NOT: @"$es13ManagedBufferCySis5UInt8VGN" = {{.*}}alias
 
-final public class MyBuffer: ManagedBuffer<Int, UInt8> {
-  // EXIST-NOT: _swift_stdlib_malloc_size
-  public final var cap: Int {
-    capacity
-  }
-}
+final public class MyBuffer: ManagedBuffer<Int, UInt8> {}

--- a/test/embedded/managed-buffer2.swift
+++ b/test/embedded/managed-buffer2.swift
@@ -16,7 +16,7 @@ struct CountAndCapacity {
 final class TestManagedBuffer<T> : ManagedBuffer<CountAndCapacity, T> {
   class func create(_ capacity: Int) -> TestManagedBuffer {
     let r = super.create(minimumCapacity: capacity) {
-      CountAndCapacity(count: 0, capacity: $0.capacity)
+      CountAndCapacity(count: 0, capacity: capacity)
     }
     return r as! TestManagedBuffer
 


### PR DESCRIPTION
This removes the `malloc_size` reference from embedded (which might not exist on some platforms) by making this API unavailable entirely. Clients should store their own reference to the allocated capacity instead.

Resolves: rdar://184234583