### PR TITLE
AST: Clarify diagnostics for unrecognized availability domains

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7419,12 +7419,12 @@ ERROR(availability_must_occur_alone, none,
       (AvailabilityDomain, bool))
 ERROR(availability_unexpected_version, none,
       "unexpected version number for %0", (AvailabilityDomain))
-GROUPED_ERROR(availability_unrecognized_platform_name,
+GROUPED_ERROR(availability_domain_not_found,
         AvailabilityUnrecognizedName, PointsToFirstBadToken,
-        "unrecognized platform name %0", (Identifier))
-GROUPED_ERROR(availability_suggest_platform_name,
+        "cannot find availability domain %0", (Identifier))
+GROUPED_ERROR(availability_suggest_domain,
         AvailabilityUnrecognizedName, PointsToFirstBadToken,
-        "unrecognized platform name %0; did you mean '%1'?",
+        "cannot find availability domain %0; did you mean '%1'?",
         (Identifier, StringRef))
 WARNING(availability_unsupported_version_number, none,
         "'%0' is not a supported version number", (llvm::VersionTuple))

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -673,14 +673,12 @@ AvailabilityDomainOrIdentifier::lookUpInDeclContext(
         !hasCustomAvailability || declContext->isInSwiftinterface();
     if (auto suggestion = closestCorrectedPlatformString(domainString)) {
       diags
-          .diagnose(loc, diag::availability_suggest_platform_name, identifier,
+          .diagnose(loc, diag::availability_suggest_domain, identifier,
                     *suggestion)
           .limitBehaviorIf(downgradeErrors, DiagnosticBehavior::Warning)
           .fixItReplace(SourceRange(loc), *suggestion);
     } else {
-      diags
-          .diagnose(loc, diag::availability_unrecognized_platform_name,
-                    identifier)
+      diags.diagnose(loc, diag::availability_domain_not_found, identifier)
           .limitBehaviorIf(downgradeErrors, DiagnosticBehavior::Warning);
     }
     return std::nullopt;

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -36,7 +36,7 @@ func deprecatedInDynamicDomain() { }
 @available(DynamicDomain, unavailable)
 func unavailableInDynamicDomain() { } // expected-note * {{'unavailableInDynamicDomain()' has been explicitly marked unavailable here}}
 
-@available(UnknownDomain) // expected-error {{unrecognized platform name 'UnknownDomain'}}
+@available(UnknownDomain) // expected-error {{cannot find availability domain 'UnknownDomain'}}
 func availableInUnknownDomain() { }
 
 @available(EnabledDomain)

--- a/test/Availability/availability_define.swift
+++ b/test/Availability/availability_define.swift
@@ -72,7 +72,7 @@ func client() {
     onMacOS51_0()
   }
 
-  if #available(_unknownMacro, *) { } // expected-warning {{unrecognized platform name '_unknownMacro'}}
+  if #available(_unknownMacro, *) { } // expected-warning {{cannot find availability domain '_unknownMacro'}}
 }
 
 public func doIt(_ closure: () -> ()) {

--- a/test/Availability/availability_define_parsing.swift
+++ b/test/Availability/availability_define_parsing.swift
@@ -36,13 +36,13 @@ public func noVersionMulti() {}
 // CHECK: duplicate definition of availability macro '_duplicateVersion' for version '1.0'
 // CHECK-NEXT: _duplicateVersion
 
-// CHECK: -define-availability argument:1:18: warning: unrecognized platform name 'spaceOS'; did you mean 'macOS'?
+// CHECK: -define-availability argument:1:18: warning: cannot find availability domain 'spaceOS'; did you mean 'macOS'?
 // CHECK-NEXT: _brokenPlatforms:spaceOS 10.11
 
-// CHECK: -define-availability argument:1:26: warning: unrecognized platform name 'macos'; did you mean 'macOS'?
+// CHECK: -define-availability argument:1:26: warning: cannot find availability domain 'macos'; did you mean 'macOS'?
 // CHECK-NEXT: _incorrectCase
 
-// CHECK: -define-availability argument:1:16: warning: unrecognized platform name 'ios'; did you mean 'iOS'?
+// CHECK: -define-availability argument:1:16: warning: cannot find availability domain 'ios'; did you mean 'iOS'?
 // CHECK-NEXT: _incorrectCase
 
 // FIXME: [availability] Diagnostic needs improvement

--- a/test/Availability/custom_domain_serialization.swift
+++ b/test/Availability/custom_domain_serialization.swift
@@ -43,6 +43,6 @@ func test2() {
 
 #endif
 
-// CHECK: error: unrecognized platform name 'EnabledDomain'
+// CHECK: error: cannot find availability domain 'EnabledDomain'
 // CHECK: warning: ignoring unresolved custom availability domain 'EnabledDomain'
 // CHECK: warning: ignoring unresolved custom availability domain 'AlwaysEnabledDomain'

--- a/test/ClangImporter/Inputs/availability_custom_domains_other.swift
+++ b/test/ClangImporter/Inputs/availability_custom_domains_other.swift
@@ -1,6 +1,6 @@
 import Seas
 
-@available(Arctic) // expected-error {{unrecognized platform name 'Arctic'}}
+@available(Arctic) // expected-error {{cannot find availability domain 'Arctic'}}
 func availableInArctic() { }
 
 @available(Mediterranean)

--- a/test/ClangImporter/availability_custom_domains.swift
+++ b/test/ClangImporter/availability_custom_domains.swift
@@ -47,7 +47,7 @@ func availableInPacific() { }
 func unavailableInColorado() { } // expected-note {{'unavailableInColorado()' has been explicitly marked unavailable here}}
 
 // The Seas module is only imported directly by the other source file.
-@available(Baltic) // expected-error {{unrecognized platform name 'Baltic'}}
+@available(Baltic) // expected-error {{cannot find availability domain 'Baltic'}}
 func availableInBaltic() { } // expected-note {{did you mean 'availableInBaltic'}}
 
 func testSwiftDecls() { // expected-note 3 {{add '@available' attribute to enclosing global function}}

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -48,23 +48,23 @@ if #available(OSX 51 { // expected-error {{expected ')'}} expected-note {{to mat
 if #available(iDishwasherOS 0) { // expected-warning {{expected version number; this is an error in the Swift 6 language mode}}
 }
 
-if #available(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(iDishwasherOS 51) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 // expected-error@-1 {{condition required for target platform}}
 }
 
-if #available(iDishwasherOS 51, *) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(iDishwasherOS 51, *) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 }
 
-if #available(macos 51, *) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{15-20=macOS}}
+if #available(macos 51, *) { // expected-warning {{cannot find availability domain 'macos'; did you mean 'macOS'?}} {{15-20=macOS}}
 }
 
-if #available(mscos 51, *) { // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{15-20=macOS}}
+if #available(mscos 51, *) { // expected-warning {{cannot find availability domain 'mscos'; did you mean 'macOS'?}} {{15-20=macOS}}
 }
 
-if #available(macoss 51, *) { // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{15-21=macOS}}
+if #available(macoss 51, *) { // expected-warning {{cannot find availability domain 'macoss'; did you mean 'macOS'?}} {{15-21=macOS}}
 }
 
