### PR TITLE
[IRGen] Allow memcpy of POD fields in assignWithCopy and assignWithTake

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -132,6 +132,8 @@ set(SWIFT_BENCH_MODULES
     single-source/NSErrorTest
     single-source/NSStringConversion
     single-source/NaiveRangeReplaceableCollectionConformance
+    single-source/NestedEnumValueTypes
+    single-source/NestedStructValueTypes
     single-source/NibbleSort
     single-source/NIOChannelPipeline
     single-source/NopDeinit

--- a/benchmark/single-source/NestedEnumValueTypes.swift
+++ b/benchmark/single-source/NestedEnumValueTypes.swift
@@ -1,0 +1,69 @@
+//===--- NestedEnumValueTypes.swift --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+// This is a benchmark meant for use measuring the size of value witnesses of nested
+// enums.
+
+public let benchmarks = BenchmarkInfo(
+  name: "NestedValue.Enum.CodeSize",
+  runFunction: run_NestedEnumValueTypes,
+  tags: [.skip])
+
+public final class Reference {
+  public init() {}
+}
+
+public struct PODPayload {
+  public var a: UInt64
+  public var b: UInt64
+  public var c: UInt64
+  public var d: UInt64
+  public var e: UInt64
+  public var f: UInt64
+}
+
+public struct ReferencePayload {
+  public var a: Reference
+  public var b: Reference
+}
+
+public struct MixedPayload {
+  public var pod: PODPayload
+  public var references: ReferencePayload
+}
+
+public enum EnumLeaf {
+  case payload(MixedPayload)
+  case empty
+}
+
+public enum EnumMiddle {
+  case payload(EnumLeaf, EnumLeaf)
+  case empty
+}
+
+public enum EnumOuter {
+  case payload(EnumMiddle, EnumMiddle)
+  case empty
+}
+
+public func copy(_ value: EnumOuter) -> EnumOuter {
+  value
+}
+
+public func assign(_ destination: inout EnumOuter, _ source: EnumOuter) {
+  destination = source
+}
+
+public func run_NestedEnumValueTypes(_ n: Int) {}

--- a/benchmark/single-source/NestedStructValueTypes.swift
+++ b/benchmark/single-source/NestedStructValueTypes.swift
@@ -1,0 +1,60 @@
+//===--- NestedStructValueTypes.swift ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+// This is a benchmark meant for use measuring the size of value witnesses of nested
+// structs.
+
+public let benchmarks = BenchmarkInfo(
+  name: "NestedValue.Struct.CodeSize",
+  runFunction: run_NestedStructValueTypes,
+  tags: [.skip])
+
+public final class Reference {
+  public init() {}
+}
+
+public struct PODLeaf {
+  public var a: UInt64
+  public var b: UInt64
+  public var c: UInt64
+  public var d: UInt64
+  public var e: UInt64
+  public var f: UInt64
+}
+
+public struct ReferenceLeaf {
+  public var a: Reference
+  public var b: Reference
+}
+
+public struct Middle {
+  public var firstPOD: PODLeaf
+  public var secondPOD: PODLeaf
+  public var references: ReferenceLeaf
+}
+
+public struct Outer {
+  public var first: Middle
+  public var second: Middle
+}
+
+public func copy(_ value: Outer) -> Outer {
+  value
+}
+
+public func assign(_ destination: inout Outer, _ source: Outer) {
+  destination = source
+}
+
+public func run_NestedStructValueTypes(_ n: Int) {}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -127,6 +127,8 @@ import Monoids
 import MonteCarloE
 import MonteCarloPi
 import NaiveRangeReplaceableCollectionConformance
+import NestedEnumValueTypes
+import NestedStructValueTypes
 import NibbleSort
 import NIOChannelPipeline
 import NSDictionaryCastToSwift
@@ -341,6 +343,8 @@ register(Monoids.benchmarks)
 register(MonteCarloE.benchmarks)
 register(MonteCarloPi.benchmarks)
 register(NaiveRangeReplaceableCollectionConformance.benchmarks)
+register(NestedEnumValueTypes.benchmarks)
+register(NestedStructValueTypes.benchmarks)
 register(NSDictionaryCastToSwift.benchmarks)
 register(NSErrorTest.benchmarks)
 #if canImport(Darwin)

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -208,6 +208,13 @@ public:
 
   void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,
                       bool isOutlined) const override {
+    // if POD, forward to generic LoadableTypeInfo implementation, which will memcpy
+    if (this->isTriviallyDestroyable(ResilienceExpansion::Maximal) &&
+        isa<LoadableTypeInfo>(this)) {
+      return cast<LoadableTypeInfo>(this)->LoadableTypeInfo::initializeWithCopy(
+          IGF, dest, src, T, isOutlined);
+    }
+
     // If the fields are not ABI-accessible, use the value witness table.
     if (!AreFieldsABIAccessible) {
       return emitAssignWithCopyCall(IGF, T, dest, src);
@@ -231,6 +238,13 @@ public:
 
   void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
                       bool isOutlined) const override {
+    // If POD, forward to initializeWithTake to memcpy
+    if (this->isTriviallyDestroyable(ResilienceExpansion::Maximal) &&
+        isa<LoadableTypeInfo>(this)) {
+      return initializeWithTake(IGF, dest, src, T, isOutlined,
+                                /*zeroizeIfSensitive=*/true);
+    }
+
     // If the fields are not ABI-accessible, use the value witness table.
     if (!AreFieldsABIAccessible) {
       return emitAssignWithTakeCall(IGF, T, dest, src);

--- a/test/IRGen/pod_record_assignment.swift
+++ b/test/IRGen/pod_record_assignment.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend %s -O -emit-ir -module-name test | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+public final class Reference {}
+
+public struct POD {
+  public var a: Int
+  public var b: Int
+  public var c: Int
+  public var d: Int
+  public var e: Int
+  public var f: Int
+}
+
+public struct Mixed {
+  public var pod: POD
+  public var reference: Reference
+}
+
+public func assignWithCopy(_ destination: inout Mixed, _ source: Mixed) {
+  destination = source
+}
+
+public func assignWithTake(_ destination: inout Mixed,
+                           _ source: consuming Mixed) {
+  destination = source
+}
+
+// The assignWithCopy witness should memcpy the POD field instead of assigning
+// each of its fields, retain the source reference, and release the reference
+// previously held by the destination. The six Int fields occupy 24 bytes on a
+// 32-bit target and 48 bytes on a 64-bit target.
+
+// CHECK-LABEL: define internal {{.*}}ptr @"$s4test5MixedVwca"
+// CHECK-32: call void @llvm.memcpy.p0.p0.i32({{.*}}i32 24, i1 false)
+// CHECK-64: call void @llvm.memcpy.p0.p0.i64({{.*}}i64 48, i1 false)
+// CHECK: call ptr @swift_retain
+// CHECK: call void @swift_release
+// CHECK: ret ptr
+
+// The assignWithTake should also memcopy,  but the witness transfers
+//the source reference rather than retaining it, and only releases the reference displaced at the destination.
+
+// CHECK-LABEL: define internal {{.*}}ptr @"$s4test5MixedVwta"
+// CHECK-32: call void @llvm.memcpy.p0.p0.i32({{.*}}i32 24, i1 false)
+// CHECK-64: call void @llvm.memcpy.p0.p0.i64({{.*}}i64 48, i1 false)
+// CHECK: call void @swift_release
+// CHECK: ret ptr


### PR DESCRIPTION
RecordTypeInfo already forwards to a memcpy if the type is trivial in initializeWithCopy and initializeWithTake. This makes the same change for assignWithCopy and assignWithTake.

Prior to this change, assignWithCopy and assignWithTake witnesses for records with POD fields would inline field wise assignment like so:

```
define internal noundef ptr @"$s6output5MixedVwca"(ptr returned captures(ret: address, provenance) initializes((0, 48)) %dest, ptr readonly captures(none) %src, ptr readnone captures(none) %Mixed) #1 !dbg !305 {
entry:
  %0 = load i64, ptr %src, align 8, !dbg !306
  store i64 %0, ptr %dest, align 8, !dbg !306
  %dest.pod.b = getelementptr inbounds nuw i8, ptr %dest, i64 8, !dbg !306
  %src.pod.b = getelementptr inbounds nuw i8, ptr %src, i64 8, !dbg !306
  %1 = load i64, ptr %src.pod.b, align 8, !dbg !306
  store i64 %1, ptr %dest.pod.b, align 8, !dbg !306
  %dest.pod.c = getelementptr inbounds nuw i8, ptr %dest, i64 16, !dbg !306
  %src.pod.c = getelementptr inbounds nuw i8, ptr %src, i64 16, !dbg !306
  %2 = load i64, ptr %src.pod.c, align 8, !dbg !306
  store i64 %2, ptr %dest.pod.c, align 8, !dbg !306
  %dest.pod.d = getelementptr inbounds nuw i8, ptr %dest, i64 24, !dbg !306
  %src.pod.d = getelementptr inbounds nuw i8, ptr %src, i64 24, !dbg !306
  %3 = load i64, ptr %src.pod.d, align 8, !dbg !306
  store i64 %3, ptr %dest.pod.d, align 8, !dbg !306
  %dest.pod.e = getelementptr inbounds nuw i8, ptr %dest, i64 32, !dbg !306
  %src.pod.e = getelementptr inbounds nuw i8, ptr %src, i64 32, !dbg !306
  %4 = load i64, ptr %src.pod.e, align 8, !dbg !306
  store i64 %4, ptr %dest.pod.e, align 8, !dbg !306
  %dest.pod.f = getelementptr inbounds nuw i8, ptr %dest, i64 40, !dbg !306
  %src.pod.f = getelementptr inbounds nuw i8, ptr %src, i64 40, !dbg !306
  %5 = load i64, ptr %src.pod.f, align 8, !dbg !306
  store i64 %5, ptr %dest.pod.f, align 8, !dbg !306
  %dest.reference = getelementptr inbounds nuw i8, ptr %dest, i64 48, !dbg !306
  %src.reference = getelementptr inbounds nuw i8, ptr %src, i64 48, !dbg !306
  %6 = load ptr, ptr %src.reference, align 8, !dbg !306
  %oldValue = load ptr, ptr %dest.reference, align 8, !dbg !306
  store ptr %6, ptr %dest.reference, align 8, !dbg !306
  %7 = tail call ptr @swift_retain(ptr returned %6) #14, !dbg !306
  tail call void @swift_release(ptr %oldValue) #2, !dbg !306
  ret ptr %dest, !dbg !306
}
```

see [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:swift,selection:(endColumn:1,endLineNumber:25,positionColumn:1,positionLineNumber:25,selectionStartColumn:1,selectionStartLineNumber:25,startColumn:1,startLineNumber:25),source:'public+final+class+Reference+%7B%7D%0A%0Apublic+struct+POD+%7B%0A++public+var+a:+Int%0A++public+var+b:+Int%0A++public+var+c:+Int%0A++public+var+d:+Int%0A++public+var+e:+Int%0A++public+var+f:+Int%0A%7D%0A%0Apublic+struct+Mixed+%7B%0A++public+var+pod:+POD%0A++public+var+reference:+Reference%0A%7D%0A%0Apublic+func+assignWithCopy(_+destination:+inout+Mixed,+_+source:+Mixed)+%7B%0A++destination+%3D+source%0A%7D%0A%0Apublic+func+assignWithTake(_+destination:+inout+Mixed,%0A+++++++++++++++++++++++++++_+source:+consuming+Mixed)+%7B%0A++destination+%3D+source%0A%7D%0A'),l:'5',n:'0',o:'Swift+source+%231',t:'0')),k:37.72489843296576,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:swiftnightly,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'1',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:swift,libs:!(),options:'-emit-ir+-O',overrides:!(),selection:(endColumn:2,endLineNumber:521,positionColumn:2,positionLineNumber:521,selectionStartColumn:1,selectionStartLineNumber:489,startColumn:1,startLineNumber:489),source:1),l:'5',n:'0',o:'+x86-64+swiftc+nightly+(Editor+%231)',t:'0')),header:(),k:62.27510156703424,l:'4',m:100,n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

This is not true of initializeWithCopy, initializeWithTake witnesses:

```
define internal noundef ptr @"$s6output5MixedVwcp"(ptr noalias returned writeonly captures(ret: address, provenance) initializes((0, 56)) %dest, ptr noalias readonly captures(none) %src, ptr readnone captures(none) %Mixed) #8 !dbg !276 {
entry:
  tail call void @llvm.memcpy.p0.p0.i64(ptr noundef nonnull align 8 dereferenceable(48) %dest, ptr noundef nonnull align 8 dereferenceable(48) %src, i64 48, i1 false), !dbg !304
  %dest.reference = getelementptr inbounds nuw i8, ptr %dest, i64 48, !dbg !304
  %src.reference = getelementptr inbounds nuw i8, ptr %src, i64 48, !dbg !304
  %0 = load ptr, ptr %src.reference, align 8, !dbg !304
  store ptr %0, ptr %dest.reference, align 8, !dbg !304
  %1 = tail call ptr @swift_retain(ptr returned %0) #14, !dbg !304
  ret ptr %dest, !dbg !304
}
```

This change brings the two to parity. Since the type is POD, the existing storage needs no destruction, the initializeWithCopy / assignWithCopy, initializeWithTake / assignWithTake operations are equivalent.