### PR TITLE
Sema: Check the availability of '@objc @implementation' extensions and members

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -925,17 +925,26 @@ public:
 
   /// Get the availability of features introduced in the specified version
   /// of the Swift compiler for the target platform.
-  AvailabilityRange getSwiftAvailability(unsigned major, unsigned minor) const;
+  ///
+  /// Some targets have a minimum supported OS version that postdates the
+  /// introduction of an older Swift runtime, and features from that runtime are
+  /// therefore reported as being always available. Pass \p ignoreMinOS to get
+  /// the OS version in which the features actually appeared instead.
+  AvailabilityRange getSwiftAvailability(unsigned major, unsigned minor,
+                                         bool ignoreMinOS = false) const;
 
   // For each feature defined in FeatureAvailability, define two functions;
   // the latter, with the suffix RuntimeAvailability, is for use with
   // AvailabilityRange::forRuntimeTarget(), and only looks at the Swift
   // runtime version.
 #define FEATURE(N, V)                                                          \
-  inline AvailabilityRange get##N##Availability() const {                      \
+  inline AvailabilityRange get##N##Availability(bool ignoreMinOS = false)      \
+      const {                                                                  \
     if (LangOpts.hasFeature(Feature::Embedded))                                \
       return AvailabilityRange::alwaysAvailable();                             \
-    return getSwiftAvailability V;                                             \
+    auto version = llvm::VersionTuple V;                                       \
+    return getSwiftAvailability(version.getMajor(), *version.getMinor(),       \
+                                ignoreMinOS);                                  \
   }                                                                            \
   inline AvailabilityRange get##N##RuntimeAvailability() const {               \
     return AvailabilityRange(VersionRange::allGTE(llvm::VersionTuple V));      \

--- a/include/swift/AST/AvailabilityRestriction.h
+++ b/include/swift/AST/AvailabilityRestriction.h
@@ -203,7 +203,7 @@ public:
   bool isActiveForRuntimeQueries(const ASTContext &ctx) const;
 
   /// Emit a note indicating the source of availability restriction.
-  bool emitNoteForDecl(const ValueDecl *decl) const;
+  bool emitNoteForDecl(const Decl *decl) const;
 
   /// Emit a note indicating the source of availability restriction.
   bool emitNoteForConformance(const ExtensionDecl *ext,

--- a/include/swift/AST/AvailabilityRestriction.h
+++ b/include/swift/AST/AvailabilityRestriction.h
@@ -209,6 +209,10 @@ public:
   bool emitNoteForConformance(const ExtensionDecl *ext,
                               const RootProtocolConformance *rootConf) const;
 
+  /// Returns true if the name of the domain of \p restriction should be omitted
+  /// from diagnostics describing the restriction.
+  bool shouldHideDomainNameInDiagnostics() const;
+
   void print(raw_ostream &os) const;
 };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2002,6 +2002,14 @@ ERROR(attr_objc_implementation_raise_minimum_deployment_target,none,
       "'@implementation' of an Objective-C class requires a minimum deployment "
       "target of at least %0 %1",
       (AvailabilityDomain, AvailabilityRange))