-if #available(mac 51, *) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{15-18=macOS}}
+if #available(mac 51, *) { // expected-warning {{cannot find availability domain 'mac'; did you mean 'macOS'?}} {{15-18=macOS}}
 }
 
 if #available(OSX 51, OSX 52, *) {  // expected-error {{version for macOS already specified}}
@@ -103,11 +103,11 @@ if #available(OSX 51,) { // expected-error {{expected platform name}}
 if #available(OSX 51, iOS { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #available(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 // expected-error@-1 {{must handle potential future platforms with '*'}}
 }
 
-if #available(iDishwasherOS 51, OSX 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #available(iDishwasherOS 51, OSX 51) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 // expected-error@-1 {{must handle potential future platforms with '*'}}
 }
 

--- a/test/Parse/availability_query_custom_domains.swift
+++ b/test/Parse/availability_query_custom_domains.swift
@@ -9,13 +9,13 @@
 if #available(EnabledDomain) { }
 if #available(DisabledDomain) { }
 if #available(DynamicDomain) { }
-if #available(UnknownDomain) { } // expected-error {{unrecognized platform name 'UnknownDomain'}}
+if #available(UnknownDomain) { } // expected-error {{cannot find availability domain 'UnknownDomain'}}
 // expected-error@-1 {{condition required for target platform}}
 
 if #unavailable(EnabledDomain) { }
 if #unavailable(DisabledDomain) { }
 if #unavailable(DynamicDomain) { }
