### PR TITLE
[Sema] Allow escaping `@called(once)` to implicitly capture self

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2294,6 +2294,13 @@ public:
       return false;
     }
 
+    // Escaping `@called(once)` closures are allowed to implicitly capture
+    // `self` because the call (which is a consuming operation) would break
+    // the cycle.
+    if (isCalledOnce(CE)) {
+      return false;
+    }
+
     if (auto autoclosure = dyn_cast<AutoClosureExpr>(CE)) {
       if (autoclosure->getThunkKind() == AutoClosureExpr::Kind::AsyncLet)
         return false;
@@ -2312,6 +2319,14 @@ public:
   static bool isNonEscaping(const AbstractClosureExpr *ACE) {
     if (auto funcTy = ACE->getType()->getAs<FunctionType>()) {
       return funcTy->isNoEscape();
+    }
+
+    return false;
+  }
+
+  static bool isCalledOnce(const AbstractClosureExpr *ACE) {
+    if (auto funcTy = ACE->getType()->getAs<FunctionType>()) {
+      return funcTy->isCalledOnce();
     }
 
     return false;

--- a/test/Sema/called_once.swift
+++ b/test/Sema/called_once.swift
@@ -178,3 +178,26 @@ struct TestCalledOnceResultWitness : P_PlainResult { // expected-error {{type 'T
 struct TestPlainResultWitness : P_CalledOnceResult {
   func f() -> () -> Void { { } } // Ok
 }
+
+// `@escaping @called(once)` implies `@_implicitSelfCapture`
+do {
+  func takeFn(fn: @escaping @called(once) () -> Int) { }
+
+  class C {
+    var property: Int = 0
+
+    func method() { }
+
+    func testMethod() {
+      takeFn { // Ok
+        method()
+        return property
+      }
+
+      let _ = { @called(once) in // Ok
+        method()
+        return property
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
