### PR TITLE
[AST] Don't strip `override` from `@objc @implementation` functions.

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1098,8 +1098,15 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (auto *BD = VD->getOverriddenDecl()) {
         // If the overridden decl won't be printed, printing override will fail
-        // the build of the interface file.
-        if (!Options.shouldPrint(BD))
+        // the build of the interface file. The exception is a member of an
+        // `@objc @implementation` extension: it's deliberately omitted from
+        // the interface because it's already visible through the imported
+        // Objective-C header, so the override is still resolvable there.
+        auto *overriddenExt = dyn_cast<ExtensionDecl>(BD->getDeclContext());
+        bool overriddenIsObjCImpl =
+            overriddenExt && overriddenExt->isObjCImplementation() &&
+            BD->isObjC();
+        if (!overriddenIsObjCImpl && !Options.shouldPrint(BD))
           return false;
         if (!BD->hasClangNode() &&
             !BD->getFormalAccessScope(VD->getDeclContext(),

--- a/test/ModuleInterface/Inputs/objc_implementation/objc_implementation.h
+++ b/test/ModuleInterface/Inputs/objc_implementation/objc_implementation.h
@@ -1,6 +1,12 @@
 #import <Foundation/Foundation.h>
 
-@interface ImplClass: NSObject
+@interface ImplBaseClass: NSObject
+
+- (void)baseMethod:(int)param;
+
+@end
+
+@interface ImplClass: ImplBaseClass
 
 - (nonnull instancetype)init;
 

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -59,6 +59,9 @@ import Foundation
   // CHECK-NOT: func mainMethod
   @objc public func mainMethod(_: Int32) { print(implProperty) }
 
+  // CHECK-NOT: func baseMethod
+  @objc public override func baseMethod(_: Int32) { print("override") }
+
   // CHECK-NOT: deinit
 }
 // CHECK: }
@@ -101,6 +104,13 @@ open class SwiftSubclass: ImplClass {
   // CHECK-DAG: @objc override dynamic open func mainMethod
   override open func mainMethod(_: Int32) {
     print("subclass mainMethod")
+  }
+
+  // rdar://184617707 - `override` must still be printed when the immediate
+  // overridden decl is itself an override implemented via `@_objcImplementation`.
+  // CHECK-DAG: @objc override dynamic open func baseMethod
+  override open func baseMethod(_: Int32) {
+    print("subclass baseMethod")
   }
 
   // CHECK-DAG: @objc override dynamic public init()


### PR DESCRIPTION
Ordinarily we omit `override` for situations where the overridden decl isn't going to be printed.  However, for `@objc @implementation` function decls, we still need to include it.

rdar://184617707

assisted-by: claude
