### PR TITLE
DeadObjectElimination: Handle `mark_dependence_addr`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadObjectElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadObjectElimination.swift
@@ -278,6 +278,12 @@ private struct UseCollector : AddressDefUseWalker {
   // there are also loads, because a trivial store has no ownership consequences.
   private var hasTrivialStoresToUnknownStorage = false
 
+  // `mark_dependence_addr` instructions whose address operand is derived from the allocation.
+  // Each records a lifetime dependence carried by memory at that program point. When the
+  // allocation is eliminated we lift each entry into an SSA-form `mark_dependence` wrapping
+  // the forwarded value produced by every load-like access it dominates.
+  private var addrDependencies: [MarkDependenceAddrInst] = []
+
   init(of startInstruction: SingleValueInstruction, _ context: FunctionPassContext) {
     self.context = context
     self.objectLiverange = BasicBlockRange(begin: startInstruction.parentBlock, context)
@@ -364,7 +370,65 @@ private struct UseCollector : AddressDefUseWalker {
     guard walkDownUses(ofAddress: allocStack, path: UnusedWalkingPath()) == .continueWalk else {
       return false
     }
-    return validateAccessTree()
+    guard validateAccessTree() else {
+      return false
+    }
+    return validateAddrDependenceCoverage()
+  }
+
+  /// Returns true if every collected `mark_dependence_addr` can be lowered to an SSA-form
+  /// `mark_dependence` wrapping the forwarded value at each load-like access.
+  ///
+  /// Require every `mark_dependence_addr` to dominate every load-like access we
+  /// would need to wrap, in the same block.
+  private func validateAddrDependenceCoverage() -> Bool {
+    if addrDependencies.isEmpty {
+      return true
+    }
+    for (_, access) in accessTree {
+      switch access {
+      case .load(let load):
+        // FixLifetimeInst doesn't propagate an SSA value, so it needs no wrapping.
+        if load is FixLifetimeInst {
+          continue
+        }
+        // Anything other than a plain LoadInst is a bail case for now.
+        guard let loadInst = load as? LoadInst else {
+          return false
+        }
+        for mda in addrDependencies where !mdaDominates(mda: mda, use: loadInst) {
+          return false
+        }
+      case .loadTake(let load):
+        for mda in addrDependencies where !mdaDominates(mda: mda, use: load) {
+          return false
+        }
+      case .store, .destroy:
+        break
+      }
+    }
+    return true
+  }
+
+  /// Conservative same-BB dominance: `mda` must strictly precede `use` in the same basic block.
+  private func mdaDominates(mda: MarkDependenceAddrInst, use: Instruction) -> Bool {
+    return mda.parentBlock == use.parentBlock && mda.strictlyDominatesInBlock(use)
+  }
+
+  /// Wraps `value` in one `mark_dependence` per collected `mark_dependence_addr`, inserted
+  /// just before `insertBefore`. Preserves each entry's `dependenceKind` (e.g. `[nonescaping]`).
+  private func wrapWithAddrDependences(value: Value, insertBefore: Instruction) -> Value {
+    if addrDependencies.isEmpty {
+      return value
+    }
+    let builder = Builder(before: insertBefore, context)
+    var result = value
+    for mda in addrDependencies {
+      result = builder.createMarkDependence(value: result, base: mda.base,
+                                            ownership: result.ownership,
+                                            kind: mda.dependenceKind)
+    }
+    return result
   }
 
   mutating func walkDown(address operand: Operand, path: Path) -> WalkResult {
@@ -478,6 +542,11 @@ private struct UseCollector : AddressDefUseWalker {
         return .continueWalk
       }
       return .abortWalk
+
+    case let mda as MarkDependenceAddrInst:
+      assert(address == mda.addressOperand)
+      addrDependencies.append(mda)
+      return .continueWalk
 
     default:
       return .abortWalk
@@ -831,8 +900,9 @@ private struct UseCollector : AddressDefUseWalker {
       case .loadTake(let load):
         let undef = Undef.get(type: load.type, context)
         let (projected, updated) = value.createProjectionAndReplace(with: undef, path: path, builder: builder)
+        let wrapped = wrapWithAddrDependences(value: projected, insertBefore: load)
         insertMarkDependencies(for: load, context)
-        load.replace(with: projected, context)
+        load.replace(with: wrapped, context)
         updatedValue = updated
 
       case .load:
@@ -855,6 +925,22 @@ private struct UseCollector : AddressDefUseWalker {
   {
     for (subPath, load) in loads {
       let value = ssaUpdater.getValue(before: load)
+      // For a plain `load [copy]`/`load [trivial]` covered by `mark_dependence_addr`
+      // entries, inline the projection+copy so we can wrap the projected result with an
+      // SSA-form `mark_dependence` before replacing the load. Delegating to
+      // `LoadInst.rewrite` would replace the load directly with the projected copy and
+      // leave nowhere to insert the wrap.
+      if let loadInst = load as? LoadInst,
+         !addrDependencies.isEmpty,
+         loadInst.loadOwnership != .take
+      {
+        let builder = Builder(before: loadInst, context)
+        let projectedValue = value.createProjectionAndCopy(path: subPath, builder: builder)
+        let wrapped = wrapWithAddrDependences(value: projectedValue, insertBefore: loadInst)
+        insertMarkDependencies(for: loadInst, context)
+        loadInst.replace(with: wrapped, context)
+        continue
+      }
       if let loadInst = load as? LoadInstruction {
         insertMarkDependencies(for: loadInst, context)
       }

--- a/test/IRGen/builtin_borrow_large.swift
+++ b/test/IRGen/builtin_borrow_large.swift
@@ -21,12 +21,12 @@ public func borrowBigPod(_ target: BigPod) -> Ref<BigPod> {
 	return Ref(target)
 }
 
+// TODO: Eliminate the remaining unused copy onto the stack.
+//
 // CHECK-LABEL: define {{.*}} @"$s{{.*}}12borrowBigArc
-// CHECK:         [[TMP:%.*]] = getelementptr inbounds nuw %T{{.*}}6BigArcVG, ptr [[BUF:%.*]], i32 0, i32 0
-// CHECK:         store ptr %0, ptr [[TMP:%.*]], align
-// CHECK:         [[TMP:%.*]] = getelementptr inbounds nuw %T{{.*}}6BigArcVG, ptr [[BUF]], i32 0, i32 0
-// CHECK:         [[RESULT:%.*]] = load ptr, ptr [[TMP]]
-// CHECK:         ret ptr [[RESULT]]
+// CHECK:         [[BUF:%[0-9]+]] = alloca
+// CHECK:         memcpy
+// CHECK:         ret ptr %0
 @_lifetime(borrow target)
 public func borrowBigArc(_ target: BigArc) -> Ref<BigArc> {
 	return Ref(target)

--- a/test/SILOptimizer/mandatory-dead-object-elimination.sil
+++ b/test/SILOptimizer/mandatory-dead-object-elimination.sil
@@ -86,3 +86,210 @@ bb0(%0 : @owned $Klass):
   dealloc_stack %stk : $*Klass
   return %r : $Klass
 }
+
+// `mark_dependence_addr` targeting an otherwise-dead alloc_stack should not
+// block elimination. Its dependence lifts to an SSA-form `mark_dependence` on
+// the forwarded value.
+//
+// CHECK-LABEL: sil [ossa] @mda_load_take :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         [[C:%.*]] = copy_value %0
+// CHECK:         mark_dependence [nonescaping] [[C]] on %0
+// CHECK-LABEL: } // end sil function 'mda_load_take'
+sil [ossa] @mda_load_take : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %3 = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// `load [copy]` variant: the dependence should still lift to an SSA-form
+// `mark_dependence` wrapping the copy.
+//
+// CHECK-LABEL: sil [ossa] @mda_load_copy :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence [nonescaping]
+// CHECK-LABEL: } // end sil function 'mda_load_copy'
+sil [ossa] @mda_load_copy : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %3 = load [copy] %2 : $*Klass
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Multiple `mark_dependence_addr` entries on the same alloc_stack should all
+// lift, producing a chain of `mark_dependence` instructions on the forwarded
+// value.
+//
+// CHECK-LABEL: sil [ossa] @mda_multiple :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence [nonescaping]
+// CHECK:         mark_dependence [nonescaping]
+// CHECK-LABEL: } // end sil function 'mda_multiple'
+sil [ossa] @mda_multiple : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  %2 = copy_value %0 : $Klass
+  %3 = alloc_stack $Klass
+  store %2 to [init] %3 : $*Klass
+  mark_dependence_addr [nonescaping] %3 on %0
+  mark_dependence_addr [nonescaping] %3 on %1
+  %4 = load [take] %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  destroy_value %4 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// The `mark_dependence_addr` dominance analysis does not use a DominatorTree;
+// the alloc_stack is preserved.
+//
+// CHECK-LABEL: sil [ossa] @mda_cross_bb_bail :
+// CHECK:         alloc_stack
+// CHECK:         mark_dependence_addr
+// CHECK-LABEL: } // end sil function 'mda_cross_bb_bail'
+sil [ossa] @mda_cross_bb_bail : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  br bb1
+bb1:
+  %3 = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// `load_borrow` covered by a `mark_dependence_addr` is not yet supported;
+// the alloc_stack is preserved.
+//
+// CHECK-LABEL: sil [ossa] @mda_load_borrow_bail :
+// CHECK:         alloc_stack
+// CHECK:         mark_dependence_addr
+// CHECK-LABEL: } // end sil function 'mda_load_borrow_bail'
+sil [ossa] @mda_load_borrow_bail : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %3 = load_borrow %2 : $*Klass
+  end_borrow %3 : $Klass
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// A `mark_dependence_addr` combined with a value-form `mark_dependence` on
+// the load's address chain. Both dependences must lift to SSA-form marks on
+// the forwarded value: the mda base wraps innermost (from `wrapWithAddrDependences`),
+// then the value-form md base wraps outermost (from `insertMarkDependencies`).
+//
+// CHECK-LABEL: sil [ossa] @mda_and_value_md :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         [[C:%.*]] = copy_value %0
+// CHECK:         [[M0:%.*]] = mark_dependence [nonescaping] [[C]] on %0
+// CHECK:         [[M1:%.*]] = mark_dependence [nonescaping] [[M0]] on %1
+// CHECK:         destroy_value [[M1]]
+// CHECK-LABEL: } // end sil function 'mda_and_value_md'
+sil [ossa] @mda_and_value_md : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  %2 = copy_value %0 : $Klass
+  %3 = alloc_stack $Klass
+  store %2 to [init] %3 : $*Klass
+  %4 = mark_dependence [nonescaping] %3 on %1
+  mark_dependence_addr [nonescaping] %4 on %0
+  %5 = load [take] %4 : $*Klass
+  dealloc_stack %3 : $*Klass
+  destroy_value %5 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// A `mark_dependence_addr` placed after a `load [copy]` does not dominate it.
+// DOE must bail — we cannot lift the mda into an SSA mark_dependence on a
+// load result that precedes the mda.
+//
+// CHECK-LABEL: sil [ossa] @mda_after_load_bail :
+// CHECK:         alloc_stack
+// CHECK:         mark_dependence_addr
+// CHECK-LABEL: } // end sil function 'mda_after_load_bail'
+sil [ossa] @mda_after_load_bail : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  %3 = load [copy] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Two loads flank a single `mark_dependence_addr`. The first load precedes
+// the mda and is therefore not dominated by it. Because the coverage rule
+// requires every mda to dominate every wrappable load, DOE bails even though
+// the second load would be handleable in isolation.
+//
+// CHECK-LABEL: sil [ossa] @mda_partial_dominance_bail :
+// CHECK:         alloc_stack
+// CHECK:         mark_dependence_addr
+// CHECK-LABEL: } // end sil function 'mda_partial_dominance_bail'
+sil [ossa] @mda_partial_dominance_bail : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  %3 = load [copy] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %4 = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  destroy_value %4 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Two mdas: the first dominates the load, but the second is placed after it.
+// The "all mdas must cover all loads" rule fails on the second mda — bail.
+//
+// CHECK-LABEL: sil [ossa] @mda_second_undominating_bail :
+// CHECK:         alloc_stack
+// CHECK:         mark_dependence_addr [nonescaping] %{{.*}} on %0
+// CHECK:         mark_dependence_addr [nonescaping] %{{.*}} on %1
+// CHECK-LABEL: } // end sil function 'mda_second_undominating_bail'
+sil [ossa] @mda_second_undominating_bail : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  %2 = copy_value %0 : $Klass
+  %3 = alloc_stack $Klass
+  store %2 to [init] %3 : $*Klass
+  mark_dependence_addr [nonescaping] %3 on %0
+  %4 = load [take] %3 : $*Klass
+  mark_dependence_addr [nonescaping] %3 on %1
+  dealloc_stack %3 : $*Klass
+  destroy_value %4 : $Klass
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
If all `mark_dependence_addr` instructions with the object as the address operand precede all load-like uses of the address, we can eliminate the object provided we introduce equivalent `mark_dependence` instructions that wrap the value that replaces each load.

Tangentially related to: rdar://183793878

Assisted-by: Claude
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