-if #unavailable(UnknownDomain) { } // expected-error {{unrecognized platform name 'UnknownDomain'}}
+if #unavailable(UnknownDomain) { } // expected-error {{cannot find availability domain 'UnknownDomain'}}
 
 if #available(EnabledDomain 1.0) { } // expected-error {{unexpected version number for EnabledDomain}}
 if #available(EnabledDomain, DisabledDomain) { } // expected-error {{EnabledDomain availability must be specified alone}}

--- a/test/Parse/availability_query_unavailability.swift
+++ b/test/Parse/availability_query_unavailability.swift
@@ -37,22 +37,22 @@ if #unavailable(OSX) { // expected-error {{expected version number}}
 if #unavailable(OSX 51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #unavailable(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(iDishwasherOS 51) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 }
 
-if #unavailable(iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(iDishwasherOS 51) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 }
 
-if #unavailable(macos 51) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
+if #unavailable(macos 51) { // expected-warning {{cannot find availability domain 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
 }
 
-if #unavailable(mscos 51) { // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{17-22=macOS}}
+if #unavailable(mscos 51) { // expected-warning {{cannot find availability domain 'mscos'; did you mean 'macOS'?}} {{17-22=macOS}}
 }
 
-if #unavailable(macoss 51) { // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{17-23=macOS}}
+if #unavailable(macoss 51) { // expected-warning {{cannot find availability domain 'macoss'; did you mean 'macOS'?}} {{17-23=macOS}}
 }
 
-if #unavailable(mac 51) { // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{17-20=macOS}}
+if #unavailable(mac 51) { // expected-warning {{cannot find availability domain 'mac'; did you mean 'macOS'?}} {{17-20=macOS}}
 }
 
 if #unavailable(OSX 51, OSX 52) {  // expected-error {{version for macOS already specified}}
@@ -84,10 +84,10 @@ if #unavailable(OSX 51, { // expected-error {{expected platform name}} // expect
 if #unavailable(OSX 51, iOS { // expected-error {{expected ')'}} expected-note {{to match this opening '('}}
 }
 
-if #unavailable(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(OSX 51, iOS 8.0, iDishwasherOS 51) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 }
 
-if #unavailable(iDishwasherOS 51, OSX 51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+if #unavailable(iDishwasherOS 51, OSX 51) { // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 }
 
 if #unavailable(OSX 51 || iOS 8.0) {// expected-error {{'||' cannot be used in an availability condition}}

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -88,7 +88,7 @@ func $declareWithDollar() { // expected-error{{cannot declare entity named '$dec
   @$dollar case _: // expected-error {{unknown attribute '$dollar'}}
     break
   }
-  if #available($Dummy 9999, *) {} // expected-warning {{unrecognized platform name '$Dummy'}}
+  if #available($Dummy 9999, *) {} // expected-warning {{cannot find availability domain '$Dummy'}}
   @_swift_native_objc_runtime_base($Dollar)
   class $Class {} // expected-error{{cannot declare entity named '$Class'; the '$' prefix is reserved}}
   enum $Enum {} // expected-error{{cannot declare entity named '$Enum'; the '$' prefix is reserved}}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -17,26 +17,26 @@ func noArgs() {}
 @available(*) // expected-error {{expected ',' in 'available' attribute}}
 func noKind() {}
 
-@available(badPlatform, unavailable) // expected-warning {{unrecognized platform name 'badPlatform'}}
+@available(badPlatform, unavailable) // expected-warning {{cannot find availability domain 'badPlatform'}}
 func unavailable_bad_platform() {}
 
-@available(macos, unavailable) // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{12-17=macOS}}
+@available(macos, unavailable) // expected-warning {{cannot find availability domain 'macos'; did you mean 'macOS'?}} {{12-17=macOS}}
 func incorrect_platform_case() {}
 
-@available(mscos, unavailable) // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{12-17=macOS}}
+@available(mscos, unavailable) // expected-warning {{cannot find availability domain 'mscos'; did you mean 'macOS'?}} {{12-17=macOS}}
 func incorrect_platform_similar1() {}
 
-@available(macoss, unavailable) // expected-warning {{unrecognized platform name 'macoss'; did you mean 'macOS'?}} {{12-18=macOS}}
+@available(macoss, unavailable) // expected-warning {{cannot find availability domain 'macoss'; did you mean 'macOS'?}} {{12-18=macOS}}
 func incorrect_platform_similar2() {}
 
