### PR TITLE
[Const Extraction] Resolve member references which are constant and embed their values

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -176,14 +176,23 @@ getResultBuilderMembersFromBraceStmt(BraceStmt *braceStmt,
                                      const DeclContext *declContext);
 
 static std::shared_ptr<CompileTimeValue>
+extractCompileTimeValue(Expr *expr, const DeclContext *declContext,
+                        llvm::SmallPtrSet<VarDecl *, 4> &resolutionCache);
+
+static std::shared_ptr<CompileTimeValue>
 extractCompileTimeValue(Expr *expr, const DeclContext *declContext);
+
+static ConstValueTypePropertyInfo
+extractTypePropertyInfo(VarDecl *propertyDecl,
+                        llvm::SmallPtrSet<VarDecl *, 4> &resolutionCache);
 
 static ConstValueTypePropertyInfo
 extractTypePropertyInfo(VarDecl *propertyDecl);
 
 static std::vector<FunctionParameter>
 extractFunctionArguments(const ArgumentList *args,
-                         const DeclContext *declContext) {
+                         const DeclContext *declContext,
+                         llvm::SmallPtrSet<VarDecl *, 4> &resolutionCache) {
   std::vector<FunctionParameter> parameters;
 
   for (auto arg : *args) {
@@ -199,7 +208,7 @@ extractFunctionArguments(const ArgumentList *args,
       argExpr = optionalInject->getSubExpr();
     }
     parameters.push_back(
-        {label, type, extractCompileTimeValue(argExpr, declContext)});
+        {label, type, extractCompileTimeValue(argExpr, declContext, resolutionCache)});
   }
 
   return parameters;
@@ -236,7 +245,8 @@ static std::optional<std::string> extractRawLiteral(Expr *expr) {
 }
 
 static std::shared_ptr<CompileTimeValue>
-extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
+extractCompileTimeValue(Expr *expr, const DeclContext *declContext,
+                        llvm::SmallPtrSet<VarDecl *, 4> &resolutionCache) {
   if (expr) {
     switch (expr->getKind()) {
     case ExprKind::BooleanLiteral:
@@ -260,7 +270,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       std::vector<std::shared_ptr<CompileTimeValue>> elementValues;
       for (const auto elementExpr : arrayExpr->getElements()) {
         elementValues.push_back(
-            extractCompileTimeValue(elementExpr, declContext));
+            extractCompileTimeValue(elementExpr, declContext, resolutionCache));
       }
       return std::make_shared<ArrayValue>(elementValues);
     }
@@ -269,7 +279,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       auto dictionaryExpr = cast<DictionaryExpr>(expr);
       std::vector<std::shared_ptr<TupleValue>> tuples;
       for (auto elementExpr : dictionaryExpr->getElements()) {
-        auto elementValue = extractCompileTimeValue(elementExpr, declContext);
+        auto elementValue = extractCompileTimeValue(elementExpr, declContext, resolutionCache);
         if (isa<TupleValue>(elementValue.get())) {
           tuples.push_back(std::static_pointer_cast<TupleValue>(elementValue));
         }
@@ -294,13 +304,13 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
 
           elements.push_back(
               {label, elementExpr->getType(),
-               extractCompileTimeValue(elementExpr, declContext)});
+               extractCompileTimeValue(elementExpr, declContext, resolutionCache)});
         }
       } else {
         for (auto elementExpr : tupleExpr->getElements()) {
           elements.push_back(
               {std::nullopt, elementExpr->getType(),
-               extractCompileTimeValue(elementExpr, declContext)});
+               extractCompileTimeValue(elementExpr, declContext, resolutionCache)});
         }
       }
       return std::make_shared<TupleValue>(elements);
@@ -314,13 +324,13 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
             declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
 
         std::vector<FunctionParameter> parameters =
-            extractFunctionArguments(callExpr->getArgs(), declContext);
+            extractFunctionArguments(callExpr->getArgs(), declContext, resolutionCache);
         return std::make_shared<FunctionCallValue>(identifier, parameters);
       }
 
       if (isa<ConstructorRefCallExpr>(callExpr->getFn())) {
         std::vector<FunctionParameter> parameters =
-            extractFunctionArguments(callExpr->getArgs(), declContext);
+            extractFunctionArguments(callExpr->getArgs(), declContext, resolutionCache);
         return std::make_shared<InitCallValue>(callExpr->getType(), parameters);
       }
 
