### PR TITLE
Forward declare `SILDebugScope`.

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -81,6 +81,7 @@ class NodeSet;
 class OperandSet;
 class FixedSizeSlabPayload;
 class FixedSizeSlab;
+class SILDebugScope;
 }
 
 struct BridgedLoop {


### PR DESCRIPTION
Compiler `main` fails to build on Ubuntu 26.04 LTS.

Command run:
`./swift/utils/build-script --release-debuginfo --debug-swift`

Error:
```
[12/1800][  0%][0.256s] Building CXX object lib/CMakeFiles/importedHeaderDependencies.dir/HeaderDependencies.cpp.o
FAILED: [code=1] lib/CMakeFiles/importedHeaderDependencies.dir/HeaderDependencies.cpp.o 
/home/jiri/.local/share/swift-6.3.3/toolchain-linux-x86_64/usr/bin/clang++ -DCMARK_STATIC_DEFINE -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -DPURE_BRIDGING_MODE -DSWIFT_BUILD_IMMEDIATE_MODE -DSWIFT_BUILD_SWIFT_SYNTAX -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/data/Code/Swift/build/Ninja-RelWithDebInfoAssert+swift-DebugAssert/swift-linux-x86_64/lib -I/data/Code/Swift/swift/lib -I/data/Code/Swift/swift/stdlib/public/SwiftShims -I/data/Code/Swift/build/Ninja-RelWithDebInfoAssert+swift-DebugAssert/swift-linux-x86_64/include -I/data/Code/Swift/swift/include -I/data/Code/Swift/llvm-project/llvm/include -I/data/Code/Swift/build/Ninja-RelWithDebInfoAssert+swift-DebugAssert/llvm-linux-x86_64/include -I/data/Code/Swift/llvm-project/clang/include -I/data/Code/Swift/build/Ninja-RelWithDebInfoAssert+swift-DebugAssert/llvm-linux-x86_64/tools/clang/include -I/data/Code/Swift/cmark/src/include -I/data/Code/Swift/build/Ninja-RelWithDebInfoAssert+swift-DebugAssert/cmark-linux-x86_64/src -I/data/Code/Swift/swift-corelibs-libdispatch/src/BlocksRuntime -I/data/Code/Swift/swift-corelibs-libdispatch -Wno-unknown-warning-option -Werror=unguarded-availability-new -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -std=c++17 -fsized-deallocation -gsplit-dwarf -Werror=switch -Werror=unused -Werror=uninitialized -Werror=unreachable-code -Werror=implicit-fallthrough -Werror=c++98-compat-extra-semi -Werror=gnu -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -Wno-nested-anon-types -MD -MT lib/CMakeFiles/importedHeaderDependencies.dir/HeaderDependencies.cpp.o -MF lib/CMakeFiles/importedHeaderDependencies.dir/HeaderDependencies.cpp.o.d -o lib/CMakeFiles/importedHeaderDependencies.dir/HeaderDependencies.cpp.o -c /data/Code/Swift/build/Ninja-RelWithDebInfoAssert+swift-DebugAssert/swift-linux-x86_64/lib/HeaderDependencies.cpp
In file included from /data/Code/Swift/build/Ninja-RelWithDebInfoAssert+swift-DebugAssert/swift-linux-x86_64/lib/HeaderDependencies.cpp:9:
/data/Code/Swift/swift/include/swift/SIL/SILBridging.h:455:16: error: no type named 'SILDebugScope' in namespace 'swift'
  455 |   const swift::SILDebugScope * _Nullable scope;
      |         ~~~~~~~^
/data/Code/Swift/swift/include/swift/SIL/SILBridging.h:459:16: error: no type named 'SILDebugScope' in namespace 'swift'
  459 |   const swift::SILDebugScope * _Nonnull scope;
      |         ~~~~~~~^
2 errors generated.
```

Cause:
https://github.com/swiftlang/swift/pull/91198 introduced the use of `SILDebugScope` in `include/swift/SIL/SILBridging.h` without declaring the symbol.

Possible solutions:
1) Add a forward declaration of the symbol.
2) Import the header that defines the symbol. The file includes a warning against importing other headers without careful consideration, therefore 1) is likely the better option.