### PR TITLE
[cxx-interop] Fix FRT base constraint lowering

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4886,12 +4886,18 @@ ReferenceCounting TypeBase::getReferenceCounting() {
                ? ReferenceCounting::Custom
                : ReferenceCounting::None;
 
-  // In the absence of Objective-C interoperability, everything uses native
-  // reference counting or is the builtin BridgeObject.
+  ReferenceCounting defaultRefCounting = ReferenceCounting::Unknown;
+
+  // In the absence of Objective-C interoperability, almost everything uses
+  // native reference counting or is the builtin BridgeObject.
   if (!ctx.LangOpts.EnableObjCInterop) {
-    return type->getKind() == TypeKind::BuiltinBridgeObject
-             ? ReferenceCounting::Bridge
-             : ReferenceCounting::Native;
+    defaultRefCounting = ReferenceCounting::Native;
+
+    // It is still possible for an FRT to be involved in an archetype or
+    // protocol type, so only short-circuit for cases other than those
+    if (!isa<ArchetypeType, ProtocolType, ProtocolCompositionType>(type))
+      return isa<BuiltinBridgeObjectType>(type) ? ReferenceCounting::Bridge
+                                                : ReferenceCounting::Native;
   }
 
   switch (type->getKind()) {
@@ -4930,21 +4936,17 @@ ReferenceCounting TypeBase::getReferenceCounting() {
   case TypeKind::PackArchetype:
   case TypeKind::ElementArchetype: {
     auto archetype = cast<ArchetypeType>(type);
-    auto layout = archetype->getLayoutConstraint();
-    (void)layout;
-    assert(layout && layout->isRefCounted());
     if (auto supertype = archetype->getSuperclass())
       return supertype->getReferenceCounting();
-    return ReferenceCounting::Unknown;
+    return defaultRefCounting;
   }
 
   case TypeKind::Protocol:
   case TypeKind::ProtocolComposition: {
     auto layout = type->getExistentialLayout();
-    assert(layout.requiresClass() && "Opaque existentials don't use refcounting");
     if (auto superclass = layout.getExplicitSuperclassOrProtocolSuperclass())
       return superclass->getReferenceCounting();
-    return ReferenceCounting::Unknown;
+    return defaultRefCounting;
   }
 
   case TypeKind::ParameterizedProtocol: {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -391,7 +391,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
   // representation.
   if (layout && layout->isRefCounted()) {
     llvm::PointerType *reprTy;
-    ReferenceCounting refcount;
+    ReferenceCounting refcount = archetype->getReferenceCounting();
     const ClassTypeInfo *customRefCountingTI = nullptr;
 
     // If the archetype has a superclass constraint, it has at least the
@@ -400,10 +400,8 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
     if (auto super = archetype->getSuperclass()) {
       auto &superTI = IGM.getTypeInfoForUnlowered(super);
       reprTy = cast<llvm::PointerType>(superTI.StorageType);
-      refcount = super->getReferenceCounting();
       customRefCountingTI = dyn_cast<const ClassTypeInfo>(&superTI);
     } else {
-      refcount = archetype->getReferenceCounting();
       if (refcount == ReferenceCounting::Native) {
         reprTy = IGM.RefCountedPtrTy;
       } else {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -37,6 +37,7 @@
 
 #include "EnumPayload.h"
 #include "Explosion.h"
+#include "ClassTypeInfo.h"
 #include "FixedTypeInfo.h"
 #include "GenClass.h"
 #include "GenHeap.h"
@@ -158,25 +159,70 @@ class ClassArchetypeTypeInfo
 {
   ReferenceCounting RefCount;
 
-  ClassArchetypeTypeInfo(llvm::PointerType *storageType,
-                         Size size, const SpareBitVector &spareBits,
-                         Alignment align,
-                         ReferenceCounting refCount)
-    : HeapTypeInfo(refCount, storageType, size, spareBits, align),
-      RefCount(refCount)
-  {}
+  // ClassTypeInfo whose retain/release functions this archetype forwards to
+  // when RefCount == ReferenceCounting::Custom
+  const ClassTypeInfo *CustomRefCountingTI;
+
+  ClassArchetypeTypeInfo(llvm::PointerType *storageType, Size size,
+                         const SpareBitVector &spareBits, Alignment align,
+                         ReferenceCounting refCount,
+                         const ClassTypeInfo *customRefCountingTI)
+      : HeapTypeInfo(refCount, storageType, size, spareBits, align),
+        RefCount(refCount), CustomRefCountingTI(customRefCountingTI) {
+    if (CONDITIONAL_ASSERT_enabled() && refCount == ReferenceCounting::Custom)
+      ASSERT(customRefCountingTI != nullptr &&
+             "custom-ref-counting archetype requires superclass TypeInfo");
+  }
 
 public:
-  static const ClassArchetypeTypeInfo *create(llvm::PointerType *storageType,
-                                         Size size, const SpareBitVector &spareBits,
-                                         Alignment align,
-                                         ReferenceCounting refCount) {
+  static const ClassArchetypeTypeInfo *
+  create(llvm::PointerType *storageType, Size size,
+         const SpareBitVector &spareBits, Alignment align,
+         ReferenceCounting refCount, const ClassTypeInfo *customRefCountingTI) {
     return new ClassArchetypeTypeInfo(storageType, size, spareBits, align,
-                                      refCount);
+                                      refCount, customRefCountingTI);
   }
 
   ReferenceCounting getReferenceCounting() const {
     return RefCount;
+  }
+
+  void emitScalarRelease(IRGenFunction &IGF, llvm::Value *value,
+                         Atomicity atomicity) const override {
+    if (getReferenceCounting() == ReferenceCounting::Custom)
+      CustomRefCountingTI->emitScalarRelease(IGF, value, atomicity);
+    else
+      HeapTypeInfo::emitScalarRelease(IGF, value, atomicity);
+  }
+
+  void emitScalarRetain(IRGenFunction &IGF, llvm::Value *value,
+                        Atomicity atomicity) const override {
+    if (getReferenceCounting() == ReferenceCounting::Custom)
+      CustomRefCountingTI->emitScalarRetain(IGF, value, atomicity);
+    else
+      HeapTypeInfo::emitScalarRetain(IGF, value, atomicity);
+  }
+
+  void strongRetain(IRGenFunction &IGF, Explosion &e,
+                    Atomicity atomicity) const override {
+    if (getReferenceCounting() == ReferenceCounting::Custom) 
+      CustomRefCountingTI->strongRetain(IGF, e, atomicity);
+    else
+      HeapTypeInfo::strongRetain(IGF, e, atomicity);
+  }
+
+  void strongRelease(IRGenFunction &IGF, Explosion &e,
+                     Atomicity atomicity) const override {
+    if (getReferenceCounting() == ReferenceCounting::Custom)
+      CustomRefCountingTI->strongRelease(IGF, e, atomicity);
+    else
+      HeapTypeInfo::strongRelease(IGF, e, atomicity);
+  }
+
+  bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                           unsigned index) const override {
+    // Custom refcounting functions might not support null pointers.
+    return index == 0 && getReferenceCounting() != ReferenceCounting::Custom;
   }
 };
 
@@ -344,9 +390,9 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
   // If the archetype is class-constrained, use a class pointer
   // representation.
   if (layout && layout->isRefCounted()) {
-    auto refcount = archetype->getReferenceCounting();
-
     llvm::PointerType *reprTy;
+    ReferenceCounting refcount;
+    const ClassTypeInfo *customRefCountingTI = nullptr;
 
     // If the archetype has a superclass constraint, it has at least the
     // retain semantics of its superclass, and it can be represented with
@@ -354,7 +400,10 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
     if (auto super = archetype->getSuperclass()) {
       auto &superTI = IGM.getTypeInfoForUnlowered(super);
       reprTy = cast<llvm::PointerType>(superTI.StorageType);
+      refcount = super->getReferenceCounting();
+      customRefCountingTI = dyn_cast<const ClassTypeInfo>(&superTI);
     } else {
+      refcount = archetype->getReferenceCounting();
       if (refcount == ReferenceCounting::Native) {
         reprTy = IGM.RefCountedPtrTy;
       } else {
@@ -368,11 +417,9 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
     auto spareBits =
       SpareBitVector::getConstant(IGM.getPointerSize().getValueInBits(), false);
 
-    return ClassArchetypeTypeInfo::create(reprTy,
-                                      IGM.getPointerSize(),
-                                      spareBits,
-                                      IGM.getPointerAlignment(),
-                                      refcount);
+    return ClassArchetypeTypeInfo::create(reprTy, IGM.getPointerSize(),
+                                          spareBits, IGM.getPointerAlignment(),
+                                          refcount, customRefCountingTI);
   }
 
   // If the archetype is trivial fixed-size layout-constrained, use a fixed size

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2418,15 +2418,8 @@ namespace {
   };
 
   static bool isImmortalForeignReferenceType(CanType type) {
-    if (type->getReferenceCounting() == ReferenceCounting::None &&
-        type.isForeignReferenceType())
-      return true;
-
-    // getReferenceCounting() on an archetype only consults the superclass when
-    // ObjC interop is enabled so here we look at the superclass explicitly
-    if (auto archetype = dyn_cast<ArchetypeType>(type))
-      if (auto superclass = archetype->getSuperclass())
-        return superclass->getReferenceCounting() == ReferenceCounting::None;
+    if (type.isForeignReferenceType() || isa<ArchetypeType>(type))
+      return type->getReferenceCounting() == ReferenceCounting::None;
     return false;
   }
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2417,6 +2417,19 @@ namespace {
     }
   };
 
+  static bool isImmortalForeignReferenceType(CanType type) {
+    if (type->getReferenceCounting() == ReferenceCounting::None &&
+        type.isForeignReferenceType())
+      return true;
+
+    // getReferenceCounting() on an archetype only consults the superclass when
+    // ObjC interop is enabled so here we look at the superclass explicitly
+    if (auto archetype = dyn_cast<ArchetypeType>(type))
+      if (auto superclass = archetype->getSuperclass())
+        return superclass->getReferenceCounting() == ReferenceCounting::None;
+    return false;
+  }
+
   /// Build the appropriate TypeLowering subclass for the given type,
   /// which is assumed to already have been lowered.
   class LowerType
@@ -2441,8 +2454,7 @@ namespace {
                                   SILTypeProperties properties) {
       properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
-      if (type.isForeignReferenceType() &&
-          type->getReferenceCounting() == ReferenceCounting::None)
+      if (isImmortalForeignReferenceType(type))
         return new (TC) TrivialTypeLowering(
             silType, SILTypeProperties::forTrivial(), Expansion);
 
@@ -3686,6 +3698,13 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
             if (constraint && constraint->isTrivial()) {
               return false;
             }
+          }
+
+          // Case (11): an archetype bounded by an immortal foreign reference
+          // superclass. Trivially lowered like the concrete immortal foreign
+          // reference type but doesn't conform to BitwiseCopyable.
+          if (isImmortalForeignReferenceType(ty)) {
+            return false;
           }
 
           auto *nominal = ty.getAnyNominal();

--- a/test/Interop/Cxx/foreign-reference/Inputs/inherited-generic-argument.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inherited-generic-argument.h
@@ -1,11 +1,20 @@
-#define IMMORTAL_FRT                                                           \
-  __attribute__((swift_attr("import_reference")))                              \
-  __attribute__((swift_attr("retain:immortal")))                              \
+#define _CXX_INTEROP_STRINGIFY(_x) #_x
+
+#define SWIFT_SHARED_REFERENCE(_retain, _release)                          \
+  __attribute__((swift_attr("import_reference")))                          \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(retain:_retain))))      \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(release:_release))))
+
+#define SWIFT_IMMORTAL_REFERENCE                     \
+  __attribute__((swift_attr("import_reference")))    \
+  __attribute__((swift_attr("retain:immortal")))     \
   __attribute__((swift_attr("release:immortal")))
 
-struct IMMORTAL_FRT BaseObj {
+#define SWIFT_RETURNS_RETAINED __attribute__((swift_attr("returns_retained")))
+
+struct BaseObj {
   virtual int tag() const { return 0; }
-};
+} SWIFT_IMMORTAL_REFERENCE;
 
 struct DerivedObj1 : BaseObj {
   int tag() const override { return 1; }
@@ -22,3 +31,39 @@ struct DerivedObj2 : BaseObj {
     return instance;
   }
 };
+
+struct SharedObj {
+  virtual int tag() const { return 42; }
+
+  SWIFT_RETURNS_RETAINED
+  static SharedObj &make() {
+    return *new SharedObj();
+  }
+
+  int currentRefCount() const { return refCount; }
+
+  // Cumulative counts of ref()/deref() calls, used to confirm the custom
+  // retain/release functions are actually invoked (holds only at -Onone).
+  static int numRefs() { return totalRefs; }
+  static int numDerefs() { return totalDerefs; }
+
+  void ref() { ++refCount; ++totalRefs; }
+  void deref() {
+    ++totalDerefs;
+    if (--refCount == 0)
+      delete this;
+  }
+
+private:
+  SharedObj() : refCount(1) {}
+  virtual ~SharedObj() = default;
+
+  int refCount;
+  static int totalRefs;
+  static int totalDerefs;
+} SWIFT_SHARED_REFERENCE(.ref, .deref);
+
+// HACK: defining these in a header is bad practice; we only use them to observe
+// retain/release activity at runtime.
+int SharedObj::totalRefs = 0;
+int SharedObj::totalDerefs = 0;

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
@@ -3,6 +3,15 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
+// This test asserts that a shared FRT's custom retain/release are actually
+// called, which only holds at -Onone. At -O the balanced operations can be
+// optimized away.
+//
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+// UNSUPPORTED: swift_test_mode_optimize_unchecked
+// UNSUPPORTED: swift_test_mode_optimize_with_implicit_dynamic
+
 import InheritedGenericArgument
 import StdlibUnittest
 
@@ -13,6 +22,38 @@ func classify<T: BaseObj>(_ obj: T) -> CInt { obj.tag() }
 Tests.test("base-constrained generic with derived FRT argument") {
   expectEqual(1, classify(DerivedObj1.make()))
   expectEqual(2, classify(DerivedObj2.make()))
+}
+
+func classifyShared<T: SharedObj>(_ obj: T) -> CInt { obj.tag() }
+
+func echoShared<T: SharedObj>(_ obj: T) -> T { obj }
+
+Tests.test("custom retain/release through a shared FRT-bound generic") {
+  expectEqual(0, SharedObj.numRefs())
+  expectEqual(0, SharedObj.numDerefs())
+
+  do {
+    let a = SharedObj.make()
+    expectEqual(1, a.currentRefCount())
+
+    expectEqual(42, classifyShared(a))
+    expectEqual(1, a.currentRefCount())
+
+    do {
+      let b = echoShared(a)
+      expectEqual(42, b.tag())
+      expectEqual(2, a.currentRefCount())
+    }
+    expectEqual(1, a.currentRefCount())
+  }
+
+  // Should have called C++ ref-counting methods instead of Swift native ones
+  expectTrue(SharedObj.numRefs() > 0)
+  expectTrue(SharedObj.numDerefs() > 0)
+
+  // `a` is now out of scope, so the object should be fully released, meaning
+  // derefs should exceed refs by exactly one
+  expectEqual(SharedObj.numRefs() + 1, SharedObj.numDerefs())
 }
 
 runAllTests()

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
@@ -1,7 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
 
-// Miscompiles due to unrelated SIL type lowering issue
-// UNSUPPORTED: OS=linux-gnu
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
@@ -8,8 +8,10 @@
 import InheritedGenericArgument
 
 func add<T: BaseObj>(_ obj: T) {}
+func addShared<T: SharedObj>(_ obj: T) {}
 
 func test() {
   add(DerivedObj1.make())
   add(DerivedObj2.make())
+  addShared(SharedObj.make())
 }


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/91213 fixed how the typechecker handles class constraints of FRT bases (e.g., `func addShared<T: ImmortalFRT>(_ obj: T) {}`), but the regression test I checked in there crashed only on Linux.

It turns out generics with immortal and shared FRT constraints were both miscompiled and used Swift native retain/releases; they only reliably failed on Linux. There were several similar but technically separate issues that I've addressed in separate patches:

- During type lowering, we were treating archetypes of immortal foreign references as using Swift native reference counting.
- During IRGen, we were emitting native Swift retain/releases for archetypes of shared foreign references.
- `TypeBase::getReferenceCounting()` short-circuits when ObjC is disabled (e.g., on Linux) and only reports native or bridged reference counting for non-FRTs. In particular, this mean that archetypes of FRTs did not report the correct refcounting scheme, but only when ObjC is disabled.

This patch set addresses these issues and allow executable types with FRT class constraints to run correctly on Linux.