### PR TITLE
[cxx-interop] Clean up attribute handling

### DIFF
--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -26,11 +26,11 @@ bool importer::hasImportReferenceAttr(const clang::RecordDecl *decl) {
 }
 
 bool importer::hasImportAsOpaquePointerAttr(const clang::RecordDecl *decl) {
-  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
-           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-             return swiftAttr->getAttribute() == "import_opaque_pointer";
-           return false;
-         });
+  return llvm::any_of(decl->specific_attrs<clang::SwiftAttrAttr>(),
+                      [](const clang::SwiftAttrAttr *swiftAttr) {
+                        return swiftAttr->getAttribute() ==
+                               "import_opaque_pointer";
+                      });
 }
 
 //===----------------------------------------------------------------------===//
@@ -151,8 +151,6 @@ namespace {
 /// The retain:/release: attributes written directly on a record.
 struct RetainReleaseInfo {
   RetainReleaseInfo(const clang::RecordDecl *decl) : decl(decl) {
-    if (!decl->hasAttrs())
-      return;
     for (auto *attr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
       StringRef attrStr = attr->getAttribute();
       if (attrStr.consume_front("retain:")) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5648,11 +5648,9 @@ getConditionalAttrParams(clang::SwiftAttrAttr *swiftAttr, StringRef attrName) {
 
 static ConditionalAttrParams
 getConditionalAttrParams(const clang::NamedDecl *decl, StringRef attrName) {
-  if (decl->hasAttrs()) {
-    for (auto attr : decl->getAttrs()) {
-      if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-        return getConditionalAttrParams(swiftAttr, attrName);
-    }
+  for (auto *swiftAttr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
+    if (swiftAttr->getAttribute().starts_with(attrName))
+      return getConditionalAttrParams(swiftAttr, attrName);
   }
 
   return {};
@@ -8315,11 +8313,11 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
 
 bool importer::hasSwiftAttribute(const clang::Decl *decl,
                                  ArrayRef<StringRef> attrs) {
-  if (decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [&](auto *A) {
-        if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(A))
-          return llvm::is_contained(attrs, swiftAttr->getAttribute());
-        return false;
-      }))
+  if (llvm::any_of(decl->specific_attrs<clang::SwiftAttrAttr>(),
+                   [&](const clang::SwiftAttrAttr *swiftAttr) {
+                     return llvm::is_contained(attrs,
+                                               swiftAttr->getAttribute());
+                   }))
     return true;
 
   if (auto *P = dyn_cast<clang::ParmVarDecl>(decl)) {
@@ -8885,99 +8883,104 @@ swift::extractNearestSourceLoc(ClangRefCountedSmartPointerDescriptor desc) {
   return SourceLoc();
 }
 
+CustomAttr *importer::getRefCountedPtrAttr(Decl *decl) {
+  for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
+    if (attr->getTypeRepr()->isSimpleUnqualifiedIdentifier("_refCountedPtr"))
+      return attr;
+  }
+
+  return nullptr;
+}
+
 RefCountedPtrRequestResult ClangRefCountedSmartPointer::evaluate(
     Evaluator &evaluator, ClangRefCountedSmartPointerDescriptor desc) const {
-  for (const auto *attr : desc.smartPtr->getAttrs()) {
-    if (const auto *customAttr = dyn_cast<CustomAttr>(attr)) {
-      if (!customAttr->getTypeRepr()->isSimpleUnqualifiedIdentifier(
-              "_refCountedPtr"))
-        continue;
-      StringRef ToRawPtrFuncName;
-      for (auto arg : *customAttr->getArgs()) {
-        if (arg.getLabel().str() == "ToRawPointer") {
-          if (const auto *literal = dyn_cast<StringLiteralExpr>(arg.getExpr()))
-            ToRawPtrFuncName = literal->getValue();
-        }
-      }
-      if (ToRawPtrFuncName.empty())
-        return {RefCountedPtrError::MissingToRawPointer, nullptr};
+  auto *customAttr = importer::getRefCountedPtrAttr(desc.smartPtr);
+  if (!customAttr)
+    return {RefCountedPtrError::NotAnnotated, nullptr};
 
-      auto results = getValueDeclsForName(desc.smartPtr, ToRawPtrFuncName);
-      if (results.empty())
-        return {RefCountedPtrError::ToRawPointerLookupFailure, nullptr,
-                ToRawPtrFuncName};
-
-      if (results.size() > 1)
-        return {RefCountedPtrError::ToRawPointerLookupAmbiguity, nullptr,
-                ToRawPtrFuncName};
-
-      auto toRawPtrFunc = dyn_cast<FuncDecl>(results.front());
-      if (!toRawPtrFunc)
-        return {RefCountedPtrError::ToRawPointerNotFunction, toRawPtrFunc};
-
-      auto pointeeType = toRawPtrFunc->getResultInterfaceType()
-                             ->lookThroughSingleOptionalType();
-      ClassDecl *referenceDecl = pointeeType->getClassOrBoundGenericClass();
-
-      if (toRawPtrFunc->getParameters()->size() != 0 || !referenceDecl)
-        return {RefCountedPtrError::ToRawPointerWrongSignature, toRawPtrFunc};
-
-      auto ctors =
-          desc.smartPtr->lookupDirect(DeclBaseName::createConstructor());
-      // We accept a constructor whose parameter imports as the foreign
-      // reference type. In C++ that means a raw pointer (T*, possibly
-      // const-qualified) or an lvalue reference (T&, possibly
-      // const-qualified). We rank candidates so that more-specific
-      // forms win when several are available:
-      //   T*  >  const T*  >  T&  >  const T&
-      // Per-rank duplicates are still ambiguous. Rvalue-reference and
-      // deleted ctors aren't bridgeable. The selected constructor is
-      // relied on during SILGen to introduce implicit bridging.
-      ConstructorDecl *selected = nullptr;
-      std::optional<int> selectedRank;
-      for (auto result : ctors) {
-        auto ctor = cast<ConstructorDecl>(result);
-        if (ctor->getParameters()->size() != 1)
-          continue;
-        Type ctorParamType = ctor->getParameters()->get(0)->getInterfaceType();
-        if (!ctorParamType->isForeignReferenceType())
-          continue;
-
-        auto *clangCtor =
-            dyn_cast_or_null<clang::CXXConstructorDecl>(ctor->getClangDecl());
-        if (!clangCtor || clangCtor->isDeleted())
-          continue;
-
-        clang::QualType paramTy = clangCtor->getParamDecl(0)->getType();
-        int rank;
-        if (paramTy->isLValueReferenceType()) {
-          rank = paramTy->getPointeeType().isConstQualified() ? 3 : 2;
-        } else if (paramTy->isPointerType()) {
-          rank = paramTy->getPointeeType().isConstQualified() ? 1 : 0;
-        } else {
-          // Not a pointer or lvalue reference (e.g., rvalue ref).
-          continue;
-        }
-
-        if (!selectedRank || rank < *selectedRank) {
-          selected = ctor;
-          selectedRank = rank;
-        } else if (rank == *selectedRank) {
-          return {RefCountedPtrError::CtorLookupAmbiguity, toRawPtrFunc};
-        }
-      }
-      if (!selected)
-        return {RefCountedPtrError::CtorLookupFailure, toRawPtrFunc};
-      Type selectedCtorParamType =
-          selected->getParameters()->get(0)->getInterfaceType();
-      if (!selectedCtorParamType->lookThroughSingleOptionalType()->isEqual(
-              pointeeType))
-        return {RefCountedPtrError::CtorWrongParamType, toRawPtrFunc};
-
-      return {RefCountedPtrInfo{selected}, toRawPtrFunc};
+  StringRef ToRawPtrFuncName;
+  for (auto arg : *customAttr->getArgs()) {
+    if (arg.getLabel().str() == "ToRawPointer") {
+      if (const auto *literal = dyn_cast<StringLiteralExpr>(arg.getExpr()))
+        ToRawPtrFuncName = literal->getValue();
     }
   }
-  return {RefCountedPtrError::NotAnnotated, nullptr};
+  if (ToRawPtrFuncName.empty())
+    return {RefCountedPtrError::MissingToRawPointer, nullptr};
+
+  auto results = getValueDeclsForName(desc.smartPtr, ToRawPtrFuncName);
+  if (results.empty())
+    return {RefCountedPtrError::ToRawPointerLookupFailure, nullptr,
+            ToRawPtrFuncName};
+
+  if (results.size() > 1)
+    return {RefCountedPtrError::ToRawPointerLookupAmbiguity, nullptr,
+            ToRawPtrFuncName};
+
+  auto toRawPtrFunc = dyn_cast<FuncDecl>(results.front());
+  if (!toRawPtrFunc)
+    return {RefCountedPtrError::ToRawPointerNotFunction, toRawPtrFunc};
+
+  auto pointeeType = toRawPtrFunc->getResultInterfaceType()
+                         ->lookThroughSingleOptionalType();
+  ClassDecl *referenceDecl = pointeeType->getClassOrBoundGenericClass();
+
+  if (toRawPtrFunc->getParameters()->size() != 0 || !referenceDecl)
+    return {RefCountedPtrError::ToRawPointerWrongSignature, toRawPtrFunc};
+
+  auto ctors =
+      desc.smartPtr->lookupDirect(DeclBaseName::createConstructor());
+  // We accept a constructor whose parameter imports as the foreign
+  // reference type. In C++ that means a raw pointer (T*, possibly
+  // const-qualified) or an lvalue reference (T&, possibly
+  // const-qualified). We rank candidates so that more-specific
+  // forms win when several are available:
+  //   T*  >  const T*  >  T&  >  const T&
+  // Per-rank duplicates are still ambiguous. Rvalue-reference and
+  // deleted ctors aren't bridgeable. The selected constructor is
+  // relied on during SILGen to introduce implicit bridging.
+  ConstructorDecl *selected = nullptr;
+  std::optional<int> selectedRank;
+  for (auto result : ctors) {
+    auto ctor = cast<ConstructorDecl>(result);
+    if (ctor->getParameters()->size() != 1)
+      continue;
+    Type ctorParamType = ctor->getParameters()->get(0)->getInterfaceType();
+    if (!ctorParamType->isForeignReferenceType())
+      continue;
+
+    auto *clangCtor =
+        dyn_cast_or_null<clang::CXXConstructorDecl>(ctor->getClangDecl());
+    if (!clangCtor || clangCtor->isDeleted())
+      continue;
+
+    clang::QualType paramTy = clangCtor->getParamDecl(0)->getType();
+    int rank;
+    if (paramTy->isLValueReferenceType()) {
+      rank = paramTy->getPointeeType().isConstQualified() ? 3 : 2;
+    } else if (paramTy->isPointerType()) {
+      rank = paramTy->getPointeeType().isConstQualified() ? 1 : 0;
+    } else {
+      // Not a pointer or lvalue reference (e.g., rvalue ref).
+      continue;
+    }
+
+    if (!selectedRank || rank < *selectedRank) {
+      selected = ctor;
+      selectedRank = rank;
+    } else if (rank == *selectedRank) {
+      return {RefCountedPtrError::CtorLookupAmbiguity, toRawPtrFunc};
+    }
+  }
+  if (!selected)
+    return {RefCountedPtrError::CtorLookupFailure, toRawPtrFunc};
+  Type selectedCtorParamType =
+      selected->getParameters()->get(0)->getInterfaceType();
+  if (!selectedCtorParamType->lookThroughSingleOptionalType()->isEqual(
+          pointeeType))
+    return {RefCountedPtrError::CtorWrongParamType, toRawPtrFunc};
+
+  return {RefCountedPtrInfo{selected}, toRawPtrFunc};
 }
 
 RefCountedPtrRequestResult
@@ -9156,13 +9159,10 @@ importer::getPrivateFileIDAttrs(const clang::CXXRecordDecl *decl) {
   llvm::SmallVector<std::pair<StringRef, clang::SourceLocation>, 1> files;
   constexpr llvm::StringLiteral prefix = "private_fileid:";
 
-  if (decl->hasAttrs()) {
-    for (const auto *attr : decl->getAttrs()) {
-      const auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
-      if (swiftAttr && swiftAttr->getAttribute().starts_with(prefix))
-        files.push_back({swiftAttr->getAttribute().drop_front(prefix.size()),
-                         attr->getLocation()});
-    }
+  for (const auto *swiftAttr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
+    StringRef attribute = swiftAttr->getAttribute();
+    if (attribute.consume_front(prefix))
+      files.push_back({attribute, swiftAttr->getLocation()});
   }
 
   return files;
@@ -9224,17 +9224,13 @@ static bool isConditionalAttr(StringRef attrName) {
 
 void ClangImporter::Implementation::validateSwiftAttributes(
     const clang::NamedDecl *decl) {
-  if (!decl->hasAttrs())
-    return;
-
   for (const auto &groupOfAttrs : ConflictingSwiftAttrs) {
     // stores this decl's attributes, grouped by annotation kind
     llvm::StringMap<std::vector<clang::SwiftAttrAttr *>> found;
     unsigned count = 0;
     for (auto [attrName, annotationName] : groupOfAttrs) {
-      for (auto attr : decl->getAttrs()) {
-        auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
-        if (swiftAttr && swiftAttr->getAttribute().starts_with(attrName)) {
+      for (auto *swiftAttr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
+        if (swiftAttr->getAttribute().starts_with(attrName)) {
           found[annotationName].push_back(swiftAttr);
           count += 1;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -182,16 +182,11 @@ void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
 
 importer::ReturnOwnershipInfo::ReturnOwnershipInfo(
     const clang::NamedDecl *decl) {
-  if (!decl->hasAttrs())
-    return;
-
-  for (const auto *attr : decl->getAttrs()) {
-    if (const auto *swiftAttr = llvm::dyn_cast<clang::SwiftAttrAttr>(attr)) {
-      if (swiftAttr->getAttribute() == "returns_unretained") {
-        hasReturnsUnretained = true;
-      } else if (swiftAttr->getAttribute() == "returns_retained") {
-        hasReturnsRetained = true;
-      }
+  for (const auto *swiftAttr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
+    if (swiftAttr->getAttribute() == "returns_unretained") {
+      hasReturnsUnretained = true;
+    } else if (swiftAttr->getAttribute() == "returns_retained") {
+      hasReturnsRetained = true;
     }
   }
 }
@@ -4967,10 +4962,7 @@ namespace {
 
       // If the decl represents an availability domain, eagerly synthesize its
       // `if #available` predicate function.
-      if (decl->hasAttrs() &&
-          llvm::any_of(decl->getAttrs(), [](clang::Attr *attr) {
-            return isa<clang::AvailabilityDomainAttr>(attr);
-          }))
+      if (decl->hasAttr<clang::AvailabilityDomainAttr>())
         (void)synthesizer.makeAvailabilityDomainPredicate(decl);
 
       return result;
@@ -6911,12 +6903,10 @@ static bool conformsToProtocolInOriginalModule(NominalTypeDecl *nominal,
 /// Determine whether the given nominal type was imported with an OptionSet
 /// conformance.
 static bool isImportedOptionSet(NominalTypeDecl *nominal) {
-  for (auto attr : nominal->getAttrs()) {
-    if (auto synthesizedAttr = dyn_cast<SynthesizedProtocolAttr>(attr)) {
-      if (synthesizedAttr->getProtocol()->isSpecificProtocol(
-              KnownProtocolKind::OptionSet))
-        return true;
-    }
+  for (auto attr :
+       nominal->getAttrs().getAttributes<SynthesizedProtocolAttr>()) {
+    if (attr->getProtocol()->isSpecificProtocol(KnownProtocolKind::OptionSet))
+      return true;
   }
 
   return false;
@@ -9524,14 +9514,13 @@ void ClangImporter::Implementation::addExplicitProtocolConformancesFromBases(
     }
   }
 
-  if (isBase && cxxRecordDecl->hasAttrs()) {
+  if (isBase) {
     llvm::SmallSet<ProtocolDecl *, 4> alreadyAdded;
-    llvm::for_each(cxxRecordDecl->getAttrs(), [&](auto *attr) {
-      if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-        if (swiftAttr->getAttribute().starts_with(conformsToPrefix))
-          addExplicitProtocolConformance(nominal, swiftAttr, alreadyAdded);
-      }
-    });
+    for (auto *swiftAttr :
+         cxxRecordDecl->specific_attrs<clang::SwiftAttrAttr>()) {
+      if (swiftAttr->getAttribute().starts_with(conformsToPrefix))
+        addExplicitProtocolConformance(nominal, swiftAttr, alreadyAdded);
+    }
   }
 }
 
@@ -9564,9 +9553,9 @@ static void filterUsableVersionedAttrs(
   // Scan through Swift-Versioned clang attributes and select which one to apply
   // if multiple candidates exist.
   SmallVector<clang::SwiftVersionedAdditionAttr *, 4> swiftVersionedAttributes;
-  for (auto attr : clangDecl->attrs())
-    if (auto versionedAttr = dyn_cast<clang::SwiftVersionedAdditionAttr>(attr))
-      swiftVersionedAttributes.push_back(versionedAttr);
+  for (auto *versionedAttr :
+       clangDecl->specific_attrs<clang::SwiftVersionedAdditionAttr>())
+    swiftVersionedAttributes.push_back(versionedAttr);
 
   // An attribute version is valid to apply if it is greater than the current
   // version or is unversioned

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1075,14 +1075,10 @@ namespace {
       if (!decl)
         return nullptr;
 
-      if (Bridging == Bridgeability::Full)
-        for (const auto *attr : decl->getAttrs())
-          if (const auto *customAttr = dyn_cast<CustomAttr>(attr))
-            if (customAttr->getTypeRepr()->isSimpleUnqualifiedIdentifier(
-                    "_refCountedPtr")) {
-              return ImportResult(decl->getDeclaredInterfaceType(),
-                                  ImportHint::IntrusivelyRefCountedSmartPtr);
-            }
+      if (Bridging == Bridgeability::Full &&
+          importer::getRefCountedPtrAttr(decl))
+        return ImportResult(decl->getDeclaredInterfaceType(),
+                            ImportHint::IntrusivelyRefCountedSmartPtr);
 
       return decl->getDeclaredInterfaceType();
     }
@@ -2540,14 +2536,9 @@ static bool isParameterContextGlobalActorIsolated(DeclContext *dc,
   if (getActorIsolationOfContext(dc).isGlobalActor())
     return true;
 
-  if (!parent->hasAttrs())
-    return false;
-
-  for (const auto *attr : parent->getAttrs()) {
-    if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-      if (isMainActorAttr(swiftAttr))
-        return true;
-    }
+  for (const auto *swiftAttr : parent->specific_attrs<clang::SwiftAttrAttr>()) {
+    if (isMainActorAttr(swiftAttr))
+      return true;
   }
 
   return false;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2804,9 +2804,10 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
   // If SendingArgsAndResults are enabled and we have a sending argument,
   // set that the param was sending.
   if (ASTContext.LangOpts.hasFeature(Feature::SendingArgsAndResults)) {
-    if (auto *attr = param->getAttr<clang::SwiftAttrAttr>()) {
+    for (auto *attr : param->specific_attrs<clang::SwiftAttrAttr>()) {
       if (attr->getAttribute() == "sending") {
         paramInfo->setSending();
+        break;
       }
     }
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2320,6 +2320,11 @@ bool hasIteratorAPIAttr(const clang::Decl *decl);
 bool hasNonEscapableAttr(const clang::RecordDecl *decl);
 bool hasNonCopyableAttr(const clang::RecordDecl *decl);
 bool hasEscapableAttr(const clang::RecordDecl *decl);
+
+/// The \c @_refCountedPtr attribute marking \p decl as a reference counting
+/// smart pointer, or null if it does not have one.
+CustomAttr *getRefCountedPtrAttr(Decl *decl);
+
 CxxValueSemanticsKind
 getCxxValueSemanticsKind(const clang::Type *type,
                          ClangImporter::Implementation &Impl);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -3421,16 +3421,9 @@ static bool isSufficientlyTrivial(const clang::CXXRecordDecl *decl) {
 /// given Clang type and return it.
 FuncDecl *SwiftDeclSynthesizer::findExplicitDestroy(
     NominalTypeDecl *nominal, const clang::RecordDecl *clangType) {
-  if (!clangType->hasAttrs())
-    return nullptr;
-
   llvm::SmallPtrSet<FuncDecl *, 2> matchingDestroyFuncs;
   llvm::TinyPtrVector<FuncDecl *> nonMatchingDestroyFuncs;
-  for (auto attr : clangType->getAttrs()) {
-    auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
-    if (!swiftAttr)
-      continue;
-
+  for (auto *swiftAttr : clangType->specific_attrs<clang::SwiftAttrAttr>()) {
     auto destroyFuncName = swiftAttr->getAttribute();
     if (!destroyFuncName.consume_front("destroy:"))
       continue;

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -763,18 +763,14 @@ namespace {
         ctx.Diags.diagnose(copyConstructorLoc, diag::failed_emit_copy,
                            recordDecl);
 
-        bool hasCopyableIfAttr =
-            recordDecl->hasAttrs() &&
-            llvm::any_of(recordDecl->getAttrs(), [&](clang::Attr *attr) {
-              if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-                StringRef attrStr = swiftAttr->getAttribute();
-                assert(!attrStr.starts_with("~Copyable") &&
-                       "Trying to emit copy of a type annotated with "
-                       "'SWIFT_NONCOPYABLE'?");
-                if (attrStr.starts_with("copyable_if:"))
-                  return true;
-              }
-              return false;
+        bool hasCopyableIfAttr = llvm::any_of(
+            recordDecl->specific_attrs<clang::SwiftAttrAttr>(),
+            [&](const clang::SwiftAttrAttr *swiftAttr) {
+              StringRef attrStr = swiftAttr->getAttribute();
+              assert(!attrStr.starts_with("~Copyable") &&
+                     "Trying to emit copy of a type annotated with "
+                     "'SWIFT_NONCOPYABLE'?");
+              return attrStr.starts_with("copyable_if:");
             });
 
         bool hasRequiresClause =

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -705,9 +705,10 @@ public:
           // Don't emit nested types that are just implicitly @objc.
           // You should have to opt into this, since they are even less
           // namespaced than usual.
-          if (llvm::any_of(VD->getAttrs(), [](const DeclAttribute *attr) {
-                return isa<ObjCAttr>(attr) && !attr->isImplicit();
-              })) {
+          if (llvm::any_of(VD->getAttrs().getAttributes<ObjCAttr>(),
+                           [](const ObjCAttr *attr) {
+                             return !attr->isImplicit();
+                           })) {
             nestedTypes.push_back(VD);
           }
         }

--- a/lib/SIL/IR/Bridging.cpp
+++ b/lib/SIL/IR/Bridging.cpp
@@ -100,10 +100,9 @@ clang::CXXRecordDecl *Lowering::getBridgedSmartPtr(AbstractionPattern pattern) {
 
   auto ty = pattern.getClangType();
   if (auto rd = ty->getAsCXXRecordDecl())
-    for (auto attr : rd->getAttrs())
-      if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-        if (swiftAttr->getAttribute().starts_with("@_refCountedPtr"))
-          return rd;
+    for (auto *swiftAttr : rd->specific_attrs<clang::SwiftAttrAttr>())
+      if (swiftAttr->getAttribute().starts_with("@_refCountedPtr"))
+        return rd;
 
   return nullptr;
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3939,17 +3939,11 @@ getDirectCParameterConvention(clang::QualType type,
     // the deinit synthesizer would mark that call site specially so we can
     // drop this exception.
     if (clangModuleLoader && clangModuleLoader->isCxxMoveOnlyType(cxxRecord)) {
-      bool hasDestroyAttr = false;
-      if (cxxRecord->hasAttrs()) {
-        for (const clang::Attr *attr : cxxRecord->getAttrs()) {
-          if (auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
-            if (swiftAttr->getAttribute().starts_with("destroy:")) {
-              hasDestroyAttr = true;
-              break;
-            }
-          }
-        }
-      }
+      bool hasDestroyAttr = llvm::any_of(
+          cxxRecord->specific_attrs<clang::SwiftAttrAttr>(),
+          [](const clang::SwiftAttrAttr *swiftAttr) {
+            return swiftAttr->getAttribute().starts_with("destroy:");
+          });
       if (!hasDestroyAttr)
         return ParameterConvention::Direct_Owned;
     }

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -66,15 +66,13 @@ static bool isSwiftTestingTestFunction(ValueDecl *decl) {
   if (!isa<FuncDecl>(decl))
     return false;
 
-  return llvm::any_of(decl->getAttrs(), [](DeclAttribute *attr) {
-    auto customAttr = dyn_cast<CustomAttr>(attr);
-    if (!customAttr)
-      return false;
-
-    auto *macro = customAttr->getResolvedMacro();
-    return macro && macro->getBaseIdentifier().is("Test") &&
-           macro->getParentModule()->getName().is("Testing");
-  });
+  return llvm::any_of(
+      decl->getAttrs().getAttributes<CustomAttr>(),
+      [](const CustomAttr *customAttr) {
+        auto *macro = customAttr->getResolvedMacro();
+        return macro && macro->getBaseIdentifier().is("Test") &&
+               macro->getParentModule()->getName().is("Testing");
+      });
 }
 
 } // end anonymous namespace

--- a/test/ClangImporter/Inputs/sending.h
+++ b/test/ClangImporter/Inputs/sending.h
@@ -43,6 +43,11 @@ sendUserDefinedFromGlobalFunction(NonSendableCStruct other) SWIFT_SENDING;
 void sendUserDefinedIntoGlobalFunction(
     NonSendableCStruct arg SWIFT_SENDING);
 
+// 'sending' is found even when another swift_attr precedes it.
+void sendUserDefinedIntoGlobalFunctionPrecededAttr(
+    NonSendableCStruct arg __attribute__((swift_attr("nonisolated(unsafe)")))
+        SWIFT_SENDING);
+
 void sendingWithCompletionHandler(void (^completion)(SWIFT_SENDING NonSendableCStruct arg));
 SWIFT_SENDING NonSendableCStruct sendingWithLazyReturn(SWIFT_SENDING NonSendableCStruct (^makeLazily)(void));
 

--- a/test/ClangImporter/sending.swift
+++ b/test/ClangImporter/sending.swift
@@ -39,6 +39,13 @@ func funcTestSendingArg() async {
   useValue(x) // expected-note {{access can happen concurrently}}
 }
 
+func funcTestSendingArgPrecededAttr() async {
+  let x = NonSendableCStruct()
+  sendUserDefinedIntoGlobalFunctionPrecededAttr(x) // expected-warning {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{'x' used after being passed as a 'sending' parameter}}
+  useValue(x) // expected-note {{access can happen concurrently}}
+}
+
 func funcTestSendingClosureArg() async {
   sendingWithCompletionHandler { (x: sending NonSendableCStruct) in
     sendUserDefinedIntoGlobalFunction(x) // expected-warning {{sending 'x' risks causing data races}}

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -129,6 +129,18 @@ MyPair<Owner, View> h2(int* x);
 // OK; MyPair<Owner, Owner> is not ~Escapable
 MyPair<Owner, Owner> h3(int* x);
 
+// SWIFT_ESCAPABLE_IF is found even when another swift_attr precedes it.
+template<typename F>
+struct SWIFT_UNCHECKED_SENDABLE SWIFT_ESCAPABLE_IF(F) MySendablePair {
+    F first;
+};
+
+// expected-NO-LIFETIMES-error@+1 {{a function cannot return a ~Escapable result}}
+MySendablePair<View> h4(int* x);
+
+// OK; MySendablePair<Owner> is not ~Escapable
+MySendablePair<Owner> h5(int* x);
+
 // expected-error@+3 {{template parameter 'Missing' does not exist}}
 // expected-error@+2 {{template parameter 'Missing' does not exist}}
 template<typename F, typename S>
@@ -390,6 +402,8 @@ public func noAnnotations() -> View {
     h1(nil)
     h2(nil)
     h3(nil)
+    h4(nil)
+    h5(nil)
     i1()
     i2()
     j1()


### PR DESCRIPTION
Simplify the code by using more specific APIs. Also a single drive-by fix (covered by tests), one of the attribute checks only checked for the first SwiftAttrs, so it did not find SWIFT_ESCAPABLE_IF if it followed another attr.
