### PR TITLE
[cxx-interop] Improvements to incomplete FRT types

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -86,6 +86,7 @@ class DeclContext;
 class DiagnosticEngine;
 class EffectiveClangContext;
 class EnumDecl;
+class Evaluator;
 class FuncDecl;
 class ImportDecl;
 class IRGenOptions;
@@ -818,6 +819,19 @@ bool isCxxConstReferenceType(const clang::Type *type);
 /// Determine whether the given Clang record declaration has an attribute that
 /// makes it import as a reference types. Does not check its bases, if any.
 bool hasImportReferenceAttr(const clang::RecordDecl *decl);
+
+/// Whether any declaration of \p decl carries one of the given swift_attrs.
+/// A swift_attr propagates to later redeclarations only, and Clang carries just
+/// the first one, so an attribute is not necessarily visible on the declaration
+/// at hand.
+bool hasSwiftAttributeOnAnyRedecl(const clang::RecordDecl *decl,
+                                  ArrayRef<StringRef> attrs);
+
+/// Whether the given Clang record is imported as a foreign reference type,
+/// including when it has no definition. Accounts for inherited reference-ness
+/// when a definition is available, and for an annotation on any declaration in
+/// the chain when it is not.
+bool isForeignReferenceRecord(const clang::RecordDecl *decl, Evaluator &eval);
 
 /// Determine whether the given Clang record declaration has the
 /// swift_attr("import_opaque_pointer") attribute, which causes any pointer

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -25,6 +25,30 @@ bool importer::hasImportReferenceAttr(const clang::RecordDecl *decl) {
   return hasSwiftAttribute(decl, {"import_reference"});
 }
 
