### PR TITLE
[Interop] Update swiftify-import tests for visionOS availability behavior (#91337)

### DIFF
--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -101,7 +101,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 @__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
-@available(visionOS 1.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
+@available(iOS 2.0, visionOS 1.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
 public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
     return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
@@ -110,7 +110,7 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
-@available(visionOS 1.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+@available(iOS 2.0, visionOS 1.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = p.withUnsafeMutableBufferPointer {


### PR DESCRIPTION
- **Explanation**:
The xros-expansions fixture in
Interop/C/swiftify-import/availability.swift expects `@available(iOS 2.0, visionOS 1.0, *)`.

- **Scope**:
This changes one test.

- **Issues**:
rdar://183989115
- **Original PRs**:
https://github.com/swiftlang/swift/pull/91397
- **Risk**:
Low. This is a test-only change.
- **Testing**:
Tested in CI.

- **Reviewers**:
