### PR TITLE
[Backtracer][DWARF] Fix SLEB128 sign extension code.

### DIFF
--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -346,7 +346,7 @@ extension ImageSource {
     }
 
     if shift < 64 && sign != 0 {
-      value |= -(1 << shift)
+      value |= Int64(-1) << shift
     }
 
     return (addr, value)

--- a/test/Backtracing/DwarfReaderSLEB128Overflow.swift
+++ b/test/Backtracing/DwarfReaderSLEB128Overflow.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %yaml2obj %S/Inputs/DwarfSLEB128Overflow.yaml -o %t/sleb128.o
+// RUN: %target-build-swift %s -parse-as-library -g -o %t/DwarfReaderSLEB128Overflow
+// RUN: %target-run %t/DwarfReaderSLEB128Overflow %t/sleb128.o | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: backtracing
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// Regression test for fetchSLEB128 (Dwarf.swift): decoding a 9-byte SLEB128
+// value whose final continuation byte leaves the running shift at exactly
+// 63 with the sign bit set used to trap while sign-extending, because
+// `-(1 << 63)` overflows Int64. Inputs/DwarfSLEB128Overflow.yaml encodes
+// DW_AT_const_value using exactly that byte pattern.
+
+@_spi(DwarfTest) import Runtime
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(SwiftWASILibc)
+import SwiftWASILibc
+#elseif canImport(ucrt)
+import ucrt
+#elseif canImport(SwiftGlibc)
+import SwiftGlibc
+#endif
+
+@main
+struct DwarfReaderSLEB128Overflow {
+  static func main() {
+    if CommandLine.argc != 2 {
+      print("usage: DwarfReaderSLEB128Overflow <path-to-binary>")
+      return
+    }
+
+    // CHECK: is a 64-bit ELF image
+    // CHECK: Units:
+
+    if !testDwarfReaderFor(path: CommandLine.arguments[1]) {
+      exit(1)
+    }
+  }
+}

--- a/test/Backtracing/Inputs/DwarfSLEB128Overflow.yaml
+++ b/test/Backtracing/Inputs/DwarfSLEB128Overflow.yaml
@@ -1,0 +1,34 @@
+## A hand-crafted ELF object with a single DW_TAG_compile_unit DIE holding
+## one DW_AT_const_value attribute encoded as DW_FORM_sdata (SLEB128).
+##
+## The value 0xC000000000000000 (as a 64-bit two's complement quantity)
+## requires exactly 9 SLEB128 bytes, and its final continuation byte leaves
+## the decoder's running bit-shift at 63 with the sign bit set. That is the
+## regression scenario for fetchSLEB128's sign-extension step: computing
+## `-(1 << 63)` traps (Int64.min has no positive counterpart), whereas
+## `Int64(-1) << 63` produces the identical bit pattern without overflowing.
+##
+## SLEB128 bytes: 80 80 80 80 80 80 80 80 40 (verified with llvm-dwarfdump).
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+DWARF:
+  debug_abbrev:
+    - Table:
+        - Code:     0x01
+          Tag:      DW_TAG_compile_unit
+          Children: DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_const_value
+              Form:      DW_FORM_sdata
+  debug_info:
+    - Version: 4
+      AddrSize: 8
+      Entries:
+        - AbbrCode: 0x01
+          Values:
+            - Value: 0xC000000000000000 # DW_AT_const_value (SLEB128 needs 9 bytes)


### PR DESCRIPTION
If we read a full 9 bytes of data, the sign extension code causes a numerical trap because it's trying to negate `Int64.min`.

Fix the sign extension code to shift `Int64(-1)` instead of shifting `1` and trying to negate afterwards.

rdar://184806813

assisted-by: claude
