### PR TITLE
[SILGen] Support for address-only consumed captures in `@called(once)` closures

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2615,9 +2615,14 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       break;
     }
     case CaptureKind::Consuming: {
-      assert(!loweredTL.isAddressOnly());
-      auto param = SILParameterInfo(loweredTy.getASTType(),
-                                    ParameterConvention::Direct_Owned, options);
+      // Address-only consumed captures (e.g. a non-Copyable generic parameter)
+      // are passed indirectly, like any other owned address-only value.
+      auto convention = loweredTL.isAddressOnly()
+                            ? ParameterConvention::Indirect_In
+                            : ParameterConvention::Direct_Owned;
+      SILType ty =
+          loweredTL.isAddressOnly() ? loweredTy.getAddressType() : loweredTy;
+      auto param = SILParameterInfo(ty.getASTType(), convention, options);
       inputs.push_back(param);
       break;
     }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1374,23 +1374,40 @@ static void emitCaptureArguments(SILGenFunction &SGF,
   case CaptureKind::Consuming: {
     assert(!isPack);
 
+    auto argIndex = SGF.F.begin()->getNumArguments();
+    auto fnConv = SGF.F.getConventions();
+    bool isIndirect =
+        fnConv.isSILIndirect(fnConv.getParamInfoForSILArg(argIndex));
+    if (isIndirect)
+      ty = ty.getAddressType();
+
     auto *fArg = SGF.F.begin()->createFunctionArgument(ty, VD);
     fArg->setClosureCapture(true);
     ManagedValue val = SGF.emitManagedRValueWithCleanup(fArg);
 
-    // Sema treats the captured decl as an lvalue since it's `Var`-introduced;
-    // materialize an address for it, moving (not copying) the incoming
-    // owned value in, since it can't be copied.
-    auto addr = SGF.emitTemporary(Loc, lowering);
-    SGF.B.emitStoreValueOperation(Loc, val.forward(SGF), addr->getAddress(),
-                                  StoreOwnershipQualifier::Init);
-    addr->finishInitialization(SGF);
-    val = addr->getManagedAddress();
+    if (isIndirect) {
+      // The incoming address is already an owned, use it directly instead of
+      // materializing and storing into a separate temporary.
+      val = SGF.B.createMarkUnresolvedNonCopyableValueInst(
+          Loc, val,
+          MarkUnresolvedNonCopyableValueInst::CheckKind::
+              ConsumableAndAssignable);
+    } else {
+      // Sema treats the captured decl as an lvalue since it's `Var`-introduced;
+      // materialize an address for it, moving (not copying) the incoming
+      // owned value in, since it can't be copied.
+      auto addr = SGF.emitTemporary(Loc, lowering);
+      SGF.B.emitStoreValueOperation(Loc, val.forward(SGF), addr->getAddress(),
+                                    StoreOwnershipQualifier::Init);
+      addr->finishInitialization(SGF);
+      val = addr->getManagedAddress();
 
-    val = val.ensurePlusOne(SGF, Loc);
-    val = SGF.B.createMarkUnresolvedNonCopyableValueInst(
-        Loc, val,
-        MarkUnresolvedNonCopyableValueInst::CheckKind::ConsumableAndAssignable);
+      val = val.ensurePlusOne(SGF, Loc);
+      val = SGF.B.createMarkUnresolvedNonCopyableValueInst(
+          Loc, val,
+          MarkUnresolvedNonCopyableValueInst::CheckKind::
+              ConsumableAndAssignable);
+    }
 
     arg = val.getValue();
     enforcement = SILAccessEnforcement::Unknown;

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2278,16 +2278,24 @@ Type swift::adjustInferredAssociatedType(TypeAdjustment adjustment, Type type,
   }
 
   auto needsAdjustment = [=](FunctionType *funcType) -> bool {
-    if (adjustment == TypeAdjustment::NoescapeToEscaping)
+    switch (adjustment) {
+    case TypeAdjustment::NoescapeToEscaping:
       return funcType->isNoEscape();
-    else
+    case TypeAdjustment::NonsendableToSendable:
       return !funcType->isSendable();
+    case TypeAdjustment::CalledOnceToPlain:
+      return funcType->isCalledOnce();
+    }
   };
   auto adjust = [=](const ASTExtInfo &info) -> ASTExtInfo {
-    if (adjustment == TypeAdjustment::NoescapeToEscaping)
+    switch (adjustment) {
+    case TypeAdjustment::NoescapeToEscaping:
       return info.withNoEscape(false);
-    else
+    case TypeAdjustment::NonsendableToSendable:
       return info.withSendable(true);
+    case TypeAdjustment::CalledOnceToPlain:
+      return info.withCalledOnce(false);
+    }
   };
 
   // If we have a noescape function type, make it escaping.
@@ -2450,6 +2458,10 @@ AssociatedTypeInference::getPotentialTypeWitnessesByMatchingTypes(ValueDecl *req
       Type inferredType =
         adjustInferredAssociatedType(TypeAdjustment::NoescapeToEscaping,
                                      secondType, noescapeToEscaping);
+      bool calledOnceToPlain = false;
+      inferredType =
+        adjustInferredAssociatedType(TypeAdjustment::CalledOnceToPlain,
+                                     inferredType, calledOnceToPlain);
       if (!inferredType->isMaterializable())
         return false;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3262,8 +3262,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   }
 
   if (func1->isCalledOnce() != func2->isCalledOnce()) {
-    if (func1->isCalledOnce() ||
-        (kind < ConstraintKind::Subtype && !isWitnessMatching(locator))) {
+    if (func1->isCalledOnce() || kind < ConstraintKind::Subtype) {
       if (!shouldAttemptFixes())
         return SolutionKind::Error;
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -701,10 +701,7 @@ public:
     if (!ref)
       return nullptr;
 
-    auto type = ref.getDecl()->getInterfaceType();
-    if (ref.isSpecialized())
-      type = type.subst(ref.getSubstitutions());
-
+    auto type = DRE->getType()->getWithoutSpecifierType();
     return type->isNoncopyable() ? ref.getDecl() : nullptr;
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -119,8 +119,16 @@ getTypesToCompare(ValueDecl *reqt, Type reqtType, bool reqtTypeIsIUO,
     // function type not in a parameter is, more or less, implicitly @escaping.
     // For Sendable, we want to behave as though it was not necessary because
     // function types that aren't in a parameter can be Sendable or not.
+    // For `@called(once)`, we want to behave as though it was not necessary
+    // because function types that aren't in a parameter can be called once
+    // or not.
+    // For `@called(once)`, we want to behave as though it was necessary, just
+    // like noescape, because a plain function type can always satisfy a
+    // `@called(once)` requirement but a `@called(once)` function type cannot
+    // satisfy a plain one.
     // FIXME: Should we check for a Sendable bound on the requirement type?
-    bool inRequirement = (adjustment != TypeAdjustment::NoescapeToEscaping);
+    bool inRequirement = (adjustment != TypeAdjustment::NoescapeToEscaping &&
+                          adjustment != TypeAdjustment::CalledOnceToPlain);
     Type adjustedReqtType =
       adjustInferredAssociatedType(adjustment, reqtType, inRequirement);
 
@@ -144,6 +152,7 @@ getTypesToCompare(ValueDecl *reqt, Type reqtType, bool reqtTypeIsIUO,
 
   applyAdjustment(TypeAdjustment::NoescapeToEscaping);
   applyAdjustment(TypeAdjustment::NonsendableToSendable);
+  applyAdjustment(TypeAdjustment::CalledOnceToPlain);
 
   // For @objc protocols, deal with differences in the optionality.
   // FIXME: It probably makes sense to extend this to non-@objc

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -201,7 +201,7 @@ matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
              DeclContext *dc, ValueDecl *req, ValueDecl *witness);
 
 enum class TypeAdjustment : uint8_t {
-  NoescapeToEscaping, NonsendableToSendable
+  NoescapeToEscaping, NonsendableToSendable, CalledOnceToPlain
 };
 
 /// Perform any necessary adjustments to the inferred associated type to

--- a/test/SIL/called_once_consuming_captures.swift
+++ b/test/SIL/called_once_consuming_captures.swift
@@ -212,3 +212,23 @@ func testConsumingSetterConsumesCapture(_ slot: consuming Slot, _ r: consuming R
   }
   g()
 }
+
+protocol Usable: ~Copyable {
+  consuming func use()
+  func test()
+}
+
+func testGenericConsumingCaptureIsAddressOnly<T: Usable & ~Copyable>(_ t: consuming T) {
+  let g = { @called(once) in
+    t.use()
+  }
+  g()
+}
+
+func testGenericConsumingCaptureIsAddressOnlyMultiUse<T: Usable & ~Copyable>(_ t: consuming T) { // expected-error {{'t' used after consume}}
+  let g = { @called(once) in // expected-note {{consumed here}}
+    t.use()
+  }
+  _ = g
+  t.test() // expected-note {{used here}}
+}

--- a/test/SILGen/called_once_consuming_captures.swift
+++ b/test/SILGen/called_once_consuming_captures.swift
@@ -308,3 +308,30 @@ func testConsumingSetterConsumesCapture(_ slot: consuming Slot, _ r: consuming R
   }
   g()
 }
+
+protocol Usable: ~Copyable {
+  consuming func use()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures40testGenericConsumingCaptureIsAddressOnlyyyxnAA6UsableRzRi_zlF : $@convention(thin) <T where T : Usable, T : ~Copyable> (@in T) -> () {
+// CHECK: bb0(%0 : $*T):
+// CHECK:  [[T_PROJ:%.*]] = project_box {{.*}} : $<{{.*}}> { var {{.*}} } <T>, 0
+// CHECK:  [[T_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[T_PROJ]] : $*T
+// CHECK:  [[T_STACK:%.*]] = alloc_stack $T
+// CHECK:  copy_addr [take] [[T_TAKE_ADDR]] to [init] [[T_STACK]] : $*T
+// CHECK:  partial_apply [called_once] {{.*}}<T>([[T_STACK]]) : $@convention(thin) <{{.*}}> (@in {{.*}}) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures40testGenericConsumingCaptureIsAddressOnlyyyxnAA6UsableRzRi_zlF'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures40testGenericConsumingCaptureIsAddressOnlyyyxnAA6UsableRzRi_zlFyyXOfU_ : $@convention(thin) <T where T : Usable, T : ~Copyable> (@in T) -> () {
+// CHECK: bb0([[T_CAPTURE:%.*]] : @closureCapture $*T):
+// CHECK:  [[T_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[T_CAPTURE]] : $*T
+// CHECK:  [[T_DEINIT_ACCESS:%.*]] = begin_access [deinit] [unknown] [[T_ADDR]] : $*T
+// CHECK:  witness_method $T, #Usable.use
+// CHECK:  end_access [[T_DEINIT_ACCESS]] : $*T
+// CHECK: } // end sil function '$s30called_once_consuming_captures40testGenericConsumingCaptureIsAddressOnlyyyxnAA6UsableRzRi_zlFyyXOfU_'
+func testGenericConsumingCaptureIsAddressOnly<T: Usable & ~Copyable>(_ t: consuming T) {
+  let g = { @called(once) in
+    t.use()
+  }
+  g()
+}

--- a/test/Sema/called_once.swift
+++ b/test/Sema/called_once.swift
@@ -109,3 +109,72 @@ func testClosures() {
   genericNC(fn) // Ok
   genericNC { @called(once) in } // Ok
 }
+
+protocol PA {
+  associatedtype A // expected-note {{protocol requires nested type 'A'}}
+  func f(_: A)
+}
+
+struct TestAssociatedTypeInference : PA {
+  func f(_: @called(once) (Int) -> Int) { } // Ok
+}
+
+struct TestExplicitAssociatedType : PA {
+  typealias A = (Int) -> Int
+  func f(_: @called(once) (Int) -> Int) { } // Ok
+}
+
+struct TestWitnessAndAssociatedTypeMismatch : PA { // expected-error {{type 'TestWitnessAndAssociatedTypeMismatch' does not conform to protocol 'PA'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  typealias A = @called(once) (Int) -> Int
+  // expected-note@-1 {{possibly intended match 'TestWitnessAndAssociatedTypeMismatch.A' (aka '@called(once) (Int) -> Int') does not conform to 'Copyable'}}
+  func f(_: (Int) -> Int) { }
+}
+
+protocol PR {
+  func f(_: (Int) -> Int)
+  func g(_: @called(once) (Int) -> Int)
+  // expected-note@-1 {{protocol requires function 'g' with type '(consuming @called(once) (Int) -> Int) -> ()'}}
+}
+
+struct TestDifferentWitnesses : PR { // expected-error {{type 'TestDifferentWitnesses' does not conform to protocol 'PR'}}
+// expected-note@-1 {{add stubs for conformance}}
+  func f(_: (Int) -> Int) { }
+  func g(_: (Int) -> Int) { }
+  // expected-note@-1 {{candidate has non-matching type '((Int) -> Int) -> ()'}}
+}
+
+struct TestSameWitnesses : PR {
+  func f(_: @called(once) (Int) -> Int) { } // Ok
+  func g(_: @called(once) (Int) -> Int) { } // Ok
+}
+
+protocol PA_Contravariant {
+  associatedtype A
+  func f(_: (A) -> Void)
+  // expected-note@-1 {{protocol requires function 'f' with type '((@escaping (Int) -> Int) -> Void) -> ()'}}
+}
+
+struct TestContravariantAssociatedTypeInference : PA_Contravariant { // expected-error {{type 'TestContravariantAssociatedTypeInference' does not conform to protocol 'PA_Contravariant'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  func f(_: (@called(once) (Int) -> Int) -> Void) { }
+  // expected-note@-1 {{candidate has non-matching type '((consuming @called(once) (Int) -> Int) -> Void) -> ()' [with A = (Int) -> Int]}}
+}
+
+protocol P_PlainResult {
+  func f() -> () -> Void // expected-note {{protocol requires function 'f()' with type '() -> () -> Void'}}
+}
+
+protocol P_CalledOnceResult {
+  func f() -> @called(once) () -> Void
+}
+
+struct TestCalledOnceResultWitness : P_PlainResult { // expected-error {{type 'TestCalledOnceResultWitness' does not conform to protocol 'P_PlainResult'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  func f() -> @called(once) () -> Void { { } }
+  // expected-note@-1 {{candidate has non-matching type '() -> @called(once) () -> Void'}}
+}
+
+struct TestPlainResultWitness : P_CalledOnceResult {
+  func f() -> () -> Void { { } } // Ok
+}


### PR DESCRIPTION
The initial implementation supported only loadable non-Copyable values,
let's expand that to address-only values like non-Copyable generic parameters
as well.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
