### PR TITLE
Source-Compat Preset: Disable LLVM Extras

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3116,6 +3116,12 @@ install-destdir=%(install_destdir)s
 install-prefix=%(install_prefix)s
 installable-package=%(installable_package)s
 
+extra-llvm-cmake-options=
+  -DLLVM_INCLUDE_BENCHMARKS=OFF
+  -DLLVM_BUILD_BENCHMARKS=OFF
+  -DLLVM_ENABLE_OCAMLDOC=OFF
+  -DLLVM_INCLUDE_EXAMPLES=OFF
+
 [preset: source_compat_suite_macos_base]
 mixin-preset=source_compat_suite_base
 build-subdir=compat_macos


### PR DESCRIPTION
Disabling configuring the benchmark suite, building the benchmarks, the OCAML docs, and LLVM examples.

build-script launches the build with the `all` and `LLVMTestingSupport` targets specified, which will then build all of these things if left to its own devices. We don't need them to verify Swift source compatibility, so disabling them for faster builds.
