### PR TITLE
AST: Prefer non-spi contexts when resolving competing conformances

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -717,11 +717,23 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
   if (lhsHasReqs != rhsHasReqs)
     return lhsHasReqs ? Ordering::After : Ordering::Before;
 
-  // If the two conformances come from the same file, pick the first context
-  // in the file.
+  auto isSPIImplier = [](ConformanceEntry *entry) {
+    if (auto *D = entry->getDeclContext()->getAsDecl())
+      return D->isSPI();
+
+    return false;
+  };
+
+  // Handle conformances that come from the same file.
   auto lhsSF = lhs->getDeclContext()->getParentSourceFile();
   auto rhsSF = rhs->getDeclContext()->getParentSourceFile();
   if (lhsSF && lhsSF == rhsSF) {
+    // Prefer the context that isn't SPI.
+    bool lhsIsSPI = isSPIImplier(lhs);
+    if (lhsIsSPI != isSPIImplier(rhs))
+      return lhsIsSPI ? Ordering::After : Ordering::Before;
+
+    // Otherwise, pick the context that was written first in the file.
     ASTContext &ctx = lhsSF->getASTContext();
     return ctx.SourceMgr.isBeforeInBuffer(lhs->getDeclaredLoc(),
                                           rhs->getDeclaredLoc())
@@ -740,6 +752,11 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
     if (typeSF == rhsSF)
       return Ordering::After;
   }
+
+  // Prefer the context that isn't SPI.
+  bool lhsIsSPI = isSPIImplier(lhs);
+  if (lhsIsSPI != isSPIImplier(rhs))
+    return lhsIsSPI ? Ordering::After : Ordering::Before;
 
   // Otherwise, pick the earlier file unit.
   auto lhsFileUnit

--- a/test/SPI/spi_conformances_multifile.swift
+++ b/test/SPI/spi_conformances_multifile.swift
@@ -1,0 +1,81 @@
+/// Checks for conformances that are implied by a conformance declared in an
+/// SPI extension.
+///
+/// When two conformances imply a conformance to the same base protocol, the one
+/// that supersedes the other determines the declaration context that the implied
+/// conformance is recorded in, and therefore whether uses of it are restricted
+/// to SPI clients. A non-SPI implier has to win whenever the choice would
+/// otherwise be arbitrary (rdar://184557488).
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Diagnostics must not depend on the order of the files.
+// RUN: %target-swift-frontend -typecheck -verify -module-name Lib %t/a.swift %t/b.swift %t/c.swift
+// RUN: %target-swift-frontend -typecheck -verify -module-name Lib %t/a.swift %t/c.swift %t/b.swift
+
+//--- a.swift
+
+public protocol BaseProto {}
+public struct Holder<T: BaseProto> {}
+
+public protocol PublicRefines: BaseProto {}
+@_spi(S) public protocol SPIRefines: BaseProto {}
+
+/// A conformance that is only reachable through an SPI extension is SPI.
+public struct SPIOnly {}
+@_spi(S) extension SPIOnly: BaseProto {}
+
+public func publicUseOfSPIOnly(_: Holder<SPIOnly>) {} // expected-error {{cannot use conformance of 'SPIOnly' to 'BaseProto' here; the conformance is declared as SPI}}
+@_spi(S) public func spiUseOfSPIOnly(_: Holder<SPIOnly>) {} // OK
+
+/// An explicit SPI conformance supersedes one implied by a public conformance,
+/// so the conformance to the base protocol really is SPI.
+public struct ExplicitSPI {}
+@_spi(S) extension ExplicitSPI: BaseProto {}
+extension ExplicitSPI: PublicRefines {} // expected-error {{cannot use conformance of 'ExplicitSPI' to 'BaseProto' here; the conformance is declared as SPI}}
+
+/// Two conformances in this file imply 'BaseProto', one of them from an SPI
+/// context. The non-SPI implier wins in either source order.
+@_spi(S) extension SPIImpliedFirst: SPIRefines {}
+public struct SPIImpliedFirst: PublicRefines {} // OK
+
+public struct SPIImpliedSecond: PublicRefines {}
+@_spi(S) extension SPIImpliedSecond: SPIRefines {} // OK
+
+public func publicUseOfImplied(_: Holder<SPIImpliedFirst>, _: Holder<SPIImpliedSecond>) {} // OK
+
+/// Neither implier of 'Conformer: BaseProto' is in this file, so the choice
+/// between them would otherwise fall back to the order of the files.
+public struct Conformer {}
+
+public func publicUseOfConformer(_: Holder<Conformer>) {} // OK
+
+//--- b.swift
+
+@_spi(S) extension Conformer: SPIRefines {}
+
+/// The only implier of 'SynthesizedConformer: Equatable' in the file that
+/// declares the type is this SPI one, so it wins over the non-SPI implier in
+/// c.swift; otherwise '==' could not be synthesized here.
+public struct SynthesizedConformer {
+  public var value: Int
+}
+
+@_spi(S) extension SynthesizedConformer: Hashable {}
+
+//--- c.swift
+
+extension Conformer: PublicRefines {}
+
+internal protocol InternalRefinesEquatable: Equatable {}
+
+extension SynthesizedConformer: InternalRefinesEquatable {} // OK
+
+/// FIXME: 'SynthesizedConformer: Equatable' is recorded in the SPI extension in
+/// b.swift, since that is the file that declares the type, so a public
+/// conformance that implies it is still diagnosed here. Preferring the non-SPI
+/// implier instead would break synthesis in b.swift.
+public protocol PublicRefinesEquatable: Equatable {}
+
+extension SynthesizedConformer: PublicRefinesEquatable {} // expected-error {{cannot use conformance of 'SynthesizedConformer' to 'Equatable' here; the conformance is declared as SPI}}


### PR DESCRIPTION
Otherwise, changing the source (or file) order of two conformances that imply other conformances can be breaking when one of the implied conformances is `@_spi`.

Resolves rdar://184557488.
