### PR TITLE
Revert "Revert "[Embedded] Support CoroutineAccessors in no-allocations embedded""

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -200,10 +200,16 @@ private struct FunctionChecker {
       )
 
     case let ba as BeginApplyInst:
-      try diagnoseHeapAllocation(
-        Violation(.embedded_swift_allocating_coroutine, in: instruction)
-      )
+      // The old yield_once_1 coroutine uses a heap-allocated frame, so it
+      // cannot be used in no-allocations mode.
+      if !ba.isCalleeAllocated {
+        try diagnoseHeapAllocation(
+          Violation(.embedded_swift_allocating_coroutine, in: instruction)
+        )
+      }
 
+      // For yield_once_2, whether it allocates on the heap or the stack
+      // depends on the provided allocator, which isn't knowable here.
       try checkApply(apply: ba)
 
     case let pai as PartialApplyInst:

--- a/test/embedded/no-allocations-coroutine-legacy.swift
+++ b/test/embedded/no-allocations-coroutine-legacy.swift
@@ -1,0 +1,25 @@
+// A yield_once_1 (_read/_modify) coroutine accessor uses a heap-allocated frame,
+// so calling one is rejected under -no-allocations.  (A callee-allocated
+// yield_once_2 accessor is allowed; see no-allocations-coroutine.swift.)
+
+// RUN: not %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -wmo 2>&1 | %FileCheck %s
+
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// CHECK: error: coroutine accessor involves heap allocation [#PerformanceHints::HeapAllocation]
+
+open class Base {
+  var _i = 42
+  // Dispatched through the class vtable, so the accessor survives inlining.
+  open var i: Int {
+    _read { yield _i }
+    _modify { yield &_i }
+  }
+}
+
+func bump(_ x: inout Int) { x += 1 }
+
+public func f(_ b: Base) { bump(&b.i) }

--- a/test/embedded/no-allocations-coroutine-legacy.swift
+++ b/test/embedded/no-allocations-coroutine-legacy.swift
@@ -2,7 +2,10 @@
 // so calling one is rejected under -no-allocations.  (A callee-allocated
 // yield_once_2 accessor is allowed; see no-allocations-coroutine.swift.)
 
-// RUN: not %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -wmo 2>&1 | %FileCheck %s
+// Note: this test is invalid with `-enable-experimental-feature CoroutineAccessors`
+// and should simply be deleted when that feature is permanently enabled.
+
+// RUN: not %target-swift-emit-ir %s -enable-experimental-feature Embedded -no-allocations -wmo 2>&1 | %FileCheck %s
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1

--- a/test/embedded/no-allocations-coroutine-legacy.swift
+++ b/test/embedded/no-allocations-coroutine-legacy.swift
@@ -10,7 +10,6 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_CoroutineAccessors
 
 // CHECK: error: coroutine accessor involves heap allocation [#PerformanceHints::HeapAllocation]
 

--- a/test/embedded/no-allocations-coroutine.swift
+++ b/test/embedded/no-allocations-coroutine.swift
@@ -1,0 +1,53 @@
+// A callee-allocated (yield_once_2) coroutine accessor allocates its frame on
+// the caller's stack, so using one is allowed under -no-allocations -- whether
+// it is inlined, dispatched through a class vtable, or reached via a protocol
+// conformance's (forwarding) witness thunk.  (A yield_once_1 accessor, which
+// uses a heap-allocated frame, is still rejected; see
+// no-allocations-coroutine-legacy.swift.)
+
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -wmo
+
+// The callee-allocated (yield_once_2) coroutine ABI (which makes coroutine
+// accessors possible in no-allocations mode) is only enabled on Darwin and
+// Linux (see CoroutineAccessorsUseYieldOnce2 in CompilerInvocation).
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public struct NC: ~Copyable { var x = 0 }
+
+func bump(_ x: inout NC) { x.x += 1 }
+
+// Non-virtual: the accessor is inlined away.
+public struct S: ~Copyable {
+  var _x = NC()
+  var x: NC {
+    yielding borrow { yield _x }
+    yielding mutate { yield &_x }
+  }
+}
+public func viaStruct(_ s: inout S) { bump(&s.x) }
+
+// Virtual (class vtable): the accessor survives inlining.
+open class Base {
+  var _s = NC()
+  open var s: NC {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
+}
+public func viaClass(_ b: Base) { bump(&b.s) }
+
+// Protocol conformance: the coroutine-accessor witness thunk forwards its
+// caller's allocator.
+public protocol Q {
+  var v: Int { yielding borrow set }
+}
+public struct Conformer: Q {
+  var _v = 0
+  public var v: Int {
+    yielding borrow { yield _v }
+    yielding mutate { yield &_v }
+  }
+}


### PR DESCRIPTION
Restores swiftlang/swift#90516, Reverts swiftlang/swift#91475

The original PR had a long delay between passing all tests and actually getting merged, so conflicted with an intervening change to the error messages being tested.  I'll use this PR to fix up the conflict and get this re-landed.