### PR TITLE
NFC: Use @export(implementation) consistently in compiler diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5648,7 +5648,7 @@ GROUPED_ERROR(opaque_type_unsupported_availability,OpaqueTypeInference,none,
 #define FRAGILE_FUNC_KIND \
   "%select{a '@_transparent' function|" \
   "an '@inlinable' function|" \
-  "an '@_alwaysEmitIntoClient' function|" \
+  "an '@export(implementation)' function|" \
   "a default argument value|" \
   "a property initializer in a '@frozen' type|" \
   "a '@backDeployed' function|" \
@@ -7822,7 +7822,7 @@ NOTE(resilience_decl_declared_here,
 
 ERROR(class_designated_init_inlinable_resilient,none,
       "initializer for class %0 is "
-      "'%select{@_transparent|@inlinable|@_alwaysEmitIntoClient|%error}1' and must "
+      "'%select{@_transparent|@inlinable|@export(implementation)|%error}1' and must "
       "delegate to another initializer", (Type, unsigned))
 
 ERROR(attribute_invalid_on_stored_property,

--- a/test/Availability/availability_define.swift
+++ b/test/Availability/availability_define.swift
@@ -92,16 +92,16 @@ public func forbidMacrosInInlinableCode() {
   }
 }
 
-@_alwaysEmitIntoClient
+@export(implementation)
 public func forbidMacrosInInlinableCode1() {
-  if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #available(_iOS54, _macOS51_0, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #available(iOS 54.0, _macOS51_0, tvOS 54.0, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #unavailable(_iOS54Aligned) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #unavailable(_iOS54, _macOS51_0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
-  if #unavailable(iOS 54.0, _macOS51_0, tvOS 54.0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@export(implementation)' function}}
+  if #available(_iOS54, _macOS51_0, *) { } // expected-error {{availability macro cannot be used in an '@export(implementation)' function}}
+  if #available(iOS 54.0, _macOS51_0, tvOS 54.0, *) { } // expected-error {{availability macro cannot be used in an '@export(implementation)' function}}
+  if #unavailable(_iOS54Aligned) { } // expected-error {{availability macro cannot be used in an '@export(implementation)' function}}
+  if #unavailable(_iOS54, _macOS51_0) { } // expected-error {{availability macro cannot be used in an '@export(implementation)' function}}
+  if #unavailable(iOS 54.0, _macOS51_0, tvOS 54.0) { } // expected-error {{availability macro cannot be used in an '@export(implementation)' function}}
   doIt {
-    if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+    if #available(_iOS54Aligned, *) { } // expected-error {{availability macro cannot be used in an '@export(implementation)' function}}
   }
 }
 

--- a/test/Sema/access-level-import-inlinable.swift
+++ b/test/Sema/access-level-import-inlinable.swift
@@ -137,45 +137,45 @@ public struct GenericType<T, U> {}
   // expected-error @-1 {{struct 'PrivateImportType' is private and cannot be referenced from an '@inlinable' function}}
 }
 
-@_alwaysEmitIntoClient public func alwaysEmitIntoClient() {
+@export(implementation) public func alwaysEmitIntoClient() {
 
   PublicFunc()
-  InternalFunc() // expected-error {{global function 'InternalFunc()' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  InternalFunc() // expected-error {{global function 'InternalFunc()' is internal and cannot be referenced from an '@export(implementation)' function}}
 
   let _: PublicImportType
-  let _: InternalImportType // expected-error {{struct 'InternalImportType' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  let _: InternalImportType // expected-error {{struct 'InternalImportType' is internal and cannot be referenced from an '@export(implementation)' function}}
 
   let _ = PublicImportType()
-  let _ = PrivateImportType() // expected-error {{struct 'PrivateImportType' is private and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  // expected-error @-1 {{initializer 'init()' is private and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  let _ = PrivateImportType() // expected-error {{struct 'PrivateImportType' is private and cannot be referenced from an '@export(implementation)' function}}
+  // expected-error @-1 {{initializer 'init()' is private and cannot be referenced from an '@export(implementation)' function}}
 
   let _: any PublicImportProto
-  let _: any InternalImportProto // expected-error {{protocol 'InternalImportProto' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  let _: any InternalImportProto // expected-error {{protocol 'InternalImportProto' is internal and cannot be referenced from an '@export(implementation)' function}}
 
-  let _: any FileprivateImportProto & InternalImportProto // expected-error {{protocol 'FileprivateImportProto' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  // expected-error @-1 {{protocol 'InternalImportProto' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  let _: any FileprivateImportProto & InternalImportProto // expected-error {{protocol 'FileprivateImportProto' is fileprivate and cannot be referenced from an '@export(implementation)' function}}
+  // expected-error @-1 {{protocol 'InternalImportProto' is internal and cannot be referenced from an '@export(implementation)' function}}
 
   func PublicFuncUsesPublic(_: PublicImportType) {}
-  func PublicFuncUsesPackage(_: PackageImportType) {} // expected-error {{struct 'PackageImportType' is package and cannot be referenced from an '@_alwaysEmitIntoClient' function}}}
+  func PublicFuncUsesPackage(_: PackageImportType) {} // expected-error {{struct 'PackageImportType' is package and cannot be referenced from an '@export(implementation)' function}}}
 
   func PublicFuncUsesPublic() -> PublicImportType {
     fatalError()
   }
-  func PublicFuncReturnUsesInternal() -> InternalImportType { // expected-error {{struct 'InternalImportType' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  func PublicFuncReturnUsesInternal() -> InternalImportType { // expected-error {{struct 'InternalImportType' is internal and cannot be referenced from an '@export(implementation)' function}}
     fatalError()
   }
 
   @PublicImportWrapper
   var wrappedPublic: PublicImportType
 
-  @FileprivateImportWrapper // expected-error {{initializer 'init(wrappedValue:)' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  // expected-error @-1 {{generic struct 'FileprivateImportWrapper' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  // expected-error @-2 {{property 'wrappedValue' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  @FileprivateImportWrapper // expected-error {{initializer 'init(wrappedValue:)' is fileprivate and cannot be referenced from an '@export(implementation)' function}}
+  // expected-error @-1 {{generic struct 'FileprivateImportWrapper' is fileprivate and cannot be referenced from an '@export(implementation)' function}}
+  // expected-error @-2 {{property 'wrappedValue' is fileprivate and cannot be referenced from an '@export(implementation)' function}}
   var wrappedFileprivate: PublicImportType
 
   let _: GenericType<PublicImportType, PublicImportType>
-  let _: GenericType<InternalImportType, PrivateImportType> // expected-error {{struct 'InternalImportType' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  // expected-error @-1 {{struct 'PrivateImportType' is private and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+  let _: GenericType<InternalImportType, PrivateImportType> // expected-error {{struct 'InternalImportType' is internal and cannot be referenced from an '@export(implementation)' function}}
+  // expected-error @-1 {{struct 'PrivateImportType' is private and cannot be referenced from an '@export(implementation)' function}}
 }
 
 @frozen public struct BadFields1 {

--- a/test/Sema/discard_resilient_inlinable.swift
+++ b/test/Sema/discard_resilient_inlinable.swift
@@ -13,9 +13,9 @@ public struct NotFrozen: ~Copyable {
 		discard self
 	}
 
-	@_alwaysEmitIntoClient
+	@export(implementation)
 	public consuming func aeic() {
-		// expected-error @+1 {{'discard' statement cannot be used in an '@_alwaysEmitIntoClient' function inside of type 'NotFrozen', which is not '@frozen'}}
+		// expected-error @+1 {{'discard' statement cannot be used in an '@export(implementation)' function inside of type 'NotFrozen', which is not '@frozen'}}
 		discard self
 	}
 
@@ -54,9 +54,9 @@ internal struct NotFrozenUFI: ~Copyable {
 		discard self
 	}
 
-	@_alwaysEmitIntoClient
+	@export(implementation)
 	public consuming func aeic() {
-		// expected-error @+1 {{'discard' statement cannot be used in an '@_alwaysEmitIntoClient' function inside of type 'NotFrozenUFI', which is not '@frozen'}}
+		// expected-error @+1 {{'discard' statement cannot be used in an '@export(implementation)' function inside of type 'NotFrozenUFI', which is not '@frozen'}}
 		discard self
 	}
 

--- a/test/attr/attr_alwaysEmitIntoClient.swift
+++ b/test/attr/attr_alwaysEmitIntoClient.swift
@@ -9,7 +9,7 @@ func internalFunction() {}
 @usableFromInline func versionedFunction() {}
 public func publicFunction() {}
 
-@export(implementation) public func alwaysEmitIntoClientFunction() {
+@_alwaysEmitIntoClient public func alwaysEmitIntoClientFunction() {
   privateFunction() // expected-error {{global function 'privateFunction()' is private and cannot be referenced from an '@export(implementation)' function}}
   fileprivateFunction() // expected-error {{global function 'fileprivateFunction()' is fileprivate and cannot be referenced from an '@export(implementation)' function}}
   internalFunction() // expected-error {{global function 'internalFunction()' is internal and cannot be referenced from an '@export(implementation)' function}}
@@ -33,7 +33,7 @@ public struct TestInitAccessors {
      set {}
    }
 
-   @export(implementation)
+   @_alwaysEmitIntoClient
    public init(x: Int) {
      self.x = 0 // expected-error {{init accessor for property 'x' is internal and cannot be referenced from an '@export(implementation)' function}}
    }

--- a/test/attr/attr_alwaysEmitIntoClient.swift
+++ b/test/attr/attr_alwaysEmitIntoClient.swift
@@ -9,10 +9,10 @@ func internalFunction() {}
 @usableFromInline func versionedFunction() {}
 public func publicFunction() {}
 
-@_alwaysEmitIntoClient public func alwaysEmitIntoClientFunction() {
-  privateFunction() // expected-error {{global function 'privateFunction()' is private and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  fileprivateFunction() // expected-error {{global function 'fileprivateFunction()' is fileprivate and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
-  internalFunction() // expected-error {{global function 'internalFunction()' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+@export(implementation) public func alwaysEmitIntoClientFunction() {
+  privateFunction() // expected-error {{global function 'privateFunction()' is private and cannot be referenced from an '@export(implementation)' function}}
+  fileprivateFunction() // expected-error {{global function 'fileprivateFunction()' is fileprivate and cannot be referenced from an '@export(implementation)' function}}
+  internalFunction() // expected-error {{global function 'internalFunction()' is internal and cannot be referenced from an '@export(implementation)' function}}
   versionedFunction()
   publicFunction()
 }
@@ -33,9 +33,9 @@ public struct TestInitAccessors {
      set {}
    }
 
-   @_alwaysEmitIntoClient
+   @export(implementation)
    public init(x: Int) {
-     self.x = 0 // expected-error {{init accessor for property 'x' is internal and cannot be referenced from an '@_alwaysEmitIntoClient' function}}
+     self.x = 0 // expected-error {{init accessor for property 'x' is internal and cannot be referenced from an '@export(implementation)' function}}
    }
 
    @inlinable


### PR DESCRIPTION
We recently moved to `@export(implementation)` for the official spelling of `@_alwaysEmitIntoClient` though some diagnostics still emit as `@_alwaysEmitIntoClient`.

Including when a type uses `@export` the error messages still sometimes would get the old spelling, causing confusion to folks adopting the official feature.
