### PR TITLE
[cxx-interop] Do not import function templates with a parameter pack

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5146,9 +5146,12 @@ namespace {
           importFullName(decl->getAsFunction());
       if (!importedName)
         return nullptr;
-      // All template parameters must be template type parameters.
+      // All template parameters must be template type parameters, and none of
+      // them may be a parameter pack.
       if (!llvm::all_of(*decl->getTemplateParameters(), [](auto param) {
-            return isa<clang::TemplateTypeParmDecl>(param);
+            const auto *typeParam =
+                dyn_cast<clang::TemplateTypeParmDecl>(param);
+            return typeParam && !typeParam->isParameterPack();
           }))
         return nullptr;
       auto *imported = importFunctionDecl(decl->getAsFunction(), importedName,

--- a/test/Interop/Cxx/templates/Inputs/function-template-parameter-pack.h
+++ b/test/Interop/Cxx/templates/Inputs/function-template-parameter-pack.h
@@ -1,0 +1,30 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_FUNCTION_TEMPLATE_PARAMETER_PACK_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_FUNCTION_TEMPLATE_PARAMETER_PACK_H
+
+// Those below include 'pack'/'Pack' in their names on purpose. We will grep by
+// name to ensure they are not imported.
+
+template <typename... Ts>
+void takesPack(Ts... ts) {}
+
+template <typename T, typename... Ts>
+void takesTypeAndPack(T t, Ts... ts) {}
+
+template <typename... Ts>
+void unusedPack() {}
+
+template <typename... Ts>
+int packInReturnTypeOnly() {
+  return sizeof...(Ts);
+}
+
+// The struct should be included, but not its member functions.
+struct HasVariadicTemplateMembers {
+  template <typename... Ts>
+  void memberTakesPack(Ts... ts) {}
+
+  template <typename... Ts>
+  static void staticMemberTakesPack(Ts... ts) {}
+};
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_FUNCTION_TEMPLATE_PARAMETER_PACK_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -202,3 +202,8 @@ module FunctionTemplateWithOptionalFrt {
   header "function-template-with-optional-frt.h"
   requires cplusplus
 }
+
+module FunctionTemplateParameterPack {
+  header "function-template-parameter-pack.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/function-template-parameter-pack-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-parameter-pack-module-interface.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test \
+// RUN:   -print-module \
+// RUN:   -module-to-print=FunctionTemplateParameterPack \
+// RUN:   -I %S/Inputs \
+// RUN:   -source-filename=x \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   | %FileCheck %s --implicit-check-not Pack --implicit-check-not pack
+
+// Ensure that function templates with a template parameter pack are not
+// imported. In our test, those contain 'pack'/'Pack' in their names, so we use
+// --implicit-check-not to verify that.  The struct HasVariadicTemplateMembers
+// itself should be printed.
+
+// CHECK: struct HasVariadicTemplateMembers

--- a/test/Interop/Cxx/templates/function-template-parameter-pack-typechecker.swift
+++ b/test/Interop/Cxx/templates/function-template-parameter-pack-typechecker.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -I %S/Inputs
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -I %S/Inputs
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
+
+import FunctionTemplateParameterPack
+
+// Function templates with a template parameter pack are not imported. Try to
+// call them anyway to make sure we don't crash trying to resolve them.
+
+public func callFreeFunctionTemplatesWithPack() {
+  takesPack(1, Ts: CInt.self)
+  // expected-error@-1{{cannot find 'takesPack' in scope}}
+  takesTypeAndPack(1, 2, Ts: CInt.self)
+  // expected-error@-1{{cannot find 'takesTypeAndPack' in scope}}
+  unusedPack(Ts: CInt.self)
+  // expected-error@-1{{cannot find 'unusedPack' in scope}}
+  let _ = packInReturnTypeOnly(Ts: CInt.self)
+  // expected-error@-1{{cannot find 'packInReturnTypeOnly' in scope}}
+}
+
+public func callMemberFunctionTemplatesWithPack(
+    _ s: inout HasVariadicTemplateMembers) {
+  s.memberTakesPack(1, Ts: CInt.self)
+  // expected-error@-1{{value of type 'HasVariadicTemplateMembers' has no member 'memberTakesPack'}}
+  HasVariadicTemplateMembers.staticMemberTakesPack(1, Ts: CInt.self)
+  // expected-error@-1{{type 'HasVariadicTemplateMembers' has no member 'staticMemberTakesPack'}}
+}


### PR DESCRIPTION
A pack `typename... Ts` is a clang::TemplateTypeParmDecl, so the existing "all template parameters must be template type parameters" guard in VisitFunctionTemplateDecl let it through. The pack collapsed into a single ordinary generic parameter and the pack expansion parameter was imported as Any:

    func parameterPack<Ts>(_ ts: Any, Ts: Ts.Type)

Calling that from Swift triggers an assertion in getPackAsArray().

Bail on packs instead, the way non-type template parameters are already treated, so a call site gets "cannot find 'parameterPack' in scope" rather than an assertion failure.

rdar://184658782

