### PR TITLE
Fix side-effects for is_unique and begin_cow_mutation

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -254,9 +254,7 @@ private struct CollectedEffects {
       break
 
     case is BeginCOWMutationInst, is IsUniqueInst:
-      // Model reference count reading as "destroy" for now. Although we could introduce a "read-refcount"
-      // effect, it would not give any significant benefit in any of our current optimizations.
-      addEffects(.destroy, to: inst.operands[0].value, fromInitialPath: SmallProjectionPath(.anyValueFields))
+      addEffects(.read, to: inst.operands[0].value, fromInitialPath: SmallProjectionPath(.anyValueFields))
 
     case isReturnInstruction:
       if inst.parentFunction.convention.hasAddressResult {

--- a/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -redundant-load-elimination | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -compute-side-effects -redundant-load-elimination | %FileCheck %s
 // TODO : Add a version with semantic-arc-opts when #34971 is landed or DCE is enabled on OSSA
 
 
@@ -1122,6 +1122,32 @@ bb0(%0 : $*MyArray<MyStruct>):
   destroy_value %7 : $MyArray<MyStruct>
   %t = tuple ()
   return %t : $() 
+}
+// CHECK-LABEL: sil [noinline] @refcount_read :
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [global: ]
+sil [noinline] @refcount_read : $@convention(thin) (@inout Klass) -> Builtin.Int1 {
+bb0(%0 : $*Klass):
+  %1 = is_unique %0 : $*Klass
+  return %1 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil [ossa] @dont_forward_over_refcount_read :
+// CHECK:         [[S:%.*]] = alloc_stack $Klass
+// CHECK:         store %0 to [init] [[S]]
+// CHECK:         apply
+// CHECK:         load [take] [[S]]
+// CHECK:       } // end sil function 'dont_forward_over_refcount_read'
+sil [ossa] @dont_forward_over_refcount_read : $@convention(thin) (@owned Klass) -> Builtin.Int1 {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack $Klass
+  store %0 to [init] %1 : $*Klass
+  %3 = function_ref @refcount_read : $@convention(thin) (@inout Klass) -> Builtin.Int1
+  %4 = apply %3(%1) : $@convention(thin) (@inout Klass) -> Builtin.Int1
+  %5 = load [take] %1 : $*Klass
+  destroy_value %5 : $Klass
+  dealloc_stack %1 : $*Klass
+  return %4 : $Builtin.Int1
 }
 
 // CHECK-LABEL: @load_trivial_from_store :

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1149,7 +1149,7 @@ sil [ossa] @callUnknownIsDeinitBarrier : $@convention(thin) () -> () {
 }
 
 // CHECK-LABEL: sil @begin_cow_test
-// CHECK-NEXT:  [%0: destroy v**]
+// CHECK-NEXT:  [%0: read v**]
 // CHECK-NEXT:  [global: ]
 // CHECK-NEXT:  {{^[^[]}}
 sil @begin_cow_test : $@convention(thin) (@guaranteed X) -> () {
@@ -1160,7 +1160,7 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: sil @is_unique_test
-// CHECK-NEXT:  [%0: destroy v**]
+// CHECK-NEXT:  [%0: read v**]
 // CHECK-NEXT:  [global: ]
 // CHECK-NEXT:  {{^[^[]}}
 sil @is_unique_test : $@convention(thin) (@inout X) -> () {


### PR DESCRIPTION
`is_unique` and `begin_cow_mutation` were modelled as a "destroy" of their operand rather than a read trigerring miscompile due to redundant load elimination.

rdar://184389976