-@available(mac, unavailable) // expected-warning {{unrecognized platform name 'mac'; did you mean 'macOS'?}} {{12-15=macOS}}
+@available(mac, unavailable) // expected-warning {{cannot find availability domain 'mac'; did you mean 'macOS'?}} {{12-15=macOS}}
 func incorrect_platform_similar3() {}
 
-@available(notValid, unavailable) // expected-warning {{unrecognized platform name 'notValid'}} {{none}}
+@available(notValid, unavailable) // expected-warning {{cannot find availability domain 'notValid'}} {{none}}
 func incorrect_platform_not_similar() {}
 
 // Handle unknown platform.
-@available(HAL9000, unavailable) // expected-warning {{unrecognized platform name 'HAL9000'}}
+@available(HAL9000, unavailable) // expected-warning {{cannot find availability domain 'HAL9000'}}
 func availabilityUnknownPlatform() {}
 
 @available(Swift 6.2, *) // expected-error {{Swift requires '-enable-experimental-feature SwiftRuntimeAvailability'}}
@@ -272,35 +272,35 @@ func shortFormMissingParen() { // expected-error {{expected ')' in 'available' a
 func shortFormMissingPlatform() {
 }
 
-@available(iOS 8.0, iDishwasherOS 22.0, *) // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
+@available(iOS 8.0, iDishwasherOS 22.0, *) // expected-warning {{cannot find availability domain 'iDishwasherOS'}}
 func shortFormWithUnrecognizedPlatform() {
 }
 
 @available(iOS 8.0, iDishwasherOS 22.0, iRefrigeratorOS 18.0, *)
-// expected-warning@-1 {{unrecognized platform name 'iDishwasherOS'}}
-// expected-warning@-2 {{unrecognized platform name 'iRefrigeratorOS'}}
+// expected-warning@-1 {{cannot find availability domain 'iDishwasherOS'}}
+// expected-warning@-2 {{cannot find availability domain 'iRefrigeratorOS'}}
 func shortFormWithTwoUnrecognizedPlatforms() {
 }
 
 @available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, iDishwasherOS 22.0, visionOS 1.0, *)
-// expected-warning@-1 {{unrecognized platform name 'iDishwasherOS'}}
+// expected-warning@-1 {{cannot find availability domain 'iDishwasherOS'}}
 func shortFormWithInteriorUnrecognizedPlatform() {
 }
 
 @available(ios 8.0, macos 10.12, *)
-// expected-warning@-1 {{unrecognized platform name 'ios'; did you mean 'iOS'?}}
-// expected-warning@-2 {{unrecognized platform name 'macos'; did you mean 'macOS'?}}
+// expected-warning@-1 {{cannot find availability domain 'ios'; did you mean 'iOS'?}}
+// expected-warning@-2 {{cannot find availability domain 'macos'; did you mean 'macOS'?}}
 func shortFormWithTwoPlatformsIncorrectCase() {
 }
 
 @available(os 8.0, *)
-// expected-warning@-1 {{unrecognized platform name 'os'; did you mean 'iOS'?}} {{12-14=iOS}}
+// expected-warning@-1 {{cannot find availability domain 'os'; did you mean 'iOS'?}} {{12-14=iOS}}
 func iosIsClosestThanMacOS() {}
 
 // Make sure that even after the parser hits an unrecognized
 // platform it validates the availability.
 @available(iOS 8.0, iDishwasherOS 22.0, iOS 9.0, *)
-// expected-warning@-1 {{unrecognized platform name 'iDishwasherOS'}}
+// expected-warning@-1 {{cannot find availability domain 'iDishwasherOS'}}
 // expected-error@-2 {{version for iOS already specified}}
 func shortFormWithUnrecognizedPlatformContinueValidating() {
 }

--- a/test/attr/attr_availability_any_apple_os.swift
+++ b/test/attr/attr_availability_any_apple_os.swift
@@ -6,7 +6,7 @@ func availableIn26Short() { }
 @available(anyAppleOS 26.0, *)
 func availableIn26_0Short() { }
 
-@available(AnyAppleOS 26, *) // expected-warning {{unrecognized platform name 'AnyAppleOS'; did you mean 'anyAppleOS'}}
+@available(AnyAppleOS 26, *) // expected-warning {{cannot find availability domain 'AnyAppleOS'; did you mean 'anyAppleOS'}}
 func miscapitalized() { }
 
 @available(anyAppleOS 25, *) // expected-warning {{'25' is not a valid version number for any Apple OS}}

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -64,7 +64,7 @@ func deprecatedInRedefinedDomain() { }
 @available(DynamicDomain)
 func availableInDynamicDomain() { }
 
