### PR TITLE
[CS] Bump default memory limit slightly

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -187,6 +187,16 @@ std::optional<KnownFoundationEntity> getKnownFoundationEntity(StringRef name);
 /// "NS" prefix stripping will apply under omit-needless-words.
 StringRef getSwiftName(KnownFoundationEntity kind);
 
+// We explicitly define the BumpPtrAllocator template parameters here since the
+// solver memory limit is based on the total number of bytes allocated for the
+// slabs, so can be affected by the values chosen. Currently these values match
+// what is used in LLVM for stable/23.x.
+struct ConstraintSolverAllocator
+    : public llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator,
+                                        /*SlabSize*/ 4096,
+                                        /*SizeThreshold*/ 4096,
+                                        /*GrowthDelay*/ 128> {};
+
 /// Introduces a new constraint checker arena, whose lifetime is
 /// tied to the lifetime of this RAII object.
 class ConstraintCheckerArenaRAII {
@@ -203,7 +213,7 @@ public:
   /// \param allocator The allocator used for allocating any data that
   /// goes into the constraint checker arena.
   ConstraintCheckerArenaRAII(ASTContext &self,
-                             llvm::BumpPtrAllocator &allocator);
+                             ConstraintSolverAllocator &allocator);
 
   ConstraintCheckerArenaRAII(const ConstraintCheckerArenaRAII &) = delete;
   ConstraintCheckerArenaRAII(ConstraintCheckerArenaRAII &&) = delete;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -995,7 +995,7 @@ namespace swift {
 
     /// The upper bound, in bytes, of temporary data that can be
     /// allocated by the constraint solver.
-    unsigned SolverMemoryThreshold = 512 * 1024 * 1024;
+    unsigned SolverMemoryThreshold = 516 * 1024 * 1024;
 
     /// The maximum number of scopes we explore before giving up.
     unsigned SolverScopeThreshold = 1024 * 1024;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -843,7 +843,7 @@ private:
   llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> ExprWeights;
 
   /// Allocator used for data that is local to this constraint system.
-  llvm::BumpPtrAllocator Allocator;
+  ConstraintSolverAllocator Allocator;
 
   /// Arena used for memory management of constraint-checker-related
   /// allocations.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -707,10 +707,10 @@ struct ASTContext::Implementation {
   /// Temporary arena used for a constraint solver.
   struct ConstraintSolverArena : public Arena {
     /// The allocator used for all allocations within this arena.
-    llvm::BumpPtrAllocator &Allocator;
+    ConstraintSolverAllocator &Allocator;
 
-    ConstraintSolverArena(llvm::BumpPtrAllocator &allocator)
-      : Allocator(allocator) { }
+    ConstraintSolverArena(ConstraintSolverAllocator &allocator)
+        : Allocator(allocator) {}
 
     ConstraintSolverArena(const ConstraintSolverArena &) = delete;
     ConstraintSolverArena(ConstraintSolverArena &&) = delete;
@@ -772,10 +772,9 @@ ASTContext::Implementation::~Implementation() {
     cleanup();
 }
 
-ConstraintCheckerArenaRAII::
-ConstraintCheckerArenaRAII(ASTContext &self, llvm::BumpPtrAllocator &allocator)
-  : Self(self), Data(self.getImpl().CurrentConstraintSolverArena.release())
-{
+ConstraintCheckerArenaRAII::ConstraintCheckerArenaRAII(
+    ASTContext &self, ConstraintSolverAllocator &allocator)
+    : Self(self), Data(self.getImpl().CurrentConstraintSolverArena.release()) {
   Self.getImpl().CurrentConstraintSolverArena.reset(
     new ASTContext::Implementation::ConstraintSolverArena(allocator));
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -911,7 +911,7 @@ ASTContext::ASTContext(
 
 void ASTContext::Implementation::dump(llvm::raw_ostream &os) const {
   os << "-------------------------------------------------\n";
-  os << "Arena\t0\t" << Allocator.getBytesAllocated() << "\n";
+  os << "Arena\t0\t" << Allocator.getTotalMemory() << "\n";
   Permanent.dump(os);
 
 #define SIZE(Name) os << #Name << "\t" << Name.size() << "\t0\n"
@@ -1015,7 +1015,7 @@ void ASTContext::setStatsReporter(UnifiedStatsReporter *stats) {
   Stats = stats;
 
   stats->getFrontendCounters().NumASTBytesAllocated =
-      getAllocator().getBytesAllocated();
+      getAllocator().getTotalMemory();
 
   if (stats->fineGrainedTimers())
     evaluator.setStatsReporter(stats);
@@ -3532,7 +3532,7 @@ size_t ASTContext::getSolverMemory() const {
 
   if (getImpl().CurrentConstraintSolverArena) {
     Size += getImpl().CurrentConstraintSolverArena->getTotalMemory();
-    Size += getImpl().CurrentConstraintSolverArena->Allocator.getBytesAllocated();
+    Size += getImpl().CurrentConstraintSolverArena->Allocator.getTotalMemory();
   }
 
   return Size;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -674,7 +674,7 @@ ConstraintSystem::SolverState::~SolverState() {
   // it in one shot at the end.
   if (ctx.Stats) {
     auto &counters = ctx.Stats->getFrontendCounters();
-    int64_t bytes = CS.getAllocator().getBytesAllocated();
+    int64_t bytes = CS.getAllocator().getTotalMemory();
     counters.NumSolverBytesAllocated += bytes;
     counters.MaxSolverBytesAllocated =
         std::max(counters.MaxSolverBytesAllocated, bytes);

--- a/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
@@ -35,8 +35,8 @@ struct AssetBrowserView: View {
         ForEach(0..<(Int(assetsFetchResult.count/3))) { i in
           HStack {
             ForEach(0..<3) { j in
-              ZStack(alignment: .center) { // expected-error {{reasonable time}}
-                Image(uiImage: PHAsset.getUIImageFromPHAsset(asset: assetsFetchResult[j]()!)!)
+              ZStack(alignment: .center) {
+                Image(uiImage: PHAsset.getUIImageFromPHAsset(asset: assetsFetchResult[j]()!)!)  // expected-error {{reasonable time}}
                   .frame(width: 0, height: 0)
               }
               .frame(width: 0, height: 0)

--- a/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
@@ -35,8 +35,8 @@ struct AssetBrowserView: View {
         ForEach(0..<(Int(assetsFetchResult.count/3))) { i in
           HStack {
             ForEach(0..<3) { j in
-              ZStack(alignment: .center) {
-                Image(uiImage: PHAsset.getUIImageFromPHAsset(asset: assetsFetchResult[j]()!)!)  // expected-error {{reasonable time}}
+              ZStack(alignment: .center) { // expected-error {{reasonable time}}
+                Image(uiImage: PHAsset.getUIImageFromPHAsset(asset: assetsFetchResult[j]()!)!)
                   .frame(width: 0, height: 0)
               }
               .frame(width: 0, height: 0)

--- a/validation-test/Sema/type_checker_perf/slow/rdar93460450.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar93460450.swift
@@ -44,10 +44,10 @@ struct MyView: View {
     })) {
       ForEach(data, id: \.id) { v in
         NavigationLink(value: v.name) {
-          HStack {
-            MySettingsView(x: 42, y: v.name)
-            // expected-error@-1 {{reasonable time}}
-          }
+          // Note: This is on a single line to ensure we get the correct location
+          // for the diagnostic on all the SDKs we test in CI.
+          HStack { MySettingsView(x: 42, y: v.name) }
+          // expected-error@-1 {{reasonable time}}
         }
       }
     }


### PR DESCRIPTION
This PR re-applies https://github.com/swiftlang/swift/pull/91343, which was previously reverted in #91452.

With the switch to basing the memory limit off `getTotalMemory` we need to bump the limit here slightly to avoid hitting compatibility issues. Also explicitly specify the bump pointer allocator parameters to ensure LLVM changes can't affect the solver memory limit.