### PR TITLE
SSAUpdater: don't mistake pre-existing block arguments for inserted phis

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/SSAUpdater.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SSAUpdater.swift
@@ -42,6 +42,9 @@ public struct SSAUpdater<Context: MutatingContext> {
   /// The phi arguments which were inserted so far by `getValue`, in the order they were created.
   public var insertedPhis = [Phi]()
 
+  /// The blocks in which this updater inserted a phi argument.
+  private var blocksWithInsertedPhis: BasicBlockSet
+
   /// Creates a new SSA-updater for values of `type` with the given `ownership`.
   ///
   /// All values that are constructed or merged by this updater (available values passed to
@@ -51,10 +54,12 @@ public struct SSAUpdater<Context: MutatingContext> {
     self.type = type
     self.ownership = ownership
     self.liverange = BasicBlockWorklist(context)
+    self.blocksWithInsertedPhis = BasicBlockSet(context)
   }
 
   public mutating func deinitialize() {
     liverange.deinitialize()
+    blocksWithInsertedPhis.deinitialize()
   }
 
   /// Registers `value` as the available value at the *end* of `block`.
@@ -136,7 +141,7 @@ public struct SSAUpdater<Context: MutatingContext> {
     // forward order. Therefore we have to reverse the list.
     for block in blocks.reversed() {
       if let existingValue = computedValuesAtBeginOfBlocks[block] {
-        if existingValue.isPhi(in: block) {
+        if isInsertedPhi(existingValue, in: block) {
           // Avoid creating another phi if we already have one created in this block.
           continue
         }
@@ -183,6 +188,7 @@ public struct SSAUpdater<Context: MutatingContext> {
           if previous != v {
             let phiArg = block.addArgument(type: type, ownership: ownership, context)
             insertedPhis.append(Phi(phiArg)!)
+            blocksWithInsertedPhis.insert(block)
             return phiArg
           }
         } else {
@@ -217,13 +223,24 @@ public struct SSAUpdater<Context: MutatingContext> {
         // merely forward `value`, it is its definition. This can happen if `value` is a loop-header
         // phi and the successor walk reaches the header again via a back-edge. Clearing it would
         // drop the genuine phi and cause a duplicate phi to be inserted on the next iteration.
-        if value.isPhi(in: block) {
+        if isInsertedPhi(value, in: block) {
           continue
         }
         computedValuesAtBeginOfBlocks.removeValue(forKey: block)
         worklist.pushIfNotVisited(contentsOf: block.successors)
       }
     }
+  }
+
+  /// Returns true if `value` is a phi argument which _this updater_ inserted into `block`.
+  private func isInsertedPhi(_ value: Value, in block: BasicBlock) -> Bool {
+    if let arg = value as? Argument,
+       arg.parentBlock == block,
+       blocksWithInsertedPhis.contains(block)
+    {
+      return true
+    }
+    return false
   }
 
   /// Rewrites each `br` predecessor of `phi`'s block to also pass the value that is live at the
@@ -354,15 +371,6 @@ public struct InstructionBasedSSAUpdater<Context: MutatingContext> {
 
   /// The phi arguments which were inserted so far by `getValue`, in the order they were created.
   public var insertedPhis: [Phi] { ssaUpdater.insertedPhis }
-}
-
-private extension Value {
-  func isPhi(in block: BasicBlock) -> Bool {
-    if let arg = self as? Argument, arg.parentBlock == block {
-      return true
-    }
-    return false
-  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/mandatory-redundant-load-elim.sil
+++ b/test/SILOptimizer/mandatory-redundant-load-elim.sil
@@ -1948,3 +1948,64 @@ bb0(%0 : $Int):
   %3 = load [trivial] %1
   return %3
 }
+
+sil @getOptInt : $@convention(thin) () -> Optional<Int>
+
+// The available value of the load in the outer loop is `%15`, which is a block argument of `bb4`
+// (the `switch_enum` payload of the inner loop). The SSA-updater must not mistake such a
+// pre-existing block argument for a phi it inserted itself, otherwise it doesn't insert the
+// required phi in `bb7` and the store in `bb5` is incorrectly forwarded on the `bb6` path, too.
+//
+// CHECK-LABEL: sil hidden [ossa] @conditional_store_in_nested_loop :
+// CHECK:       bb5:
+// CHECK:         store [[STORED:%.*]] to [trivial]
+// CHECK:         br bb7([[STORED]] : $Int)
+// CHECK:       bb6:
+// CHECK:         br bb7([[OUTER:%.*]] : $Int)
+// CHECK:       bb7([[PHI:%.*]] : $Int):
+// CHECK-NEXT:    br bb3([[PHI]] : $Int)
+// CHECK:       } // end sil function 'conditional_store_in_nested_loop'
+sil hidden [ossa] @conditional_store_in_nested_loop : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_stack [var_decl] $Int, var, name "b", type $Int
+  store %0 to [trivial] %1
+  br bb1
+
+bb1:
+  %f1 = function_ref @getOptInt : $@convention(thin) () -> Optional<Int>
+  %o1 = apply %f1() : $@convention(thin) () -> Optional<Int>
+  switch_enum %o1, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb9
+
+bb2(%i : $Int):
+  br bb3
+
+bb3:
+  %f2 = function_ref @getOptInt : $@convention(thin) () -> Optional<Int>
+  %o2 = apply %f2() : $@convention(thin) () -> Optional<Int>
+  switch_enum %o2, case #Optional.some!enumelt: bb4, case #Optional.none!enumelt: bb8
+
+bb4(%j : $Int):
+  cond_br undef, bb5, bb6
+
+bb5:
+  %acc = begin_access [modify] [static] %1
+  store %j to [trivial] %acc
+  end_access %acc
+  br bb7
+
+bb6:
+  br bb7
+
+bb7:
+  br bb3
+
+bb8:
+  br bb1
+
+bb9:
+  %racc = begin_access [read] [static] %1
+  %r = load [trivial] %racc
+  end_access %racc
+  dealloc_stack %1
+  return %r
+}


### PR DESCRIPTION
`isPhi(in:)` returned true for _any_ block argument of a block, but both of its uses meant "a phi which this updater inserted into this block". If an available value happened to be a pre-existing block argument (e.g. a `switch_enum` payload argument), the guards misfired:

* `clearValues` refused to invalidate the stale value in that block, so the block and its successors kept forwarding it.
* `propagateValuesThrough` then never recomputed the block for the same reason.

Consequently a join block could see the same value arriving from both the defining and the non-defining path, conclude that its predecessors agree, and skip the required phi. The value was then forwarded unconditionally on a path where it was never defined.

This miscompiled nested loops with a conditional assignment in the inner loop: MandatoryRedundantLoadElimination turned the store of the inner loop's induction variable into an unconditional back-edge argument, so the variable was updated in every iteration instead of only when the condition held. Wrong code was generated even at -Onone.

Track the blocks in which the updater inserted a phi in a `BasicBlockSet` and check that in addition to the value being an argument of the block.

rdar://184416312