@@ -331,7 +341,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
               declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
 
           std::vector<FunctionParameter> parameters =
-              extractFunctionArguments(callExpr->getArgs(), declContext);
+              extractFunctionArguments(callExpr->getArgs(), declContext, resolutionCache);
 
           auto declRef = dotSyntaxCallExpr->getFn()->getReferencedDecl();
           switch (declRef.getDecl()->getKind()) {
@@ -349,7 +359,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
             return std::make_shared<MemberFunctionCallValue>(
                 baseIdentifierName,
                 extractCompileTimeValue(dotSyntaxCallExpr->getBase(),
-                                        declContext),
+                                        declContext, resolutionCache),
                 parameters);
           }
 
@@ -366,7 +376,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
               declRefExpr->getDecl()->getName().getBaseIdentifier().str().str();
 
           std::vector<FunctionParameter> parameters =
-              extractFunctionArguments(callExpr->getArgs(), declContext);
+              extractFunctionArguments(callExpr->getArgs(), declContext, resolutionCache);
           return std::make_shared<FunctionCallValue>(identifier, parameters);
         }
       }
@@ -388,23 +398,23 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
 
     case ExprKind::Erasure: {
       auto erasureExpr = cast<ErasureExpr>(expr);
-      return extractCompileTimeValue(erasureExpr->getSubExpr(), declContext);
+      return extractCompileTimeValue(erasureExpr->getSubExpr(), declContext, resolutionCache);
     }
 
     case ExprKind::Paren: {
       auto parenExpr = cast<ParenExpr>(expr);
-      return extractCompileTimeValue(parenExpr->getSubExpr(), declContext);
+      return extractCompileTimeValue(parenExpr->getSubExpr(), declContext, resolutionCache);
     }
 
     case ExprKind::PropertyWrapperValuePlaceholder: {
       auto placeholderExpr = cast<PropertyWrapperValuePlaceholderExpr>(expr);
       return extractCompileTimeValue(placeholderExpr->getOriginalWrappedValue(),
-                                     declContext);
+                                     declContext, resolutionCache);
     }
 
     case ExprKind::Coerce: {
       auto coerceExpr = cast<CoerceExpr>(expr);
-      return extractCompileTimeValue(coerceExpr->getSubExpr(), declContext);
+      return extractCompileTimeValue(coerceExpr->getSubExpr(), declContext, resolutionCache);
     }
 
     case ExprKind::DotSelf: {
@@ -419,7 +429,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
     case ExprKind::UnderlyingToOpaque: {
       auto underlyingToOpaque = cast<UnderlyingToOpaqueExpr>(expr);
       return extractCompileTimeValue(underlyingToOpaque->getSubExpr(),
-                                     declContext);
+                                     declContext, resolutionCache);
     }
 
     case ExprKind::DefaultArgument: {
@@ -471,12 +481,12 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
     case ExprKind::InjectIntoOptional: {
       auto injectIntoOptionalExpr = cast<InjectIntoOptionalExpr>(expr);
       return extractCompileTimeValue(injectIntoOptionalExpr->getSubExpr(),
-                                     declContext);
+                                     declContext, resolutionCache);
     }
 
     case ExprKind::Load: {
       auto loadExpr = cast<LoadExpr>(expr);
-      return extractCompileTimeValue(loadExpr->getSubExpr(), declContext);
+      return extractCompileTimeValue(loadExpr->getSubExpr(), declContext, resolutionCache);
     }
 
     case ExprKind::MemberRef: {
@@ -486,16 +496,13 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
         auto label = memberExpr->getDecl().getDecl()->getBaseIdentifier().str();
 
         // Attempt to resolve static stored/computed properties to their
-        // compile-time value. A thread-local visited set breaks cycles that
-        // would otherwise cause infinite recursion (e.g. A.x -> B.y -> A.x).
+        // compile-time value. Account for cycles.
         if (auto *varDecl =
                 dyn_cast<VarDecl>(memberExpr->getDecl().getDecl())) {
           if (varDecl->isStatic()) {
-            static thread_local llvm::SmallPtrSet<VarDecl *, 4>
-                resolvingVarDecls;
-            if (resolvingVarDecls.insert(varDecl).second) {
-              auto info = extractTypePropertyInfo(varDecl);
-              resolvingVarDecls.erase(varDecl);
+            if (resolutionCache.insert(varDecl).second) {
+              auto info = extractTypePropertyInfo(varDecl, resolutionCache);
+              resolutionCache.erase(varDecl);
               if (!isa<RuntimeValue>(info.Value.get())) {
                 return info.Value;
               }
@@ -519,7 +526,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
           Ctx, [&](bool isInterpolation, CallExpr *segment) -> void {
             auto arg = segment->getArgs()->get(0);
             auto expr = arg.getExpr();
-            segments.push_back(extractCompileTimeValue(expr, declContext));
+            segments.push_back(extractCompileTimeValue(expr, declContext, resolutionCache));
           });
 
       return std::make_shared<InterpolatedStringLiteralValue>(segments);
@@ -539,22 +546,22 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
 
     case ExprKind::DerivedToBase: {
       auto derivedExpr = cast<DerivedToBaseExpr>(expr);
-      return extractCompileTimeValue(derivedExpr->getSubExpr(), declContext);
+      return extractCompileTimeValue(derivedExpr->getSubExpr(), declContext, resolutionCache);
     }
 
     case ExprKind::OpenExistential: {
       auto openExistentialExpr = cast<OpenExistentialExpr>(expr);
-      return extractCompileTimeValue(openExistentialExpr->getExistentialValue(), declContext);
+      return extractCompileTimeValue(openExistentialExpr->getExistentialValue(), declContext, resolutionCache);
     }
 
     case ExprKind::VarargExpansion: {
       auto varargExpansionExpr = cast<VarargExpansionExpr>(expr);
-      return extractCompileTimeValue(varargExpansionExpr->getSubExpr(), declContext);
+      return extractCompileTimeValue(varargExpansionExpr->getSubExpr(), declContext, resolutionCache);
     }
 
     case ExprKind::ForceValue: {
       auto forceValueExpr = cast<ForceValueExpr>(expr);
-      return extractCompileTimeValue(forceValueExpr->getSubExpr(), declContext);
+      return extractCompileTimeValue(forceValueExpr->getSubExpr(), declContext, resolutionCache);
     }
 
     default: {
@@ -566,8 +573,15 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
   return std::make_shared<RuntimeValue>();
 }
 
+static std::shared_ptr<CompileTimeValue>
+extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
+  llvm::SmallPtrSet<VarDecl *, 4> resolutionCache;
+  return extractCompileTimeValue(expr, declContext, resolutionCache);
+}
+
 static CustomAttrValue extractAttributeValue(const CustomAttr *attr,
-                                             const DeclContext *declContext) {
+                                             const DeclContext *declContext,
+                                             llvm::SmallPtrSet<VarDecl *, 4> &resolutionCache) {
   std::vector<FunctionParameter> parameters;
   if (const auto *args = attr->getArgs()) {
     for (auto arg : *args) {
@@ -581,32 +595,37 @@ static CustomAttrValue extractAttributeValue(const CustomAttr *attr,
         }
       }
       parameters.push_back({label, argExpr->getType(),
-                            extractCompileTimeValue(argExpr, declContext)});
+                            extractCompileTimeValue(argExpr, declContext, resolutionCache)});
     }
   }
   return {attr, parameters};
 }
 
 static AttrValueVector
