### PR TITLE
[IRGen] Prepare for LLVM's removal of the Os pipeline

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -54,6 +54,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/InlineCost.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/CodeGen/BasicTTIImpl.h"
@@ -392,6 +393,22 @@ void swift::performLLVMOptimizations(
     // LLVM is removing the Os pipeline and will instead rely
     // on O2 with the appropriate function attributes
     level = llvm::OptimizationLevel::O2;
+
+    // Swift always used the Os pipeline for optimized builds; a few of its
+    // tunings are keyed off the pipeline size level rather than the function
+    // optsize/minsize attribute, so reproduce them on O2 to preserve behavior.
+    // (Loop unrolling/vectorization and the per-caller inline clamps are
+    // attribute-driven and identical on Os and O2, so need no adjustment.)
+
+    // Os used the size-tuned inline threshold; O2 uses the larger speed default.
+    PTO.InlinerThreshold = llvm::InlineConstants::OptSizeThreshold;
+
+    // Os disabled IPSCCP function specialization. There is no PTO knob, so
+    // neutralize it through its cost option.
+    auto &RegisteredOpts = llvm::cl::getRegisteredOptions();
+    if (auto *MaxClones = static_cast<llvm::cl::opt<unsigned> *>(
+            RegisteredOpts.lookup("funcspec-max-clones")))
+      *MaxClones = 0;
   } else {
     level = llvm::OptimizationLevel::O0;
   }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -389,7 +389,9 @@ void swift::performLLVMOptimizations(
     PTO.MergeFunctions = !Opts.DisableLLVMMergeFunctions;
     // Splitting trades code size to enhance memory locality, avoid in -Osize.
     DoHotColdSplit = Opts.EnableHotColdSplit && !Opts.optimizeForSize();
-    level = llvm::OptimizationLevel::Os;
+    // LLVM is removing the Os pipeline and will instead rely
+    // on O2 with the appropriate function attributes
+    level = llvm::OptimizationLevel::O2;
   } else {
     level = llvm::OptimizationLevel::O0;
   }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1642,6 +1642,9 @@ void IRGenModule::constructInitialFnAttributes(
   if (FuncOptMode == OptimizationMode::ForSize) {
     Attrs.addAttribute(llvm::Attribute::OptimizeForSize);
     Attrs.addAttribute(llvm::Attribute::MinSize);
+  } else if (FuncOptMode == OptimizationMode::ForSpeed) {
+    Attrs.removeAttribute(llvm::Attribute::MinSize);
+    Attrs.addAttribute(llvm::Attribute::OptimizeForSize);
   } else {
     Attrs.removeAttribute(llvm::Attribute::MinSize);
     Attrs.removeAttribute(llvm::Attribute::OptimizeForSize);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1639,12 +1639,11 @@ void IRGenModule::constructInitialFnAttributes(
   // Add/remove MinSize based on the appropriate setting.
   if (FuncOptMode == OptimizationMode::NotSet)
     FuncOptMode = IRGen.Opts.OptMode;
+  // Mirror Clang (getTrivialDefaultFunctionAttributes): only size-optimized
+  // functions get OptimizeForSize/MinSize; speed functions get neither.
   if (FuncOptMode == OptimizationMode::ForSize) {
     Attrs.addAttribute(llvm::Attribute::OptimizeForSize);
     Attrs.addAttribute(llvm::Attribute::MinSize);
-  } else if (FuncOptMode == OptimizationMode::ForSpeed) {
-    Attrs.removeAttribute(llvm::Attribute::MinSize);
-    Attrs.addAttribute(llvm::Attribute::OptimizeForSize);
   } else {
     Attrs.removeAttribute(llvm::Attribute::MinSize);
     Attrs.removeAttribute(llvm::Attribute::OptimizeForSize);


### PR DESCRIPTION
rdar://184934555

LLVM has removed the Os and Oz pipelines and instead relies on O2 with the appropriate function attributes.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
