### PR TITLE
[lldb] fix stale iterator crash reading artificial subclass metadata

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -3304,8 +3304,9 @@ private:
       auto it =
           TypeCache.find({getAddress(metadata), skipArtificialSubclasses});
       if (it != TypeCache.end()) {
+        BuiltType cached = it->second;
         TypeCache.erase({getAddress(origMetadata), skipArtificialSubclasses});
-        return it->second;
+        return cached;
       }
     }
 


### PR DESCRIPTION
`MetadataReader::readNominalTypeFromMetadata` read `it->second` from `TypeCache` after calling `TypeCache.erase(...)` on the same map, dereferencing an iterator invalidated by the erase, a stale-iterator crash when resolving the dynamic type of an artificial (runtime-created) ObjC subclass. Now copies the cached value out before erasing.

Fixes a deterministic crash (`isHandleInSync() && "invalid iterator access!"`, DenseMap.h) in LLDB's `lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py`.