-extractPropertyWrapperAttrValues(VarDecl *propertyDecl) {
+extractPropertyWrapperAttrValues(VarDecl *propertyDecl,
+                                 llvm::SmallPtrSet<VarDecl *, 4> &resolutionCache) {
   AttrValueVector customAttrValues;
   for (auto *propertyWrapper : propertyDecl->getAttachedPropertyWrappers())
     customAttrValues.push_back(
-        extractAttributeValue(propertyWrapper, propertyDecl->getDeclContext()));
+        extractAttributeValue(propertyWrapper, propertyDecl->getDeclContext(),
+                              resolutionCache));
   return customAttrValues;
 }
 
 static ConstValueTypePropertyInfo
-extractTypePropertyInfo(VarDecl *propertyDecl) {
+extractTypePropertyInfo(VarDecl *propertyDecl,
+                        llvm::SmallPtrSet<VarDecl *, 4> &resolutionCache) {
   std::optional<AttrValueVector> propertyWrapperValues;
   if (propertyDecl->hasAttachedPropertyWrapper())
-    propertyWrapperValues = extractPropertyWrapperAttrValues(propertyDecl);
+    propertyWrapperValues = extractPropertyWrapperAttrValues(propertyDecl,
+                                                             resolutionCache);
 
   if (const auto binding = propertyDecl->getParentPatternBinding()) {
     if (const auto originalInit = binding->getInit(0)) {
       return {propertyDecl,
               extractCompileTimeValue(originalInit,
-                                      propertyDecl->getInnermostDeclContext()),
+                                      propertyDecl->getInnermostDeclContext(),
+                                      resolutionCache),
               propertyWrapperValues};
     }
   }
@@ -619,7 +638,8 @@ extractTypePropertyInfo(VarDecl *propertyDecl) {
           return {
               propertyDecl,
               extractCompileTimeValue(cast<ReturnStmt>(stmt)->getResult(),
-                                      accessorDecl->getInnermostDeclContext()),
+                                      accessorDecl->getInnermostDeclContext(),
+                                      resolutionCache),
               propertyWrapperValues};
         }
       }
