### PR TITLE
[DebugInfo] Emit DWARF for the concurrency types a debugger presents a task through

### DIFF
--- a/include/swift/AST/KnownSDKTypes.def
+++ b/include/swift/AST/KnownSDKTypes.def
@@ -38,6 +38,8 @@ KNOWN_SDK_TYPE_DECL(ObjectiveC, ObjCBool, StructDecl, 0)
 
 KNOWN_SDK_TYPE_DECL(Concurrency, CheckedContinuation, NominalTypeDecl, 2)
 KNOWN_SDK_TYPE_DECL(Concurrency, UnsafeContinuation, NominalTypeDecl, 2)
+KNOWN_SDK_TYPE_DECL(Concurrency, UnsafeCurrentTask, StructDecl, 0)
+KNOWN_SDK_TYPE_DECL(Concurrency, TaskPriority, StructDecl, 0)
 KNOWN_SDK_TYPE_DECL(Concurrency, MainActor, NominalTypeDecl, 0)
 KNOWN_SDK_TYPE_DECL(Concurrency, Job, StructDecl, 0) // legacy type; prefer ExecutorJob
 KNOWN_SDK_TYPE_DECL(Concurrency, ExecutorJob, StructDecl, 0)

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2716,6 +2716,32 @@ private:
 #undef MAP_BUILTIN_TYPE
   }
 
+  /// Anchor DIEs for the concurrency types a debugger presents a task through.
+  /// A debugger builds values of these itself, out of task state it reads from
+  /// the process, so nothing in the program has to name them and nothing else
+  /// pulls them into the debug info.
+  void anchorConcurrencyTypes() {
+    if (Opts.DebugInfoLevel <= IRGenDebugInfoLevel::ASTTypes)
+      return;
+
+    ASTContext &Ctx = IGM.Context;
+    for (StructDecl *Decl :
+         {Ctx.getUnsafeCurrentTaskDecl(), Ctx.getTaskPriorityDecl()}) {
+      // Null when the concurrency module was never imported; such a program has
+      // no task to present.
+      if (!Decl)
+        continue;
+      // Across a resilience boundary the layout is not this module's to
+      // describe, and a debugger there has reflection metadata to read instead.
+      if (IGM.isResilient(Decl, ResilienceExpansion::Maximal))
+        continue;
+      Type Ty = Decl->getDeclaredInterfaceType();
+      auto DbgTy = DebugTypeInfo::getFromTypeInfo(
+          Ty, IGM.getTypeInfoForUnlowered(Ty), IGM);
+      anchorType(getOrCreateType(DbgTy));
+    }
+  }
+
   /// Forward-declared composite types may still refer refer to a type alias by
   /// name in their mangled name. We need to make sure they are emitted in
   /// DWARF.
@@ -3233,6 +3259,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
   }
   createSpecialStlibBuiltinTypes();
   anchorClangInteropTypeAliases();
+  anchorConcurrencyTypes();
 }
 
 void IRGenDebugInfoImpl::finalize() {

--- a/test/DebugInfo/concurrency-anchored-types.swift
+++ b/test/DebugInfo/concurrency-anchored-types.swift
@@ -1,0 +1,36 @@
+/*
+Verify that the concurrency types a debugger presents a task through
+reach the debug info even though the program never names them.
+
+RUN: %target-swift-frontend %s -target %target-cpu-apple-macos14 -emit-ir -g -enable-experimental-feature Embedded -wmo -o - | %FileCheck %s
+RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | %FileCheck %s --check-prefix=RESILIENT
+
+REQUIRES: OS=macosx
+REQUIRES: embedded_stdlib
+REQUIRES: swift_feature_Embedded
+REQUIRES: concurrency
+
+A name and a size are not enough: a debugger reads the stored task pointer and
+the raw priority back out of a value it built itself, by member name.
+
+CHECK-DAG: ![[TASK:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "UnsafeCurrentTask",{{.*}} elements: ![[TASK_ELEMENTS:[0-9]+]],{{.*}} identifier: "$eSctD")
+CHECK-DAG: ![[TASK_ELEMENTS]] = !{![[RAW_TASK:[0-9]+]]
+CHECK-DAG: ![[RAW_TASK]] = !DIDerivedType(tag: DW_TAG_member, name: "_rawTask",
+CHECK-DAG: ![[PRIORITY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "TaskPriority",{{.*}} elements: ![[PRIORITY_ELEMENTS:[0-9]+]],{{.*}} identifier: "$eScPD")
+CHECK-DAG: ![[PRIORITY_ELEMENTS]] = !{![[RAW_VALUE:[0-9]+]]
+CHECK-DAG: ![[RAW_VALUE]] = !DIDerivedType(tag: DW_TAG_member, name: "rawValue",
+
+Each one is anchored with a DW_TAG_imported_declaration; retaining the type is
+not enough to survive dsymutil, since nothing in the program refers to it.
+
+CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{[0-9]+}}, entity: ![[TASK]],
+CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !{{[0-9]+}}, entity: ![[PRIORITY]],
+
+Across a resilience boundary the layout is not this module's to describe, and a
+debugger there has the reflection metadata to read instead.
+
+RESILIENT-NOT: name: "UnsafeCurrentTask"
+RESILIENT-NOT: name: "TaskPriority"
+*/
+
+import _Concurrency


### PR DESCRIPTION
A debugger builds UnsafeCurrentTask and TaskPriority values itself, out of task
state it reads from the process, so nothing in the program has to name those
types and nothing else pulls them into the debug info. Where there is no
reflection metadata -- always the case in embedded Swift -- DWARF is a
debugger's only description of a type, so it could not find their size or read
their fields by name.

Assisted-by: claude

rdar://184754539
