### PR TITLE
[Distributed] Solve SIL validation issue on distributed var cross module

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -671,13 +671,12 @@ static FuncDecl *createSameSignatureDistributedThunkDecl(DeclContext *DC,
 
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
-  if (!isa<AccessorDecl>(thunk)) {
-    // TODO(distributed): It would be nicer to make distributed thunks nonisolated(nonsending) instead;
-    //                    this way we would not hop off the caller when calling system.remoteCall;
-    //                    it'd need new ABI and the remoteCall also to become nonisolated(nonsending)
-    thunk->addAttribute(NonisolatedAttr::createImplicit(C));
+
+  // TODO(distributed): It would be nicer to make distributed thunks nonisolated(nonsending) instead;
+  //                    this way we would not hop off the caller when calling system.remoteCall;
+  //                    it'd need new ABI and the remoteCall also to become nonisolated(nonsending)
+  if (DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::Concurrent, thunk))
     thunk->addAttribute(new (C) ConcurrentAttr(/*IsImplicit=*/true));
-  }
 
   return thunk;
 }

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -671,11 +671,13 @@ static FuncDecl *createSameSignatureDistributedThunkDecl(DeclContext *DC,
 
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
-  thunk->addAttribute(NonisolatedAttr::createImplicit(C));
-  // TODO(distributed): It would be nicer to make distributed thunks nonisolated(nonsending) instead;
-  //                    this way we would not hop off the caller when calling system.remoteCall;
-  //                    it'd need new ABI and the remoteCall also to become nonisolated(nonsending)
-  thunk->addAttribute(new (C) ConcurrentAttr(/*IsImplicit=*/true));
+  if (!isa<AccessorDecl>(thunk)) {
+    // TODO(distributed): It would be nicer to make distributed thunks nonisolated(nonsending) instead;
+    //                    this way we would not hop off the caller when calling system.remoteCall;
+    //                    it'd need new ABI and the remoteCall also to become nonisolated(nonsending)
+    thunk->addAttribute(NonisolatedAttr::createImplicit(C));
+    thunk->addAttribute(new (C) ConcurrentAttr(/*IsImplicit=*/true));
+  }
 
   return thunk;
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6696,6 +6696,14 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
   // declaration. All of the logic for FuncDecls below only applies to
   // non-accessor functions.
   if (auto accessor = dyn_cast<AccessorDecl>(value)) {
+    // A synthesized distributed thunk accessor is always 'nonisolated @concurrent'
+    // regardless of the storage's isolation. We can't put those attributes
+    // on the accessor itself, and there is no "thunk var" to attach them to,
+    // so we handle the semantics here instead.
+    if (accessor->isDistributedThunk()) {
+      return {ActorIsolation::forNonisolatedConcurrent(),
+              IsolationSource(/*source*/ nullptr, IsolationSource::Explicit)};
+    }
     return getInferredActorIsolation(accessor->getStorage());
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6696,9 +6696,9 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
   // declaration. All of the logic for FuncDecls below only applies to
   // non-accessor functions.
   if (auto accessor = dyn_cast<AccessorDecl>(value)) {
-    // A synthesized distributed thunk accessor is always 'nonisolated @concurrent'
-    // regardless of the storage's isolation. We can't put those attributes
-    // on the accessor itself, and there is no "thunk var" to attach them to,
+    // A synthesized distributed thunk accessor is always '@concurrent',
+    // regardless of the storage's isolation. We can't put that attribute
+    // on the accessor itself, and there is no "thunk var" to attach it to,
     // so we handle the semantics here instead.
     if (accessor->isDistributedThunk()) {
       return {ActorIsolation::forNonisolatedConcurrent(),

--- a/test/Distributed/Inputs/GreeterWithDistributedVar.swift
+++ b/test/Distributed/Inputs/GreeterWithDistributedVar.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Distributed
+
+// A 'distributed var' declared as a requirement on a DistributedActor-refining
+// protocol, satisfied by a concrete 'distributed actor' in the same module.
+// The point of housing this in a separate module is to exercise the
+// cross-module deserialization path for the synthesized getter thunk
+// ('...vgTE') from a client that imports this module.
+public protocol Greeter: DistributedActor
+  where ActorSystem == LocalTestingDistributedActorSystem {
+  distributed var greeting: String { get }
+}
+
+public distributed actor GreeterWithDistributedVar: Greeter {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  public init(actorSystem: ActorSystem) {
+    self.actorSystem = actorSystem
+  }
+
+  public distributed var greeting: String { "hello" }
+}

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -1,10 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -module-name main -j2 -parse-as-library -I %t %s -plugin-path %swift-plugin-dir -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/GreeterWithDistributedVar.swiftmodule -module-name GreeterWithDistributedVar %S/../Inputs/GreeterWithDistributedVar.swift
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -I %t %s %S/../Inputs/GreeterWithDistributedVar.swift -plugin-path %swift-plugin-dir -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // Run again with library evolution:
-// RUN: %target-build-swift -module-name main -j2 -parse-as-library -enable-library-evolution -I %t %s -plugin-path %swift-plugin-dir -o %t/evo.out
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -enable-library-evolution -I %t %s %S/../Inputs/GreeterWithDistributedVar.swift -plugin-path %swift-plugin-dir -o %t/evo.out
 // RUN: %target-codesign %t/evo.out
 // RUN: %target-run %t/evo.out | %FileCheck %s --color
 
@@ -20,6 +21,7 @@
 // UNSUPPORTED: OS=watchos
 
 import Distributed
+import GreeterWithDistributedVar
 
 @Resolvable
 @available(SwiftStdlib 6.0, *)
@@ -53,6 +55,11 @@ func test_distributedVariable<DA: WorkerProtocol>(actor: DA) async throws -> Str
 }
 
 @available(SwiftStdlib 6.0, *)
+func test_crossModuleDistributedVariable<G: Greeter>(_ actor: G) async throws -> String {
+  try await actor.greeting
+}
+
+@available(SwiftStdlib 6.0, *)
 @main struct Main {
   static func main() async throws {
     let system = LocalTestingDistributedActorSystem()
@@ -68,5 +75,13 @@ func test_distributedVariable<DA: WorkerProtocol>(actor: DA) async throws -> Str
 
     let v2 = try await actor.distributedVariable
     print("v2 = \(v2)") // CHECK: v2 = implemented variable
+
+    let host = GreeterWithDistributedVar(actorSystem: system)
+
+    let v3 = try await host.greeting
+    print("v3 = \(v3)") // CHECK: v3 = hello
+
+    let v4 = try await test_crossModuleDistributedVariable(host)
+    print("v4 = \(v4)") // CHECK: v4 = hello
   }
 }

--- a/test/Distributed/distributed_thunk_cross_module.swift
+++ b/test/Distributed/distributed_thunk_cross_module.swift
@@ -7,9 +7,6 @@
 // REQUIRES: distributed
 // UNSUPPORTED: back_deploy_concurrency
 
-// Reproduces a SILFunction type mismatch uncovered by DistributedCluster.
-// This happens only for a synchronous distributed var decl, across modules.
-
 import Distributed
 import FakeDistributedActorSystems
 
@@ -31,6 +28,15 @@ public distributed actor WorkerPool<W: DistWorker>: DistributedActor {
   public distributed func count() async throws -> Int {
     self.workers.count
   }
+}
+
+public protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
+  distributed var greeting: String { get }
+}
+
+public distributed actor Host: Greeter {
+  public typealias ActorSystem = FakeActorSystem
+  public distributed var greeting: String { "hello" }
 }
 
 #endif
@@ -58,5 +64,12 @@ public func use(_ system: FakeActorSystem) async throws {
   // distributed thunk to be deserialized.
   _ = try await pool.size
   _ = try await pool.count()
+}
+
+public func useGreeter(_ system: FakeActorSystem) async throws {
+  let host = Host(actorSystem: system)
+  // Reading a distributed var declared as a protocol requirement across
+  // modules forces the getter thunk (mangled ...vgTE) to be deserialized.
+  _ = try await host.greeting
 }
 #endif


### PR DESCRIPTION
Cross module distributed variables ended up failing SIL validation because the accessor would get the nonisolated concurrent attrs, but this is actually illegal.

Instead, dont add the attrs, but handle the isolation correctly when we get isolation for a thunk.

resolves rdar://159628968
resovles rdar://184708838

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