@@ -627,6 +647,12 @@ extractTypePropertyInfo(VarDecl *propertyDecl) {
   }
 
   return {propertyDecl, std::make_shared<RuntimeValue>()};
+}
+
+static ConstValueTypePropertyInfo
+extractTypePropertyInfo(VarDecl *propertyDecl) {
+  llvm::SmallPtrSet<VarDecl *, 4> resolutionCache;
+  return extractTypePropertyInfo(propertyDecl, resolutionCache);
 }
 
 std::optional<std::vector<EnumElementDeclValue>>

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -26,6 +26,7 @@
 #include "swift/ConstExtract/ConstExtractRequests.h"
 #include "swift/Subsystems.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/PrefixMapper.h"
@@ -176,6 +177,9 @@ getResultBuilderMembersFromBraceStmt(BraceStmt *braceStmt,
 
 static std::shared_ptr<CompileTimeValue>
 extractCompileTimeValue(Expr *expr, const DeclContext *declContext);
+
+static ConstValueTypePropertyInfo
+extractTypePropertyInfo(VarDecl *propertyDecl);
 
 static std::vector<FunctionParameter>
 extractFunctionArguments(const ArgumentList *args,
@@ -480,6 +484,25 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       if (isa<TypeExpr>(memberExpr->getBase())) {
         auto baseTypeExpr = cast<TypeExpr>(memberExpr->getBase());
         auto label = memberExpr->getDecl().getDecl()->getBaseIdentifier().str();
+
+        // Attempt to resolve static stored/computed properties to their
+        // compile-time value. A thread-local visited set breaks cycles that
+        // would otherwise cause infinite recursion (e.g. A.x -> B.y -> A.x).
+        if (auto *varDecl =
+                dyn_cast<VarDecl>(memberExpr->getDecl().getDecl())) {
+          if (varDecl->isStatic()) {
+            static thread_local llvm::SmallPtrSet<VarDecl *, 4>
+                resolvingVarDecls;
+            if (resolvingVarDecls.insert(varDecl).second) {
+              auto info = extractTypePropertyInfo(varDecl);
+              resolvingVarDecls.erase(varDecl);
+              if (!isa<RuntimeValue>(info.Value.get())) {
+                return info.Value;
+              }
+            }
+          }
+        }
+
         return std::make_shared<MemberReferenceValue>(
             baseTypeExpr->getInstanceType(), label.str());
       }

--- a/test/ConstExtraction/ExtractInterpolatedStringLiterals.swift
+++ b/test/ConstExtraction/ExtractInterpolatedStringLiterals.swift
@@ -90,11 +90,8 @@ public struct External: MyProto {
 // CHECK-NEXT:               "value": "Start Interpolation with Member Reference: "
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
-// CHECK-NEXT:               "valueKind": "MemberReference",
-// CHECK-NEXT:               "value": {
-// CHECK-NEXT:                 "baseType": "ExtractInterpolatedStringLiterals.Internal",
-// CHECK-NEXT:                 "memberLabel": "internalTitle"
-// CHECK-NEXT:               }
+// CHECK-NEXT:               "valueKind": "RawLiteral",
+// CHECK-NEXT:               "value": "Inner title"
 // CHECK-NEXT:             },
 // CHECK-NEXT:             {
 // CHECK-NEXT:               "valueKind": "RawLiteral",

--- a/test/ConstExtraction/ExtractResolvedMemberReferences.swift
+++ b/test/ConstExtraction/ExtractResolvedMemberReferences.swift
@@ -6,22 +6,23 @@
 
 protocol MyProto {}
 
-// A type outside the extraction protocol list, mimicking e.g. CSCustomAttributeKey
-// from an external framework.
+// A type outside the extraction protocol list
 struct CustomKey {
     let keyName: String
     init(keyName: String) { self.keyName = keyName }
 
-    // Static stored let — constant initializer
     static let storedKey = CustomKey(keyName: "stored")
 
-    // Static computed property returning an init call
     static var computedKey: CustomKey {
-        return CustomKey(keyName: "computed")
+        CustomKey(keyName: "computed")
     }
 
-    // Static computed property returning a string literal
-    static var labelKey: String { return "label" }
+    static var labelKey: String { "label" }
+
+    static var dynamicLabelKey: String {  Int.random(in: 0...100) > 50 ? "dynamic1" : "dynamic2" }
+    static var dyanmicComputedKey: CustomKey { Int.random(in: 0...100) > 50 ? CustomKey(keyName: "dynamic1") : CustomKey(keyName: "dynamic2") }
+    static let dynamicStoredKey: CustomKey = Int.random(in: 0...100) > 50 ? CustomKey(keyName: "a") : CustomKey(keyName: "b")
+    static let interpolatedStringKey: String = "interpolated \(Self.labelKey)"
 }
 
 // Two types that reference each other — cycle detection test
@@ -45,6 +46,14 @@ struct Container: MyProto {
 
     // Unresolvable: cycle — must fall back to MemberReference
     var prop4 = CycleA.value
+
+    // Unresolvable: dynamic values — must fall back to MemberReference
+    var prop5 = CustomKey.dynamicLabelKey
+    var prop6 = CustomKey.dyanmicComputedKey
+    var prop7 = CustomKey.dynamicStoredKey
+
+    // Resolved: static stored property containing an interpolated string literal with a member reference
+    var prop8 = CustomKey.interpolatedStringKey
 }
 
 // CHECK:       "label": "prop1",
@@ -84,4 +93,44 @@ struct Container: MyProto {
 // CHECK-NEXT:  "value": {
 // CHECK-NEXT:    "baseType": "ExtractResolvedMemberReferences.CycleA",
 // CHECK-NEXT:    "memberLabel": "value"
+// CHECK-NEXT:  }
+
+// CHECK:       "label": "prop5",
+// CHECK:       "valueKind": "MemberReference",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "baseType": "ExtractResolvedMemberReferences.CustomKey",
+// CHECK-NEXT:    "memberLabel": "dynamicLabelKey"
+// CHECK-NEXT:  }
+
+// CHECK:       "label": "prop6",
+// CHECK:       "valueKind": "MemberReference",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "baseType": "ExtractResolvedMemberReferences.CustomKey",
+// CHECK-NEXT:    "memberLabel": "dyanmicComputedKey"
+// CHECK-NEXT:  }
+
+// CHECK:       "label": "prop7",
+// CHECK:       "valueKind": "MemberReference",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "baseType": "ExtractResolvedMemberReferences.CustomKey",
+// CHECK-NEXT:    "memberLabel": "dynamicStoredKey"
+// CHECK-NEXT:  }
+
+// CHECK:       "label": "prop8",
+// CHECK:       "valueKind": "InterpolatedStringLiteral",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "segments": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "interpolated "
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "label"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": ""
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
 // CHECK-NEXT:  }

--- a/test/ConstExtraction/ExtractResolvedMemberReferences.swift
+++ b/test/ConstExtraction/ExtractResolvedMemberReferences.swift
@@ -1,0 +1,87 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractResolvedMemberReferences.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractResolvedMemberReferences.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+
+// A type outside the extraction protocol list, mimicking e.g. CSCustomAttributeKey
+// from an external framework.
+struct CustomKey {
+    let keyName: String
+    init(keyName: String) { self.keyName = keyName }
+
+    // Static stored let — constant initializer
+    static let storedKey = CustomKey(keyName: "stored")
+
+    // Static computed property returning an init call
+    static var computedKey: CustomKey {
+        return CustomKey(keyName: "computed")
+    }
+
+    // Static computed property returning a string literal
+    static var labelKey: String { return "label" }
+}
+
+// Two types that reference each other — cycle detection test
+struct CycleA {
+    static var value: String { return CycleB.value }
+}
+
+struct CycleB {
+    static var value: String { return CycleA.value }
+}
+
+struct Container: MyProto {
+    // Resolved: static let stored property with init call
+    var prop1 = CustomKey.storedKey
+
+    // Resolved: static computed property returning an init call
+    var prop2 = CustomKey.computedKey
+
+    // Resolved: static computed property returning a string literal
+    var prop3 = CustomKey.labelKey
+
+    // Unresolvable: cycle — must fall back to MemberReference
+    var prop4 = CycleA.value
+}
+
+// CHECK:       "label": "prop1",
+// CHECK:       "valueKind": "InitCall",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "type": "ExtractResolvedMemberReferences.CustomKey",
+// CHECK-NEXT:    "arguments": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "keyName",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "stored"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  }
+
+// CHECK:       "label": "prop2",
+// CHECK:       "valueKind": "InitCall",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "type": "ExtractResolvedMemberReferences.CustomKey",
+// CHECK-NEXT:    "arguments": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "keyName",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "computed"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  }
+
+// CHECK:       "label": "prop3",
+// CHECK:       "valueKind": "RawLiteral",
+// CHECK-NEXT:  "value": "label"
+
+// CHECK:       "label": "prop4",
+// CHECK:       "valueKind": "MemberReference",
+// CHECK-NEXT:  "value": {
+// CHECK-NEXT:    "baseType": "ExtractResolvedMemberReferences.CycleA",
+// CHECK-NEXT:    "memberLabel": "value"
+// CHECK-NEXT:  }

--- a/test/ConstExtraction/ExtractStaticFunctions.swift
+++ b/test/ConstExtraction/ExtractStaticFunctions.swift
@@ -55,10 +55,10 @@ struct Statics: MyProto {
 // CHECK-NEXT:  }
 // CHECK:       "label": "baz1",
 // CHECK-NEXT:  "type": "ExtractStaticFunctions.Baz",
-// CHECK:       "valueKind": "MemberReference"
+// CHECK:       "valueKind": "InitCall",
 // CHECK-NEXT:  "value": {
-// CHECK-NEXT:    "baseType": "ExtractStaticFunctions.Baz",
-// CHECK-NEXT:    "memberLabel": "one"
+// CHECK-NEXT:    "type": "ExtractStaticFunctions.Baz",
+// CHECK-NEXT:    "arguments": []
 // CHECK-NEXT:  }
 // CHECK:       "label": "baz2",
 // CHECK-NEXT:  "type": "ExtractStaticFunctions.Baz",


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Try to follow and resolve member references to their constant values and embed into the const values file. If they are not resolvable fall back to a MemberReference kind. This allows extraction for usages like

```
enum MyConstants {
  static let key = "mykey"
}

struct MyEntity: IndexedEntity {
   @Property(indexingKey: MyConstants.key) let someProperty: String
   ....
}
```
fixes rdar://184639902