### PR TITLE
[Runtime] Gate SWIFT_* environment variables on process privilege.

### DIFF
--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(swiftRuntimeCore OBJECT
     Once.cpp
     Paths.cpp
     Portability.cpp
+    Privilege.cpp
     ProtocolConformance.cpp
     RefCount.cpp
     ReflectionMirror.cpp

--- a/include/swift/Runtime/Privilege.h
+++ b/include/swift/Runtime/Privilege.h
@@ -1,0 +1,51 @@
+//===--- Privilege.h - Process privilege checks -----------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Checks for whether the current process holds privileges or protections that
+// are relevant to runtime behavior.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_PRIVILEGE_H
+#define SWIFT_RUNTIME_PRIVILEGE_H
+
+#include "swift/shims/Visibility.h"
+
+namespace swift {
+namespace runtime {
+
+/// True if the process gained credentials at exec that its invoker does not
+/// hold: `AT_SECURE` on Linux, `issetugid()` elsewhere. Windows has no
+/// equivalent and always reports false.
+SWIFT_RUNTIME_STDLIB_INTERNAL
+bool _swift_isPrivilegedProcess();
+
+/// True if `_swift_isPrivilegedProcess()`, or, on macOS, if the process is a
+/// platform binary or uses the hardened runtime.
+///
+/// Gates environment variables that disable a check that's important for
+/// memory safety.
+SWIFT_RUNTIME_STDLIB_SPI
+bool _swift_isRestrictedProcess();
+
+/// True if `_swift_isRestrictedProcess()`, or, on macOS, if the process
+/// disallows task_for_pid.
+///
+/// Gates the backtracer, which is only active for processes with the
+/// get-task-allow entitlement.
+SWIFT_RUNTIME_STDLIB_INTERNAL
+bool _swift_isRestrictedProcessForExec();
+
+} // end namespace runtime
+} // end namespace swift
+
+#endif // SWIFT_RUNTIME_PRIVILEGE_H

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -4379,9 +4379,9 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
       if (auto willSet = storage->getParsedAccessor(AccessorKind::WillSet)) {
         willSet->diagnose(diag::observing_accessor_conflicts_with_accessor, 0,
                           getAccessorNameForDiagnostic(
-                              firstNonObserver->getAccessorKind(),
+                              firstNonObserver,
                               /*article=*/true,
-                              /*underscored=*/hasCoroutineAccessorFeature));
+                              /*legacy=*/hasCoroutineAccessorFeature));
         willSet->setInvalid();
         hasWillSet = false;
       }
@@ -4389,9 +4389,9 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
       if (auto didSet = storage->getParsedAccessor(AccessorKind::DidSet)) {
         didSet->diagnose(diag::observing_accessor_conflicts_with_accessor, 1,
                          getAccessorNameForDiagnostic(
-                             firstNonObserver->getAccessorKind(),
+                             firstNonObserver,
                              /*article=*/true,
-                             /*underscored=*/hasCoroutineAccessorFeature));
+                             /*legacy=*/hasCoroutineAccessorFeature));
         didSet->setInvalid();
         hasDidSet = false;
       }

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -40,6 +40,7 @@
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/Exception.h"
 #include "swift/Runtime/Heap.h"
+#include "swift/Runtime/Privilege.h"
 #include "swift/Threading/Mutex.h"
 #include "swift/Threading/Once.h"
 #include "swift/Threading/Thread.h"