-@available(UnknownDomain) // expected-error {{unrecognized platform name 'UnknownDomain'}}
+@available(UnknownDomain) // expected-error {{cannot find availability domain 'UnknownDomain'}}
 func availableInUnknownDomain() { }
 
 @available(EnabledDomain)

--- a/test/attr/spi_available.swift
+++ b/test/attr/spi_available.swift
@@ -6,16 +6,16 @@ public class SPIClass1 {} // expected-warning {{symbols that are '@_spi_availabl
 @_spi_available(*, unavailable) // expected-error {{SPI available only supports introducing version on specific platform}}
 public class SPIClass2 {} // expected-warning {{symbols that are '@_spi_available' on all platforms should use '@_spi' instead}}
 
-@_spi_available(AlienPlatform 5.2, *) // expected-warning {{unrecognized platform name 'AlienPlatform'}}
+@_spi_available(AlienPlatform 5.2, *) // expected-warning {{cannot find availability domain 'AlienPlatform'}}
 public class SPIClass3 {}
 
 @_spi_available(macOS 10.4, *)
 public class SPIClass4 {} // expected-warning {{symbols that are '@_spi_available' on all platforms should use '@_spi' instead}}
 
-@_spi_available(macos 10.15, *) // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
+@_spi_available(macos 10.15, *) // expected-warning {{cannot find availability domain 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
 public class SPIClass5 {}
 
-@_spi_available(mscos 10.15, *) // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{17-22=macOS}}
+@_spi_available(mscos 10.15, *) // expected-warning {{cannot find availability domain 'mscos'; did you mean 'macOS'?}} {{17-22=macOS}}
 public class SPIClass6 {}
 
 public class ClassWithMembers {

--- a/test/decl/protocol/special/case_iterable/case_iterable_supported.swift
+++ b/test/decl/protocol/special/case_iterable/case_iterable_supported.swift
@@ -40,6 +40,6 @@ extension FromOtherFile: CaseIterable {
 
 enum InvalidAvailableAttribute: CaseIterable {
   case a
-  @available(deprecated, renamed: "a") // expected-warning {{unrecognized platform name 'deprecated'}}
+  @available(deprecated, renamed: "a") // expected-warning {{cannot find availability domain 'deprecated'}}
   case b
 }

--- a/userdocs/diagnostics/availability-unrecognized-name.md
+++ b/userdocs/diagnostics/availability-unrecognized-name.md
@@ -1,18 +1,18 @@
-# Unrecognized availability platforms (AvailabilityUnrecognizedName)
+# Unrecognized availability domains (AvailabilityUnrecognizedName)
 
-Warnings that identify unrecognized platform names in `@available` attributes and `if #available` statements.
+Warnings that identify unrecognized availability domain names in `@available` attributes and `if #available` statements.
 
 ## Overview
 
-The `AvailabilityUnrecognizedName` group covers warnings emitted when the platform name specified in an availability related construct is unrecognized by the compiler:
+The `AvailabilityUnrecognizedName` group covers warnings emitted when the availability domain specified in an availability related construct is unrecognized by the compiler:
 
 ```
-@available(NotAValidPlatform, introduced: 1.0) // warning: unrecognized platform name 'NotAValidPlatform'
+@available(NotAValidPlatform, introduced: 1.0) // warning: cannot find availability domain 'NotAValidPlatform'
 public func function() {
-  if #available(NotAValidPlatform 2.0, *) { // warning: unrecognized platform name 'NotAValidPlatform'
+  if #available(NotAValidPlatform 2.0, *) { // warning: cannot find availability domain 'NotAValidPlatform'
     // ...
   }
 }
 ```
 
-Availability specifications with unrecognized platform names in `@available` attributes and `#available` queries are ignored by the compiler.
+Availability specifications with unrecognized availability domains in `@available` attributes and `#available` queries are ignored by the compiler.


### PR DESCRIPTION
The names specified in `@available` attributes and `if #available` queries are not limited to platform names anymore, so a diagnostic like this one can be confusing for users of custom availability domains:

    @available(MyFeature) // error: unrecognized platform name 'MyFeature'
    func f() { }

Generalize the diagnostics to refer to these entities as "availability domains" instead of platforms.

Addresses rdar://184624711.
