### PR TITLE
[6.3] Build the static Windows runtime against static dispatch

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2923,6 +2923,10 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
 
         dispatch_DIR = (Get-ProjectCMakeModules $Platform CDispatch);
 
+        # FIXME(hjyamauchi) Should dynamic to libdispatch https://github.com/swiftlang/swift/issues/87548
+        CMAKE_CXX_FLAGS = $(if ($Static) { @("-Ddispatch_STATIC") } else { @() });
+        CMAKE_Swift_FLAGS = $(if ($Static) { @("-Xcc", "-static-libclosure") } else { @() });
+
         # FIXME(compnerd) remove this once the default option is flipped to `ON`.
         SwiftCore_ENABLE_CONCURRENCY = "YES";
         # FIXME(compnerd) remove this once the default option is flipped to `ON`.


### PR DESCRIPTION
## Explanation

  The static Windows runtime build compiles the concurrency runtime without the static-dispatch configuration, so its dispatch references such as `dispatch_after_f` carry `dllimport` storage (`__imp_dispatch_*`). Linked against the SDK's own static dispatch archive, at least one such slot resolves to RVA 0, and the first delayed task calls the PE image base with `0xC0000005`. This cherry-picks main's fix by passing `-Ddispatch_STATIC` for C++ and `-Xcc -static-libclosure` for Swift when building the static runtime variant.

## Scope

  `utils/build.ps1` only. This affects only the experimental static Windows runtime build. The dynamic path is untouched.

## Issues

  swiftlang/swift#91442. Related tracking is swiftlang/swift#87548.

## Original PRs

  https://github.com/swiftlang/swift/pull/87547

## Risk

  Low. The flags are gated on the static variant and are identical to what main already ships.

## Testing

  A/B on a real workload. The Swift 6.3.3 static build crashes with `0xC0000005` at the first `Task.sleep`. The August 1, 2026 snapshot containing this change passes a delayed-task probe covering `Task.sleep(for:)`, `Task.sleep(nanoseconds:)`, and `ContinuousClock.sleep`, plus a packaged reconnect test. Details are in #91442.

## Reviewers

  @hjyamauchi @compnerd

Happy to close this if no further 6.3.x toolchain/SDK builds are planned — we're unblocked on the snapshot either way; this is offered as the road back to a release pin.