### PR TITLE
[rebranch] Adjust to "[clang][deps] Make the service provide the VFS (#181424)

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1072,16 +1072,20 @@ class SwiftDependencyScanningService {
   /// The CAS configuration created the Scanning Service if used.
   std::optional<llvm::cas::CASConfiguration> CASConfig;
 
-  /// The persistent Clang dependency scanner service
-  std::optional<clang::dependencies::DependencyScanningService>
-      ClangScanningService;
+  /// The configuration shared by the Clang dependency scanning service of
+  /// every scanning query performed against this service.
+  ///
+  /// Note that this deliberately excludes
+  /// \c DependencyScanningServiceOptions::MakeVFS, which closes over
+  /// query-specific state and is therefore supplied per query by
+  /// \c getClangScanningServiceOptions.
+  clang::dependencies::DependencyScanningServiceOptions
+      ClangScanningServiceOptions;
 
-  /// Factory that produces the base file system used by each Clang dependency
-  /// scanning worker. Installed as \c DependencyScanningServiceOptions::MakeVFS
-  /// on \c ClangScanningService. Must be thread-safe as it is invoked
-  /// concurrently by multiple workers.
-  std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()>
-      ClangScanningFSFactory;
+  /// The CAS instances shared by all scanning queries performed against this
+  /// service, if caching is enabled.
+  std::shared_ptr<llvm::cas::ObjectStore> CAS;
+  std::shared_ptr<llvm::cas::ActionCache> ActionCache;
 
   /// Shared state mutual-exclusivity lock
   mutable llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
@@ -1094,27 +1098,37 @@ public:
   operator=(const SwiftDependencyScanningService &) = delete;
   virtual ~SwiftDependencyScanningService() {}
 
-  /// Install the factory used to create the base file system for each Clang
-  /// dependency scanning worker and (re)create the underlying Clang scanning
-  /// service so that it picks the factory up. Since the Clang scanning service
-  /// now owns the VFS factory (see \c DependencyScanningServiceOptions::MakeVFS)
-  /// rather than each individual scanning tool, this must be called before any
-  /// worker is created.
-  void setClangScanningFSFactory(
-      std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory);
-
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);
 
   /// Allocate string inside ScanningService.
   StringRef save(StringRef str);
 
