### PR TITLE
Revert "Differentiate explicit submodules for export_as"

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -41,7 +41,6 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
 #include "clang/AST/Type.h"
-#include "clang/Basic/Module.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
@@ -3044,15 +3043,8 @@ namespace {
 
     void visitModuleDecl(ModuleDecl *MD, Label label) {
       printCommon(MD, "module", label);
-      printAttributes(MD);
       printFlag(MD->isNonSwiftModule(), "non_swift");
-      if (auto clangMod = MD->findUnderlyingClangModule()) {
-        printFlag(clangMod->isSubModule(), "is_submodule");
-        if (clangMod->isSubModule()) {
-          printFieldQuoted(clangMod->getFullModuleName(),
-                           Label::always("clang_full_name"));
-        }
-      }
+      printAttributes(MD);
       printFoot();
     }
 
@@ -6547,13 +6539,6 @@ namespace {
       printCommon("module_type", label);
       printDeclName(T->getModule(), Label::always("module"));
       printFlag(T->getModule()->isNonSwiftModule(), "foreign");
-      if (auto clangMod = T->getModule()->findUnderlyingClangModule()) {
-        printFlag(clangMod->isSubModule(), "is_submodule");
-        if (clangMod->isSubModule()) {
-          printFieldQuoted(clangMod->getFullModuleName(),
-                           Label::always("clang_full_name"));
-        }
-      }
       printFoot();
     }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6463,18 +6463,14 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     return Options.CurrentModule->getVisibleClangModules(Options.InterfaceContentKind);
   }
 
-  /// If \p TyDecl belongs to an explicit submodule, return the \c ModuleDecl
-  /// for that submodule; otherwise just return the parent module.
+  /// If \p TyDecl belongs to a submodule, return the \c ModuleDecl for that
+  /// submodule; otherwise just return the parent module.
   ModuleDecl *getParentSubModuleOrModule(GenericTypeDecl *TyDecl) {
     // Only clang declarations can belong to a submodule
     if (auto clangNode = TyDecl->getClangNode()) {
       auto importer = TyDecl->getASTContext().getClangModuleLoader();
       if (auto clangMod = importer->getClangOwningModule(clangNode)) {
-        // Explicit submodules are only visible if specifically imported;
-        // everything else has the visibility of its top-level module.
-        if (clangMod->isSubModule() && clangMod->IsExplicit) {
-          return importer->getWrapperForModule(clangMod);
-        }
+        return importer->getWrapperForModule(clangMod);
       }
     }
 

--- a/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces-submodules.swift
@@ -35,11 +35,6 @@ module LibraryCore {
   header "LibraryCore/LibraryCore.h"
   export *
 
-  module NonExplicitSubmodule {
-    header "LibraryCore/NonExplicitSubmodule.h"
-    export *
-  }
-
   explicit module * { export * }
 }
 
@@ -54,18 +49,12 @@ module Library {
 //--- LibraryCore/LibraryCore.h
 // This file is re-exported by Library
 #pragma once
-#include "LibraryCore/NonExplicitSubmodule.h"
 struct LibraryCoreType {};
 
 //--- LibraryCore/Submodule.h
 // This file is re-exported by Library.Submodule (which Swift does not respect)
 #pragma once
 struct LibraryCoreSubmoduleType {};
-
-//--- LibraryCore/NonExplicitSubmodule.h
-// This file is re-exported by Library
-#pragma once
-struct LibraryCoreNonExplicitSubmoduleType {};
 
 //--- LibraryCore/ReexportedSubmodule.h
 // This file is re-exported by Library
@@ -100,9 +89,6 @@ public func foo(
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
   c: LibraryCoreReexportedSubmoduleType,
-  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
-  // PRIVATE-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
-  c2: LibraryCoreNonExplicitSubmoduleType,
   // PUBLIC-SAME: d: Library::LibraryType
   // PRIVATE-SAME: d: Library::LibraryType
   d: LibraryType,
@@ -128,8 +114,5 @@ public func foo(
   b: LibraryCoreSubmoduleType,
   // PUBLIC-SAME: c: Library::LibraryCoreReexportedSubmoduleType
   // PRIVATE-SAME: c: LibraryCore::LibraryCoreReexportedSubmoduleType
-  c: LibraryCoreReexportedSubmoduleType,
-  // PUBLIC-SAME: c2: Library::LibraryCoreNonExplicitSubmoduleType
-  // PRIVATE-SAME: c2: LibraryCore::LibraryCoreNonExplicitSubmoduleType
-  c2: LibraryCoreNonExplicitSubmoduleType
+  c: LibraryCoreReexportedSubmoduleType
 ) {}


### PR DESCRIPTION
Reverts swiftlang/swift#90484, which has been found to cause regressions. 