### PR TITLE
[Diagnostics] Report the required parameter type for contextual members

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2847,6 +2847,10 @@ bool ContextualFailure::diagnoseAsError() {
 
     ParameterListInfo info(
         params, choice, hasAppliedSelf(solution, overload->choice));
+    auto missingParamIdx = llvm::find_if(
+        indices(params), [&info](const unsigned paramIdx) -> bool {
+          return !info.hasDefaultArgument(paramIdx);
+        });
     auto numMissingArgs = llvm::count_if(
         indices(params), [&info](const unsigned paramIdx) -> bool {
           return !info.hasDefaultArgument(paramIdx);
@@ -2871,7 +2875,7 @@ bool ContextualFailure::diagnoseAsError() {
       }
     } else {
       emitDiagnostic(diag::expected_argument_in_contextual_member,
-                     choice, params.front().getPlainType());
+                     choice, params[*missingParamIdx].getPlainType());
     }
 
     return true;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -407,6 +407,16 @@ enum Color {
   static var svar: Color { return .Red }
 }
 
+struct ContextualMemberWithDefaultArguments {
+  static func foo(x: Int = 0, y: String) -> Self { Self() }
+  static func bar(x: Int = 0, y: Double = 0, z: String) -> Self { Self() }
+}
+
+let _: ContextualMemberWithDefaultArguments = .foo
+// expected-error@-1 {{member 'foo(x:y:)' expects argument of type 'String'}}
+let _: ContextualMemberWithDefaultArguments = .bar
+// expected-error@-1 {{member 'bar(x:y:z:)' expects argument of type 'String'}}
+
 let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) })
 // expected-error@-1 {{cannot convert value of type 'Array<(Int, _)>' to specified type '(Int, Color)'}}
 // expected-error@-2 {{cannot infer contextual base in reference to member 'Unknown'}}


### PR DESCRIPTION



When diagnosing a contextual member reference to a function that requires exactly one argument, `CSDiagnostics.cpp` always used the type of the first parameter.

This produced an incorrect diagnostic when an earlier parameter had a default value:

```swift
struct S {
  static func foo(x: Int = 0, y: String) -> S { S() }
}

let _: S = .foo
```

Previously, this diagnosed:

```text
member 'foo(x:y:)' expects argument of type 'Int'
```

However, `x` can be omitted and `y` is the parameter that requires an argument.

This change finds the unique required parameter and reports its type. It also excludes variadic parameters when determining whether an argument is required.

Tests cover required parameters following one and multiple defaulted parameters, as well as variadic parameters.

