### PR TITLE
[swift-inspect] Stop leaking RemoteProcess in some cases.

### DIFF
--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -80,9 +80,11 @@ add_executable(swift-inspect
   Sources/swift-inspect/Operations/DumpRawMetadata.swift
   Sources/swift-inspect/AndroidRemoteProcess.swift
   Sources/swift-inspect/Backtrace.swift
+  Sources/swift-inspect/Cleanup.swift
   Sources/swift-inspect/DarwinRemoteProcess.swift
   Sources/swift-inspect/LinuxRemoteProcess.swift
   Sources/swift-inspect/main.swift
+  Sources/swift-inspect/OpaqueRef.swift
   Sources/swift-inspect/Process.swift
   Sources/swift-inspect/RemoteMirror+Extensions.swift
   Sources/swift-inspect/RemoteProcess.swift

--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -42,6 +42,14 @@ internal final class DarwinRemoteProcess: RemoteProcess {
   private var swiftCore: CSTypeRef
   private let swiftConcurrency: CSTypeRef
 
+  /// The reference passed to the reflection context, which the context holds
+  /// until `releaseContextRef()` clears it.
+  private var contextRef: OpaqueRef?
+
+  func releaseContextRef() {
+    contextRef = nil
+  }
+
   private lazy var threadInfos = getThreadInfos()
 
   static var QueryDataLayout: QueryDataLayoutFunction {
@@ -166,7 +174,7 @@ internal final class DarwinRemoteProcess: RemoteProcess {
     if forkCorpse || forceForkCorpse {
       var corpse = task_t()
       let maxRetry = 6
-      for retry in 0..<maxRetry {
+      for retry in 1...maxRetry {
         let corpseResult = task_generate_corpse(task.value, &corpse)
         if corpseResult == KERN_SUCCESS {
           task.value = corpse
@@ -177,7 +185,7 @@ internal final class DarwinRemoteProcess: RemoteProcess {
             to: &Std.err)
           return nil
         }
-        sleep(UInt32(1 << retry))
+        sleep(UInt32(1 << (retry - 1)))
       }
     }
 
@@ -195,8 +203,9 @@ internal final class DarwinRemoteProcess: RemoteProcess {
 
     _ = task_start_peeking(self.task.value)
 
+    self.contextRef = OpaqueRef(self)
     guard let context =
-        swift_reflection_createReflectionContextWithDataLayout(self.toOpaqueRef(),
+        swift_reflection_createReflectionContextWithDataLayout(self.contextRef?.pointer,
                                                                Self.QueryDataLayout,
                                                                Self.Free,
                                                                Self.ReadBytes,

--- a/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
@@ -31,6 +31,14 @@
     let memoryMap: SwiftInspectLinux.MemoryMap
     let symbolCache: SwiftInspectLinux.SymbolCache
 
+    /// The reference passed to the reflection context, which the context holds
+    /// until `releaseContextRef()` clears it.
+    private var contextRef: OpaqueRef?
+
+    func releaseContextRef() {
+      contextRef = nil
+    }
+
     /// A symbol resolved (lazily) against the target process's symbol cache.
     /// `addr` is `nil` when the symbol isn't found.
     struct RemoteSymbol {
@@ -141,10 +149,11 @@
         return nil
       }
 
+      self.contextRef = OpaqueRef(self)
       guard
         let context = swift_reflection_createReflectionContextWithDataLayout(
-          self.toOpaqueRef(), Self.QueryDataLayout, Self.Free, Self.ReadBytes, Self.GetStringLength,
-          Self.GetSymbolAddress)
+          self.contextRef?.pointer, Self.QueryDataLayout, Self.Free, Self.ReadBytes,
+          Self.GetStringLength, Self.GetSymbolAddress)
       else { return nil }
       self.context = context
     }

--- a/tools/swift-inspect/Sources/swift-inspect/OpaqueRef.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/OpaqueRef.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A strong reference to an object, presented as an opaque pointer for passing
+/// through a C API's context parameter while keeping the object alive for the
+/// duration. Suitable for temporary references in locals, or in stored
+/// properties to keep an object alive for a longer time.
+struct OpaqueRef: ~Copyable {
+  private let object: AnyObject
+
+  init(_ object: AnyObject) {
+    self.object = object
+  }
+
+  /// The opaque pointer to pass to C.
+  var pointer: UnsafeMutableRawPointer {
+    Unmanaged.passUnretained(self.object).toOpaque()
+  }
+}

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
@@ -36,11 +36,11 @@ internal struct DumpArrays: ParsableCommand {
 
         let ReadBytes: RemoteProcess.ReadBytesFunction =
             type(of: process).ReadBytes
-        let this = process.toOpaqueRef()
+        let this = OpaqueRef(process)
 
         let isClass = process.context.isArrayOfClass(swift_reflection_ptr_t(metadata))
         let count = process.context.arrayCount(swift_reflection_ptr_t(allocation),
-                                               { ReadBytes(this, $0, UInt64($1), nil) })
+                                               { ReadBytes(this.pointer, $0, UInt64($1), nil) })
         print("\(hex: swift_reflection_ptr_t(allocation))\t\(size)\t\(count.map(String.init) ?? "<unknown>")\t\(isClass)")
       }
     }

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -102,9 +102,10 @@ fileprivate class ConcurrencyDumper {
             type(of: process).GetSymbolAddress
       let ReadBytes: RemoteProcess.ReadBytesFunction =
             type(of: process).ReadBytes
-      let this = process.toOpaqueRef()
-      let addr = GetSymbolAddress(this, symbolName, UInt64(symbolName.utf8.count))
-      if addr != 0, let ptr = ReadBytes(this, addr, UInt64(MemoryLayout<UInt>.size), nil) {
+      let this = OpaqueRef(process)
+      let addr = GetSymbolAddress(this.pointer, symbolName, UInt64(symbolName.utf8.count))
+      if addr != 0,
+         let ptr = ReadBytes(this.pointer, addr, UInt64(MemoryLayout<UInt>.size), nil) {
         return swift_reflection_ptr_t(ptr.load(as: UInt.self))
       }
       return nil

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -46,20 +46,17 @@ internal protocol RemoteProcess: AnyObject {
   func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void)
   func iteratePotentialMetadataPages(_ body: (swift_addr_t, UInt64) -> Void)
 
+  /// Releases the strong reference this process passed to its reflection
+  /// context, breaking the resulting cycle so the process can be destroyed.
+  /// The context must not be used afterwards.
+  func releaseContextRef()
+
   var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] { get }
 }
 
 extension RemoteProcess {
-  internal func toOpaqueRef() -> UnsafeMutableRawPointer {
-    return Unmanaged.passRetained(self).toOpaque()
-  }
-
   internal static func fromOpaque(_ ptr: UnsafeRawPointer) -> Self {
     return Unmanaged.fromOpaque(ptr).takeUnretainedValue()
-  }
-
-  internal func release() {
-    Unmanaged.passUnretained(self).release()
   }
 }
 

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -33,6 +33,14 @@ internal final class WindowsRemoteProcess: RemoteProcess {
   private var hSwiftCore: HMODULE = HMODULE(bitPattern: -1)!
   private var hSwiftConcurrency: HMODULE = HMODULE(bitPattern: -1)!
 
+  /// The reference passed to the reflection context, which the context holds
+  /// until `releaseContextRef()` clears it.
+  private var contextRef: OpaqueRef?
+
+  func releaseContextRef() {
+    contextRef = nil
+  }
+
   static var QueryDataLayout: QueryDataLayoutFunction {
     return { (context, type, _, output) in
       let _ = WindowsRemoteProcess.fromOpaque(context!)
@@ -148,10 +156,11 @@ internal final class WindowsRemoteProcess: RemoteProcess {
     self.process = process
 
     // Initialize SwiftReflectionContextRef
+    self.contextRef = OpaqueRef(self)
     guard
       let context =
         swift_reflection_createReflectionContextWithDataLayout(
-          self.toOpaqueRef(),
+          self.contextRef?.pointer,
           Self.QueryDataLayout,
           Self.Free,
           Self.ReadBytes,
@@ -188,7 +197,6 @@ internal final class WindowsRemoteProcess: RemoteProcess {
     swift_reflection_destroyReflectionContext(self.context)
     _ = SymCleanup(self.process)
     _ = CloseHandle(self.process)
-    self.release()
   }
 
   func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?, offset: Int?) {

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -105,7 +105,7 @@ internal func inspect(options: UniversalOptions,
           } catch {
             print(" - \(error)", terminator: "", to: &Std.err)
           }
-          remoteProcess.release() // break retain cycle
+          remoteProcess.releaseContextRef() // break retain cycle
         } else {
           print(progress, " - failed to create inspector for process id \(processIdentifier)",
             terminator: "\n", to: &Std.err)


### PR DESCRIPTION
dump-concurrency and dump-arrays would call toOpaqueRef without a balancing release, leaking the process. This could then result in leaked resources which would cause --all runs to fail.

Replace toOpaqueRef with a noncopyable OpaqueRef wrapper that automatically handles the lifetimes for us. The various RemoteProcess implementations get one as a stored property that they clear it when requested. Code that needs a locally scoped opaque reference uses OpaqueRef in a local variable to ensure the value gets released at the end of the scope.

Also fix the corpse retry loop on Darwin, which meant to report the error if the last retry failed, but had an off-by-one error that prevented it from being shown at all. This hindered diagnosis of the leak issue.

rdar://184760789