+bool importer::hasSwiftAttributeOnAnyRedecl(const clang::RecordDecl *decl,
+                                            ArrayRef<StringRef> attrs) {
+  return llvm::any_of(decl->redecls(), [&](const clang::Decl *redecl) {
+    return hasSwiftAttribute(redecl, attrs);
+  });
+}
+
+bool importer::isForeignReferenceRecord(const clang::RecordDecl *decl,
+                                        Evaluator &eval) {
+  // Only ask the request once there is a definition. It is cached per
+  // declaration, so asking about a class template specialization that has not
+  // been instantiated yet would cache "not a reference" for good, even though
+  // instantiating it may reveal a reference base.
+  if (decl->getDefinition())
+    return evaluateOrDefault(eval, ForeignReferenceTypeInfoRequest({decl}),
+                             ForeignReferenceTypeInfo())
+        .isReference();
+
+  // Without one, a direct annotation is all there is to go on.
+  return llvm::any_of(decl->redecls(), [](const clang::Decl *redecl) {
+    return hasImportReferenceAttr(cast<clang::RecordDecl>(redecl));
+  });
+}
+
 bool importer::hasImportAsOpaquePointerAttr(const clang::RecordDecl *decl) {
   return llvm::any_of(decl->specific_attrs<clang::SwiftAttrAttr>(),
                       [](const clang::SwiftAttrAttr *swiftAttr) {
@@ -55,21 +79,20 @@ bool isSelfContainedForDirectView(const clang::Type *type, Evaluator &eval) {
     return true;
 
   if (const auto *recordType = type->getAs<clang::RecordType>()) {
-    auto *definition = recordType->getDecl()->getDefinition();
-    if (!definition)
-      return false;
+    auto *recordDecl = recordType->getDecl();
+    auto *definition = recordDecl->getDefinition();
     // An explicitly unsafe type is never self-contained, so its unsafety is
-    // not silently dropped by an enclosing view.
-    if (importer::hasSwiftAttribute(definition, {"unsafe"}))
+    // not silently dropped by an enclosing view. The annotation may sit on any
+    // declaration of the type, so consider the whole chain.
+    if (importer::hasSwiftAttributeOnAnyRedecl(recordDecl, {"unsafe"}))
       return false;
     // Reference types are managed by Swift, so a pointer to one does not
-    // introduce a lifetime dependency. Use the request rather than a raw
-    // attribute lookup, so that reference-ness inherited from a base class is
-    // taken into account.
-    if (evaluateOrDefault(eval, ForeignReferenceTypeInfoRequest({definition}),
-                          ForeignReferenceTypeInfo())
-            .isReference())
+    // introduce a lifetime dependency. This holds for a reference type that has
+    // only been declared, too.
+    if (importer::isForeignReferenceRecord(recordDecl, eval))
       return true;
+    if (!definition)
+      return false;
     if (importer::hasOwnedValueAttr(definition))
       return true;
   }
@@ -151,7 +174,29 @@ namespace {
 /// The retain:/release: attributes written directly on a record.
 struct RetainReleaseInfo {
   RetainReleaseInfo(const clang::RecordDecl *decl) : decl(decl) {
-    for (auto *attr : decl->specific_attrs<clang::SwiftAttrAttr>()) {
+    // Only the first swift_attr is propagated to a redeclaration, so
+    // retain:/release: are often missing from the declaration at hand even
+    // though the type is annotated. Read them from the declaration that spells
+    // them, and from that one alone, so inherited copies are not counted twice.
+    auto spellsRetainRelease = [](const clang::RecordDecl *record) {
+      return llvm::any_of(record->specific_attrs<clang::SwiftAttrAttr>(),
+                          [](const clang::SwiftAttrAttr *attr) {
+                            return attr->getAttribute().starts_with("retain:") ||
+                                   attr->getAttribute().starts_with("release:");
+                          });
+    };
+    const clang::RecordDecl *carrier = decl;
+    if (!spellsRetainRelease(carrier)) {
+      for (auto *redecl : decl->redecls()) {
+        auto *record = cast<clang::RecordDecl>(redecl);
+        if (spellsRetainRelease(record)) {
+          carrier = record;
+          break;
+        }
+      }
+    }
+
+    for (auto *attr : carrier->specific_attrs<clang::SwiftAttrAttr>()) {
       StringRef attrStr = attr->getAttribute();
       if (attrStr.consume_front("retain:")) {
         ++retainCount;
@@ -419,6 +464,25 @@ swift::extractNearestSourceLoc(const ForeignReferenceTypeInfoDescriptor &desc) {
 ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
     Evaluator &evaluator, ForeignReferenceTypeInfoDescriptor desc) const {
   auto *decl = desc.decl;
+
+  // A swift_attr propagates to later redeclarations only, so an earlier
+  // declaration does not see the annotation, and the retain/release parameters
+  // of SWIFT_SHARED_REFERENCE declare the type before the annotated declaration
+  // is reached. Answer for the declaration that carries the information: the
+  // definition when there is one, since reference-ness can also be inherited
+  // from a base class, and otherwise the declaration spelling the annotation.
+  // Clients can then use the request without walking the chain themselves.
+  if (auto *definition = decl->getDefinition()) {
+    decl = definition;
+  } else if (!importer::hasImportReferenceAttr(decl)) {
+    for (auto *redecl : decl->redecls()) {
+      auto *record = cast<clang::RecordDecl>(redecl);
+      if (importer::hasImportReferenceAttr(record)) {
+        decl = record;
+        break;
+      }
+    }
+  }
 
   if (auto *cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl))
     return ForeignReferenceTypeChecker(cxxDecl).check();
@@ -851,7 +915,10 @@ void importer::checkRetainReleaseFunctions(
   // FIXME: should not be necessary to keep track of this, it is confusing.
   const ClassDecl *annotatedClassDecl = classDecl;
 
-  if (cxxRecordDecl && baseCxxRecordDecl && baseCxxRecordDecl != cxxRecordDecl)
+  // Compare canonical decls: frtInfo may name a different redeclaration of
+  // recordDecl, which is not inheritance.
+  if (cxxRecordDecl && baseCxxRecordDecl &&
+      baseCxxRecordDecl->getCanonicalDecl() != cxxRecordDecl->getCanonicalDecl())
     annotatedClassDecl = cast<ClassDecl>(
         Impl.importDecl(baseCxxRecordDecl, Impl.CurrentVersion));
   else
@@ -860,8 +927,12 @@ void importer::checkRetainReleaseFunctions(
   // Check that the record carrying the retain:/release: attributes has exactly
   // one of each. Only diagnose when those attributes are on this type, to avoid
   // repeating diagnostics once per derived type.
+  //
+  // frtInfo names the declaration the annotation was found on, which for a
+  // forward-declared type need not be the one classDecl was imported from.
   const clang::RecordDecl *annotatedDecl =
-      baseCxxRecordDecl ? baseCxxRecordDecl : recordDecl;
+      baseCxxRecordDecl ? baseCxxRecordDecl
+                        : (frtInfo.getDecl() ? frtInfo.getDecl() : recordDecl);
 
   auto rrInfo = RetainReleaseInfo(annotatedDecl);
   if (!rrInfo.checkShape(/*Impl=*/baseCxxRecordDecl ? nullptr : &Impl))

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1597,6 +1597,13 @@ void swift::deriveAutomaticCxxConformances(
 
   ASSERT(result && clangDecl && "this should not be called with nullptrs");
 
+  // A foreign reference type is imported even when it is only declared, so
+  // this can be reached without a definition. Every conformance below is
+  // derived from members, which an incomplete type does not have, and the
+  // requests used to look them up require a definition.
+  if (!clangDecl->isCompleteDefinition())
+    return;
+
   // Skip synthesizing conformances if the associated Clang node is from
   // a module that doesn't require cplusplus, to prevent us from accidentally
   // pulling in Cxx/CxxStdlib modules when a client is importing a C library.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5759,21 +5759,8 @@ ClangTypeEscapability::evaluate(Evaluator &evaluator,
       // escapable, including a SWIFT_UNSAFE_REFERENCE, whose unsafety is a
       // separate axis. Non-escapable fields and bases are rejected separately,
       // where the type is imported.
-      if (auto *definition = recordDecl->getDefinition()) {
-        if (evaluateOrDefault(evaluator,
-                              ForeignReferenceTypeInfoRequest({definition}), {})
-                .isReference())
-          continue;
-      } else if (llvm::any_of(recordDecl->redecls(), [](const auto *redecl) {
-                   return hasImportReferenceAttr(
-                       cast<clang::RecordDecl>(redecl));
-                 })) {
-        // Inherited reference-ness needs a definition, but a direct annotation
-        // is enough. Ask the attribute, not the request: the request is cached
-        // per decl, so an uninstantiated class template would cache
-        // "not a reference" for good.
+      if (importer::isForeignReferenceRecord(recordDecl, evaluator))
         continue;
-      }
       if (hasSwiftAttribute(recordDecl, {"unsafe", "unsafe(always)"}))
         return CxxEscapability::Unknown;
       llvm::ArrayRef<int> STLParams;
@@ -8774,7 +8761,8 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
       auto *recordDecl = pointeeType->getAsRecordDecl();
       // Pointers are ok if imported as foreign reference types,
       // all other pointers are considered unsafe.
-      return !(recordDecl && hasImportReferenceAttr(recordDecl));
+      return !(recordDecl &&
+               importer::isForeignReferenceRecord(recordDecl, evaluator));
     }
     if (auto *decl = type->getAsTagDecl()) {
       // We need to check the safety of the TagDecl corresponding to this type
@@ -8793,10 +8781,19 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
 
     // Found unsafe; whether decl == desc.decl or not, desc.decl is unsafe
     // (see invariant, above)
-    if (hasSwiftAttribute(decl, {"unsafe", "unsafe(always)"}))
+    //
+    // For a record, the annotation may sit on any of its declarations, so the
+    // verdict must not depend on which one we were handed.
+    auto hasAttrs = [&](ArrayRef<StringRef> attrs) {
+      if (auto *recordDecl = dyn_cast<clang::RecordDecl>(decl))
+        return hasSwiftAttributeOnAnyRedecl(recordDecl, attrs);
+      return hasSwiftAttribute(decl, attrs);
+    };
+
+    if (hasAttrs({"unsafe", "unsafe(always)"}))
       return ExplicitSafety::Unsafe;
 
-    if (hasSwiftAttribute(decl, {"safe"}))
+    if (hasAttrs({"safe"}))
       continue;
 
     if (desc.isClass) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -11001,7 +11001,12 @@ void ClangRecordMemberLoader::load(const clang::RecordDecl *clangRecord,
     }
   }
 
-  if ((isa<clang::CXXRecordDecl>(swiftDecl->getClangDecl())) && !storage &&
+  // These all look up members by name in the Clang record, which requires a
+  // complete definition. A foreign reference type is imported even when it is
+  // only declared, and such a type has no members to find.
+  if (auto *cxxSwiftDecl =
+          dyn_cast<clang::CXXRecordDecl>(swiftDecl->getClangDecl());
+      cxxSwiftDecl && cxxSwiftDecl->isCompleteDefinition() && !storage &&
       !inheritance) {
     (void)Impl.lookupAndImportPointee(swiftDecl);
     (void)Impl.lookupAndImportSuccessor(swiftDecl);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -297,6 +297,11 @@ namespace {
       if (!cxxRecord)
         return;
 
+      // A foreign reference type is imported even when it is only declared, and
+      // an incomplete type has neither bases nor a layout to ask for.
+      if (!cxxRecord->isCompleteDefinition())
+        return;
+
       auto bases = getBasesAndOffsets(cxxRecord);
       for (auto base : bases) {
         if (base.offset != CurSize) {

--- a/test/Interop/Cxx/foreign-reference/incomplete-frt-escapability.swift
+++ b/test/Interop/Cxx/foreign-reference/incomplete-frt-escapability.swift
@@ -1,0 +1,151 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}test.swift \
+// RUN:   -I %t%{fs-sep}Inputs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking \
+// RUN:   -strict-memory-safety
+//
+// An incomplete reference type has no layout to ask Clang for, so check that
+// lowering one does not crash either.
+// RUN: %target-swift-frontend -emit-ir -o /dev/null %t%{fs-sep}test.swift \
+// RUN:   -I %t%{fs-sep}Inputs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -disable-availability-checking
+
+// A foreign reference type may be declared without a definition; it is still
+// imported as a Swift class, and is still escapable and safe. Importing one used
+// to crash, because member loading and conformance synthesis assumed a
+// definition.
+
+//--- Inputs/module.modulemap
+module Test {
+    header "incomplete.h"
+    requires cplusplus
+}
+
+//--- Inputs/incomplete.h
+#include "swift/bridging"
+
+void retainFwd(struct FwdShared *);
+void releaseFwd(struct FwdShared *);
+
+// Declared, never defined.
+struct SWIFT_IMMORTAL_REFERENCE FwdImmortal;
+struct SWIFT_SHARED_REFERENCE(retainFwd, releaseFwd) FwdShared;
+
+// A struct holding pointers to them. The pointers are imported as class
+// references, so nothing here is unsafe.
+struct HoldsIncompleteFRTs {
+  FwdImmortal *immortal;
+  FwdShared *shared;
+};
+
+FwdImmortal *makeImmortal();
+FwdShared *makeShared() SWIFT_RETURNS_UNRETAINED;
+void takeImmortal(FwdImmortal *);
+
+// A non-escapable view over an incomplete reference type is a direct view: the
+// pointee is managed by Swift, so nothing here can dangle.
+struct SWIFT_NONESCAPABLE ViewOfIncomplete {
+  FwdShared *shared;
+};
+ViewOfIncomplete makeView();
+
+// Same shape without the reference annotation: not imported as a class, so this
+// one stays unsafe. Keeps the test honest about -strict-memory-safety being on.
+struct PlainFwd;
+struct HoldsPlainFwd {
+  PlainFwd *plain;
+};
+PlainFwd *makePlain();
+
+// swift_attr only propagates forward, so 'retainLate' declares the type before
+// the annotation is seen. Which declaration gets imported follows name order, so
+// keep the reference type sorting after its holder.
+void retainLate(struct ZLateAnnotated *);
+void releaseLate(struct ZLateAnnotated *);
+struct SWIFT_SHARED_REFERENCE(retainLate, releaseLate) ZLateAnnotated;
+struct AHoldsLateAnnotated {
+  ZLateAnnotated *late;
+};
+
+// SWIFT_NAME injects members via an extension, so they survive skipping member
+// loading for incomplete records.
+int getWeight(FwdImmortal *self) __attribute__((swift_name("getter:FwdImmortal.weight(self:)")));
+void doThing(FwdImmortal *self) __attribute__((swift_name("FwdImmortal.doThing(self:)")));
+
+// An unsafe reference type stays unsafe, whichever declaration is reached first.
+void retainUnsafe(struct FwdUnsafe *);
+void releaseUnsafe(struct FwdUnsafe *);
+struct SWIFT_SHARED_REFERENCE(retainUnsafe, releaseUnsafe) SWIFT_UNSAFE FwdUnsafe;
+struct HoldsFwdUnsafe {
+  FwdUnsafe *p;
+};
+
+//--- test.swift
+import Test
+
+// The incomplete foreign reference types are imported as classes.
+func useImmortal(_ x: FwdImmortal) { _ = x }
+func useShared(_ x: FwdShared) { _ = x }
+// 'public' so that IRGen emits metadata for it, which needs a layout.
+public func useOptional(_ x: FwdImmortal?) { _ = x }
+
+// Returning and passing them requires no 'unsafe'.
+func roundTrip() {
+  let x = makeImmortal()
+  takeImmortal(x)
+  let y = makeShared()
+  _ = y
+}
+
+// A struct holding them is escapable and safe.
+func useHolder(_ x: HoldsIncompleteFRTs) {
+  _ = x
+  _ = x.immortal
+  _ = x.shared
+}
+
+// A non-escapable view over one is a direct view, so it is safe too.
+func useView(_ x: ViewOfIncomplete) {
+  _ = x
+}
+
+// A late-seen annotation still imports the field as a class reference.
+func useLateAnnotated(_ x: AHoldsLateAnnotated) {
+  _ = x
+  _ = x.late
+}
+
+// SWIFT_NAME-injected members are still available.
+func useInjectedMembers(_ x: FwdImmortal) {
+  _ = x.weight
+  x.doThing()
+}
+
+// These two differ only in which declaration is reached first; both must warn.
+func useUnsafeFirst(_ x: FwdUnsafe) {
+  _ = x // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1 {{reference to parameter 'x' involves unsafe type 'FwdUnsafe'}}
+}
+
+func useUnsafeSecond(_ x: HoldsFwdUnsafe) {
+  _ = x.p // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1 {{reference to property 'p' involves unsafe type 'FwdUnsafe'}}
+}
+
+// Without the annotation the pointer is imported as an opaque pointer, which
+// confirms -strict-memory-safety is in effect above.
+func usePlain(_ x: HoldsPlainFwd) {
+  _ = x.plain // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1 {{reference to property 'plain' involves unsafe type 'OpaquePointer'}}
+  // expected-note@-2 {{reference to parameter 'x' involves unsafe type 'HoldsPlainFwd'}}
+}
+
+func makePlainIsUnsafe() {
+  let p = makePlain() // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1 {{reference to global function 'makePlain()' involves unsafe type 'OpaquePointer'}}
+  _ = p // expected-warning {{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  // expected-note@-1 {{reference to let 'p' involves unsafe type 'OpaquePointer'}}
+}


### PR DESCRIPTION
Importing incomplete FRTs in C++ mode caused crashes because we tried to automatically conform them to some protocols but we could not without the definition. This PR skips the automatic conformance code path for incomplete types.

There were some other problematic parts:
* When there are multiple redeclarations, some of them might not have the annotations. This is very frequent as the forward declarations of the retain/release functions might introduce redeclarations of the FRT itself. The code needs to be careful to always find the relevant redeclaration. This confused many parts of the importer.
* There was a code path that tried to load member of incomplete types resulting in a crash.
* Make sure that the ForeignReferenceTypeInfoRequest will return the annotated declaration so the clients do not need to walk the redecl chain to figure out what declarations to look at.
* There was one code path that checked for the inheritance case based on the Decl node's address identity. We should always use the canonical declaration when we do that otherwise redeclarations can confuse this check.