### PR TITLE
[Sema] Fix `@called(once)` matching in protocol requirements/witnesses

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2278,16 +2278,24 @@ Type swift::adjustInferredAssociatedType(TypeAdjustment adjustment, Type type,
   }
 
   auto needsAdjustment = [=](FunctionType *funcType) -> bool {
-    if (adjustment == TypeAdjustment::NoescapeToEscaping)
+    switch (adjustment) {
+    case TypeAdjustment::NoescapeToEscaping:
       return funcType->isNoEscape();
-    else
+    case TypeAdjustment::NonsendableToSendable:
       return !funcType->isSendable();
+    case TypeAdjustment::CalledOnceToPlain:
+      return funcType->isCalledOnce();
+    }
   };
   auto adjust = [=](const ASTExtInfo &info) -> ASTExtInfo {
-    if (adjustment == TypeAdjustment::NoescapeToEscaping)
+    switch (adjustment) {
+    case TypeAdjustment::NoescapeToEscaping:
       return info.withNoEscape(false);
-    else
+    case TypeAdjustment::NonsendableToSendable:
       return info.withSendable(true);
+    case TypeAdjustment::CalledOnceToPlain:
+      return info.withCalledOnce(false);
+    }
   };
 
   // If we have a noescape function type, make it escaping.
@@ -2450,6 +2458,10 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
       Type inferredType =
         adjustInferredAssociatedType(TypeAdjustment::NoescapeToEscaping,
                                      secondType, noescapeToEscaping);