@@ -478,6 +479,11 @@ __swift_bincompat_useLegacyNonCrashingExecutorChecks() {
 const char *__swift_runtime_env_useLegacyNonCrashingExecutorChecks() {
   // Potentially, override the platform detected mode, primarily used in tests.
 #if SWIFT_STDLIB_HAS_ENVIRON && !SWIFT_CONCURRENCY_EMBEDDED
+  // The override downgrades the isolation check from fatal to a warning, so it
+  // is unavailable in processes don't allow disabling safety checks.
+  if (swift::runtime::_swift_isRestrictedProcess())
+    return nullptr;
+
   return swift::runtime::environment::
       concurrencyIsCurrentExecutorLegacyModeOverride();
 #else
@@ -810,6 +816,12 @@ static unsigned unexpectedExecutorLogLevel =
 
 static void checkUnexpectedExecutorLogLevel(void *context) {
 #if SWIFT_STDLIB_HAS_ENVIRON
+  // SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL can downgrade the executor check from a
+  // fatal error to a warning, so it is unavailable in processes don't allow
+  // disabling safety checks.
+  if (swift::runtime::_swift_isRestrictedProcess())
+    return;
+
   const char *levelStr = getenv("SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL");
   if (!levelStr)
     return;

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -23,13 +23,10 @@
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Paths.h"
 #include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Runtime/Privilege.h"
 #include "swift/Runtime/Win32.h"
 
 #include "swift/Demangling/Demangler.h"
-
-#ifdef __linux__
-#include <sys/auxv.h>
-#endif
 
 #ifdef _WIN32
 #include <windows.h>
@@ -44,17 +41,6 @@
 #endif
 
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
-#if __has_include(<sys/codesign.h>)
-#include <sys/codesign.h>
-#else
-// SPI
-#define CS_OPS_STATUS 0
-#define CS_GET_TASK_ALLOW  0x00000004
-#define CS_RUNTIME         0x00010000
-#define CS_PLATFORM_BINARY 0x04000000
-#define CS_PLATFORM_PATH   0x08000000
-extern "C" int csops(int, unsigned int, void *, size_t);
-#endif
 #include <spawn.h>
 #endif
 #include <unistd.h>
@@ -295,37 +281,6 @@ const char *presetToString(Preset preset) {
 }
 #endif
 
-#ifdef __linux__
-bool isPrivileged() {
-  return getauxval(AT_SECURE);
-}
-#elif TARGET_OS_OSX || TARGET_OS_MACCATALYST
-bool isPrivileged() {
-  if (issetugid())
-    return true;
-
-  uint32_t flags = 0;
-  if (csops(getpid(),
-            CS_OPS_STATUS,
-            &flags,
-            sizeof(flags)) != 0)
-    return true;
-
-  if (flags & (CS_PLATFORM_BINARY | CS_PLATFORM_PATH | CS_RUNTIME))
-    return true;
-
-  return !(flags & CS_GET_TASK_ALLOW);
-}
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-bool isPrivileged() {
-  return issetugid();
-}
-#elif _WIN32
-bool isPrivileged() {
-  return false;
-}
-#endif
-
 #if SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
 #if _WIN32
 bool writeProtectMemory(void *ptr, size_t size) {
@@ -344,8 +299,8 @@ bool writeProtectMemory(void *ptr, size_t size) {
 BacktraceInitializer::BacktraceInitializer() {
   const char *backtracing = swift::runtime::environment::SWIFT_BACKTRACE();
 
-  // Force off for setuid processes.
-  if (isPrivileged()) {
+  // Force off for privileged processes.
+  if (swift::runtime::_swift_isRestrictedProcessForExec()) {
     _swift_backtraceSettings.enabled = OnOffTty::Off;
   }
 
@@ -394,7 +349,8 @@ BacktraceInitializer::BacktraceInitializer() {
   }
 #else
 
-  if (isPrivileged() && _swift_backtraceSettings.enabled != OnOffTty::Off) {
+  if (swift::runtime::_swift_isRestrictedProcessForExec()
+      && _swift_backtraceSettings.enabled != OnOffTty::Off) {
     // You'll only see this warning if you do e.g.
     //
     //    SWIFT_BACKTRACE=enable=on /path/to/some/setuid/binary

--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -18,6 +18,7 @@
 #include "swift/Runtime/Bincompat.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Runtime/Privilege.h"
 #include "swift/Threading/Once.h"
 #include "swift/shims/RuntimeShims.h"
 #include "swift/shims/Target.h"
@@ -94,6 +95,11 @@ static bool isKnownBinCompatVersion(_SwiftStdlibVersion version) {
 }
 
 static void checkBinCompatEnvironmentVariable(void *context) {
+  // Overriding the bincompat version can remove safety checks, so it is
+  // unavailable in processes that don't allow that.
+  if (_swift_isRestrictedProcess())
+    return;
+
   _SwiftStdlibVersion version =
     { runtime::environment::SWIFT_BINARY_COMPATIBILITY_VERSION() };
 

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -72,6 +72,7 @@ set(swift_runtime_sources
     Once.cpp
     Paths.cpp
     Portability.cpp
+    Privilege.cpp
     ProtocolConformance.cpp
     RefCount.cpp
     ReflectionMirror.cpp

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Paths.h"
+#include "swift/Runtime/Privilege.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 
 #include <string.h>
@@ -222,6 +223,11 @@ static void platformInitialize(void *context) {
 
 #if defined(ENVIRON)
 void swift::runtime::environment::initialize(void *context) {
+  // Dno't allow the user executing this process to modify the environment if
+  // it's privileged (setuid/setgid).
+  if (_swift_isPrivilegedProcess())
+    return;
+
   // On platforms where we have an environment variable array available, scan it
   // directly. This optimizes for the common case where no variables are set,
   // since we only need to perform one scan to set all variables. It also allows
@@ -278,6 +284,11 @@ void swift::runtime::environment::initialize(void *context) {
 }
 #else
 void swift::runtime::environment::initialize(void *context) {
+  // Dno't allow the user executing this process to modify the environment if
+  // it's privileged (setuid/setgid).
+  if (_swift_isPrivilegedProcess())
+    return;
+
   // Emit a getenv call for each variable. This is less efficient but works
   // everywhere.
 #define VARIABLE(name, type, defaultValue, help)                               \

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -18,6 +18,7 @@
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Paths.h"
+#include "swift/Runtime/Privilege.h"
 #include "swift/Runtime/Win32.h"
 #include "swift/Threading/Once.h"
 
@@ -311,8 +312,12 @@ _swift_joinPaths(const char *path, ...)
 void
 _swift_initRootPath(void *)
 {
-  // SWIFT_ROOT overrides the path returned by this function
-  const char *swiftRoot = swift::runtime::environment::SWIFT_ROOT();
+  // SWIFT_ROOT overrides the path returned by this function. The root is used to
+  // locate executables to spawn and libraries to load, so gate it on the
+  // strongest check.
+  const char *swiftRoot = swift::runtime::_swift_isRestrictedProcessForExec()
+    ? nullptr
+    : swift::runtime::environment::SWIFT_ROOT();
 
   if (!swiftRoot || !*swiftRoot) {
     rootPath = _swift_getDefaultRootPath();

--- a/stdlib/public/runtime/Privilege.cpp
+++ b/stdlib/public/runtime/Privilege.cpp
@@ -1,0 +1,94 @@
+//===--- Privilege.cpp - Process privilege checks ----------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Checks for whether the current process holds privileges or protections that
+// are relevant to runtime behavior.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Privilege.h"
+
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
+#ifdef __linux__
+#include <sys/auxv.h>
+#endif
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if __has_include(<sys/codesign.h>)
+#include <sys/codesign.h>
+#else
+// SPI
+#define CS_OPS_STATUS 0
+#define CS_GET_TASK_ALLOW  0x00000004
+#define CS_RUNTIME         0x00010000
+#define CS_PLATFORM_BINARY 0x04000000
+#define CS_PLATFORM_PATH   0x08000000
+extern "C" int csops(int, unsigned int, void *, size_t);
+#endif
+#include <stdint.h>
+#endif
+
+bool swift::runtime::_swift_isPrivilegedProcess() {
+#if defined(__linux__)
+  return getauxval(AT_SECURE);
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+  return issetugid();
+#else
+  return false;
+#endif
+}
+
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+// Returns false if the flags can't be read, so callers treat a failed query as
+// the most restrictive answer.
+static bool getCodeSigningFlags(uint32_t &flags) {
+  flags = 0;
+  return csops(getpid(), CS_OPS_STATUS, &flags, sizeof(flags)) == 0;
+}
+#endif
+
+bool swift::runtime::_swift_isRestrictedProcess() {
+  if (_swift_isPrivilegedProcess())
+    return true;
+
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+  uint32_t flags;
+  if (!getCodeSigningFlags(flags))
+    return true;
+
+  return (flags & (CS_PLATFORM_BINARY | CS_PLATFORM_PATH | CS_RUNTIME)) != 0;
+#else
+  return false;
+#endif
+}
+
+bool swift::runtime::_swift_isRestrictedProcessForExec() {
+  if (_swift_isRestrictedProcess())
+    return true;
+
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
+  uint32_t flags;
+  if (!getCodeSigningFlags(flags))
+    return true;
+
+  return !(flags & CS_GET_TASK_ALLOW);
+#else
+  return false;
+#endif
+}

--- a/test/Runtime/Inputs/hardened-runtime.plist
+++ b/test/Runtime/Inputs/hardened-runtime.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>com.apple.security.get-task-allow</key>
+<true/>
+<key>com.apple.security.cs.disable-library-validation</key>
+<true/>
+</dict>
+</plist>

--- a/test/Runtime/privilege.swift
+++ b/test/Runtime/privilege.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+
+// RUN: mkdir -p %t/swift-root/libexec/swift
+// RUN: touch %t/swift-root/libexec/swift/Foo
+
+// RUN: %target-build-swift -enable-experimental-feature Extern %s -o %t/privilege-test
+
+// A test binary is signed with get-task-allow, so it is neither restricted nor
+// restricted-for-exec and every variable applies.
+// RUN: %target-codesign %t/privilege-test
+// RUN: env %env-SWIFT_ROOT=%t/swift-root %target-run %t/privilege-test | %FileCheck %s --check-prefix CHECK-UNRESTRICTED
+
+// Dropping get-task-allow leaves the process debuggable-restricted only, which
+// gates SWIFT_ROOT but not the checks. This is what a plain `swiftc` build
+// gets, so the check-weakening variables should keep working here.
+// RUN: codesign -f -s - %t/privilege-test
+// RUN: env %env-SWIFT_ROOT=%t/swift-root %target-run %t/privilege-test | %FileCheck %s --check-prefix CHECK-NO-TASK-ALLOW
+
+// The hardened runtime sets CS_RUNTIME, which gates the check-weakening
+// variables too. Library validation has to be off for the test binary to load
+// the just-built runtime.
+// RUN: codesign -f -s - --options runtime --entitlements %S/Inputs/hardened-runtime.plist %t/privilege-test
+// RUN: env %env-SWIFT_ROOT=%t/swift-root %target-run %t/privilege-test | %FileCheck %s --check-prefix CHECK-HARDENED
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Extern
+// REQUIRES: OS=macosx
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+@_extern(c, "_swift_isRestrictedProcess")
+func _swift_isRestrictedProcess() -> CBool
+
+@_extern(c, "swift_getRootPath")
+func swift_getRootPath() -> UnsafePointer<CChar>?
+
+// Gates the variables that disable a check. A plain `swiftc` build lands in
+// the CHECK-NO-TASK-ALLOW configuration and must report no.
+// CHECK-UNRESTRICTED: restricted: no
+// CHECK-NO-TASK-ALLOW: restricted: no
+// CHECK-HARDENED: restricted: yes
+print("restricted: \(_swift_isRestrictedProcess() ? "yes" : "no")")
+
+// CHECK-UNRESTRICTED: SWIFT_ROOT honored: yes
+// CHECK-NO-TASK-ALLOW: SWIFT_ROOT honored: no
+// CHECK-HARDENED: SWIFT_ROOT honored: no
+let rootPath = swift_getRootPath().map { String(cString: $0) }
+print("SWIFT_ROOT honored: \(rootPath?.contains("swift-root") == true ? "yes" : "no")")

--- a/test/Sema/generalized_accessors_coroutine_accessors.swift
+++ b/test/Sema/generalized_accessors_coroutine_accessors.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature CoroutineAccessors
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// Companion to generalized_accessors.swift's ReadModifiable: with the
+// CoroutineAccessors feature enabled, `_read`/`_modify` are represented
+// internally as `yielding borrow`/`yielding mutate` (the two are synonyms),
+// but diagnostics must still name the accessor using the spelling the user
+// actually wrote, not the internal representation.
+
+struct ReadModifiable {
+  var readAndWillSet: Int {
+    _read {}
+    willSet {} // expected-error {{'willSet' cannot be provided together with a '_read' accessor}}
+  }
+
+  var readAndDidSet: Int {
+    _read {}
+    didSet {} // expected-error {{'didSet' cannot be provided together with a '_read' accessor}}
+  }
+}
+
+struct ModifyModifiable {
+  var _s = 0
+
+  // `_modify` is declared before `get` so it -- not the getter -- is the
+  // first non-observing accessor and the one named in the diagnostic.
+  var modifyAndWillSet: Int {
+    _modify { yield &_s }
+    get { _s }
+    willSet {} // expected-error {{'willSet' cannot be provided together with a '_modify' accessor}}
+  }
+
+  var modifyAndDidSet: Int {
+    _modify { yield &_s }
+    get { _s }
+    didSet {} // expected-error {{'didSet' cannot be provided together with a '_modify' accessor}}
+  }
+}

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1355,3 +1355,6 @@ Added: _swift_distributed_getGenericEnvironmentKeyArgumentCount
 
 // Task Registry
 Added: _concurrencyEnableTaskRegistry
+
+// Privilege gating for environment variables
+Added: __swift_isRestrictedProcess

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1350,3 +1350,6 @@ Added: _swift_distributed_getGenericEnvironmentKeyArgumentCount
 
 // Task Registry
 Added: _concurrencyEnableTaskRegistry
+
+// Privilege gating for environment variables
+Added: __swift_isRestrictedProcess


### PR DESCRIPTION
setuid/setgid binaries should ignore all SWIFT_* environment variables. Environment variables that disable safety checks should also be ignored in platform-binary and hardened-runtime executables.

Take the existing privilege check code out of Backtrace.cpp and put it into its own file since it now used in more places.

rdar://183443811