### PR TITLE
[Embedded] Downgrade non-unique cast diagnostic to a warning

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -159,13 +159,13 @@ private struct FunctionChecker {
          if !checkedCast.supportedInEmbeddedSwift {
            throw Violation(.embedded_swift_dynamic_cast, in: instruction)
          }
-         try checkCastTargetUniqueness(checkedCast.targetFormalType, in: instruction)
+         checkCastTargetUniqueness(checkedCast.targetFormalType, in: instruction)
        } else {
          let checkedCast = instruction as! UnconditionalCheckedCastAddrInst
          if !checkedCast.supportedInEmbeddedSwift {
            throw Violation(.embedded_swift_dynamic_cast, in: instruction)
          }
-         try checkCastTargetUniqueness(checkedCast.targetFormalType, in: instruction)
+         checkCastTargetUniqueness(checkedCast.targetFormalType, in: instruction)
        }
 
     // The value-form checked casts (e.g. a class-bound `any P` downcast to a
@@ -174,10 +174,10 @@ private struct FunctionChecker {
     // allocating module and this module may see different metadata records, so
     // the cast silently fails at runtime. Diagnose it.
     case let ccb as CheckedCastBranchInst:
-      try checkCastTargetUniqueness(ccb.targetFormalType, in: instruction)
+      checkCastTargetUniqueness(ccb.targetFormalType, in: instruction)
 
     case let ucc as UnconditionalCheckedCastInst:
-      try checkCastTargetUniqueness(ucc.targetFormalType, in: instruction)
+      checkCastTargetUniqueness(ucc.targetFormalType, in: instruction)
 
     case let abi as AllocBoxInst:
       // It needs a bit of work to support alloc_box of generic non-copyable structs/enums with deinit,
@@ -272,8 +272,8 @@ private struct FunctionChecker {
   // definition unless the type is `@export(interface)` (or defined in the main
   // module), so an object allocated in one module and downcast in another can
   // compare against a different metadata record and the cast silently fails.
-  // Reject casting to such a type here (rdar://179424428).
-  mutating func checkCastTargetUniqueness(_ targetType: CanonicalType, in instruction: Instruction) throws {
+  // Warn about casting to such a type here (rdar://179424428).
+  mutating func checkCastTargetUniqueness(_ targetType: CanonicalType, in instruction: Instruction) {
     // Only class metadata identity is at stake: `swift_dynamicCastClass`
     // compares isa pointers. Struct/enum casts don't rely on a unique metadata
     // record the same way.
@@ -288,7 +288,8 @@ private struct FunctionChecker {
     else {
       return
     }
-    throw Violation(.embedded_swift_cast_to_nonunique_type, targetType.rawType, in: instruction)
+    diagnose(Violation(.embedded_swift_cast_to_nonunique_type, targetType.rawType, in: instruction),
+             popCallStack: false)
   }
 
   mutating func checkApply(apply: ApplySite) throws {

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -406,10 +406,10 @@ GROUPED_WARNING(perf_hint_keypath_captures_values,HeapAllocation,none,
       (unsigned))
 GROUPED_ERROR(embedded_swift_dynamic_cast,EmbeddedRestrictions,none,
       "cannot do dynamic casting in embedded Swift", ())
-GROUPED_ERROR(embedded_swift_cast_to_nonunique_type,EmbeddedRestrictions,none,
-      "cannot cast to %0 across a module boundary in embedded Swift because its "
-      "type metadata is not unique; mark %0 with '@export(interface)' in its "
-      "defining module", (Type))
+GROUPED_WARNING(embedded_swift_cast_to_nonunique_type,EmbeddedRestrictions,none,
+      "casting to %0 across a module boundary in embedded Swift may fail at "
+      "runtime because its type metadata is not unique; mark %0 with "
+      "'@export(interface)' in its defining module", (Type))
 GROUPED_ERROR(embedded_capture_of_generic_value_with_deinit,EmbeddedRestrictions,none,
       "capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift", ())
 GROUPED_ERROR(embedded_call_generic_function,EmbeddedRestrictions,none,

--- a/test/embedded/cast-to-nonunique-type.swift
+++ b/test/embedded/cast-to-nonunique-type.swift
@@ -30,9 +30,9 @@ import Lib
 // the cast cannot be folded away.
 
 public func conditionalCast(_ w: any ResourceWriter) -> PSWriterM3Demo? {
-  return w as? PSWriterM3Demo // expected-error {{cannot cast to 'PSWriterM3Demo' across a module boundary in embedded Swift because its type metadata is not unique; mark 'PSWriterM3Demo' with '@export(interface)' in its defining module}}
+  return w as? PSWriterM3Demo // expected-warning {{casting to 'PSWriterM3Demo' across a module boundary in embedded Swift may fail at runtime because its type metadata is not unique; mark 'PSWriterM3Demo' with '@export(interface)' in its defining module}}
 }
 
 public func forcedCast(_ w: any ResourceWriter) -> PSWriterM3Demo {
-  return w as! PSWriterM3Demo // expected-error {{cannot cast to 'PSWriterM3Demo' across a module boundary in embedded Swift because its type metadata is not unique; mark 'PSWriterM3Demo' with '@export(interface)' in its defining module}}
+  return w as! PSWriterM3Demo // expected-warning {{casting to 'PSWriterM3Demo' across a module boundary in embedded Swift may fail at runtime because its type metadata is not unique; mark 'PSWriterM3Demo' with '@export(interface)' in its defining module}}
 }


### PR DESCRIPTION
The cross-module cast to a non-unique class type (rdar://179424428) is still emitted and works whenever the target's metadata happens to be unique at runtime, so a hard error is too strict. Make it a warning.

Emit it directly instead of throwing so that genuine errors later in the same function are still reported.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
