### PR TITLE
build.ps1: Enable batch mode

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2130,6 +2130,9 @@ function Build-CMakeProject {
             Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-gnone")
           }
 
+          Add-KeyValueIfNew $Defines CMAKE_PROJECT_INCLUDE `
+            "$SourceCache\swift\utils\swift-batch-mode.cmake"
+
           # CMake 3.30+ passes all linker flags to Swift as the linker driver,
           # including those from the internal CMake modules files, without
           # a `-Xlinker` prefix. This causes build failures as Swift cannot
@@ -2254,7 +2257,8 @@ function Build-CMakeProject {
             Add-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS ($AndroidLinkerFlags + @("-Xlinker", "--gc-sections"))
             Add-FlagsDefine $Defines CMAKE_MODULE_LINKER_FLAGS $AndroidLinkerFlags
             Add-KeyValueIfNew $Defines SWIFT_ANDROID_LD_PATH $ld
-            Add-KeyValueIfNew $Defines CMAKE_PROJECT_INCLUDE "$SourceCache\swift\utils\android-overrides.cmake"
+            Add-KeyValueIfNew $Defines CMAKE_PROJECT_INCLUDE `
+              "$SourceCache\swift\utils\android-overrides.cmake;$SourceCache\swift\utils\swift-batch-mode.cmake"
           } else {
             # Clang Runtime explicitly sets linker flags for every target,
             # making the `add_link_options()` approach via

--- a/utils/swift-batch-mode.cmake
+++ b/utils/swift-batch-mode.cmake
@@ -1,0 +1,15 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+# Included via CMAKE_PROJECT_INCLUDE for Windows builds. Enables batch
+# mode for incremental compilation modes.
+cmake_policy(GET CMP0157 _SwiftBatchMode_CMP0157)
+if(_SwiftBatchMode_CMP0157 STREQUAL "NEW")
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:Swift>,$<OR:$<STREQUAL:$<TARGET_PROPERTY:Swift_COMPILATION_MODE>,incremental>,$<NOT:$<BOOL:$<TARGET_PROPERTY:Swift_COMPILATION_MODE>>>>>:-enable-batch-mode>")
+endif()
+unset(_SwiftBatchMode_CMP0157)


### PR DESCRIPTION
This is showing as a ~30% improvement locally on Swift compiles with CAS disabled, 15-20% with cold or warm CAS.