+      bool calledOnceToPlain = false;
+      inferredType =
+        adjustInferredAssociatedType(TypeAdjustment::CalledOnceToPlain,
+                                     inferredType, calledOnceToPlain);
       if (!inferredType->isMaterializable())
         return false;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3262,8 +3262,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   }
 
   if (func1->isCalledOnce() != func2->isCalledOnce()) {
-    if (func1->isCalledOnce() ||
-        (kind < ConstraintKind::Subtype && !isWitnessMatching(locator))) {
+    if (func1->isCalledOnce() || kind < ConstraintKind::Subtype) {
       if (!shouldAttemptFixes())
         return SolutionKind::Error;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -119,8 +119,16 @@ getTypesToCompare(ValueDecl *reqt, Type reqtType, bool reqtTypeIsIUO,
     // function type not in a parameter is, more or less, implicitly @escaping.
     // For Sendable, we want to behave as though it was not necessary because
     // function types that aren't in a parameter can be Sendable or not.
+    // For `@called(once)`, we want to behave as though it was not necessary
+    // because function types that aren't in a parameter can be called once
+    // or not.
+    // For `@called(once)`, we want to behave as though it was necessary, just
+    // like noescape, because a plain function type can always satisfy a
+    // `@called(once)` requirement but a `@called(once)` function type cannot
+    // satisfy a plain one.
     // FIXME: Should we check for a Sendable bound on the requirement type?
-    bool inRequirement = (adjustment != TypeAdjustment::NoescapeToEscaping);
+    bool inRequirement = (adjustment != TypeAdjustment::NoescapeToEscaping &&
+                          adjustment != TypeAdjustment::CalledOnceToPlain);
     Type adjustedReqtType =
       adjustInferredAssociatedType(adjustment, reqtType, inRequirement);
 
@@ -144,6 +152,7 @@ getTypesToCompare(ValueDecl *reqt, Type reqtType, bool reqtTypeIsIUO,
 
   applyAdjustment(TypeAdjustment::NoescapeToEscaping);
   applyAdjustment(TypeAdjustment::NonsendableToSendable);
+  applyAdjustment(TypeAdjustment::CalledOnceToPlain);
 
   // For @objc protocols, deal with differences in the optionality.
   // FIXME: It probably makes sense to extend this to non-@objc

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -201,7 +201,7 @@ matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
              DeclContext *dc, ValueDecl *req, ValueDecl *witness);
 
 enum class TypeAdjustment : uint8_t {
-  NoescapeToEscaping, NonsendableToSendable
+  NoescapeToEscaping, NonsendableToSendable, CalledOnceToPlain
 };
 
 /// Perform any necessary adjustments to the inferred associated type to

--- a/test/Sema/called_once.swift
+++ b/test/Sema/called_once.swift
@@ -109,3 +109,72 @@ func testClosures() {
   genericNC(fn) // Ok
   genericNC { @called(once) in } // Ok
 }
+
+protocol PA {
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+  func f(_: A)
+}
+
+struct TestAssociatedTypeInference : PA {
+  func f(_: @called(once) (Int) -> Int) { } // Ok
+}
+
+struct TestExplicitAssociatedType : PA {
+  typealias A = (Int) -> Int
+  func f(_: @called(once) (Int) -> Int) { } // Ok
+}
+
+struct TestWitnessAndAssociatedTypeMismatch : PA { // expected-error {{type 'TestWitnessAndAssociatedTypeMismatch' does not conform to protocol 'PA'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  typealias A = @called(once) (Int) -> Int
+  // expected-note@-1 {{possibly intended match 'TestWitnessAndAssociatedTypeMismatch.A' (aka '@called(once) (Int) -> Int') does not conform to 'Copyable'}}
+  func f(_: (Int) -> Int) { }
+}
+
+protocol PR {
+  func f(_: (Int) -> Int)
+  func g(_: @called(once) (Int) -> Int)
+  // expected-note@-1 {{protocol requires function 'g' with type '(consuming @called(once) (Int) -> Int) -> ()'}}
+}
+
+struct TestDifferentWitnesses : PR { // expected-error {{type 'TestDifferentWitnesses' does not conform to protocol 'PR'}}
+// expected-note@-1 {{add stubs for conformance}}
+  func f(_: (Int) -> Int) { }
+  func g(_: (Int) -> Int) { }
+  // expected-note@-1 {{candidate has non-matching type '((Int) -> Int) -> ()'}}
+}
+
+struct TestSameWitnesses : PR {
+  func f(_: @called(once) (Int) -> Int) { } // Ok
+  func g(_: @called(once) (Int) -> Int) { } // Ok
+}
+
+protocol PA_Contravariant {
+  associatedtype A
+  func f(_: (A) -> Void)
+  // expected-note@-1 {{protocol requires function 'f' with type '((@escaping (Int) -> Int) -> Void) -> ()'}}
+}
+
+struct TestContravariantAssociatedTypeInference : PA_Contravariant { // expected-error {{type 'TestContravariantAssociatedTypeInference' does not conform to protocol 'PA_Contravariant'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  func f(_: (@called(once) (Int) -> Int) -> Void) { }
+  // expected-note@-1 {{candidate has non-matching type '((consuming @called(once) (Int) -> Int) -> Void) -> ()' [with A = (Int) -> Int]}}
+}
+
+protocol P_PlainResult {
+  func f() -> () -> Void // expected-note {{protocol requires function 'f()' with type '() -> () -> Void'}}
+}
+
+protocol P_CalledOnceResult {
+  func f() -> @called(once) () -> Void
+}
+
+struct TestCalledOnceResultWitness : P_PlainResult { // expected-error {{type 'TestCalledOnceResultWitness' does not conform to protocol 'P_PlainResult'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  func f() -> @called(once) () -> Void { { } }
+  // expected-note@-1 {{candidate has non-matching type '() -> @called(once) () -> Void'}}
+}
+
+struct TestPlainResultWitness : P_CalledOnceResult {
+  func f() -> () -> Void { { } } // Ok
+}


### PR DESCRIPTION
- A witness may declare a parameter as `@called(once)` even where the requirement does not; this only adds a restriction the witness imposes on its own argument, and is invisible to callers going through the protocol. A witness may *not* drop `@called(once)` from a parameter the requirement declares as such, since that would let the witness call the argument more times than callers of the protocol would expect

- A witness may return a plain function value even where the requirement declares a `@called(once)` result; callers going through the protocol are still bound by the requirement's declared (more restrictive) type, so they can never observe the extra flexibility of the underlying value. A witness may *not* return a `@called(once)` value where the requirement promises an ordinary result, because that value would then be exposed to callers as if it could be called any number of times, when it can really only be called once.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
