### PR TITLE
Revert "[cxx-interop] Enable ForeignReferenceTypeInheritance by default"

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -537,7 +537,7 @@ EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
 
 /// Import a C++ foreign reference type's primary FRT base as a Swift
 /// superclass.
-LANGUAGE_FEATURE(ForeignReferenceTypeInheritance, 0, "foreign reference type inheritance hierarchy")
+EXPERIMENTAL_FEATURE(ForeignReferenceTypeInheritance, true)
 
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
 // TODO: When this is turned on by default, take care of:

--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -481,7 +481,8 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
     // from that base: they are reachable via the Swift superclass chain
     // instead.
     const clang::RecordDecl *superclassClangDecl = nullptr;
-    if (!inheritance) {
+    if (!inheritance &&
+        ctx.LangOpts.hasFeature(Feature::ForeignReferenceTypeInheritance)) {
       auto derivedInfo = evaluateOrDefault(
           ctx.evaluator, ForeignReferenceTypeInfoRequest({cxxRecord}), {});
       if (auto primaryBase = derivedInfo.getPrimarySuperclass())
@@ -912,9 +913,13 @@ ClangImporter::Implementation::lookupAndImportSubscripts(
   // declaring class is that superclass (or a Clang base of it) are reachable
   // via the Swift superclass chain and should not be synthesized here again.
   const clang::CXXRecordDecl *superclassClangDecl = nullptr;
-  auto frtInfo = evaluateOrDefault(
-      SwiftContext.evaluator, ForeignReferenceTypeInfoRequest({CXXRecord}), {});
-  superclassClangDecl = frtInfo.getPrimarySuperclass();
+  if (SwiftContext.LangOpts.hasFeature(
+          Feature::ForeignReferenceTypeInheritance)) {
+    auto frtInfo =
+        evaluateOrDefault(SwiftContext.evaluator,
+                          ForeignReferenceTypeInfoRequest({CXXRecord}), {});
+    superclassClangDecl = frtInfo.getPrimarySuperclass();
+  }
 
   llvm::SmallMapVector<CXXOverloadArgTypes,
                        std::pair<CXXOverload, CXXOverload>, 1>

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2558,15 +2558,18 @@ namespace {
 
           // If this is an inherited foreign reference type, check if it has a
           // suitable superclass.
-          if (auto primaryBase = frtInfo.getPrimarySuperclass()) {
-            if (auto baseDecl = cast_or_null<ClassDecl>(
-                    Impl.importDecl(primaryBase, getVersion()))) {
-              auto classResult = cast<ClassDecl>(result);
-              Type superclassType = baseDecl->getDeclaredInterfaceType();
-              classResult->setSuperclass(superclassType);
-              classResult->setInherited(
-                  Impl.SwiftContext.AllocateCopy(ArrayRef<InheritedEntry>{
-                      TypeLoc::withoutLoc(superclassType)}));
+          if (Impl.SwiftContext.LangOpts.hasFeature(
+                  Feature::ForeignReferenceTypeInheritance)) {
+            if (auto primaryBase = frtInfo.getPrimarySuperclass()) {
+              if (auto baseDecl = cast_or_null<ClassDecl>(
+                      Impl.importDecl(primaryBase, getVersion()))) {
+                auto classResult = cast<ClassDecl>(result);
+                Type superclassType = baseDecl->getDeclaredInterfaceType();
+                classResult->setSuperclass(superclassType);
+                classResult->setInherited(
+                    Impl.SwiftContext.AllocateCopy(ArrayRef<InheritedEntry>{
+                        TypeLoc::withoutLoc(superclassType)}));
+              }
             }
           }
         }
@@ -10973,10 +10976,13 @@ void ClangRecordMemberLoader::load(const clang::RecordDecl *clangRecord,
   if ((cxxRecord = dyn_cast<clang::CXXRecordDecl>(clangRecord)) &&
       cxxRecord->isCompleteDefinition()) {
     const clang::RecordDecl *superclassClangDecl = nullptr;
-    auto derivedInfo =
-        evaluateOrDefault(Impl.SwiftContext.evaluator,
-                          ForeignReferenceTypeInfoRequest({cxxRecord}), {});
-    superclassClangDecl = derivedInfo.getPrimarySuperclass();
+    if (Impl.SwiftContext.LangOpts.hasFeature(
+            Feature::ForeignReferenceTypeInheritance)) {
+      auto derivedInfo =
+          evaluateOrDefault(Impl.SwiftContext.evaluator,
+                            ForeignReferenceTypeInfoRequest({cxxRecord}), {});
+      superclassClangDecl = derivedInfo.getPrimarySuperclass();
+    }
 
     for (auto base : cxxRecord->bases()) {
       if (skipIfNonPublic && base.getAccessSpecifier() != clang::AS_public)

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-executable.swift
@@ -1,8 +1,9 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
 
 // Miscompiles due to unrelated SIL type lowering issue
 // UNSUPPORTED: OS=linux-gnu
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import InheritedGenericArgument
 import StdlibUnittest

--- a/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/inherited-generic-argument-typechecker.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // Native classes conform to AnyObject, but foreign reference types do not, so a
 // base-constrained generic called with a derived FRT must not be ambiguous.

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
@@ -1,15 +1,26 @@
 // RUN: %target-swift-ide-test -source-filename=x -print-module -print-implicit-attrs \
 // RUN:   -cxx-interoperability-mode=default \
 // RUN:   -module-to-print=MemberInheritance -I %S/Inputs  \
-// RUN: | %FileCheck %s
+// RUN: | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -print-implicit-attrs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -module-to-print=MemberInheritance -I %S/Inputs  \
+// RUN:   -enable-experimental-feature ForeignReferenceTypeInheritance \
+// RUN: | %FileCheck --check-prefixes=CHECK,CHECK-ON %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // CHECK: class ImmortalBase {
 // CHECK:  func get42() -> CInt
 // CHECK:  func getOverridden42() -> CInt
 // CHECK: }
-// CHECK: class Immortal : ImmortalBase {
-// CHECK:  override func getOverridden42() -> CInt
-// CHECK: }
+// CHECK-OFF: class Immortal {
+// CHECK-OFF:  func getOverridden42() -> CInt
+// CHECK-OFF:  func get42() -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class Immortal : ImmortalBase {
+// CHECK-ON:  override func getOverridden42() -> CInt
+// CHECK-ON: }
 
 // CHECK: class Immortal2 {
 // CHECK-NEXT: final func virtualMethod(_: HasDestructor)
@@ -23,31 +34,55 @@
 // CHECK:  final func swiftParamsRename(a1 i: CInt) -> CInt
 // CHECK: }
 
-// CHECK: class B1 : A1 {
-// CHECK:  final override func virtualMethod() -> CInt
-// CHECK:  final override func swiftFooRename() -> CInt
-// CHECK:  final override func swiftBarRename() -> CInt
-// CHECK:  final override func swiftParamsRename(a1 i: CInt) -> CInt
-// CHECK: }
+// CHECK-OFF: class B1 {
+// CHECK-OFF:  final func virtualMethod() -> CInt
+// CHECK-OFF:  final func swiftFooRename() -> CInt
+// CHECK-OFF:  final func swiftBarRename() -> CInt
+// CHECK-OFF:  final func swiftParamsRename(a1 i: CInt) -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class B1 : A1 {
+// CHECK-ON:  final override func virtualMethod() -> CInt
+// CHECK-ON:  final override func swiftFooRename() -> CInt
+// CHECK-ON:  final override func swiftBarRename() -> CInt
+// CHECK-ON:  final override func swiftParamsRename(a1 i: CInt) -> CInt
+// CHECK-ON: }
 
-// CHECK: class B2 : A1 {
-// CHECK:   final override func virtualMethod() -> CInt
-// CHECK:   final override func swiftFooRename() -> CInt
-// CHECK:   final override func swiftBarRename() -> CInt
-// CHECK: }
+// CHECK-OFF: class B2 {
+// CHECK-OFF:   final func virtualMethod() -> CInt
+// CHECK-OFF:   final func swiftFooRename() -> CInt
+// CHECK-OFF:   final func swiftBarRename() -> CInt
+// CHECK-OFF:   final func swiftParamsRename(a1 i: CInt) -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class B2 : A1 {
+// CHECK-ON:   final override func virtualMethod() -> CInt
+// CHECK-ON:   final override func swiftFooRename() -> CInt
+// CHECK-ON:   final override func swiftBarRename() -> CInt
+// CHECK-ON: }
 
-// CHECK: class C1 : B1 {
-// CHECK:  final override func swiftFooRename() -> CInt
-// CHECK:  final override func swiftBarRename() -> CInt
-// CHECK:  final override func swiftParamsRename(a1 i: CInt) -> CInt
-// CHECK: }
+// CHECK-OFF: class C1 {
+// CHECK-OFF:  final func swiftFooRename() -> CInt
+// CHECK-OFF:  final func swiftBarRename() -> CInt
+// CHECK-OFF:  final func swiftParamsRename(a1 i: CInt) -> CInt
+// CHECK-OFF:  final func virtualMethod() -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class C1 : B1 {
+// CHECK-ON:  final override func swiftFooRename() -> CInt
+// CHECK-ON:  final override func swiftBarRename() -> CInt
+// CHECK-ON:  final override func swiftParamsRename(a1 i: CInt) -> CInt
+// CHECK-ON: }
 
-// CHECK: class C2 : B1 {
-// CHECK:  final override func virtualMethod() -> CInt
-// CHECK:  final override func swiftFooRename() -> CInt
-// CHECK:  final override func swiftBarRename() -> CInt
-// CHECK:  final override func swiftParamsRename(a1 i: CInt) -> CInt
-// CHECK: }
+// CHECK-OFF: class C2 {
+// CHECK-OFF:  final func virtualMethod() -> CInt
+// CHECK-OFF:  final func swiftFooRename() -> CInt
+// CHECK-OFF:  final func swiftBarRename() -> CInt
+// CHECK-OFF:  final func swiftParamsRename(a1 i: CInt) -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class C2 : B1 {
+// CHECK-ON:  final override func virtualMethod() -> CInt
+// CHECK-ON:  final override func swiftFooRename() -> CInt
+// CHECK-ON:  final override func swiftBarRename() -> CInt
+// CHECK-ON:  final override func swiftParamsRename(a1 i: CInt) -> CInt
+// CHECK-ON: }
 
 // CHECK: class A2 {
 // CHECK:  final func swiftVirtualMethod() -> CInt
@@ -144,26 +179,44 @@
 // CHECK:   final func pureRenameDerived() -> CInt
 // CHECK: }
 
-// CHECK: class DerivedAbstractFRT : AbstractFRT {
-// CHECK:   final override func pureVirtualMethod() -> CInt
-// CHECK:   final override func swiftPureRenameBase() -> CInt
-// CHECK:   final override func pureRenameDerived() -> CInt
-// CHECK: }
+// CHECK-OFF: class DerivedAbstractFRT {
+// CHECK-OFF:   init()
+// CHECK-OFF:   final func pureVirtualMethod() -> CInt
+// CHECK-OFF:   final func swiftPureRenameBase() -> CInt
+// CHECK-OFF:   final func pureRenameDerived() -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class DerivedAbstractFRT : AbstractFRT {
+// CHECK-ON:   final override func pureVirtualMethod() -> CInt
+// CHECK-ON:   final override func swiftPureRenameBase() -> CInt
+// CHECK-ON:   final override func pureRenameDerived() -> CInt
+// CHECK-ON: }
 
-// CHECK: class EmptyDerivedAbstractFRT : AbstractFRT {
-// CHECK: }
+// CHECK-OFF: class EmptyDerivedAbstractFRT {
+// CHECK-OFF:   final func pureVirtualMethod() -> CInt
+// CHECK-OFF:   final func swiftPureRenameBase() -> CInt
+// CHECK-OFF:   final func pureRenameDerived() -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class EmptyDerivedAbstractFRT : AbstractFRT {
+// CHECK-ON: }
 
 // CHECK: class BaseWithInitMethod {
 // CHECK:   func `init`() -> CInt
 // CHECK: }
 
-// CHECK: class DerivedWithInitMethod : BaseWithInitMethod {
-// CHECK:   func `init`() -> CInt
-// CHECK: }
+// CHECK-OFF: class DerivedWithInitMethod {
+// CHECK-OFF:   func `init`() -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class DerivedWithInitMethod : BaseWithInitMethod {
+// CHECK-ON:   func `init`() -> CInt
+// CHECK-ON: }
 
 // CHECK: class RenamedBaseWithInitMethod {
 // CHECK:   func method() -> CInt
 // CHECK: }
 
-// CHECK: class RenamedDerivedWithInitMethod : RenamedBaseWithInitMethod {
-// CHECK: }
+// CHECK-OFF: class RenamedDerivedWithInitMethod {
+// CHECK-OFF:   func method() -> CInt
+// CHECK-OFF: }
+// CHECK-ON: class RenamedDerivedWithInitMethod : RenamedBaseWithInitMethod {
+// CHECK-ON-NOT:   func method() -> CInt
+// CHECK-ON: }

--- a/test/Interop/Cxx/foreign-reference/refcounting-methods-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounting-methods-module-interface.swift
@@ -1,11 +1,18 @@
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -module-to-print=RefCountingMethods -I %S/Inputs -source-filename=x | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -module-to-print=RefCountingMethods -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature ForeignReferenceTypeInheritance -module-to-print=RefCountingMethods -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-ON %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // CHECK: class RefCountedBox {
 // CHECK:   func doRetain()
 // CHECK:   func doRelease()
 // CHECK: }
-// CHECK: class DerivedRefCountedBox : RefCountedBox {
-// CHECK: }
+// CHECK-OFF: class DerivedRefCountedBox {
+// CHECK-OFF:   func doRetain()
+// CHECK-OFF:   func doRelease()
+// CHECK-OFF: }
+// CHECK-ON: class DerivedRefCountedBox : RefCountedBox {
+// CHECK-ON: }
 
 // CHECK: class DerivedHasRelease {
 // CHECK:   func doRetainInBase()
@@ -23,7 +30,8 @@
 // CHECK:   func doRetainInBase()
 // CHECK: }
 
-// CHECK: class CRTPDerived : CRTPBase<CRTPDerived> {
+// CHECK-OFF: class CRTPDerived {
+// CHECK-ON: class CRTPDerived : CRTPBase<CRTPDerived> {
 // CHECK:   var value: CInt
 // CHECK: }
 
@@ -31,7 +39,8 @@
 // CHECK:   func doRetainVirtual()
 // CHECK:   func doReleaseVirtual()
 // CHECK: }
-// CHECK: class DerivedVirtualRetainRelease : VirtualRetainRelease {
+// CHECK-OFF: class DerivedVirtualRetainRelease {
+// CHECK-ON: class DerivedVirtualRetainRelease : VirtualRetainRelease {
 // CHECK:   func doRetainVirtual()
 // CHECK:   func doReleaseVirtual()
 // CHECK: }
@@ -40,7 +49,8 @@
 // CHECK:   func doRetainPure()
 // CHECK:   func doReleasePure()
 // CHECK: }
-// CHECK: class DerivedPureVirtualRetainRelease : PureVirtualRetainRelease {
+// CHECK-OFF: class DerivedPureVirtualRetainRelease {
+// CHECK-ON: class DerivedPureVirtualRetainRelease : PureVirtualRetainRelease {
 // CHECK:   func doRetainPure()
 // CHECK:   func doReleasePure()
 // CHECK:   var refCount: CInt

--- a/test/Interop/Cxx/foreign-reference/super-static-dispatch-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/super-static-dispatch-silgen.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import SuperStaticDispatch
 

--- a/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-silgen.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import SuperVirtualDispatch
 

--- a/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-typechecker.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import SuperVirtualDispatch
 

--- a/test/Interop/Cxx/foreign-reference/super-virtual-dispatch.swift
+++ b/test/Interop/Cxx/foreign-reference/super-virtual-dispatch.swift
@@ -1,6 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import SuperVirtualDispatch
 import StdlibUnittest

--- a/test/Interop/Cxx/foreign-reference/upcast-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-irgen.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import Upcast
 

--- a/test/Interop/Cxx/foreign-reference/upcast-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-module-interface.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Upcast -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -source-filename=x -cxx-interoperability-mode=upcoming-swift -print-implicit-attrs | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Upcast -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -source-filename=x -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature ForeignReferenceTypeInheritance -print-implicit-attrs | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // CHECK: class Base {
 // CHECK:   var baseValue: CInt

--- a/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -disable-availability-checking -I %S/Inputs
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking -I %S/Inputs
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import Upcast
 

--- a/test/Interop/Cxx/foreign-reference/upcast.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast.swift
@@ -1,6 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking -Onone)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // Temporarily disable when running with an older runtime (rdar://181060167)
 // UNSUPPORTED: use_os_stdlib

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -1,6 +1,7 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_SafeInteropWrappersNullAsEmptySpan
- 
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
@@ -8,6 +9,7 @@
 // RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking \
 // RUN:   -Xcc -Wno-nullability-completeness -target %target-swift-6.2-abi-triple \
 // RUN:   -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature SafeInteropWrappersNullAsEmptySpan \
+// RUN:   -enable-experimental-feature ForeignReferenceTypeInheritance \
 // RUN:   -verify-additional-prefix %target-vendor- \
 // RUN:   %if OS_FAMILY=darwin && !OS=xros %{ -verify-additional-prefix nonxros- %}
 

--- a/test/Interop/Cxx/swiftify-import/runtime.swift
+++ b/test/Interop/Cxx/swiftify-import/runtime.swift
@@ -1,16 +1,17 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 // REQUIRES: std_span
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
 
 // RUN: %target-run-simple-swift-split-file(test.swift -I %t%{fs-sep}Inputs -target %target-swift-6.2-abi-triple \
-// RUN:   -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SafeInteropWrappers)
+// RUN:   -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature ForeignReferenceTypeInheritance)
 
 // Signal if unsupported functions start compiling to remind the author of creating a runtime test case.
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs \
 // RUN:   -target %target-swift-6.2-abi-triple -cxx-interoperability-mode=default -Xcc -std=c++20 \
-// RUN:   -enable-experimental-feature SafeInteropWrappers -D NOT_YET_SUPPORTED -verify \
+// RUN:   -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature ForeignReferenceTypeInheritance -D NOT_YET_SUPPORTED -verify \
 // RUN:   -suppress-notes %t/test.swift
 
 // This is the C++ counterpart of test/Interop/C/swiftify-import/runtime.swift.


### PR DESCRIPTION
This reverts commit https://github.com/swiftlang/swift/commit/44c8bd753b9574d4afadb08ca10fe349fc24040b

Enabling this feature by default turned out to be more commonly source breaking than expected.

rdar://182098358