### PR TITLE
Handle mark_dependence_addr in LoadableByAddress

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -4790,6 +4790,14 @@ protected:
     assignment.markForDeletion(m);
   }
 
+  void visitMarkDependenceAddrInst(MarkDependenceAddrInst *m) {
+    auto builder = assignment.getBuilder(m->getIterator());
+    auto opdAddr = assignment.getAddressForValue(m->getBase());
+    builder.createMarkDependenceAddr(m->getLoc(), m->getAddress(), opdAddr,
+                                     m->dependenceKind());
+    assignment.markForDeletion(m);
+  }
+
   void visitStoreInst(StoreInst *store) {
     auto builder = assignment.getBuilder(store->getIterator());
     SILValue addr = assignment.getAddressForValue(store->getSrc());

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -499,3 +499,35 @@ bb0:
   return %ret : $()
 }
 
+
+struct LargeRef {
+  var c: C1
+  var p: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)
+}
+
+// CHECK-LABEL: sil @test_mark_dependence_addr_large_argument
+// CHECK:       bb0(%0 : $*LargeRef, %1 : $*Builtin.NativeObject):
+// CHECK:         [[STK:%.*]] = alloc_stack $LargeRef
+// CHECK:         copy_addr [take] %0 to [init] [[STK]]
+// CHECK:         mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on [[STK]] : $*LargeRef
+// CHECK:       } // end sil function 'test_mark_dependence_addr_large_argument'
+sil @test_mark_dependence_addr_large_argument : $@convention(thin) (@guaranteed LargeRef, @in_guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $LargeRef, %1 : $*Builtin.NativeObject):
+  mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on %0 : $LargeRef
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil @test_mark_dependence_addr_large_loaded_value
+// CHECK:       bb0(%0 : $*LargeRef, %1 : $*Builtin.NativeObject):
+// CHECK-NOT:     alloc_stack
+// CHECK:         mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on %0 : $*LargeRef
+// CHECK:       } // end sil function 'test_mark_dependence_addr_large_loaded_value'
+sil @test_mark_dependence_addr_large_loaded_value : $@convention(thin) (@in_guaranteed LargeRef, @in_guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $*LargeRef, %1 : $*Builtin.NativeObject):
+  %2 = load %0 : $*LargeRef
+  mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on %2 : $LargeRef
+  %4 = tuple ()
+  return %4 : $()
+}
+


### PR DESCRIPTION
RewriteUser implements visitMarkDependenceInst for the value form of the instruction but had no visitor for the address form, so a mark_dependence_addr whose base is a large loadable value fell through to visitSILInstruction: a "Unimplemented user" fatal error on an asserts build.

Rewrite the instruction with the address assigned to its base instead.

Encountered while reproducing rdar://184166791

