### PR TITLE
Don't assert that mark_dependence_addr is non-escaping while inlining coroutines.

### DIFF
--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -157,7 +157,6 @@ public:
         if (!mdi) {
           continue;
         }
-        assert(mdi.isNonEscaping());
         if (auto *valueMDI = dyn_cast<MarkDependenceInst>(*mdi)) {
           valueMDI->replaceAllUsesWith(valueMDI->getValue());
         }

--- a/validation-test/SILOptimizer/rdar184427237.swift
+++ b/validation-test/SILOptimizer/rdar184427237.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend %s -enable-experimental-feature Lifetimes -O -emit-sil
+
+// REQUIRES: swift_feature_Lifetimes
+
+// Ensure we don't crash
+
+protocol Carrier: ~Escapable {
+    associatedtype Underlying: ~Copyable & ~Escapable
+    var underlying: Underlying {
+        @_lifetime(borrow self)
+        borrowing get
+    }
+}
+
+protocol Value {
+    func read() -> Int
+}
+
+struct Payload: Value {
+    var n: Int
+    func read() -> Int { n }
+}
+
+struct Box: Carrier {
+    var underlying: Payload
+}
+
+func readUnderlying<C: Carrier>(_ value: C) -> Int where C.Underlying: Value {
+    value.underlying.read()
+}
+
+public func entryPoint(_ x: Int) -> Int {
+    readUnderlying(Box(underlying: Payload(n: x)))
+}


### PR DESCRIPTION
When we have a mark_dependence_addr on the begin_apply token, the value maybe Escapable in which case LifetimeDependenceDiagnostics settles that dependence as escaping without raising any diagnostics. Remove unnecessary assert when inlining such begin_applies.

Resolves rdar://184427237 and https://github.com/swiftlang/swift/issues/91342

