### PR TITLE
XFAIL a few swiftify-import tests on xros

### DIFF
--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -12,6 +12,8 @@
 // RUN: %} %else %{\
 // RUN:   %diff %t/other-expansions.expected %t/expansions.out \
 // RUN: %}
+// XFAIL: OS=xros
+// rdar://183989115
 
 //--- test.h
 #pragma once

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -9,6 +9,8 @@
 // RUN:   -Xcc -Wno-nullability-completeness -target %target-swift-6.2-abi-triple \
 // RUN:   -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature SafeInteropWrappersNullAsEmptySpan \
 // RUN:   -verify-additional-prefix %target-vendor-
+// XFAIL: OS=xros
+// rdar://183989115
 
 //--- test.h
 #define __counted_by(x) __attribute__((__counted_by__(x)))


### PR DESCRIPTION
https://ci.swift.org/job/oss-swift-package-macos-arm64/311/console

```
00:27:36  Failed Tests (2):
00:27:36    Swift(xrsimulator-arm64) :: Interop/C/swiftify-import/availability.swift
00:27:36    Swift(xrsimulator-arm64) :: Interop/Cxx/swiftify-import/counted-by-method.swift
```

rdar://183989115
