### PR TITLE
Windows: Disable library evolution in stdlib

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -72,8 +72,8 @@ elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "CYGWIN")
   # TODO(mracek): This should get turned off, as this is not an ABI stable platform.
   set(SWIFT_STDLIB_STABLE_ABI_default TRUE)
 elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
-  # TODO(mracek): This should get turned off, as this is not an ABI stable platform.
-  set(SWIFT_STDLIB_STABLE_ABI_default TRUE)
+  # There is no stable ABI on Windows.
+  set(SWIFT_STDLIB_STABLE_ABI_default FALSE)
 elseif("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "HAIKU")
   # TODO(mracek): This should get turned off, as this is not an ABI stable platform.
   set(SWIFT_STDLIB_STABLE_ABI_default TRUE)

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -501,10 +501,15 @@ struct swift_closure {
   void *fptr;
   HeapObject *context;
 };
+#if SWIFT_LIBRARY_EVOLUTION
 SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
 MANGLE_SYM(s20_playgroundPrintHookySScSgvg)() {
   return {nullptr, nullptr};
 }
+#else
+SWIFT_RUNTIME_STDLIB_API swift_closure
+MANGLE_SYM(s20_playgroundPrintHookySScSgvp) = {nullptr, nullptr};
+#endif
 
 // ObjectiveC Bridgeable
 


### PR DESCRIPTION
There is no stable ABI for Swift on Windows.
SWIFT_STDLIB_STABLE_ABI_default was set to TRUE, which caused the in-tree stdlib build to be built with library evolution enabled. In the Windows toolchain build, the in-tree stdlib is enabled when we reconfigure the compilers build for tests. This is the copy that lldb compiles against.

This left lldb compiling against a "resilient" resource directory while repl_swift correctly loaded the installed, non-resilient runtime. As a result, some REPL tests started failing when the test build was correctly set up as incrmental over the real build in #91277.

Flipping the default setting for Windows to FALSE fixes the test failures.