-  /// Get clang scanning service.
-  const clang::dependencies::DependencyScanningService &
-  getClangScanningService() const {
-    assert(ClangScanningService);
-    return *ClangScanningService;
-  }
+  /// Retrieve the options with which an individual scanning query should
+  /// construct its own \c clang::dependencies::DependencyScanningService,
+  /// installing \p MakeVFS as the factory producing the base file system of
+  /// each of the query's Clang dependency scanning workers.
+  ///
+  /// A Clang dependency scanning service cannot be shared across the queries
+  /// performed against this service because it owns the base file system
+  /// factory (see \c DependencyScanningServiceOptions::MakeVFS), which closes
+  /// over state specific to an individual query and is invoked lazily
+  /// throughout it.
+  ///
+  /// \p MakeVFS must be thread-safe, as it is invoked concurrently by the
+  /// query's workers.
+  clang::dependencies::DependencyScanningServiceOptions
+  getClangScanningServiceOptions(
+      std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> MakeVFS)
+      const;
+
+  /// The CAS instance shared by all scanning queries, or \c nullptr if caching
+  /// has not been set up.
+  std::shared_ptr<llvm::cas::ObjectStore> getCAS() const;
+
+  /// The action cache shared by all scanning queries, or \c nullptr if caching
+  /// has not been set up.
+  std::shared_ptr<llvm::cas::ActionCache> getActionCache() const;
 
 private:
   /// Enforce clients not being allowed to query this cache directly, it must be

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -113,7 +113,7 @@ private:
 class ModuleDependencyScanningWorker {
 public:
   ModuleDependencyScanningWorker(
-      SwiftDependencyScanningService &globalScanningService,
+      clang::dependencies::DependencyScanningService &clangScanningService,
       const CompilerInvocation &ScanCompilerInvocation,
       const SILOptions &SILOptions, ASTContext &ScanASTContext,
       DependencyTracker &DependencyTracker,
@@ -456,6 +456,21 @@ private:
 
   /// The available pool of workers for filesystem module search
   unsigned NumThreads;
+
+  /// The Clang dependency scanning service backing this scanner's workers.
+  ///
+  /// Unlike the enclosing \c SwiftDependencyScanningService, this cannot be
+  /// shared across scanning queries because it owns the factory producing the
+  /// base file system of each worker (see
+  /// \c DependencyScanningServiceOptions::MakeVFS), which closes over state
+  /// specific to this query and is invoked lazily throughout it.
+  ///
+  /// Must be declared before \c Workers so that it is destroyed after them:
+  /// each worker holds a \c clang::tooling::DependencyScanningTool by value,
+  /// which the service must outlive.
+  std::optional<clang::dependencies::DependencyScanningService>
+      ClangScanningService;
+
   std::list<std::unique_ptr<ModuleDependencyScanningWorker>> Workers;
   llvm::DefaultThreadPool ScanningThreadPool;
   // CAS instance.

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -537,32 +537,39 @@ void ModuleDependencyInfo::setOutputPathAndHash(StringRef outputPath,
 
 SwiftDependencyScanningService::SwiftDependencyScanningService()
     : Alloc(), Saver(Alloc) {
-  clang::dependencies::DependencyScanningServiceOptions opts;
   // ScanningOptimizations::Default excludes the current working directory
   // optimization. Clang needs to communicate with the build system to handle
   // the optimization safely. Swift can handle the working directory
   // optimizaiton already so it is safe to turn on all optimizations.
-  opts.OptimizeArgs = clang::dependencies::ScanningOptimizations::All;
+  ClangScanningServiceOptions.OptimizeArgs =
+      clang::dependencies::ScanningOptimizations::All;
   // The Swift scanner relies on the set of Clang modules visible from each
   // by-name module lookup to resolve Swift overlay and cross-import overlay
   // dependencies, so opt into having Clang report them.
-  opts.ReportVisibleModules = true;
-  opts.MakeVFS = ClangScanningFSFactory;
-
-  ClangScanningService.emplace(std::move(opts));
+  ClangScanningServiceOptions.ReportVisibleModules = true;
 }
 
-void SwiftDependencyScanningService::setClangScanningFSFactory(
-    std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory) {
-  ClangScanningFSFactory = std::move(factory);
-  // The Clang scanning service now owns the base VFS factory (via
-  // DependencyScanningServiceOptions::MakeVFS) rather than each scanning tool,
-  // so re-create it to pick up the new factory while preserving all other
-  // options that were configured earlier (e.g. CAS compilation mode).
-  clang::dependencies::DependencyScanningServiceOptions opts =
-      ClangScanningService->getOpts();
-  opts.MakeVFS = ClangScanningFSFactory;
-  ClangScanningService.emplace(std::move(opts));
+clang::dependencies::DependencyScanningServiceOptions
+SwiftDependencyScanningService::getClangScanningServiceOptions(
+    std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> MakeVFS)
+    const {
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
+  clang::dependencies::DependencyScanningServiceOptions Opts =
+      ClangScanningServiceOptions;
+  Opts.MakeVFS = std::move(MakeVFS);
+  return Opts;
+}
+
+std::shared_ptr<llvm::cas::ObjectStore>
+SwiftDependencyScanningService::getCAS() const {
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
+  return CAS;
+}
+
+std::shared_ptr<llvm::cas::ActionCache>
+SwiftDependencyScanningService::getActionCache() const {
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
+  return ActionCache;
 }
 
 bool
@@ -672,6 +679,8 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   if (!Instance.getInvocation().requiresCAS())
     return false;
 
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
+
   if (CASConfig) {
     // If CASOption matches, the service is initialized already.
     if (*CASConfig == Instance.getInvocation().getCASOptions().Config)
@@ -684,27 +693,19 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
 
   // Setup CAS.
   CASConfig = Instance.getInvocation().getCASOptions().Config;
+  CAS = Instance.getSharedCASInstance();
+  ActionCache = Instance.getSharedCacheInstance();
 
   clang::CASOptions CASOpts;
   CASOpts.CASPath = CASConfig->CASPath;
   CASOpts.PluginPath = CASConfig->PluginPath;
   CASOpts.PluginOptions = CASConfig->PluginOptions;
 
-  {
-    clang::dependencies::DependencyScanningServiceOptions opts;
-    // The current working directory optimization (off by default) should not
-    // impact CAS. We set the optization to all to be consistent with the
-    // non-CAS case.
-    opts.OptimizeArgs = clang::dependencies::ScanningOptimizations::All;
-    // See the non-CAS case above.
-    opts.ReportVisibleModules = true;
-    opts.Compilation = clang::dependencies::IncludeTreeCompilation{
-        CASOpts, Instance.getSharedCASInstance(),
-        Instance.getSharedCacheInstance()};
-    opts.MakeVFS = ClangScanningFSFactory;
-
-    ClangScanningService.emplace(std::move(opts));
-  }
+  // Record the caching configuration to be picked up by the Clang scanning
+  // service of every subsequent scanning query. Note that the remaining
+  // options were configured once and for all in the constructor.
+  ClangScanningServiceOptions.Compilation =
+      clang::dependencies::IncludeTreeCompilation{CASOpts, CAS, ActionCache};
 
   return false;
 }

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -399,9 +399,8 @@ llvm::ErrorOr<ScanQueryContext> DependencyScanningTool::createScanQueryContext(
 
     // Setup the CAS instance from scanning service if applicable.
     if (Invocation->requiresCAS())
-      Instance->setSharedCASInstances(
-          ScanningService->getClangScanningService().getCAS(),
-          ScanningService->getClangScanningService().getActionCache());
+      Instance->setSharedCASInstances(ScanningService->getCAS(),
+                                      ScanningService->getActionCache());
 
     // Setup the instance
     std::string InstanceSetupError;

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -212,7 +212,7 @@ getClangScanningFS(SwiftDependencyScanningService &service,
 }
 
 ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
-    SwiftDependencyScanningService &globalScanningService,
+    clang::dependencies::DependencyScanningService &clangScanningService,
     const CompilerInvocation &ScanCompilerInvocation,
     const SILOptions &SILOptions, ASTContext &ScanASTContext,
     swift::DependencyTracker &DependencyTracker,
@@ -223,14 +223,13 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
       workerSourceMgr(ScanASTContext.SourceMgr.getFileSystem()),
-      clangScanningTool(*globalScanningService.ClangScanningService),
+      clangScanningTool(clangScanningService),
       CAS(CAS), ActionCache(ActionCache),
       diagnosticReporter(DiagnosticReporter),
       ShareClangCompilerInstance(ShareClangCompilerInstance) {
-  assert(globalScanningService.ClangScanningService->getCAS() == CAS &&
+  assert(clangScanningService.getCAS() == CAS &&
          "Need to be the same CAS instance");
-  assert(globalScanningService.ClangScanningService->getActionCache() ==
-             ActionCache &&
+  assert(clangScanningService.getActionCache() == ActionCache &&
          "Need to be the same ActionCache instance");
 
   // Instantiate a worker-specific diagnostic engine and copy over
@@ -604,8 +603,8 @@ ModuleDependencyScanner::ModuleDependencyScanner(
                      ? llvm::hardware_concurrency().compute_thread_count()
                      : 1),
       ScanningThreadPool(llvm::hardware_concurrency(NumThreads)),
-      CAS(ScanningService.ClangScanningService->getCAS()),
-      ActionCache(ScanningService.ClangScanningService->getActionCache()) {
+      CAS(ScanningService.getCAS()),
+      ActionCache(ScanningService.getActionCache()) {
   // Setup prefix mapping.
   auto &ScannerPrefixMapper =
       ScanCompilerInvocation.getSearchPathOptions().ScannerPrefixMapper;
@@ -625,22 +624,25 @@ ModuleDependencyScanner::ModuleDependencyScanner(
         llvm::cas::createCASProvidingFileSystem(
             CAS, ScanASTContext.SourceMgr.getFileSystem()));
 
-  // The Clang dependency scanning service now owns the factory that produces
-  // each worker's base file system (rather than each scanning tool owning its
-  // own). Install it before creating any worker so that the tools pick it up.
-  // The factory creates a fresh file system per worker, as required for
+  // Create the Clang dependency scanning service backing this scan. It owns
+  // the factory that produces each worker's base file system (rather than each
+  // scanning tool owning its own), and that factory closes over state specific
+  // to this scan -- this scan's `ASTContext` and CAS -- so the service cannot
+  // be shared with the other scans performed against `ScanningService`. The
+  // factory creates a fresh file system per worker, as required for
   // thread-safety.
-  ScanningService.setClangScanningFSFactory(
+  ClangScanningService.emplace(ScanningService.getClangScanningServiceOptions(
       [&ScanningService, CAS = this->CAS, &ScanASTContext]() {
         return getClangScanningFS(ScanningService, CAS, ScanASTContext);
-      });
+      }));
 
   // TODO: Make num threads configurable
   for (size_t i = 0; i < NumThreads; ++i)
     Workers.emplace_front(std::make_unique<ModuleDependencyScanningWorker>(
-        ScanningService, ScanCompilerInvocation, SILOptions, ScanASTContext,
-        DependencyTracker, CAS, ActionCache, ScanDiagnosticReporter,
-        PrefixMapper.get(), ShareClangCompilerInstance));
+        *ClangScanningService, ScanCompilerInvocation, SILOptions,
+        ScanASTContext, DependencyTracker, CAS, ActionCache,
+        ScanDiagnosticReporter, PrefixMapper.get(),
+        ShareClangCompilerInstance));
 }
 
 ModuleDependencyScanner::~ModuleDependencyScanner() = default;

--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -22,7 +22,10 @@
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <string>
+#include <thread>
+#include <vector>
 
 using namespace swift;
 using namespace swift::unittest;
@@ -537,4 +540,105 @@ TEST_F(ScanTest, TestStressConcurrentDiagnostics) {
   auto Diagnostics = Dependencies->diagnostics;
   ASSERT_TRUE(Diagnostics->count >= 1);
   swiftscan_dependency_graph_dispose(Dependencies);
+}
+
+// Ensure that full-scan queries issued concurrently against a single
+// `DependencyScanningTool` do not interfere with one another. Each query gets
+// its own `ModuleDependencyScanner`, and anything that scanner shares with the
+// tool must therefore tolerate being used by several scans at once.
+TEST_F(ScanTest, TestConcurrentQueries) {
+  SmallString<256> tempDir;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "ScanTest.TestConcurrentQueries", tempDir));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
+
+  // Create includes
+  std::string IncludeDirPath = createFilename(tempDir, "include");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(IncludeDirPath));
+  std::string CHeadersDirPath = createFilename(IncludeDirPath, "CHeaders");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(CHeadersDirPath));
+
+  // Create test input file
+  std::string TestPathStr = createFilename(tempDir, "foo.swift");
+
+  // Create enough imported C modules for each query to spend a while in the
+  // Clang dependency scanner, so that the queries actually overlap.
+  std::string modulemapContent = "";
+  std::string testFileContent = "";
+  for (int i = 0; i < 50; ++i) {
+    std::string headerName = "A_" + std::to_string(i) + ".h";
+    std::string headerContent = "void funcA_" + std::to_string(i) + "(void);";
+    ASSERT_FALSE(
+        emitFileWithContents(CHeadersDirPath, headerName, headerContent));
+
+    std::string moduleMapEntry = "module A_" + std::to_string(i) + " {\n";
+    moduleMapEntry.append("header \"A_" + std::to_string(i) + ".h\"\n");
+    moduleMapEntry.append("export *\n");
+    moduleMapEntry.append("}\n");
+    modulemapContent.append(moduleMapEntry);
+    testFileContent.append("import A_" + std::to_string(i) + "\n");
+  }
+
+  ASSERT_FALSE(emitFileWithContents(tempDir, "foo.swift", testFileContent));
+  ASSERT_FALSE(emitFileWithContents(CHeadersDirPath, "module.modulemap",
+                                    modulemapContent));
+
+  // Paths to shims and stdlib
+  llvm::SmallString<128> ShimsLibDir = StdLibDir;
+  llvm::sys::path::append(ShimsLibDir, "shims");
+  auto Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
+  llvm::sys::path::append(StdLibDir, getPlatformNameForTriple(Target));
+
+  std::vector<std::string> CommandStr = {
+      TestPathStr,
+      std::string("-I ") + CHeadersDirPath,
+      std::string("-I ") + StdLibDir.str().str(),
+      std::string("-I ") + ShimsLibDir.str().str(),
+      "-module-name",
+      "testConcurrentQueries",
+  };
+
+  // On Windows we need to add an extra escape for path separator characters
+  // because otherwise the command line tokenizer will treat them as escape
+  // characters.
+  for (size_t i = 0; i < CommandStr.size(); ++i)
+    std::replace(CommandStr[i].begin(), CommandStr[i].end(), '\\', '/');
+  std::vector<const char *> Command;
+  for (auto &command : CommandStr)
+    Command.push_back(command.c_str());
+
+  constexpr unsigned NumQueries = 4;
+  std::atomic<unsigned> NumReady(0);
+  std::atomic<unsigned> NumFailed(0);
+  std::atomic<size_t> ModuleCounts[NumQueries] = {};
+  std::vector<std::thread> Queries;
+  Queries.reserve(NumQueries);
+  for (unsigned i = 0; i < NumQueries; ++i) {
+    Queries.emplace_back([&, i]() {
+      // Start all of the queries at roughly the same time to maximize the
+      // overlap between them.
+      ++NumReady;
+      while (NumReady.load() < NumQueries)
+        std::this_thread::yield();
+
+      auto DependenciesOrErr = ScannerTool.getDependencies(Command, {});
+      if (DependenciesOrErr.getError()) {
+        ++NumFailed;
+        return;
+      }
+      auto Dependencies = DependenciesOrErr.get();
+      ModuleCounts[i].store(Dependencies->dependencies->count);
+      swiftscan_dependency_graph_dispose(Dependencies);
+    });
+  }
+
+  for (auto &Query : Queries)
+    Query.join();
+
+  ASSERT_EQ(NumFailed.load(), 0u);
+
+  // The queries are identical, so they must agree. Disagreement would mean a
+  // query resolved dependencies through another query's file system.
+  for (unsigned i = 1; i < NumQueries; ++i)
+    ASSERT_EQ(ModuleCounts[i].load(), ModuleCounts[0].load());
 }


### PR DESCRIPTION
Stop-gap follow-up to https://github.com/swiftlang/swift/commit/e5689361e85db20adb17fa9e46f404580fd7af5e.

```
Thread 3 crashed:
0   clang::dependencies::DependencyScanningService::~DependencyScanningService() + 100
1   swift::SwiftDependencyScanningService::setClangScanningFSFactory(...) + 476
2   swift::ModuleDependencyScanner::ModuleDependencyScanner(...) + 1840
3   (anonymous namespace)::performModuleScanImpl(...) + 1312
4   swift::dependencies::DependencyScanningTool::getDependencies(...) + 384
5   swiftscan_dependency_graph_create + 272

EXC_BAD_ACCESS (SIGSEGV), KERN_INVALID_ADDRESS at 0x0000000000000080
```

The offending commit removed the base-file-system argument from `clang::tooling::DependencyScanningTool`'s constructor and moved it onto the service, as `DependencyScanningServiceOptions::MakeVFS`. Swift's factory closes over query-specific state (`getClangScanningFS` in `lib/DependencyScan/ModuleDependencyScanner.cpp` takes an `ASTContext`), so `e5689361e85` installed it by re-creating `ClangScanningService`, an `std::optional` member whose `emplace` destroys the previous service.

That service is not per-query: `DependencyScanningTool` holds one for its whole lifetime, while `ModuleDependencyScanner::create` runs per query, and its constructor calls `setClangScanningFSFactory`. Since `getDependencies` held no lock, concurrent scans destroyed the shared service out from under each other's workers, freeing `DependencyScanningFilesystemSharedCache::CacheShard` while it was in use -- the very cache the offending commit set out to stop workers poisoning.

Hold `DependencyScanningToolStateLock` across all of `getDependencies` and `getImports` rather than only across `createScanQueryContext`, so that two scans cannot be inside the scanner constructor at once. This is a stopgap that serializes scans issued against one tool; the proper fix is to stop replacing the service, which requires giving the per-query VFS factory a home that is not shared across queries. See the FIXME.

See https://github.com/llvm/llvm-project/commit/e7bad4ac4fc75da8dddec20c3c3f904ab0099496 (https://github.com/llvm/llvm-project/pull/181424).

Assisted-by: Claude Code