### PR TITLE
[any ~Copyable] End-to-end tests

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -431,6 +431,10 @@ void ExistentialTransform::populateThunkBody() {
   struct Temp {
     SILValue DeallocStackEntry;
     SILValue DestroyValue;
+    // If set, we moved the (non-copyable) value out of an existential box and
+    // so we need to clean up the empty box with deinit_existential_addr instead
+    // of destroy_addr.
+    bool DestroyEmptyBox = false;
   };
   SmallVector<Temp, 8> Temps;
   SmallDenseMap<GenericTypeParamType *, Type> GenericToOpenedTypeMap;
@@ -457,12 +461,16 @@ void ExistentialTransform::populateThunkBody() {
         if (OriginallyConsumed) {
           // open_existential_addr projects a borrowed address into the
           // existential box. Since the callee consumes the generic value, we
-          // must pass in a copy.
+          // must pass in a copy -- unless the value is move-only, in which
+          // case we use a take instead: the callee already consumes the whole
+          // existential, so nothing else can observe OrigOperand's payload afterward.
+          bool isMoveOnly = OpenedSILType.isMoveOnly();
           auto *ASI =
             Builder.createAllocStack(Loc, OpenedSILType);
-          Builder.createCopyAddr(Loc, archetypeValue, ASI, IsNotTake,
+          Builder.createCopyAddr(Loc, archetypeValue, ASI,
+                                 isMoveOnly ? IsTake : IsNotTake,
                                  IsInitialization_t::IsInitialization);
-          Temps.push_back({ASI, OrigOperand});
+          Temps.push_back({ASI, OrigOperand, isMoveOnly});
           calleeArg = ASI;
         }
         ApplyArgs.push_back(calleeArg);
@@ -602,8 +610,17 @@ void ExistentialTransform::populateThunkBody() {
     //     dealloc_stack %temp : $*T
     //
     // Otherwise, if we had an object, we just emit a destroy_value.
-    if (Temp.DestroyValue)
-      Builder.emitDestroyOperation(cleanupLoc, Temp.DestroyValue);
+    //
+    // If the payload is move-only, the copy_addr above was actually a take,
+    // so %consumedExistential's payload is already gone; only the (now
+    // empty) existential container itself still needs to be torn down, via
+    // deinit_existential_addr rather than destroy_addr.
+    if (Temp.DestroyValue) {
+      if (Temp.DestroyEmptyBox)
+        Builder.createDeinitExistentialAddr(cleanupLoc, Temp.DestroyValue);
+      else
+        Builder.emitDestroyOperation(cleanupLoc, Temp.DestroyValue);
+    }
     if (Temp.DeallocStackEntry)
       Builder.createDeallocStack(cleanupLoc, Temp.DeallocStackEntry);
   }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -208,6 +208,12 @@ bool noncopyable::memInstMustInitialize(Operand *memOper) {
   case SILInstructionKind::InitBorrowAddrInst:
     return cast<InitBorrowAddrInst>(memInst)->getDest() == address;
 
+  case SILInstructionKind::UnconditionalCheckedCastAddrInst:
+    // The instruction traps on failure, so if we're still executing, Dest
+    // was successfully initialized with the cast result.
+    return cast<UnconditionalCheckedCastAddrInst>(memInst)->getDest() ==
+           address;
+
   case SILInstructionKind::BeginApplyInst:
   case SILInstructionKind::TryApplyInst:
   case SILInstructionKind::ApplyInst: {
@@ -329,6 +335,20 @@ bool noncopyable::memInstMustConsume(Operand *memOper) {
   }
   case SILInstructionKind::UncheckedTakeEnumDataAddrInst:
     return true;
+  case SILInstructionKind::UnconditionalCheckedCastAddrInst:
+    // Src is always taken, unconditionally (the instruction traps on
+    // failure, so if we're still executing, Src was consumed).
+    return cast<UnconditionalCheckedCastAddrInst>(memInst)->getSrc() ==
+           address;
+  case SILInstructionKind::CheckedCastAddrBranchInst: {
+    auto *ccabi = cast<CheckedCastAddrBranchInst>(memInst);
+    // Only a source operand consumed under TakeAlways is unconditionally
+    // consumed by this instruction, regardless of which successor is
+    // taken. TakeOnSuccess/CopyOnSuccess/BorrowAlways all leave Src valid
+    // on at least one path, so they aren't a *must*-consume here.
+    return ccabi->getSrc() == address &&
+           ccabi->getConsumptionKind() == CastConsumptionKind::TakeAlways;
+  }
   }
 }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1186,6 +1186,15 @@ struct ConcreteArgumentCopy {
     if (!paramInfo.isFormalIndirect())
       return std::nullopt;
 
+    // A move-only concrete value can't be copied into a temporary.
+    // Decline the substitution; the caller falls back to
+    // passing existentialInfo.ConcreteValue directly, which is exactly a
+    // take (the callee's parameter convention is still formally indirect
+    // and consumed at this point).
+    if (existentialInfo.ConcreteValue->getType().isAddress() &&
+        existentialInfo.ConcreteValue->getType().isMoveOnly())
+      return std::nullopt;
+
     SILBuilderWithScope builder(apply.getInstruction(), builderCtx);
     auto loc = apply.getLoc();
     auto *asi =

--- a/test/Interpreter/existential_specializer_moveonly.swift
+++ b/test/Interpreter/existential_specializer_moveonly.swift
@@ -10,7 +10,6 @@
 // RUN: %target-run %t/main_ounchecked | %FileCheck %s
 
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Regression test: ExistentialSpecializer clones a function that consumes
 // an existential parameter into a version taking the concrete type

--- a/test/Interpreter/existential_specializer_moveonly.swift
+++ b/test/Interpreter/existential_specializer_moveonly.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -Onone -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift %s -O -o %t/main_opt
+// RUN: %target-codesign %t/main_opt
+// RUN: %target-run %t/main_opt | %FileCheck %s
+// RUN: %target-build-swift %s -Ounchecked -o %t/main_ounchecked
+// RUN: %target-codesign %t/main_ounchecked
+// RUN: %target-run %t/main_ounchecked | %FileCheck %s
+
+// REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+// Regression test: ExistentialSpecializer clones a function that consumes
+// an existential parameter into a version taking the concrete type
+// directly, and rewrites the call site by opening the existential and
+// copying its payload into a fresh temporary for the specialized callee,
+// while separately destroying the original existential container. That's
+// fine for a copyable payload (two independent owned copies, each
+// destroyed once), but was illegal for a move-only payload: it required
+// making a copy of a value that can't be copied, and even if it could,
+// the container's separate destroy would double-destroy the payload. Under
+// -O this used to either crash the compiler outright or, with the
+// unconditional copy patched around, silently double-destroy the payload.
+
+protocol P: ~Copyable {}
+
+final class Canary {
+  static var deinitCount = 0
+  deinit { Canary.deinitCount += 1 }
+}
+
+// Carries a class reference so we can verify the payload is destroyed
+// exactly once. Also large enough that the opened-value temporary isn't
+// trivially folded away by an earlier pass.
+struct Payload: ~Copyable, P {
+  let canary: Canary
+  var pad0, pad1, pad2, pad3, pad4, pad5: Int
+}
+
+@inline(never)
+func consumeIt(_ box: consuming any P & ~Copyable) {
+}
+
+@inline(never)
+func makeAndConsume() {
+  consumeIt(Payload(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0,
+                    pad4: 0, pad5: 0))
+}
+
+makeAndConsume()
+// CHECK: deinit count: 1
+print("deinit count:", Canary.deinitCount)

--- a/test/Interpreter/noncopyable_existential_casting.swift
+++ b/test/Interpreter/noncopyable_existential_casting.swift
@@ -1,0 +1,107 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableCasting)
+
+// REQUIRES: swift_feature_NoncopyableCasting
+// REQUIRES: executable_test
+
+// End-to-end verification that `is`/`as?`/`as!` work correctly on a
+// noncopyable existential value: SILGen and the move-only checker must
+// agree that the cast fully consumes its source (a `checked_cast_addr_br`
+// or `unconditional_checked_cast_addr` with `take_always` semantics), for
+// both inline-sized and boxed (out-of-line) payloads.
+
+protocol P: ~Copyable {}
+
+// Small enough to be stored inline in the existential container.
+struct Small: ~Copyable, P {
+  var tag: Int
+}
+
+// Large enough to force the existential to box the payload out-of-line.
+struct Big: ~Copyable, P {
+  var tag: Int
+  var pad0, pad1, pad2, pad3, pad4, pad5, pad6: Int
+}
+
+struct Unrelated: ~Copyable, P {}
+
+final class Canary {
+  static var deinitCount = 0
+  deinit { Canary.deinitCount += 1 }
+}
+
+// Large enough to be boxed, and carries a class reference so we can verify
+// the box is freed -- and its payload destroyed -- exactly once.
+struct BigWithCanary: ~Copyable, P {
+  let canary: Canary
+  var pad0, pad1, pad2, pad3, pad4, pad5: Int
+}
+
+func asOptional(_ box: consuming any P & ~Copyable) -> Int? {
+  if let s = box as? Small { return s.tag }
+  return nil
+}
+
+func asBang(_ box: consuming any P & ~Copyable) -> Int {
+  let s = box as! Small
+  return s.tag
+}
+
+func isCheck(_ box: consuming any P & ~Copyable) -> Bool {
+  return box is Small
+}
+
+func asOptionalBoxed(_ box: consuming any P & ~Copyable) -> Int? {
+  if let b = box as? Big { return b.tag }
+  return nil
+}
+
+func asBangBoxed(_ box: consuming any P & ~Copyable) -> Int {
+  let b = box as! Big
+  return b.tag
+}
+
+func isCheckBoxed(_ box: consuming any P & ~Copyable) -> Bool {
+  return box is Big
+}
+
+func takeCanary(_ box: consuming any P & ~Copyable) -> Bool {
+  return box is BigWithCanary
+}
+
+// CHECK: as? inline success: Optional(42)
+print("as? inline success:", asOptional(Small(tag: 42)) as Any)
+// CHECK: as? inline failure: nil
+print("as? inline failure:", asOptional(Unrelated()) as Any)
+// CHECK: as! inline: 43
+print("as! inline:", asBang(Small(tag: 43)))
+// CHECK: is inline true: true
+print("is inline true:", isCheck(Small(tag: 0)))
+// CHECK: is inline false: false
+print("is inline false:", isCheck(Unrelated()))
+
+// CHECK: as? boxed success: Optional(99)
+print("as? boxed success:", asOptionalBoxed(
+  Big(tag: 99, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)
+) as Any)
+// CHECK: as? boxed failure: nil
+print("as? boxed failure:", asOptionalBoxed(Unrelated()) as Any)
+// CHECK: as! boxed: 100
+print("as! boxed:", asBangBoxed(
+  Big(tag: 100, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)
+))
+// CHECK: is boxed true: true
+print("is boxed true:", isCheckBoxed(
+  Big(tag: 0, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)
+))
+// CHECK: is boxed false: false
+print("is boxed false:", isCheckBoxed(Unrelated()))
+
+// Leak/double-free check: construct the boxed, canary-carrying payload
+// directly as a call argument (never bound to a named local -- doing so
+// currently trips an unrelated, pre-existing move-only-checker crash for
+// *any* consuming use of a boxed noncopyable existential local, unrelated
+// to casting), exercise a successful `is` check on it, and confirm the
+// class reference inside gets destroyed exactly once.
+_ = takeCanary(BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0))
+// CHECK: canary deinit count: 1
+print("canary deinit count:", Canary.deinitCount)

--- a/test/Interpreter/noncopyable_extended_existential_casting.swift
+++ b/test/Interpreter/noncopyable_extended_existential_casting.swift
@@ -1,0 +1,118 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableCasting)
+
+// REQUIRES: swift_feature_NoncopyableCasting
+// REQUIRES: executable_test
+
+// End-to-end verification that `is`/`as?`/`as!` work correctly on an
+// *extended* noncopyable existential. A protocol with a primary associated
+// type (like `P<T>` below) uses ExtendedExistentialTypeMetadata at runtime
+// (MetadataKind::ExtendedExistential), a distinct representation -- and a
+// distinct runtime code path, tryCastUnwrappingExtendedExistentialSource --
+// from the plain existentials covered by noncopyable_existential_casting.swift.
+
+protocol P<T>: ~Copyable {
+  associatedtype T
+  var tag: T { get }
+}
+
+// Small enough to be stored inline in the existential container.
+struct Small: ~Copyable, P {
+  typealias T = Int
+  var tag: Int
+}
+
+// Large enough to force the existential to box the payload out-of-line.
+struct Big: ~Copyable, P {
+  typealias T = Int
+  var tag: Int
+  var pad0, pad1, pad2, pad3, pad4, pad5, pad6: Int
+}
+
+struct Unrelated: ~Copyable, P {
+  typealias T = Int
+  var tag: Int { 0 }
+}
+
+final class Canary {
+  static var deinitCount = 0
+  deinit { Canary.deinitCount += 1 }
+}
+
+// Large enough to be boxed, and carries a class reference so we can verify
+// the box is freed -- and its payload destroyed -- exactly once.
+struct BigWithCanary: ~Copyable, P {
+  typealias T = Int
+  let canary: Canary
+  var tag: Int { 0 }
+  var pad0, pad1, pad2, pad3, pad4, pad5: Int
+}
+
+func asOptional(_ box: consuming any P<Int> & ~Copyable) -> Int? {
+  if let s = box as? Small { return s.tag }
+  return nil
+}
+
+func asBang(_ box: consuming any P<Int> & ~Copyable) -> Int {
+  let s = box as! Small
+  return s.tag
+}
+
+func isCheck(_ box: consuming any P<Int> & ~Copyable) -> Bool {
+  return box is Small
+}
+
+func asOptionalBoxed(_ box: consuming any P<Int> & ~Copyable) -> Int? {
+  if let b = box as? Big { return b.tag }
+  return nil
+}
+
+func asBangBoxed(_ box: consuming any P<Int> & ~Copyable) -> Int {
+  let b = box as! Big
+  return b.tag
+}
+
+func isCheckBoxed(_ box: consuming any P<Int> & ~Copyable) -> Bool {
+  return box is Big
+}
+
+func takeCanary(_ box: consuming any P<Int> & ~Copyable) -> Bool {
+  return box is BigWithCanary
+}
+
+// CHECK: as? inline success: Optional(42)
+print("as? inline success:", asOptional(Small(tag: 42)) as Any)
+// CHECK: as? inline failure: nil
+print("as? inline failure:", asOptional(Unrelated()) as Any)
+// CHECK: as! inline: 43
+print("as! inline:", asBang(Small(tag: 43)))
+// CHECK: is inline true: true
+print("is inline true:", isCheck(Small(tag: 0)))
+// CHECK: is inline false: false
+print("is inline false:", isCheck(Unrelated()))
+
+// CHECK: as? boxed success: Optional(99)
+print("as? boxed success:", asOptionalBoxed(
+  Big(tag: 99, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)
+) as Any)
+// CHECK: as? boxed failure: nil
+print("as? boxed failure:", asOptionalBoxed(Unrelated()) as Any)
+// CHECK: as! boxed: 100
+print("as! boxed:", asBangBoxed(
+  Big(tag: 100, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)
+))
+// CHECK: is boxed true: true
+print("is boxed true:", isCheckBoxed(
+  Big(tag: 0, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)
+))
+// CHECK: is boxed false: false
+print("is boxed false:", isCheckBoxed(Unrelated()))
+
+// Leak/double-free check: construct the boxed, canary-carrying payload
+// directly as a call argument (never bound to a named local -- doing so
+// currently trips an unrelated, pre-existing move-only-checker crash for
+// *any* consuming use of a boxed noncopyable existential local, unrelated
+// to casting), exercise a successful `is` check on it, and confirm the
+// class reference inside gets destroyed exactly once.
+_ = takeCanary(BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0))
+// CHECK: canary deinit count: 1
+print("canary deinit count:", Canary.deinitCount)


### PR DESCRIPTION
(Note: This follows #91333 and #91386)

This has full end-to-end testing of non-copyable existentials being constructed and cast to concrete types. It includes tests for the basic existential cases
```
any ~Copyable
any P & ~Copyable
```
as well as the extended existential cases
```
any P<Int> & ~Copyable
```

A fix to the MoveOnlyUtils fills in correct memory classifications for the casting instructions.

This is all gated by the NoncopyableCasting feature flag.  The flag remains disabled by default.

**Caveat**: These tests just verify that we can actually write some basic casting operations and have them work.  There's still significant work to do before this is fully usable.  For example, `box as? NCType` is consuming always, so you can't yet do 
```
   if let x as? NCType1 {
       ... 
   } else if let x as? NCType2 {
        ...
   }
```
