### PR TITLE
[Windows] Archive baf.dll from the installer build

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -5560,6 +5560,9 @@ function Copy-BuildArtifactsToStage([Hashtable] $Platform) {
   Copy-File "$BinaryCache\$($Platform.Triple)\msi\$($Platform.Architecture.VSName)-$([System.IO.Path]::GetFileNameWithoutExtension("bundle\installer.wixproj")).binlog" $Stage
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.cab" $Stage
   Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\*.msi" $Stage
+  # Needed by the swift.org code-signing pipeline, which re-links the bundle
+  # from pre-built artifacts without rebuilding project references.
+  Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Platform.Architecture.VSName)\baf.dll" $Stage
   foreach ($Build in $WindowsSDKBuilds) {
     Copy-File "$BinaryCache\$($Platform.Triple)\installer\Release\$($Build.Architecture.VSName)\*.msm" $Stage
   }


### PR DESCRIPTION
The bundle's BAF (BootstrapperApplication Function) DLL, built from platforms/Windows/bundle/baf/baf.vcxproj and embedded into the bundle as a WixBundlePayload, was never copied into the staged artifacts directory, so it never reached the archived build outputs consumed by the swift.org code-signing pipeline.