### PR TITLE
[any ~Copyable] Don't copy a non-copyable existential

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -431,6 +431,10 @@ void ExistentialTransform::populateThunkBody() {
   struct Temp {
     SILValue DeallocStackEntry;
     SILValue DestroyValue;
+    // If set, we moved the (non-copyable) value out of an existential box and
+    // so we need to clean up the empty box with deinit_existential_addr instead
+    // of destroy_addr.
+    bool DestroyEmptyBox = false;
   };
   SmallVector<Temp, 8> Temps;
   SmallDenseMap<GenericTypeParamType *, Type> GenericToOpenedTypeMap;
@@ -457,12 +461,16 @@ void ExistentialTransform::populateThunkBody() {
         if (OriginallyConsumed) {
           // open_existential_addr projects a borrowed address into the
           // existential box. Since the callee consumes the generic value, we
-          // must pass in a copy.
+          // must pass in a copy -- unless the value is move-only, in which
+          // case we use a take instead: the callee already consumes the whole
+          // existential, so nothing else can observe OrigOperand's payload afterward.
+          bool isMoveOnly = OpenedSILType.isMoveOnly();
           auto *ASI =
             Builder.createAllocStack(Loc, OpenedSILType);
-          Builder.createCopyAddr(Loc, archetypeValue, ASI, IsNotTake,
+          Builder.createCopyAddr(Loc, archetypeValue, ASI,
+                                 isMoveOnly ? IsTake : IsNotTake,
                                  IsInitialization_t::IsInitialization);
-          Temps.push_back({ASI, OrigOperand});
+          Temps.push_back({ASI, OrigOperand, isMoveOnly});
           calleeArg = ASI;
         }
         ApplyArgs.push_back(calleeArg);
@@ -602,8 +610,17 @@ void ExistentialTransform::populateThunkBody() {
     //     dealloc_stack %temp : $*T
     //
     // Otherwise, if we had an object, we just emit a destroy_value.
-    if (Temp.DestroyValue)
-      Builder.emitDestroyOperation(cleanupLoc, Temp.DestroyValue);
+    //
+    // If the payload is move-only, the copy_addr above was actually a take,
+    // so %consumedExistential's payload is already gone; only the (now
+    // empty) existential container itself still needs to be torn down, via
+    // deinit_existential_addr rather than destroy_addr.
+    if (Temp.DestroyValue) {
+      if (Temp.DestroyEmptyBox)
+        Builder.createDeinitExistentialAddr(cleanupLoc, Temp.DestroyValue);
+      else
+        Builder.emitDestroyOperation(cleanupLoc, Temp.DestroyValue);
+    }
     if (Temp.DeallocStackEntry)
       Builder.createDeallocStack(cleanupLoc, Temp.DeallocStackEntry);
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1186,6 +1186,15 @@ struct ConcreteArgumentCopy {
     if (!paramInfo.isFormalIndirect())
       return std::nullopt;
 
+    // A move-only concrete value can't be copied into a temporary.
+    // Decline the substitution; the caller falls back to
+    // passing existentialInfo.ConcreteValue directly, which is exactly a
+    // take (the callee's parameter convention is still formally indirect
+    // and consumed at this point).
+    if (existentialInfo.ConcreteValue->getType().isAddress() &&
+        existentialInfo.ConcreteValue->getType().isMoveOnly())
+      return std::nullopt;
+
     SILBuilderWithScope builder(apply.getInstruction(), builderCtx);
     auto loc = apply.getLoc();
     auto *asi =

--- a/test/Interpreter/existential_specializer_moveonly.swift
+++ b/test/Interpreter/existential_specializer_moveonly.swift
@@ -10,7 +10,6 @@
 // RUN: %target-run %t/main_ounchecked | %FileCheck %s
 
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Regression test: ExistentialSpecializer clones a function that consumes
 // an existential parameter into a version taking the concrete type

--- a/test/Interpreter/existential_specializer_moveonly.swift
+++ b/test/Interpreter/existential_specializer_moveonly.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -Onone -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift %s -O -o %t/main_opt
+// RUN: %target-codesign %t/main_opt
+// RUN: %target-run %t/main_opt | %FileCheck %s
+// RUN: %target-build-swift %s -Ounchecked -o %t/main_ounchecked
+// RUN: %target-codesign %t/main_ounchecked
+// RUN: %target-run %t/main_ounchecked | %FileCheck %s
+
+// REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+// Regression test: ExistentialSpecializer clones a function that consumes
+// an existential parameter into a version taking the concrete type
+// directly, and rewrites the call site by opening the existential and
+// copying its payload into a fresh temporary for the specialized callee,
+// while separately destroying the original existential container. That's
+// fine for a copyable payload (two independent owned copies, each
+// destroyed once), but was illegal for a move-only payload: it required
+// making a copy of a value that can't be copied, and even if it could,
+// the container's separate destroy would double-destroy the payload. Under
+// -O this used to either crash the compiler outright or, with the
+// unconditional copy patched around, silently double-destroy the payload.
+
+protocol P: ~Copyable {}
+
+final class Canary {
+  static var deinitCount = 0
+  deinit { Canary.deinitCount += 1 }
+}
+
+// Carries a class reference so we can verify the payload is destroyed
+// exactly once. Also large enough that the opened-value temporary isn't
+// trivially folded away by an earlier pass.
+struct Payload: ~Copyable, P {
+  let canary: Canary
+  var pad0, pad1, pad2, pad3, pad4, pad5: Int
+}
+
+@inline(never)
+func consumeIt(_ box: consuming any P & ~Copyable) {
+}
+
+@inline(never)
+func makeAndConsume() {
+  consumeIt(Payload(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0,
+                    pad4: 0, pad5: 0))
+}
+
+makeAndConsume()
+// CHECK: deinit count: 1
+print("deinit count:", Canary.deinitCount)


### PR DESCRIPTION
In ExistentialSpecialization, use `load [take]` instead of `load [copy]` when the existential is non-copyable.

This was found while working on #91386 