### PR TITLE
[CSBindings] Fix UAF in `inferTransitiveProtocolRequirements`

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -711,8 +711,8 @@ void BindingSet::inferTransitiveProtocolRequirements() {
 
   auto propagateProtocolsTo =
       [&protocols](TypeVariableType *dstVar,
-                   const ArrayRef<Constraint *> &direct,
-                   const SmallPtrSetImpl<Constraint *> &transitive) {
+                   ArrayRef<Constraint *> direct,
+                   SmallPtrSet<Constraint *, 4> transitive) {
         auto &destination = protocols[dstVar];
 
         if (direct.size() > 0)
@@ -789,7 +789,7 @@ void BindingSet::inferTransitiveProtocolRequirements() {
       auto conformanceReqs =
           node.getPotentialBindings().getConformanceRequirements();
 
-      llvm::SmallPtrSet<Constraint *, 2> placeholder;
+      llvm::SmallPtrSet<Constraint *, 4> placeholder;
       // Add any direct protocols from members of the
       // equivalence class, so they could be propagated
       // to all of the members.


### PR DESCRIPTION
`propagateProtocolsTo` used to take an element from `protocols` map by reference and insert into the same collection before using that element, which could trigger re-bucketing of the map if the insertion exceeds inline size, which leads to UAF on that reference.


