### PR TITLE
6.4: InFlightSubstitution-lookupConformance-577ddb.swift UNSUPPORTED on Linux

### DIFF
--- a/validation-test/compiler_crashers/CxxInterop/InFlightSubstitution-lookupConformance-577ddb.swift
+++ b/validation-test/compiler_crashers/CxxInterop/InFlightSubstitution-lookupConformance-577ddb.swift
@@ -3,6 +3,8 @@
 // RUN: not %{python} %swift_src_root/test/Inputs/timeout.py 60 \
 // RUN:             %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s || \
 // RUN: not --crash %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
+// UNSUPPORTED: OS=linux-gnu
+
 enum a<b: Hashable> {
   case (a<[b]>)
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/91299

rdar://184244867