### PR TITLE
[Embedded] Verify previous behavior without `CoroutineAccessors`

### DIFF
--- a/test/embedded/no-allocations-coroutine-legacy.swift
+++ b/test/embedded/no-allocations-coroutine-legacy.swift
@@ -2,7 +2,10 @@
 // so calling one is rejected under -no-allocations.  (A callee-allocated
 // yield_once_2 accessor is allowed; see no-allocations-coroutine.swift.)
 
-// RUN: not %target-swift-emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature CoroutineAccessors -no-allocations -wmo 2>&1 | %FileCheck %s
+// Note: this test is invalid with `-enable-experimental-feature CoroutineAccessors`
+// and should simply be deleted when that feature is permanently enabled.
+
+// RUN: not %target-swift-emit-ir %s -enable-experimental-feature Embedded -no-allocations -wmo 2>&1 | %FileCheck %s
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1


### PR DESCRIPTION
This test was intended to verify that we preserved the old behavior without the `CoroutineAccessors` feature. But the command line got copied from the other test.