### PR TITLE
utils: Remove repl_swift SxS runtime binding for tests

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3258,6 +3258,11 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
 
     Invoke-IsolatingEnvVars {
       # Test-time tools execute on the build host.
+      # TODO(Steelskin): `repl_swift.exe` is explicitly excluded here because
+      # the test reconfigure here makes lldb compile expressions against the in-
+      # tree resilient stdlib, which breaks SwiftREPL tests if `repl_swift.exe`
+      # uses the shipped runtime instead.
+      # See https://github.com/swiftlang/swift/issues/91537 for details.
       Invoke-VsDevShell $BuildPlatform
       Set-WindowsSxSToolchainRuntime `
         -BinaryDir              $Stage2BinDir `
@@ -3274,8 +3279,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
                                    "swift-ide-test.exe",
                                    "swift-plugin-server.exe",
                                    "swiftc-legacy-driver.exe",
-                                   "lldb.exe",
-                                   "repl_swift.exe"
+                                   "lldb.exe"
                                  )
       # SxS only probes the EXE's own directory for the named assembly.
       if (Test-Path (Join-Path $Stage2LibexecSwiftDir "swift-backtrace.exe")) {


### PR DESCRIPTION
`Test-Compilers` stamps a side-by-side assembly manifest onto the tools it runs so that they resolve to the freshly staged Swift runtime rather than one found on PATH. For tests, lldb uses an in-tree resilient stdlib. Stamping `repl_swift.exe` results in that binary loading the shipped runtime, which causes tests to fail.

This is a no-op today: a CMake bug makes the test re-configure of the Stage2Compilers directory rebuild everything, so the freshly stamped binaries are overwritten before they are ever used. #91277 works around that, and in making the stamping effective for the first time, is what brought this to light.

Bug: #91537