### PR TITLE
[cxx-interop] Honor libkern's return ownership attributes

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -183,10 +183,18 @@ void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
 
 importer::ReturnOwnershipInfo::ReturnOwnershipInfo(
     const clang::NamedDecl *decl) {
-  for (const auto *swiftAttr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
-    if (swiftAttr->getAttribute() == "returns_unretained") {
+  if (!decl->hasAttrs())
+    return;
+
+  for (const auto *attr : decl->getAttrs()) {
+    if (const auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
+      if (swiftAttr->getAttribute() == "returns_unretained")
+        hasReturnsUnretained = true;
+      else if (swiftAttr->getAttribute() == "returns_retained")
+        hasReturnsRetained = true;
+    } else if (isa<clang::OSReturnsNotRetainedAttr>(attr)) {
       hasReturnsUnretained = true;
-    } else if (swiftAttr->getAttribute() == "returns_retained") {
+    } else if (isa<clang::OSReturnsRetainedAttr>(attr)) {
       hasReturnsRetained = true;
     }
   }

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2321,6 +2321,10 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
     newMethod->addAttr(swiftNameAttr->clone(clangCtx));
   for (auto swiftAttr : method->specific_attrs<clang::SwiftAttrAttr>())
     newMethod->addAttr(swiftAttr->clone(clangCtx));
+  if (auto attr = method->getAttr<clang::OSReturnsRetainedAttr>())
+    newMethod->addAttr(attr->clone(clangCtx));
+  if (auto attr = method->getAttr<clang::OSReturnsNotRetainedAttr>())
+    newMethod->addAttr(attr->clone(clangCtx));
 
   llvm::SmallVector<clang::ParmVarDecl *, 4> params;
   for (auto *param : method->parameters()) {

--- a/test/Interop/Cxx/foreign-reference/Inputs/libkern-ownership.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/libkern-ownership.hpp
@@ -1,0 +1,174 @@
+/// Test libkern's ownership semantics and attributes
+
+#pragma once
+
+#include <swift/bridging>
+
+#define LIBKERN_RETURNS_RETAINED __attribute__((os_returns_retained))
+#define LIBKERN_RETURNS_NOT_RETAINED __attribute__((os_returns_not_retained))
+
+class ObjectManager {
+  mutable int totalRetains = 0;
+  mutable int totalReleases = 0;
+
+  ObjectManager() = default;
+  ObjectManager(const ObjectManager&) = delete;
+
+  public:
+  static ObjectManager &get() {
+    static ObjectManager manager;
+    return manager;
+  }
+
+  int getTotalRetains() const { return totalRetains; }
+  int getTotalReleases() const { return totalReleases; }
+
+  void recordRetain() const { ++totalRetains; }
+  void recordRelease() const { ++totalReleases; }
+
+  void reset() {
+    totalRetains = 0;
+    totalReleases = 0;
+  }
+} SWIFT_IMMORTAL_REFERENCE;
+
+class BaseObject {
+  mutable int retainCount;
+  
+protected:
+  BaseObject() : retainCount(1) {}
+  virtual ~BaseObject() = default;
+
+public:
+  virtual void retain() const { 
+    ObjectManager::get().recordRetain();
+    ++retainCount; 
+  }
+  virtual void release() const {
+    ObjectManager::get().recordRelease();
+    if (--retainCount == 0)
+      delete this;
+  }
+
+  virtual int getRetainCount() const { return retainCount; }
+} SWIFT_SHARED_REFERENCE(.retain, .release);
+
+class RegistryEntry : public BaseObject {
+  RegistryEntry *parent = nullptr;
+  RegistryEntry *child = nullptr;
+
+protected:
+  RegistryEntry() = default;
+
+  virtual bool attachToParent(RegistryEntry *_Nonnull newParent) {
+    if (this == newParent)
+      return false;
+
+    newParent->retain();
+    parent = newParent;
+
+    retain();
+    newParent->child = this;
+    return true;
+  }
+
+  virtual void detachFromParent() {
+    if (!parent)
+      return;
+
+    RegistryEntry *oldParent = parent;
+
+    parent = nullptr;
+    oldParent->child = nullptr;
+    
+    oldParent->release();
+    release();
+  }
+
+  virtual RegistryEntry *_Nullable getParent() const {
+    return parent;
+  }
+
+  virtual RegistryEntry *_Nullable getChild() const {
+    return child;
+  }
+};
+
+class Service : public RegistryEntry {
+  int id = 0;
+  
+protected:
+  explicit Service(int n) : id(n) {}
+
+public:
+  int getID() const { return id; }
+
+  // Without an annotation Swift would infer +0, while libkern expects +1.
+  static LIBKERN_RETURNS_RETAINED Service *_Nonnull withID(int id) {
+    return new Service(id);
+  }
+
+  // Without an annotation Swift would infer +0, while libkern expects +1.
+  virtual LIBKERN_RETURNS_NOT_RETAINED Service* probe(Service *provider, int *_Nonnull score) {
+    *score += 1;
+    return this;
+  }
+
+  // attachToParent retains both this service and the parent
+  virtual bool attach(Service *_Nonnull provider) {
+    return attachToParent(provider);
+  }
+
+  // detachFromParent releases both this service and the parent
+  virtual void detach() {
+    detachFromParent();
+  }
+
+  // Both Swift and libkern infer +0 (the method's name begins with "get")
+  virtual Service *_Nullable getProvider(void) const {
+    return static_cast<Service *>(getParent());
+  }
+
+  // Without an annotation Swift would infer +0, while libkern expects +1.
+  virtual LIBKERN_RETURNS_RETAINED Service *_Nonnull copyService() const {
+    return new Service(id);
+  }
+
+  // Without an annotation both Swift and libkern would infer +0 (the
+  // name of the function starts with "get")
+  static LIBKERN_RETURNS_RETAINED Service *_Nonnull getCopyOfService(Service *_Nonnull service) {
+    return new Service(service->getID());
+  }
+};
+
+class NastyService : public Service {
+private:
+  class SubService {
+  public:
+    void retain() {}
+    void release() {}
+  } SWIFT_SHARED_REFERENCE(.retain, .release);
+
+protected:
+  explicit NastyService(int id) : Service(id) {}
+
+public:
+  static LIBKERN_RETURNS_RETAINED NastyService *_Nonnull withID(int id) {
+    return new NastyService(id);
+  }
+
+  static SWIFT_RETURNS_RETAINED LIBKERN_RETURNS_NOT_RETAINED NastyService *
+  toRetainOrNotToRetain() { // expected-error {{'toRetainOrNotToRetain' cannot be annotated with both SWIFT_RETURNS_RETAINED and SWIFT_RETURNS_UNRETAINED}}
+    return NastyService::withID(-1);
+  }
+};
+
+// Swift infers +1 (free function whose name begins with "copy"), and so does
+// libkern
+inline Service *_Nonnull copyServiceFreeFunction(Service *_Nonnull service) {
+  return Service::withID(service->getID());
+}
+
+inline bool checkEqual(Service *_Nullable serviceA, Service *_Nullable serviceB) {
+  return serviceA == serviceB;
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -149,3 +149,8 @@ module InheritedGenericArgument {
   header "inherited-generic-argument.h"
   requires cplusplus
 }
+
+module LibkernOwnership {
+  header "libkern-ownership.hpp"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/libkern-ownership-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/libkern-ownership-executable.swift
@@ -1,0 +1,127 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+
+// This test asserts that LIBKERN_RETURNS_RETAINED and LIBKERN_RETURNS_NOT_RETAINED are honored. 
+// The retain/release counts chcked below are only correct at -Onone.
+//
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+// UNSUPPORTED: swift_test_mode_optimize_unchecked
+// UNSUPPORTED: swift_test_mode_optimize_with_implicit_dynamic
+
+import LibkernOwnership
+import StdlibUnittest
+
+var Tests = TestSuite("LibkernOwnershipAttributes")
+
+let manager = ObjectManager.get()
+
+Tests.test("Create a new service") {
+  manager.reset()
+  expectEqual(0, manager.getTotalRetains())
+  expectEqual(0, manager.getTotalReleases())
+
+  do {
+    let service = Service.withID(7)
+    expectEqual(7, service.getID())
+  }
+
+  expectEqual(manager.getTotalRetains() + 1, manager.getTotalReleases())
+}
+
+Tests.test("Attach service") {
+  manager.reset()
+  expectEqual(0, manager.getTotalRetains())
+  expectEqual(0, manager.getTotalReleases())
+
+  do {
+    let service = Service.withID(11)
+    expectEqual(11, service.getID())
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+
+    do {
+      let provider = Service.withID(13)
+      expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+
+      service.attach(provider)
+      expectEqual(manager.getTotalRetains(), manager.getTotalReleases() + 2)
+
+      do {
+        let serviceProvider = service.getProvider()
+
+        expectTrue(checkEqual(provider, serviceProvider))
+        expectEqual(manager.getTotalRetains(), manager.getTotalReleases() + 3)
+      }
+
+      expectEqual(manager.getTotalRetains(), manager.getTotalReleases() + 2)
+
+      service.detach()
+      expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+    }
+
+    expectEqual(manager.getTotalRetains() + 1, manager.getTotalReleases())
+  }
+
+  expectEqual(manager.getTotalRetains() + 2, manager.getTotalReleases())
+}
+
+Tests.test("Probe service") {
+  manager.reset()
+
+  do {
+    let service = Service.withID(17)
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+
+    let provider = Service.withID(19)
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+
+    var score: Int32 = 41
+    let probed = service.probe(provider, &score)
+
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases() + 1)
+
+    expectEqual(42, score)
+    expectTrue(checkEqual(service, probed))
+  }
+
+  expectEqual(manager.getTotalRetains() + 2, manager.getTotalReleases())
+}
+
+Tests.test("Copy service") {
+  manager.reset()
+
+  do {
+    let service = Service.withID(23)
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+
+    let copy = service.copyService()
+    expectFalse(checkEqual(service, copy))
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+  }
+
+  expectEqual(manager.getTotalRetains() + 2, manager.getTotalReleases())
+
+  manager.reset()
+  do {
+    let service = Service.withID(29)
+    let copy = Service.getCopyOfService(service)
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+    expectFalse(checkEqual(service, copy))
+  }
+
+  expectEqual(2, manager.getTotalRetains())
+  expectEqual(4, manager.getTotalReleases())
+
+  manager.reset()
+  do {
+    let service = Service.withID(31)
+    let copy = copyServiceFreeFunction(service)
+    expectEqual(manager.getTotalRetains(), manager.getTotalReleases())
+    expectFalse(checkEqual(service, copy))
+  }
+
+  expectEqual(manager.getTotalRetains() + 2, manager.getTotalReleases())
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/libkern-ownership-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/libkern-ownership-silgen.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -cxx-interoperability-mode=default -disable-availability-checking %s | %FileCheck %s
+
+import LibkernOwnership
+
+let service = Service.withID(7)
+// CHECK: sil {{.*}}[clang Service.withID] {{.*}} -> @owned Service
+
+var score: Int32 = 5
+_ = service.probe(service, &score)
+// CHECK: sil {{.*}}[clang Service.probe] {{.*}} -> Optional<Service>
+
+_ = service.getProvider()
+// CHECK: sil {{.*}}[clang Service.getProvider] {{.*}} -> Optional<Service>
+
+_ = service.copyService()
+// CHECK: sil {{.*}}__synthesizedVirtualCall_copyService{{.*}}[clang Service.copyService] {{.*}} -> @owned Service
+_ = Service.getCopyOfService(service)
+// CHECK: sil {{.*}}[clang Service.getCopyOfService] {{.*}} -> @owned Service
+
+_ = copyServiceFreeFunction(service)
+// CHECK: sil {{.*}}[clang copyServiceFreeFunction] {{.*}} -> @owned Service

--- a/test/Interop/Cxx/foreign-reference/libkern-ownership-typecheck.swift
+++ b/test/Interop/Cxx/foreign-reference/libkern-ownership-typecheck.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -I %S%{fs-sep}Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -cxx-interoperability-mode=default -disable-availability-checking -Xcc -Wno-nullability-completeness -verify-ignore-unknown -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}libkern-ownership.hpp
+
+import LibkernOwnership
+
+let service = Service.withID(3)
+_ = service.getProvider() 
+// expected-warning@-1 {{cannot infer ownership of foreign reference value returned by 'getProvider()'}}
+
+_ = service.copyService() // no warning expected
+
+let _ = NastyService.toRetainOrNotToRetain()


### PR DESCRIPTION
This is the first step to support libkern's ownership semantics. `LIBKERN_RETURNS_RETAINED` and `LIBKERN_RETURNS_NOT_RETAINED` are now accepted as equivalent to `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED`, respectively.

rdar://184619770

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