+ERROR(objc_implementation_extension_only_available_in,none,
+      "'@objc @implementation' extension cannot implement %kind0 because it is "
+      "only available in %1%select{| %3 or newer}2",
+      (const ValueDecl *, AvailabilityDomain, bool, AvailabilityRange))
+ERROR(objc_implementation_extension_unavailable,none,
+      "'@objc @implementation' extension cannot implement %kind0 because it is "
+      "unavailable%select{ in %2|}1",
+      (const ValueDecl *, bool, AvailabilityDomain))
 ERROR(attr_implementation_requires_language,none,
       "'@implementation' used without specifying the language being "
       "implemented",
@@ -2115,6 +2123,17 @@ ERROR(objc_implementation_mismatched_error_convention_other,none,
       "different Objective-C error convention; please file a bug report with a "
       "sample project, as the compiler should be able to describe the mismatch",
       (const ValueDecl *))
+
+ERROR(objc_implementation_availability_mismatch_only_available_in,none,
+      "%kind0 does not match the declaration in the header because it "
+      "%select{is|must be}1 only available in %2%select{| %4 or newer}3",
+      (const ValueDecl *, /*mustBe=*/bool, AvailabilityDomain, bool,
+       AvailabilityRange))
+
+ERROR(objc_implementation_availability_mismatch_unavailable,none,
+      "%kind0 does not match the declaration in the header because it "
+      "%select{is|must be}1 unavailable%select{ in %3|}2",
+      (const ValueDecl *, /*mustBe=*/bool, bool, AvailabilityDomain))
 
 ERROR(objc_implementation_wrong_objc_name,none,
       "selector %0 for %kind1 not found in header; did you mean %2?",
@@ -7483,15 +7502,15 @@ ERROR(availability_decl_unavailable_rename, none,
 
 NOTE(availability_marked_unavailable, none,
      "%0 has been explicitly marked unavailable here",
-     (const ValueDecl *))
+     (const Decl *))
 
 NOTE(availability_introduced_in_version, none,
      "%0 was introduced in %1 %2",
-     (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
+     (const Decl *, AvailabilityDomain, AvailabilityRange))
 
 NOTE(availability_obsoleted, none,
      "%0 was obsoleted in %1 %2",
-     (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
+     (const Decl *, AvailabilityDomain, AvailabilityRange))
 
 GROUPED_WARNING(availability_deprecated, DeprecatedDeclaration, Deprecation,
                 "%0 %select{is|%select{is|was}3}1 "

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -982,11 +982,12 @@ AvailabilityRange ASTContext::getSwiftFutureAvailability() const {
 }
 
 AvailabilityRange ASTContext::getSwiftAvailability(unsigned major,
-                                                   unsigned minor) const {
+                                                   unsigned minor,
+                                                   bool ignoreMinOS) const {
   auto target = LangOpts.Target;
 
   // Deal with special cases for Swift 5.3 and lower
-  if (major == 5 && minor <= 3) {
+  if (major == 5 && minor <= 3 && !ignoreMinOS) {
     if (target.getArchName() == "arm64e")
       return AvailabilityRange::alwaysAvailable();
     if (target.isMacOSX() && target.isAArch64())

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -65,7 +65,7 @@ bool AvailabilityRestriction::isActiveForRuntimeQueries(
                                  /*forRuntimeQuery=*/true);
 }
 
-bool AvailabilityRestriction::emitNoteForDecl(const ValueDecl *decl) const {
+bool AvailabilityRestriction::emitNoteForDecl(const Decl *decl) const {
   auto &ctx = decl->getASTContext();
   auto &diags = ctx.Diags;
   auto parsedAttr = getAttr().getParsedAttr();

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -143,6 +143,29 @@ bool AvailabilityRestriction::emitNoteForConformance(
   return true;
 }
 
+bool AvailabilityRestriction::shouldHideDomainNameInDiagnostics() const {
+  switch (getDomain().getKind()) {
+  case AvailabilityDomain::Kind::Universal:
+  case AvailabilityDomain::Kind::Embedded:
+  case AvailabilityDomain::Kind::Custom:
+  case AvailabilityDomain::Kind::PackageDescription:
+    return true;
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
+  case AvailabilityDomain::Kind::Platform:
+    return false;
+  case AvailabilityDomain::Kind::SwiftLanguageMode:
+    switch (getReason()) {
+    case AvailabilityRestriction::Reason::UnavailableUnconditionally:
+    case AvailabilityRestriction::Reason::UnavailableUnintroduced:
+      return false;
+    case AvailabilityRestriction::Reason::Unintroduced:
+    case AvailabilityRestriction::Reason::UnavailableObsolete:
+    case AvailabilityRestriction::Reason::Deprecated:
+      return true;
+    }
+  }
+}
+
 void AvailabilityRestriction::print(llvm::raw_ostream &os) const {
   os << "AvailabilityRestriction(";
   getAttr().getDomain().print(os);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1858,30 +1858,6 @@ diagnoseExplicitUnavailability(const ValueDecl *D, SourceRange R,
       });
 }
 
-bool shouldHideDomainNameForRestrictionDiagnostic(
-    const AvailabilityRestriction &restriction) {
-  switch (restriction.getDomain().getKind()) {
-  case AvailabilityDomain::Kind::Universal:
-  case AvailabilityDomain::Kind::Embedded:
-  case AvailabilityDomain::Kind::Custom:
-  case AvailabilityDomain::Kind::PackageDescription:
-    return true;
-  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
-  case AvailabilityDomain::Kind::Platform:
-    return false;
-  case AvailabilityDomain::Kind::SwiftLanguageMode:
-    switch (restriction.getReason()) {
-    case AvailabilityRestriction::Reason::UnavailableUnconditionally:
-    case AvailabilityRestriction::Reason::UnavailableUnintroduced:
-      return false;
-    case AvailabilityRestriction::Reason::Unintroduced:
-    case AvailabilityRestriction::Reason::UnavailableObsolete:
-    case AvailabilityRestriction::Reason::Deprecated:
-      return true;
-    }
-  }
-}
-
 bool diagnoseExplicitUnavailability(SourceLoc loc,
                                     const AvailabilityRestriction &restriction,
                                     const RootProtocolConformance *rootConf,
@@ -1912,7 +1888,7 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
   EncodedDiagnosticMessage EncodedMessage(attr.getMessage());
   diags
       .diagnose(loc, diag::conformance_availability_unavailable, type, proto,
-                shouldHideDomainNameForRestrictionDiagnostic(restriction),
+                restriction.shouldHideDomainNameInDiagnostics(),
                 domainAndRange.getDomain(), EncodedMessage.Message)
       .limitBehaviorWithPreconcurrency(behavior, preconcurrency)
       .warnUntilLanguageModeIf(warnIfConformanceUnavailablePreSwift6,
@@ -2252,7 +2228,7 @@ bool diagnoseExplicitUnavailability(
     EncodedDiagnosticMessage EncodedMessage(message);
     diags
         .diagnose(Loc, diag::availability_decl_unavailable, D,
-                  shouldHideDomainNameForRestrictionDiagnostic(restriction),
+                  restriction.shouldHideDomainNameInDiagnostics(),
                   domainAndRange.getDomain(), EncodedMessage.Message)
         .highlight(R)
         .limitBehavior(limit);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3659,3 +3659,25 @@ void swift::checkExplicitAvailability(Decl *decl) {
     }
   }
 }
+
+std::optional<AvailabilityRestriction>
+swift::getRequirementMatchAvailabilityRestriction(
+    const Decl *requirement, const Decl *candidate,
+    AvailabilityRestrictionFlags flags,
+    std::optional<AvailabilityContext> baseAvailability) {
+  auto &ctx = requirement->getASTContext();
+  auto availability = AvailabilityContext::forDeclSignature(requirement);
+
+  if (auto *parent = candidate->parentDeclForAvailability()) {
+    // The candidate cannot be any more available than the decl it is contained
+    // by so only report availability restrictions that are unmet beyond the
+    // parent's availability.
+    auto parentAvailability = AvailabilityContext::forDeclSignature(parent);
+    availability.constrainWithContext(parentAvailability, ctx);
+  }
+
+  if (baseAvailability)
+    availability.constrainWithContext(*baseAvailability, ctx);
+
+  return availability.unsatisfiedRestrictionForDecl(candidate, flags);
+}

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -281,6 +281,19 @@ void fixAvailability(SourceRange ReferenceRange, const DeclContext *ReferenceDC,
                      const AvailabilityDomainAndRange &DomainAndRange,
                      ASTContext &Context);
 
+/// If \p candidate is not available in all contexts in which \p requirement is
+/// available, returns the primary availability restriction that makes
+/// \p candidate less available.
+///
+/// If \p baseAvailability is given, the availability of \p requirement is
+/// further constrained by it, so that \p candidate may be restricted to that
+/// range without being considered less available.
+std::optional<AvailabilityRestriction>
+getRequirementMatchAvailabilityRestriction(
+    const Decl *requirement, const Decl *candidate,
+    AvailabilityRestrictionFlags flags = std::nullopt,
+    std::optional<AvailabilityContext> baseAvailability = std::nullopt);
+
 } // namespace swift
 
 #endif // SWIFT_SEMA_TYPE_CHECK_AVAILABILITY_H

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -14,12 +14,14 @@
 // aspects of declarations.
 //
 //===----------------------------------------------------------------------===//
+#include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckProtocol.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
+#include "swift/AST/AvailabilityRestriction.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ForeignErrorConvention.h"
@@ -30,6 +32,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/Parse/Lexer.h"
 
 #include "clang/AST/DeclObjC.h"
 
@@ -3418,6 +3421,8 @@ public:
     if (interfaceDecls.empty())
       return;
 
+    diagnoseExtensionAvailability(ext, interfaceDecls);
+
     // Add the @_objcImplementation extension's members as candidates.
     addCandidates(ext);
 
@@ -3487,6 +3492,114 @@ private:
     diagnose(afd, diag::objc_implementation_member_requires_vtable, afd);
   }
 
+  /// Adds a fix-it to \p diag inserting the `@available` attribute that would
+  /// impose \p restriction on \p decl.
+  static void addAvailabilityFixIt(InFlightDiagnostic &diag,
+                                   const ValueDecl *decl,
+                                   const AvailabilityRestriction &restriction) {
+    // FIXME: [availability] Consolidate with TypeCheckAvailability.cpp fix-its
+    auto &ctx = decl->getASTContext();
+    auto domainAndRange = restriction.getFixItDomainAndRange(ctx);
+    auto domain = domainAndRange.getDomain();
+
+    llvm::SmallString<64> attrText;
+    llvm::raw_svector_ostream out(attrText);
+    out << "@available(" << domain.getNameForAttributePrinting();
+
+    switch (restriction.getReason()) {
+    case AvailabilityRestriction::Reason::UnavailableUnconditionally:
+      // Don't suggest adding an attribute that we would then diagnose.
+      if (TypeChecker::diagnosticIfDeclCannotBeUnavailable(
+              decl, restriction.getAttr()))
+        return;
+
+      // Likewise, some domains cannot be spelled 'unavailable' at all.
+      switch (domain.getKind()) {
+      case AvailabilityDomain::Kind::SwiftLanguageMode:
+      case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
+      case AvailabilityDomain::Kind::PackageDescription:
+        return;
+
+      case AvailabilityDomain::Kind::Universal:
+      case AvailabilityDomain::Kind::Platform:
+      case AvailabilityDomain::Kind::Custom:
+      case AvailabilityDomain::Kind::Embedded:
+        break;
+      }
+
+      out << ", unavailable";
+      break;
+
+    case AvailabilityRestriction::Reason::Unintroduced:
+    case AvailabilityRestriction::Reason::UnavailableUnintroduced:
+      // Don't suggest adding an attribute that we would then diagnose.
+      if (TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(decl))
+        return;
+
+      if (domain.isVersioned())
+        out << " " << domainAndRange.getRange().getVersionString();
+      if (domain.isPlatform())
+        out << ", *";
+      break;
+
+    case AvailabilityRestriction::Reason::UnavailableObsolete:
+    case AvailabilityRestriction::Reason::Deprecated:
+      // There isn't an attribute that would make the declaration obsolete in
+      // exactly the same way, and deprecation is never unsatisfied.
+      return;
+    }
+
+    auto insertionLoc = decl->getAttributeInsertionLoc(/*forModifier=*/false);
+    if (insertionLoc.isInvalid())
+      return;
+
+    out << ")\n" << Lexer::getIndentationForLine(ctx.SourceMgr, insertionLoc);
+
+    diag.fixItInsert(insertionLoc, attrText);
+  }
+
+  /// If \p ext is less available than the Objective-C declarations in
+  /// \p interfaceDecls that it implements, diagnoses the availability
+  /// restriction that makes it so.
+  void diagnoseExtensionAvailability(ExtensionDecl *ext,
+                                     ArrayRef<Decl *> interfaceDecls) {
+    auto &ctx = ext->getASTContext();
+    if (ctx.LangOpts.DisableAvailabilityChecking)
+      return;
+
+    // Compute the availability of the interface. Imported categories and class
+    // extensions don't carry the availability of the class they extend, so
+    // start from the class; their members are only reachable in contexts where
+    // it is available.
+    auto *nominal = ext->getSelfNominalTypeDecl();
+    auto availability = AvailabilityContext::forDeclSignature(nominal);
+    for (auto interfaceDecl : interfaceDecls)
+      availability.constrainWithContext(
+          AvailabilityContext::forDeclSignature(interfaceDecl), ctx);
+
+    auto restriction = availability.unsatisfiedRestrictionForDecl(ext);
+    if (!restriction)
+      return;
+
+    auto domainAndRange = restriction->getDomainAndRange(ctx);
+    auto domain = domainAndRange.getDomain();
+
+    auto emit = [&]() -> InFlightDiagnostic {
+      if (restriction->isUnavailable())
+        return diagnose(
+            ext, diag::objc_implementation_extension_unavailable, nominal,
+            restriction->shouldHideDomainNameInDiagnostics(), domain);
+
+      return diagnose(
+          ext, diag::objc_implementation_extension_only_available_in, nominal,
+          domain, domain.isVersioned(), domainAndRange.getRange());
+    };
+
+    emit().warnUntilLanguageModeIf(domain.isPlatform(), LanguageMode::future);
+
+    restriction->emitNoteForDecl(ext);
+  }
+
   void addRequirement(Decl *D) {
     auto VD = dyn_cast<ValueDecl>(D);
     if (!VD)
@@ -3497,9 +3610,24 @@ private:
     if (VD->getOverriddenDecl() && !VD->getOverriddenDecl()->isUnavailable())
       return;
 
-    // Skip alternate Swift names for other language modes.
-    if (VD->isUnavailable())
-      return;
+    // Skip members that Swift can never use, like alternate Swift names for
+    // other language modes. Members that are unavailable in a platform or
+    // custom domain, on the other hand, still exist in Objective-C and can be
+    // implemented by an equally unavailable member of the extension.
+    if (auto unavailableAttr = VD->getUnavailableAttr()) {
+      switch (unavailableAttr->getDomain().getKind()) {
+      case AvailabilityDomain::Kind::Universal:
+      case AvailabilityDomain::Kind::SwiftLanguageMode:
+      case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
+      case AvailabilityDomain::Kind::PackageDescription:
+      case AvailabilityDomain::Kind::Embedded:
+        return;
+
+      case AvailabilityDomain::Kind::Platform:
+      case AvailabilityDomain::Kind::Custom:
+        break;
+      }
+    }
 
     // Skip async versions of members. We'll match against the completion
     // handler versions, hopping over to `getAsyncAlternative()` if needed.
@@ -3613,6 +3741,7 @@ private:
     WrongForeignErrorConvention,
     WrongParameterOwnership,
     WrongSendability,
+    WrongAvailability,
 
     Match,
     MatchWithExplicitObjCName,
@@ -3896,6 +4025,55 @@ private:
     return decl->getInterfaceType();
   }
 
+  /// Describes an availability mismatch between a requirement and a candidate
+  /// that implements it.
+  struct AvailabilityMismatch {
+    /// The restriction that makes one of the two declarations unusable in
+    /// contexts where the other one is usable.
+    AvailabilityRestriction restriction;
+
+    /// True if \c restriction applies to the candidate, false if it applies to
+    /// the requirement.
+    bool candidateIsLessAvailable;
+  };
+
+  /// Returns a description of the availability mismatch between \p req and
+  /// \p cand, if there is one. The two must be equally available since the
+  /// Swift declaration is reachable via calls to the Obj-C decl it implements.
+  static std::optional<AvailabilityMismatch>
+  getAvailabilityMismatch(ValueDecl *req, ValueDecl *cand) {
+    auto &ctx = cand->getASTContext();
+    if (ctx.LangOpts.DisableAvailabilityChecking)
+      return std::nullopt;
+
+    std::optional<AvailabilityContext> baseRequirementAvailability;
+
+    // Async functions cannot be any less available than Swift concurrency
+    // support.
+    if (cand->isAsync())
+      baseRequirementAvailability = AvailabilityContext::forPlatformRange(
+          ctx.getBackDeployedConcurrencyAvailability(/*ignoreMinOS=*/true),
+          ctx);
+
+    // A universally unavailable declaration may implement a universally
+    // unavailable requirement.
+    AvailabilityRestrictionFlags flags;
+    flags |= AvailabilityRestrictionFlag::
+        AllowUniversallyUnavailableInCompatibleContexts;
+
+    if (auto restriction = getRequirementMatchAvailabilityRestriction(
+            req, cand, flags, baseRequirementAvailability))
+      return AvailabilityMismatch{*restriction,
+                                  /*candidateIsLessAvailable=*/true};
+
+    if (auto restriction =
+            getRequirementMatchAvailabilityRestriction(cand, req, flags))
+      return AvailabilityMismatch{*restriction,
+                                  /*candidateIsLessAvailable=*/false};
+
+    return std::nullopt;
+  }
+
   MatchOutcome matchesImpl(ValueDecl *req, ValueDecl *cand,
                            ObjCSelector explicitObjCName) const {
     bool hasObjCNameMatch = getObjCName(req) == getObjCName(cand);
@@ -3959,6 +4137,9 @@ private:
       }
     }
 
+    if (getAvailabilityMismatch(req, cand))
+      return MatchOutcome::WrongAvailability;
+
     // If we got here, everything matched. But at what quality?
     if (explicitObjCName)
       return MatchOutcome::MatchWithExplicitObjCName;
@@ -4007,6 +4188,8 @@ private:
       // Successful outcomes!
       // If this member will require a vtable entry, diagnose that now.
       diagnoseVTableUse(cand);
+      // The storage matched, but its accessors may not have.
+      diagnoseAccessorAvailability(req, cand);
       return;
 
     case MatchOutcome::WrongSendability: {
@@ -4140,9 +4323,89 @@ private:
 
       return;
     }
+
+    case MatchOutcome::WrongAvailability: {
+      auto mismatch = getAvailabilityMismatch(req, cand);
+      ASSERT(mismatch);
+
+      diagnoseAvailabilityMismatch(req, cand, *mismatch);
+      return;
+    }
     }
 
     llvm_unreachable("Unknown MatchOutcome");
+  }
+
+  /// Diagnoses \p mismatch, an availability mismatch between the requirement
+  /// \p req and the candidate \p cand that implements it.
+  void diagnoseAvailabilityMismatch(ValueDecl *req, ValueDecl *cand,
+                                    const AvailabilityMismatch &mismatch) {
+    auto &ctx = cand->getASTContext();
+    auto restriction = mismatch.restriction;
+    auto domainAndRange = restriction.getDomainAndRange(ctx);
+    auto domain = domainAndRange.getDomain();
+
+    // If the candidate is the less available of the two, describe how it is
+    // restricted; otherwise, describe how it must be restricted to match the
+    // header.
+    bool mustBe = !mismatch.candidateIsLessAvailable;
+
+    bool hideDomainName = mustBe
+                              ? domain.isUniversal()
+                              : restriction.shouldHideDomainNameInDiagnostics();
+
+    auto emit = [&]() -> InFlightDiagnostic {
+      if (restriction.isUnavailable())
+        return diagnose(
+            cand, diag::objc_implementation_availability_mismatch_unavailable,
+            cand, mustBe, hideDomainName, domain);
+
+      return diagnose(
+          cand,
+          diag::objc_implementation_availability_mismatch_only_available_in,
+          cand, mustBe, domain, domain.isVersioned(),
+          domainAndRange.getRange());
+    };
+
+    {
+      auto diag = emit();
+      diag.warnUntilLanguageModeIf(domain.isPlatform(), LanguageMode::future);
+
+      if (mustBe)
+        addAvailabilityFixIt(diag, cand, restriction);
+    }
+
+    if (!mustBe)
+      restriction.emitNoteForDecl(req);
+  }
+
+  /// Diagnoses the explicitly written accessors of \p cand whose availability
+  /// does not match the corresponding accessor of the storage requirement
+  /// \p req that it implements.
+  ///
+  /// Accessors are not matched against the header individually, but callers
+  /// reach them through the declaration in the header, so the availability of
+  /// the accessors must match.
+  void diagnoseAccessorAvailability(ValueDecl *req, ValueDecl *cand) {
+    auto *reqStorage = dyn_cast<AbstractStorageDecl>(req);
+    auto *candStorage = dyn_cast<AbstractStorageDecl>(cand);
+    if (!reqStorage || !candStorage)
+      return;
+
+    for (auto *candAccessor : candStorage->getAllAccessors()) {
+      // Implicit accessors are synthesized with the availability of their
+      // storage, so they can never mismatch on their own.
+      if (candAccessor->isImplicit())
+        continue;
+
+      auto *reqAccessor =
+          reqStorage->getAccessor(candAccessor->getAccessorKind());
+      if (!reqAccessor)
+        continue;
+
+      if (auto mismatch = getAvailabilityMismatch(reqAccessor, candAccessor))
+        diagnoseAvailabilityMismatch(reqAccessor, candAccessor, *mismatch);
+    }
   }
 
   static Identifier getCategoryName(DeclContext *dc) {
@@ -4178,6 +4441,33 @@ public:
       // Ignore `@optional` protocol requirements.
       if (isOptionalObjCProtocolRequirement(req))
         continue;
+
+      if (auto unavailableAttr = req->getUnavailableAttr()) {
+        switch (unavailableAttr->getDomain().getKind()) {
+        case AvailabilityDomain::Kind::Universal:
+        case AvailabilityDomain::Kind::PackageDescription:
+        case AvailabilityDomain::Kind::Embedded:
+          // Requirements in these domains are either dropped entirely or
+          // never expected to be seen.
+          llvm_unreachable("bad domain kind");
+
+        case AvailabilityDomain::Kind::SwiftLanguageMode:
+        case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
+        case AvailabilityDomain::Kind::Platform:
+          // Requirements that are unavailable on the current platform or in the
+          // current language mode do not have to be implemented.
+          // FIXME: [availability] Be stricter about these requirements.
+          // Just because these requirements are unavailable to *this* Swift
+          // module does not mean that the declaration is unreachable at
+          // runtime.
+          continue;
+
+        case AvailabilityDomain::Kind::Custom:
+          // A requirement that is unavailable in a custom domain can be
+          // dynamically reachable at runtime.
+          break;
+        }
+      }
 
       if (numEmitted == 0) {
         // Emit overall diagnostic for all the notes to attach to.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3384,7 +3384,15 @@ public:
 
     if (isa<AbstractFunctionDecl>(D)) {
       addCandidate(D);
-      addRequirement(D->getImplementedObjCDecl());
+
+      // Unlike the members of an imported interface, which are discovered by
+      // scanning it, the requirement implemented by a function is named by its
+      // attribute, so the filtering that `addRequirement()` performs to weed
+      // out members that cannot be implemented does not apply to it. Add it
+      // directly so that a mismatch is diagnosed instead of leaving the
+      // function unmatched.
+      if (auto *req = dyn_cast<ValueDecl>(D->getImplementedObjCDecl()))
+        unmatchedRequirements.insert(req);
 
       return;
     }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1843,11 +1843,11 @@ enum class OverrideAvailability {
 
 static std::pair<OverrideAvailability, std::optional<AvailabilityRestriction>>
 getOverrideAvailability(ValueDecl *override, ValueDecl *base) {
+  // FIXME: [availability] Adopt getRequirementMatchAvailabilityRestriction().
   auto &ctx = override->getASTContext();
 
-  // Availability is contravariant so make sure the availability of of an
-  // overridden declaration is fully contained in the availability of the
-  // overriding declaration.
+  // Availability is contravariant so make sure the overriding declaration is
+  // at least as available as the overridden declaration.
   auto baseAvailability = AvailabilityContext::forDeclSignature(base);
 
   // The override is allowed to be less available than the base decl as long as

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2024,6 +2024,8 @@ checkWitnessAvailability(const ValueDecl *requirement, const ValueDecl *witness,
   assert(dc->getSelfNominalTypeDecl() &&
          "Must have a nominal or extension context");
 
+  // FIXME: [availability] Adopt getRequirementMatchAvailabilityRestriction().
+
   auto requirementAvailability =
       AvailabilityContext::forDeclSignature(requirement);
   requiredContext.constrainWithContext(requirementAvailability, ctx);

--- a/test/ClangImporter/Inputs/availability_domains_bridging_header.h
+++ b/test/ClangImporter/Inputs/availability_domains_bridging_header.h
@@ -30,6 +30,13 @@ __attribute__((availability(domain:BayBridge, UNAVAIL)))
 
 @end
 
+@interface ImplementMe2 : NSObject
+- (instancetype)init;
+- (void)availableInBayBridge __attribute__((availability(domain:BayBridge, AVAIL)));
+- (void)unavailableInBayBridge
+    __attribute__((availability(domain:BayBridge, UNAVAIL)));
+@end
+
 __attribute__((availability(domain:BayBridge, AVAIL)))
 @interface ImplementMeBayBridgeAvailable : NSObject
 - (instancetype)init;

--- a/test/ClangImporter/availability_custom_domains_objc.swift
+++ b/test/ClangImporter/availability_custom_domains_objc.swift
@@ -28,22 +28,25 @@ func testObjCClasses( // expected-note {{add '@available' attribute to enclosing
 
 @objc @implementation
 extension ImplementMe {
-  // FIXME: [availability] @available(BayBridge) should be required
   func availableInBayBridge() { }
+  // expected-error@-1 {{instance method 'availableInBayBridge()' does not match the declaration in the header because it must be only available in BayBridge}} {{3-3=@available(BayBridge)\n  }}
 
-  // FIXME: [availability] Should match and suggest @available(BayBridge, unavailable)
-  func unavailableInBayBridge() { } // expected-error {{instance method 'unavailableInBayBridge()' does not match any instance method declared in the headers for 'ImplementMe'}}
-  // expected-note@-1 {{add 'private' or 'fileprivate'}}
-  // expected-note@-2 {{add 'final' to define a Swift-only instance method}}
+  func unavailableInBayBridge() { }
+  // expected-error@-1 {{instance method 'unavailableInBayBridge()' does not match the declaration in the header because it must be unavailable in BayBridge}} {{3-3=@available(BayBridge, unavailable)\n  }}
 
   @available(GoldenGateBridge)
   func availableInGoldenGateBridge() { }
 
-  // FIXME: [availability] This should be accepted
   @available(GoldenGateBridge, unavailable)
-  func unavailableInGoldenGateBridge() { } // expected-error {{instance method 'unavailableInGoldenGateBridge()' does not match any instance method declared in the headers for 'ImplementMe'}}
-  // expected-note@-1 {{add 'private' or 'fileprivate'}}
-  // expected-note@-2 {{add 'final' to define a Swift-only instance method}}
+  func unavailableInGoldenGateBridge() { }
+}
+
+@objc @implementation
+extension ImplementMe2 {
+  // expected-error@-1 {{extension for main class interface does not provide all required implementations}}
+  // expected-note@-2 {{missing instance method 'availableInBayBridge()'}}
+  // expected-note@-3 {{missing instance method 'unavailableInBayBridge()'}}
+  // expected-note@-4 {{add stubs for missing '@implementation' requirements}}
 }
 
 @objc @implementation
@@ -63,15 +66,17 @@ extension ImplementMeGoldenGateBridgeAvailable {
 @available(BayBridge)
 @objc @implementation
 extension ImplementMeGoldenGateBridgeAvailable2 { // expected-error {{'ImplementMeGoldenGateBridgeAvailable2' is only available in GoldenGateBridge}}
-  // expected-note@-1 {{add '@available' attribute to enclosing extension}}
+  // expected-error@-1 {{'@objc @implementation' extension cannot implement class 'ImplementMeGoldenGateBridgeAvailable2' because it is only available in BayBridge}}
+  // expected-note@-2 {{add '@available' attribute to enclosing extension}}
 }
 
-// FIXME: [availability] This implementation should be rejected because its less
-// available than the original class declaration.
+// This implementation is rejected because it is less available than the
+// original class declaration.
 @available(BayBridge)
 @available(GoldenGateBridge)
 @objc @implementation
 extension ImplementMeGoldenGateBridgeAvailable3 {
+  // expected-error@-1 {{'@objc @implementation' extension cannot implement class 'ImplementMeGoldenGateBridgeAvailable3' because it is only available in BayBridge}}
 }
 
 @available(GoldenGateBridge, unavailable)

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -234,6 +234,26 @@
 
 @end
 
+__attribute__((deprecated("use SomethingElse instead")))
+@interface UniversallyDeprecatedClass1 : NSObject
+@end
+
+__attribute__((deprecated("use SomethingElse instead")))
+@interface UniversallyDeprecatedClass2 : NSObject
+@end
+
+@interface UniversallyDeprecatedMembersClass : NSObject
+
+- (void)deprecatedMethod1 __attribute__((deprecated("use something else")));
+- (void)deprecatedMethod2 __attribute__((deprecated("use something else")));
+
+@property int deprecatedProperty1
+    __attribute__((deprecated("use something else")));
+
+- (void)notDeprecatedMethod1;
+
+@end
+
 #endif
 
 void CImplFunc1(int param);
@@ -247,6 +267,13 @@ void CImplFuncMismatch2(int param);
 void CImplDuplicate(int param);
 
 void CImplFuncUnavailable1(int param) __attribute__((unavailable));
+void CImplFuncUnavailable2(int param) __attribute__((unavailable));
+void CImplFuncUnavailableInSwift1(int param)
+    __attribute__((availability(swift, unavailable)));
+void CImplFuncDeprecated1(int param)
+    __attribute__((deprecated("use something else")));
+void CImplFuncAvailable1(int param);
+void CImplFuncAvailable2(int param);
 
 #if __OBJC__
 void CImplFuncMismatch3(_Nullable id param);

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -246,6 +246,8 @@ void CImplFuncMismatch2(int param);
 
 void CImplDuplicate(int param);
 
+void CImplFuncUnavailable1(int param) __attribute__((unavailable));
+
 #if __OBJC__
 void CImplFuncMismatch3(_Nullable id param);
 void CImplFuncMismatch4(_Nullable id param);

--- a/test/decl/ext/Inputs/objc_implementation_availability.h
+++ b/test/decl/ext/Inputs/objc_implementation_availability.h
@@ -1,0 +1,143 @@
+@import Foundation;
+
+__attribute__((availability(macosx,introduced=99.0)))
+@interface MacOS99Class1 : NSObject
+@end
+
+__attribute__((availability(macosx,introduced=99.0)))
+@interface MacOS99Class2 : NSObject
+@end
+
+__attribute__((availability(macosx,introduced=99.0)))
+@interface MacOS99Class3 : NSObject
+@end
+
+__attribute__((availability(macosx,unavailable)))
+@interface MacOSUnavailableClass1 : NSObject
+@end
+
+__attribute__((availability(macosx,unavailable)))
+@interface MacOSUnavailableClass2 : NSObject
+@end
+
+__attribute__((availability(macosx,unavailable)))
+@interface MacOSUnavailableClass3 : NSObject
+@end
+
+__attribute__((availability(macosx,introduced=99.0)))
+@interface MacOS99Class4 : NSObject
+@end
+
+// A class extension has no availability of its own; the availability of the
+// class it extends applies to it.
+@interface MacOS99Class4 ()
+- (void)macOS99ClassExtensionMethod;
+@end
+
+@interface AlwaysAvailableClass : NSObject
+
+- (void)macOS99Method1 __attribute__((availability(macosx,introduced=99.0)));
+- (void)macOS99Method2 __attribute__((availability(macosx,introduced=99.0)));
+- (void)macOS99Method3 __attribute__((availability(macosx,introduced=99.0)));
+- (void)macOS99Method4 __attribute__((availability(macosx,introduced=99.0)));
+
+@property int macOS99Property1 __attribute__((availability(macosx,introduced=99.0)));
+@property int macOS99Property2 __attribute__((availability(macosx,introduced=99.0)));
+@property int macOS99Property3 __attribute__((availability(macosx,introduced=99.0)));
+
+- (void)macOSUnavailableMethod1 __attribute__((availability(macosx,unavailable)));
+- (void)macOSUnavailableMethod2 __attribute__((availability(macosx,unavailable)));
+- (void)macOSUnavailableMethod3 __attribute__((availability(macosx,unavailable)));
+
+@end
+
+__attribute__((availability(macosx, deprecated = 10.10)))
+@interface MacOSDeprecated10_10Class1 : NSObject
+@end
+
+__attribute__((availability(macosx, deprecated = 10.10)))
+@interface MacOSDeprecated10_10Class2 : NSObject
+@end
+
+__attribute__((availability(macosx, deprecated = 99.0)))
+@interface MacOSDeprecated99Class1 : NSObject
+@end
+
+@interface DeprecatedMembersClass : NSObject
+
+- (void)macOSDeprecated10_10Method1
+    __attribute__((availability(macosx, deprecated = 10.10)));
+- (void)macOSDeprecated10_10Method2
+    __attribute__((availability(macosx, deprecated = 10.10)));
+- (void)macOSDeprecated99Method1
+    __attribute__((availability(macosx, deprecated = 99.0)));
+
+@property int macOSDeprecated10_10Property1
+    __attribute__((availability(macosx, deprecated=10.10)));
+
+- (void)alwaysAvailableMethod1;
+
+@end
+
+@interface AsyncMembersClass : NSObject
+
+- (void)macOS99Method1WithCompletionHandler:
+    (void (^_Nonnull)(void))completionHandler
+    __attribute__((availability(macosx, introduced = 99.0)));
+- (void)macOS99Method2WithCompletionHandler:
+    (void (^_Nonnull)(void))completionHandler
+    __attribute__((availability(macosx, introduced = 99.0)));
+- (void)macOS99Method3WithCompletionHandler:
+    (void (^_Nonnull)(void))completionHandler
+    __attribute__((availability(macosx, introduced = 99.0)));
+- (void)macOS99Method4WithCompletionHandler:
+    (void (^_Nonnull)(void))completionHandler
+    __attribute__((availability(macosx, introduced = 99.0)));
+- (void)macOSUnavailableMethod1WithCompletionHandler:
+    (void (^_Nonnull)(void))completionHandler
+    __attribute__((availability(macosx, unavailable)));
+- (void)alwaysAvailableMethod1WithCompletionHandler:
+    (void (^_Nonnull)(void))completionHandler;
+- (void)alwaysAvailableMethod2WithCompletionHandler:
+    (void (^_Nonnull)(void))completionHandler;
+
+@end
+
+@interface AccessorMembersClass : NSObject
+
+@property int macOS99Property1
+    __attribute__((availability(macosx, introduced=99.0)));
+@property int macOS99Property2
+    __attribute__((availability(macosx, introduced=99.0)));
+@property int macOS99Property3
+    __attribute__((availability(macosx, introduced=99.0)));
+@property(readonly) int macOS99Property4
+    __attribute__((availability(macosx, introduced=99.0)));
+@property int alwaysAvailableProperty1;
+@property int alwaysAvailableProperty2;
+
+@end
+
+// C functions implemented with '@implementation @_cdecl'.
+
+void macOS99CDeclFunc1(int param)
+    __attribute__((availability(macosx, introduced=99.0)));
+void macOS99CDeclFunc2(int param)
+    __attribute__((availability(macosx, introduced=99.0)));
+void macOS99CDeclFunc3(int param)
+    __attribute__((availability(macosx, introduced=99.0)));
+void macOSUnavailableCDeclFunc1(int param)
+    __attribute__((availability(macosx, unavailable)));
+void alwaysAvailableCDeclFunc1(int param);
+
+// C functions implemented with '@implementation @c'.
+
+void macOS99CFunc1(int param)
+    __attribute__((availability(macosx, introduced=99.0)));
+void macOS99CFunc2(int param)
+    __attribute__((availability(macosx, introduced=99.0)));
+void macOS99CFunc3(int param)
+    __attribute__((availability(macosx, introduced=99.0)));
+void macOSUnavailableCFunc1(int param)
+    __attribute__((availability(macosx, unavailable)));
+void alwaysAvailableCFunc1(int param);

--- a/test/decl/ext/Inputs/objc_implementation_swift_version.apinotes
+++ b/test/decl/ext/Inputs/objc_implementation_swift_version.apinotes
@@ -1,0 +1,25 @@
+Name: objc_implementation_swift_version
+Classes:
+  - Name: ImplementedWithCurrentName
+    Methods:
+      - Selector: "methodWithVersionedName"
+        MethodKind: Instance
+        SwiftName: "currentSwiftName()"
+  - Name: ImplementedWithSwift4Name
+    Methods:
+      - Selector: "methodWithVersionedName"
+        MethodKind: Instance
+        SwiftName: "currentSwiftName()"
+SwiftVersions:
+  - Version: 5
+    Classes:
+      - Name: ImplementedWithCurrentName
+        Methods:
+          - Selector: "methodWithVersionedName"
+            MethodKind: Instance
+            SwiftName: "swift5Name()"
+      - Name: ImplementedWithSwift4Name
+        Methods:
+          - Selector: "methodWithVersionedName"
+            MethodKind: Instance
+            SwiftName: "swift5Name()"

--- a/test/decl/ext/Inputs/objc_implementation_swift_version.h
+++ b/test/decl/ext/Inputs/objc_implementation_swift_version.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+@interface ImplementedWithCurrentName : NSObject
+- (void)methodWithVersionedName;
+@end
+
+@interface ImplementedWithSwift4Name : NSObject
+- (void)methodWithVersionedName;
+@end

--- a/test/decl/ext/Inputs/objc_implementation_swift_version.modulemap
+++ b/test/decl/ext/Inputs/objc_implementation_swift_version.modulemap
@@ -1,0 +1,4 @@
+module objc_implementation_swift_version {
+  header "objc_implementation_swift_version.h"
+  export *
+}

--- a/test/decl/ext/c_implementation.swift
+++ b/test/decl/ext/c_implementation.swift
@@ -50,11 +50,33 @@ func CImplFuncNameMismatch2(_: Int32) {
   // FIXME: Improve diagnostic for a partial match.
 }
 
-// The declaration in the header is unavailable, which used to leave this
-// function unmatched and crash while diagnosing it as an unimplementable
-// member.
+
 @implementation @c
 func CImplFuncUnavailable1(_: Int32) { }
+// expected-error@-1 {{global function 'CImplFuncUnavailable1' does not match the declaration in the header because it must be unavailable}}
+
+@available(*, unavailable)
+@implementation @c
+func CImplFuncUnavailable2(_: Int32) { }
+
+// FIXME: There is no way to satisfy this diagnostic, since 'unavailable' cannot
+// be used in an '@available' attribute for the 'swift' domain.
+@implementation @c
+func CImplFuncUnavailableInSwift1(_: Int32) { }
+// expected-error@-1 {{global function 'CImplFuncUnavailableInSwift1' does not match the declaration in the header because it must be unavailable in Swift}} {{none}}
+
+@implementation @c
+func CImplFuncDeprecated1(_: Int32) { }
+
+@available(*, unavailable)
+@implementation @c
+func CImplFuncAvailable1(_: Int32) { }
+// expected-error@-1 {{global function 'CImplFuncAvailable1' does not match the declaration in the header because it is unavailable}}
+// expected-note@-4 {{'CImplFuncAvailable1' has been explicitly marked unavailable here}}
+
+@available(*, deprecated, message: "use something else")
+@implementation @c
+func CImplFuncAvailable2(_: Int32) { }
 
 //
 // TODO: @c for global functions imported as computed vars

--- a/test/decl/ext/c_implementation.swift
+++ b/test/decl/ext/c_implementation.swift
@@ -50,6 +50,12 @@ func CImplFuncNameMismatch2(_: Int32) {
   // FIXME: Improve diagnostic for a partial match.
 }
 
+// The declaration in the header is unavailable, which used to leave this
+// function unmatched and crash while diagnosing it as an unimplementable
+// member.
+@implementation @c
+func CImplFuncUnavailable1(_: Int32) { }
+
 //
 // TODO: @c for global functions imported as computed vars
 //

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -487,6 +487,24 @@ protocol EmptySwiftProto {}
   }
 }
 
+@objc @implementation extension UniversallyDeprecatedClass1 { }
+// expected-warning@-1 {{'UniversallyDeprecatedClass1' is deprecated: use SomethingElse instead}}
+
+@available(*, deprecated, message: "use SomethingElse instead")
+@objc @implementation extension UniversallyDeprecatedClass2 { }
+
+@objc @implementation extension UniversallyDeprecatedMembersClass {
+  func deprecatedMethod1() { }
+
+  @available(*, deprecated, message: "use something else")
+  func deprecatedMethod2() { }
+
+  var deprecatedProperty1: CInt
+
+  @available(*, deprecated, message: "use something else")
+  func notDeprecatedMethod1() { }
+}
+
 // Intentionally using `@_objcImplementation` for this test; do not upgrade!
 @_objcImplementation(EmptyCategory) extension ObjCClass {
   // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-36=@implementation}} {{1-1=@objc(EmptyCategory) }}
@@ -632,6 +650,33 @@ func CImplFuncNameMismatch2(_: Int32) {
   // expected-error@-2 {{could not find imported function 'mismatchedName2' matching global function 'CImplFuncNameMismatch2'; make sure you import the module or header that declares it}}
   // FIXME: Improve diagnostic for a partial match.
 }
+
+@implementation @_cdecl("CImplFuncUnavailable1")
+func CImplFuncUnavailable1(_: Int32) { }
+// expected-error@-1 {{global function 'CImplFuncUnavailable1' does not match the declaration in the header because it must be unavailable}}
+
+@available(*, unavailable)
+@implementation @_cdecl("CImplFuncUnavailable2")
+func CImplFuncUnavailable2(_: Int32) { }
+
+// FIXME: There is no way to satisfy this diagnostic, since 'unavailable' cannot
+// be used in an '@available' attribute for the 'swift' domain.
+@implementation @_cdecl("CImplFuncUnavailableInSwift1")
+func CImplFuncUnavailableInSwift1(_: Int32) { }
+// expected-error@-1 {{global function 'CImplFuncUnavailableInSwift1' does not match the declaration in the header because it must be unavailable in Swift}} {{none}}
+
+@implementation @_cdecl("CImplFuncDeprecated1")
+func CImplFuncDeprecated1(_: Int32) { }
+
+@available(*, unavailable)
+@implementation @_cdecl("CImplFuncAvailable1")
+func CImplFuncAvailable1(_: Int32) { }
+// expected-error@-1 {{global function 'CImplFuncAvailable1' does not match the declaration in the header because it is unavailable}}
+// expected-note@-4 {{'CImplFuncAvailable1' has been explicitly marked unavailable here}}
+
+@available(*, deprecated, message: "use something else")
+@implementation @_cdecl("CImplFuncAvailable2")
+func CImplFuncAvailable2(_: Int32) { }
 
 //
 // TODO: @_cdecl for global functions imported as computed vars

--- a/test/decl/ext/objc_implementation_availability.swift
+++ b/test/decl/ext/objc_implementation_availability.swift
@@ -1,0 +1,214 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_implementation_availability.h -target %target-stable-abi-triple -Xcc -Wno-nullability-completeness
+// REQUIRES: OS=macosx
+
+@objc @implementation extension MacOS99Class1 {
+  // expected-error@-1 {{'MacOS99Class1' is only available in macOS 99.0 or newer}}
+  // expected-note@-2 {{add '@available' attribute to enclosing extension}}{{1-1=@available(macOS 99.0, *)\n}}
+}
+
+@available(macOS 99.0, *)
+@objc @implementation extension MacOS99Class2 { }
+
+@available(macOS 100.0, *)
+@objc @implementation extension MacOS99Class3 {
+  // expected-warning@-1 {{'@objc @implementation' extension cannot implement class 'MacOS99Class3' because it is only available in macOS 100.0 or newer}}
+}
+
+@objc @implementation extension MacOSUnavailableClass1 {
+  // expected-error@-1 {{'MacOSUnavailableClass1' is unavailable in macOS}}
+}
+
+@available(macOS, unavailable)
+@objc @implementation extension MacOSUnavailableClass2 { }
+
+@available(*, unavailable)
+@objc @implementation extension MacOSUnavailableClass3 {
+  // expected-error@-1 {{'@objc @implementation' extension cannot implement class 'MacOSUnavailableClass3' because it is unavailable}} {{none}}
+  // expected-note@-3 {{extension of 'MacOSUnavailableClass3' has been explicitly marked unavailable here}} {{none}}
+}
+
+// The class extension in the header does not have availability of its own, so
+// matching the availability of the class is sufficient.
+@available(macOS 99.0, *)
+@objc @implementation extension MacOS99Class4 {
+  func macOS99ClassExtensionMethod() { }
+}
+
+@objc @implementation extension AlwaysAvailableClass {
+  func macOS99Method1() { }
+  // expected-warning@-1 {{instance method 'macOS99Method1()' does not match the declaration in the header because it must be only available in macOS 99.0 or newer}} {{3-3=@available(macOS 99.0, *)\n  }}
+
+  @available(macOS 99.0, *)
+  func macOS99Method2() { }
+
+  @available(macOS 100.0, *)
+  func macOS99Method3() { }
+  // expected-warning@-1 {{instance method 'macOS99Method3()' does not match the declaration in the header because it is only available in macOS 100.0 or newer}}
+
+  @objc(macOS99Method4)
+  func macOS99Method4() { }
+  // expected-warning@-1 {{instance method 'macOS99Method4()' does not match the declaration in the header because it must be only available in macOS 99.0 or newer}} {{-1:3-3=@available(macOS 99.0, *)\n  }}
+
+  // No fix-it is offered because a stored property cannot be marked
+  // potentially unavailable.
+  var macOS99Property1: CInt
+  // expected-warning@-1 {{property 'macOS99Property1' does not match the declaration in the header because it must be only available in macOS 99.0 or newer}}
+
+  @available(macOS 99.0, *) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  var macOS99Property2: CInt
+
+  @available(macOS 100.0, *) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  var macOS99Property3: CInt
+  // expected-warning@-1 {{property 'macOS99Property3' does not match the declaration in the header because it is only available in macOS 100.0 or newer}}
+
+  func macOSUnavailableMethod1() { }
+  // expected-warning@-1 {{instance method 'macOSUnavailableMethod1()' does not match the declaration in the header because it must be unavailable in macOS}} {{3-3=@available(macOS, unavailable)\n  }}
+
+  @available(macOS, unavailable)
+  func macOSUnavailableMethod2() { }
+
+  @available(*, unavailable)
+  func macOSUnavailableMethod3() { }
+  // expected-error@-1 {{instance method 'macOSUnavailableMethod3()' does not match the declaration in the header because it is unavailable}}
+  // expected-note@-3 {{'macOSUnavailableMethod3()' has been explicitly marked unavailable here}}
+}
+
+@objc @implementation extension MacOSDeprecated10_10Class1 { }
+// expected-warning@-1 {{'MacOSDeprecated10_10Class1' was deprecated in macOS 10.10}}
+
+@available(macOS, deprecated: 10.10)
+@objc @implementation extension MacOSDeprecated10_10Class2 { }
+
+@objc @implementation extension MacOSDeprecated99Class1 { }
+
+@objc @implementation extension DeprecatedMembersClass {
+  func macOSDeprecated10_10Method1() { }
+
+  // But it may be.
+  @available(macOS, deprecated: 10.10)
+  func macOSDeprecated10_10Method2() { }
+
+  func macOSDeprecated99Method1() { }
+
+  var macOSDeprecated10_10Property1: CInt
+
+  @available(macOS, deprecated: 10.10)
+  func alwaysAvailableMethod1() { }
+}
+
+@objc @implementation extension AsyncMembersClass {
+  @available(macOS 99.0, *)
+  func macOS99Method1() async { }
+
+  @available(macOS 10.15, *)
+  func macOS99Method2() async { }
+  // expected-warning@-1 {{instance method 'macOS99Method2()' does not match the declaration in the header because it must be only available in macOS 99.0 or newer}} {{-1:3-3=@available(macOS 99.0, *)\n  }}
+
+  @available(macOS 100.0, *)
+  func macOS99Method3() async { }
+  // expected-warning@-1 {{instance method 'macOS99Method3()' does not match the declaration in the header because it is only available in macOS 100.0 or newer}}
+
+  func macOS99Method4(completionHandler: @escaping () -> Void) { }
+  // expected-warning@-1 {{instance method 'macOS99Method4(completionHandler:)' does not match the declaration in the header because it must be only available in macOS 99.0 or newer}} {{3-3=@available(macOS 99.0, *)\n  }}
+
+  @available(macOS 10.15, *)
+  func macOSUnavailableMethod1() async { }
+  // expected-warning@-1 {{instance method 'macOSUnavailableMethod1()' does not match the declaration in the header because it must be unavailable in macOS}} {{-1:3-3=@available(macOS, unavailable)\n  }}
+
+  @available(macOS 99.0, *)
+  func alwaysAvailableMethod1() async { }
+  // expected-warning@-1 {{instance method 'alwaysAvailableMethod1()' does not match the declaration in the header because it is only available in macOS 99.0 or newer}}
+
+  // An 'async' implementation may additionally require the availability of the
+  // back deployed Swift concurrency runtime, since it cannot be called without
+  // it and the header has no way to express that requirement.
+  @available(macOS 10.15, *)
+  func alwaysAvailableMethod2() async { }
+}
+
+@objc @implementation extension AccessorMembersClass {
+  @available(macOS 99.0, *)
+  var macOS99Property1: CInt {
+    get { 0 }
+    set { }
+  }
+
+  @available(macOS 99.0, *)
+  var macOS99Property2: CInt {
+    @available(macOS 100.0, *)
+    get { 0 }
+    // expected-warning@-1 {{getter for property 'macOS99Property2' does not match the declaration in the header because it is only available in macOS 100.0 or newer}}
+    set { }
+  }
+
+  @available(macOS 99.0, *)
+  var macOS99Property3: CInt {
+    get { 0 }
+    @available(macOS, unavailable)
+    // expected-note@-1 {{setter for 'macOS99Property3' has been explicitly marked unavailable here}}
+    set { }
+    // expected-warning@-1 {{setter for property 'macOS99Property3' does not match the declaration in the header because it is unavailable in macOS}}
+  }
+
+  // OK, the implicit getter of a read-only property inherits its availability.
+  @available(macOS 99.0, *)
+  var macOS99Property4: CInt { 0 }
+
+  var alwaysAvailableProperty1: CInt {
+    @available(macOS 99.0, *)
+    get { 0 }
+    // expected-warning@-1 {{getter for property 'alwaysAvailableProperty1' does not match the declaration in the header because it is only available in macOS 99.0 or newer}}
+    set { }
+  }
+
+  @available(macOS 99.0, *)
+  var alwaysAvailableProperty2: CInt {
+    // expected-warning@-1 {{property 'alwaysAvailableProperty2' does not match the declaration in the header because it is only available in macOS 99.0 or newer}}
+    get { 0 }
+    set { }
+  }
+}
+
+@implementation @_cdecl("macOS99CDeclFunc1")
+func macOS99CDeclFunc1(_: Int32) { }
+// expected-warning@-1 {{global function 'macOS99CDeclFunc1' does not match the declaration in the header because it must be only available in macOS 99.0 or newer}}
+
+@available(macOS 99.0, *)
+@implementation @_cdecl("macOS99CDeclFunc2")
+func macOS99CDeclFunc2(_: Int32) { }
+
+@available(macOS 100.0, *)
+@implementation @_cdecl("macOS99CDeclFunc3")
+func macOS99CDeclFunc3(_: Int32) { }
+// expected-warning@-1 {{global function 'macOS99CDeclFunc3' does not match the declaration in the header because it is only available in macOS 100.0 or newer}}
+
+@implementation @_cdecl("macOSUnavailableCDeclFunc1")
+func macOSUnavailableCDeclFunc1(_: Int32) { }
+// expected-warning@-1 {{global function 'macOSUnavailableCDeclFunc1' does not match the declaration in the header because it must be unavailable in macOS}}
+
+@available(macOS 99.0, *)
+@implementation @_cdecl("alwaysAvailableCDeclFunc1")
+func alwaysAvailableCDeclFunc1(_: Int32) { }
+// expected-warning@-1 {{global function 'alwaysAvailableCDeclFunc1' does not match the declaration in the header because it is only available in macOS 99.0 or newer}}
+
+@implementation @c
+func macOS99CFunc1(_: Int32) { }
+// expected-warning@-1 {{global function 'macOS99CFunc1' does not match the declaration in the header because it must be only available in macOS 99.0 or newer}}
+
+@available(macOS 99.0, *)
+@implementation @c
+func macOS99CFunc2(_: Int32) { }
+
+@available(macOS 100.0, *)
+@implementation @c
+func macOS99CFunc3(_: Int32) { }
+// expected-warning@-1 {{global function 'macOS99CFunc3' does not match the declaration in the header because it is only available in macOS 100.0 or newer}}
+
+@implementation @c
+func macOSUnavailableCFunc1(_: Int32) { }
+// expected-warning@-1 {{global function 'macOSUnavailableCFunc1' does not match the declaration in the header because it must be unavailable in macOS}}
+
+@available(macOS 99.0, *)
+@implementation @c
+func alwaysAvailableCFunc1(_: Int32) { }
+// expected-warning@-1 {{global function 'alwaysAvailableCFunc1' does not match the declaration in the header because it is only available in macOS 99.0 or newer}}

--- a/test/decl/ext/objc_implementation_direct_to_storage.swift
+++ b/test/decl/ext/objc_implementation_direct_to_storage.swift
@@ -4,9 +4,10 @@
 
 import objc_implementation_internal
 
-// FIXME: [availability] An implementation that is less available than the interface it implements should be diagnosed
 @available(macOS, unavailable)
 @objc @implementation extension ObjCPropertyTest {
+  // expected-warning@-1 {{'@objc @implementation' extension cannot implement class 'ObjCPropertyTest' because it is unavailable in macOS; this will be an error in a future Swift language mode}}
+  // expected-note@-3 {{extension of 'ObjCPropertyTest' has been explicitly marked unavailable here}}
   let prop1: Int32
 
   var prop2: Int32 {

--- a/test/decl/ext/objc_implementation_swift_version_names.swift
+++ b/test/decl/ext/objc_implementation_swift_version_names.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-additional-prefix swift6- -swift-version 6 -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_swift_version.modulemap -target %target-stable-abi-triple
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-additional-prefix swift5- -swift-version 5 -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_swift_version.modulemap -target %target-stable-abi-triple
+
+// REQUIRES: objc_interop
+
+import objc_implementation_swift_version
+
+@objc @implementation extension ImplementedWithCurrentName {
+  // In Swift 6 this implements the requirement. In Swift 5 it spells a name
+  // that is not introduced until a future language mode, so the requirement it
+  // appears to implement is 'swift5Name()' instead.
+  @objc(methodWithVersionedName)
+  func currentSwiftName() { }
+  // expected-swift5-error@-1 {{selector 'methodWithVersionedName' used in header by instance method with a different name; did you mean 'swift5Name()'?}}
+}
+
+@objc @implementation extension ImplementedWithSwift4Name {
+  // In Swift 5 this implements the requirement. In Swift 6 it spells a name
+  // that is obsoleted in the current language mode, so the requirement it
+  // appears to implement is 'currentSwiftName()' instead.
+  @objc(methodWithVersionedName)
+  func swift5Name() { }
+  // expected-swift6-error@-1 {{selector 'methodWithVersionedName' used in header by instance method with a different name; did you mean 'currentSwiftName()'?}}
+}


### PR DESCRIPTION
An `@objc @implementation` extension and its members have to be exactly as available as the Objective-C declarations they implement. An implementation that is less available than its interface cannot be allowed because that would admit an availability checking soundness hole. An implementation that is more available, on the other hand, is sound but is likely not what the developer intended. For example, if the declaration in the header is marked as available in a custom availability domain, then the developer likely expects the Swift implementation to be compiled out when that domain is disabled at compile time.

Diagnose an extension that is less available than the `@interface` it implements, and add a 'WrongAvailability' match outcome that diagnoses a member whose availability differs from the declaration in the header in either direction, offering a fix-it to add the necessary `@available` attribute when the header is the more restrictive of the two.

Requirements that are unavailable in a platform or custom domain are no longer skipped when matching, since they still exist in Objective-C and can be implemented by an equally unavailable member. They don't require an implementation, though, so they are ignored when diagnosing missing implementations.

Resolves rdar://156564928.