### PR TITLE
Naming and comment updates -- No Functional Change

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -9055,7 +9055,7 @@ class AccessorDecl final : public FuncDecl {
   AbstractStorageDecl *Storage;
 
   /// Whether a yield_once_2 coroutine accessor (yielding borrow/mutate) was
-  /// written by the user with the underscored spelling (_read/_modify).  This
+  /// written by the user with the legacy spelling (_read/_modify).  This
   /// only affects diagnostics; it has no ABI or type-system effect.
   bool SpelledWithLegacyCoroutineSyntax = false;
 
@@ -9139,15 +9139,15 @@ public:
   /// When the CoroutineAccessors feature is enabled, a `_read`/`_modify`
   /// accessor is represented as a `yielding borrow`/`yielding mutate`
   /// (yield_once_2) accessor so that it uses the same ABI, remembering here that
-  /// the user wrote the underscored spelling.  This only affects diagnostics.
+  /// the user wrote the legacy spelling.  This only affects diagnostics.
   ///
-  /// Rewrites this accessor's kind from the underscored coroutine accessor
-  /// (Read/Modify) to its yielding counterpart (YieldingBorrow/YieldingMutate),
-  /// recording that it was spelled with the underscored keyword.
+  /// Rewrites this accessor's kind from the legacy coroutine accessor
+  /// (Read/Modify) to its official counterpart (YieldingBorrow/YieldingMutate),
+  /// recording that it was spelled with the legacy keyword.
   void changeLegacyCoroutineAccessorToYielding();
 
   /// Whether this yield_once_2 coroutine accessor was written by the user with
-  /// the underscored spelling (`_read`/`_modify`) rather than the
+  /// the `_read`/`_modify` spelling rather than the
   /// `yielding borrow`/`yielding mutate` spelling.
   bool isSpelledWithLegacyCoroutineSyntax() const {
     return SpelledWithLegacyCoroutineSyntax;
@@ -10651,11 +10651,10 @@ public:
 template<typename SpecificDecl>
 ABIRoleInfo(const SpecificDecl *decl) -> ABIRoleInfo<SpecificDecl>;
 
-StringRef
-getAccessorNameForDiagnostic(AccessorDecl *accessor, bool article,
-                             std::optional<bool> underscored = std::nullopt);
+StringRef getAccessorNameForDiagnostic(AccessorDecl *accessor, bool article,
+                             std::optional<bool> legacy = std::nullopt);
 StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind, bool article,
-                                       bool underscored);
+                                       bool legacy);
 
 inline void simple_display(llvm::raw_ostream &out,
                            MemberwiseInitKind initKind) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8122,7 +8122,7 @@ bool ProtocolDecl::hasCircularInheritedProtocols() const {
 
 /// Returns a descriptive name for the given accessor/addressor kind.
 StringRef swift::getAccessorNameForDiagnostic(AccessorKind accessorKind,
-                                              bool article, bool underscored) {
+                                              bool article, bool legacy) {
   switch (accessorKind) {
   case AccessorKind::Get:
     return article ? "a getter" : "getter";
@@ -8158,7 +8158,7 @@ StringRef swift::getAccessorNameForDiagnostic(AccessorKind accessorKind,
 
 StringRef swift::getAccessorNameForDiagnostic(AccessorDecl *accessor,
                                               bool article,
-                                              std::optional<bool> underscored) {
+                                              std::optional<bool> legacy) {
   auto kind = accessor->getAccessorKind();
   // A yield_once_2 coroutine accessor that the user spelled with the
   // underscored keyword (`_read`/`_modify`) should be named with that spelling
@@ -8171,7 +8171,7 @@ StringRef swift::getAccessorNameForDiagnostic(AccessorDecl *accessor,
   }
   return getAccessorNameForDiagnostic(
       kind, article,
-      underscored.value_or(accessor->getASTContext().LangOpts.hasFeature(
+      legacy.value_or(accessor->getASTContext().LangOpts.hasFeature(
           Feature::CoroutineAccessors)));
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8486,7 +8486,7 @@ bool Parser::parseAccessorAfterIntroducer(
       !Context.LangOpts.hasFeature(Feature::CoroutineAccessors)) {
     diagnose(Tok, diag::accessor_requires_coroutine_accessors,
              getAccessorNameForDiagnostic(Kind, /*article*/ false,
-                                          /*underscored*/ false));
+                                          /*legacy*/ false));
   }
 
   if (Kind == AccessorKind::Borrow || Kind == AccessorKind::Mutate) {
@@ -8495,7 +8495,7 @@ bool Parser::parseAccessorAfterIntroducer(
         !Flags.contains(PD_InProtocol)) {
       diagnose(Tok, diag::borrow_mutate_accessor_not_supported_in_decl,
                getAccessorNameForDiagnostic(Kind, /*article*/ true,
-                                            /*underscored*/ false));
+                                            /*legacy*/ false));
     }
   }
 
@@ -8505,7 +8505,7 @@ bool Parser::parseAccessorAfterIntroducer(
     if (Tok.is(tok::l_brace))
       diagnose(Tok, diag::unexpected_getset_implementation_in_protocol,
                getAccessorNameForDiagnostic(Kind, /*article*/ false,
-                                            /*underscored*/ false));
+                                            /*legacy*/ false));
     return false;
   }
 
@@ -8969,7 +8969,7 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
 }
 
 static std::optional<AccessorKind>
-getCorrespondingUnderscoredAccessorKind(AccessorKind kind) {
+getCorrespondingLegacyAccessorKind(AccessorKind kind) {
   switch (kind) {
   case AccessorKind::YieldingBorrow:
     return {AccessorKind::Read};
@@ -8994,20 +8994,20 @@ getCorrespondingUnderscoredAccessorKind(AccessorKind kind) {
 static void diagnoseConflictingAccessors(Parser &P, AccessorDecl *first,
                                          AccessorDecl *&second) {
   if (!second) return;
-  bool underscored =
-      (getCorrespondingUnderscoredAccessorKind(first->getAccessorKind()) ==
+  bool legacy =
+      (getCorrespondingLegacyAccessorKind(first->getAccessorKind()) ==
        second->getAccessorKind()) ||
-      (getCorrespondingUnderscoredAccessorKind(second->getAccessorKind()) ==
+      (getCorrespondingLegacyAccessorKind(second->getAccessorKind()) ==
        first->getAccessorKind()) ||
       first->getASTContext().LangOpts.hasFeature(Feature::CoroutineAccessors);
   P.diagnose(
       second->getLoc(), diag::conflicting_accessor,
       isa<SubscriptDecl>(first->getStorage()),
-      getAccessorNameForDiagnostic(second, /*article*/ true, underscored),
-      getAccessorNameForDiagnostic(first, /*article*/ true, underscored));
+      getAccessorNameForDiagnostic(second, /*article*/ true, legacy),
+      getAccessorNameForDiagnostic(first, /*article*/ true, legacy));
   P.diagnose(
       first->getLoc(), diag::previous_accessor,
-      getAccessorNameForDiagnostic(first, /*article*/ false, underscored),
+      getAccessorNameForDiagnostic(first, /*article*/ false, legacy),
       /*already*/ false);
   second->setInvalid();
 }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -909,9 +909,9 @@ static void diagnoseReadWriteMutatingnessMismatch(
   auto nameForAccessor = [&](AccessorKind kind) -> StringRef {
     if (auto *decl = storage->getParsedAccessor(kind))
       return getAccessorNameForDiagnostic(
-          decl, /*article=*/false, /*underscored=*/hasCoroutineAccessorFeature);
+          decl, /*article=*/false, /*legacy=*/hasCoroutineAccessorFeature);
     return getAccessorNameForDiagnostic(
-        kind, /*article=*/false, /*underscored=*/hasCoroutineAccessorFeature);
+        kind, /*article=*/false, /*legacy=*/hasCoroutineAccessorFeature);
   };
 
   auto readerAccessor = directAccessorKindForReadImpl(storage->getReadImpl());
@@ -941,7 +941,7 @@ static void diagnoseReadWriteMutatingnessMismatch(
   modifyAccessor->diagnose(
       diag::readwriter_mutatingness_differs_from_reader_or_writer_mutatingness,
       getAccessorNameForDiagnostic(modifyAccessor, /*article=*/false,
-                                   /*underscored=*/hasCoroutineAccessorFeature),
+                                   /*legacy=*/hasCoroutineAccessorFeature),
       isModifierMutating ? SelfAccessKind::Mutating
                          : SelfAccessKind::NonMutating,
       diagnosticForm, writerAccessorName, SelfAccessKind::NonMutating,
@@ -952,7 +952,7 @@ static void diagnoseReadWriteMutatingnessMismatch(
                      getAccessorNameForDiagnostic(
                          writerAccesor,
                          /*article=*/false,
-                         /*underscored=*/hasCoroutineAccessorFeature),
+                         /*legacy=*/hasCoroutineAccessorFeature),
                      0);
   }
   AccessorDecl *reader = nullptr;

--- a/test/SILGen/coroutine_accessors_availability.swift
+++ b/test/SILGen/coroutine_accessors_availability.swift
@@ -72,7 +72,7 @@ public func getNew() -> StructNew {
 @_silgen_name("readNewInlinableNew")
 public func readNewInlinableNew(_ n: StructNew) -> Int {
 // CHECK-LABEL: sil {{.*}}@readNewInlinableNew : {{.*}} {
-                  // function_ref StructNew.i.read2
+                  // function_ref StructNew.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructNewV1iSivy
 // CHECK-LABEL: } // end sil function 'readNewInlinableNew'
   return n.i
@@ -82,7 +82,7 @@ public func readNewInlinableNew(_ n: StructNew) -> Int {
 @_silgen_name("readNewNoninlinableNew")
 public func readNewNoninlinableNew(_ n: StructNew) -> Int {
 // CHECK-LABEL: sil {{.*}}@readNewNoninlinableNew : {{.*}} {
-                  // function_ref StructNew.i.read2
+                  // function_ref StructNew.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructNewV1iSivy
 // CHECK-LABEL: } // end sil function 'readNewNoninlinableNew'
   return n.i
@@ -93,7 +93,7 @@ public func readNewNoninlinableNew(_ n: StructNew) -> Int {
 @_silgen_name("modifyNewInlinableNew")
 public func modifyNewInlinableNew(_ n: inout StructNew) {
 // CHECK-LABEL: sil {{.*}}@modifyNewInlinableNew : {{.*}} {
-                  // function_ref StructNew.i.modify2
+                  // function_ref StructNew.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructNewV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyNewInlinableNew'
   n.i.increment()
@@ -103,7 +103,7 @@ public func modifyNewInlinableNew(_ n: inout StructNew) {
 @_silgen_name("modifyNewNoninlinableNew")
 public func modifyNewNoninlinableNew(_ n: inout StructNew) {
 // CHECK-LABEL: sil {{.*}}@modifyNewNoninlinableNew : {{.*}} {
-                  // function_ref StructNew.i.modify2
+                  // function_ref StructNew.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructNewV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyNewNoninlinableNew'
   n.i.increment()
@@ -142,8 +142,8 @@ public func readOldNoninlinableOld(_ n: StructOld) -> Int {
 // CHECK-LABEL: sil {{.*}}@readOldNoninlinableOld : {{.*}} {
 // Opaque symbol never inlined.  Even though it was available before
 // CoroutineAccessors was, the implementation in this version of the module--can
-// use read2.
-                  // function_ref StructOld.i.read2
+// use yielding_borrow.
+                  // function_ref StructOld.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructOldV1iSivy
 // CHECK-LABEL: } // end sil function 'readOldNoninlinableOld'
   return n.i
@@ -155,8 +155,8 @@ public func readOldNoninlinableOld(_ n: StructOld) -> Int {
 public func readOldInlinableNew(_ n: StructOld) -> Int {
 // CHECK-LABEL: sil {{.*}}@readOldInlinableNew : {{.*}} {
 // Could be inlined, but only into code that's running at or after
-// CoroutineAccessors is available--can use read2.
-                  // function_ref StructOld.i.read2
+// CoroutineAccessors is available--can use yielding_borrow.
+                  // function_ref StructOld.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructOldV1iSivy
 // CHECK-LABEL: } // end sil function 'readOldInlinableNew'
   return n.i
@@ -166,8 +166,8 @@ public func readOldInlinableNew(_ n: StructOld) -> Int {
 @_silgen_name("readOldNoninlinableNew")
 public func readOldNoninlinableNew(_ n: StructOld) -> Int {
 // CHECK-LABEL: sil {{.*}}@readOldNoninlinableNew : {{.*}} {
-// Neither inlinable nor available before CoroutineAccessors--can use read2.
-                  // function_ref StructOld.i.read2
+// Neither inlinable nor available before CoroutineAccessors--can use yielding_borrow.
+                  // function_ref StructOld.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructOldV1iSivy
 // CHECK-LABEL: } // end sil function 'readOldNoninlinableNew'
   return n.i
@@ -190,8 +190,8 @@ public func modifyOldNoninlinableOld(_ n: inout StructOld) {
 // CHECK-LABEL: sil {{.*}}@modifyOldNoninlinableOld : {{.*}} {
 // Opaque symbol never inlined.  Even though it was available before
 // CoroutineAccessors was, the implementation in this version of the module--can
-// use modify2.
-                  // function_ref StructOld.i.modify2
+// use yielding_mutate.
+                  // function_ref StructOld.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructOldV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyOldNoninlinableOld'
   n.i.increment()
@@ -203,8 +203,8 @@ public func modifyOldNoninlinableOld(_ n: inout StructOld) {
 public func modifyOldInlinableNew(_ n: inout StructOld) {
 // CHECK-LABEL: sil {{.*}}@modifyOldInlinableNew : {{.*}} {
 // Could be inlined, but only into code that's running at or after
-// CoroutineAccessors is available--can use modify2.
-                  // function_ref StructOld.i.modify2
+// CoroutineAccessors is available--can use yielding_mutate.
+                  // function_ref StructOld.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructOldV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyOldInlinableNew'
   n.i.increment()
@@ -214,8 +214,8 @@ public func modifyOldInlinableNew(_ n: inout StructOld) {
 @_silgen_name("modifyOldNoninlinableNew")
 public func modifyOldNoninlinableNew(_ n: inout StructOld) {
 // CHECK-LABEL: sil {{.*}}@modifyOldNoninlinableNew : {{.*}} {
-// Neither inlinable nor available before CoroutineAccessors--can use modify2.
-                  // function_ref StructOld.i.modify2
+// Neither inlinable nor available before CoroutineAccessors--can use yielding_mutate.
+                  // function_ref StructOld.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructOldV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyOldNoninlinableNew'
   n.i.increment()
@@ -259,8 +259,8 @@ import Library
 @_silgen_name("readNewOld")
 func readNewOld() {
 // CHECK-LABEL: sil {{.*}}@readNewOld : {{.*}} {
-// Neither inlinable nor available before CoroutineAccessors--can use read2.
-                  // function_ref StructNew.i.read2
+// Neither inlinable nor available before CoroutineAccessors--can use yielding_borrow.
+                  // function_ref StructNew.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructNewV1iSivy
 // CHECK-LABEL: } // end sil function 'readNewOld'
   if #available(SwiftStdlib 9999, *) {
@@ -274,8 +274,8 @@ func readNewOld() {
 @_silgen_name("readNewNew")
 func readNewNew() {
 // CHECK-LABEL: sil {{.*}}@readNewNew : {{.*}} {
-// Neither inlinable nor available before CoroutineAccessors--can use read2.
-                  // function_ref StructNew.i.read2
+// Neither inlinable nor available before CoroutineAccessors--can use yielding_borrow.
+                  // function_ref StructNew.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructNewV1iSivy
 // CHECK-LABEL: } // end sil function 'readNewNew'
   let n = getNew()
@@ -289,8 +289,8 @@ func readOldNew() {
 // CHECK-LABEL: sil {{.*}}@readOldNew : {{.*}} {
 // Although this module could be back-deployed to before CoroutineAccessors were
 // available, it can only run in environments where the feature is available--
-// can use read2.
-                  // function_ref StructOld.i.read2
+// can use yielding_borrow.
+                  // function_ref StructOld.i.yielding_borrow
 // CHECK:         function_ref @$s7Library9StructOldV1iSivy
 // CHECK-LABEL: } // end sil function 'readOldNew'
   let n = getOld()
@@ -309,7 +309,7 @@ func readOldOld() {
 // This module cannot be back-deployed (the deployment target is
 // available, and nothing ensures the function is available only after the
 // feature is available--must use read.
-                  // function_ref StructOld.i.read2
+                  // function_ref StructOld.i.yielding_borrow
 // CHECK-NEW:     function_ref @$s7Library9StructOldV1iSivy
 // CHECK-LABEL: } // end sil function 'readOldOld'
   let n = getOld()
@@ -320,8 +320,8 @@ func readOldOld() {
 @_silgen_name("modifyNewOld")
 func modifyNewOld() {
 // CHECK-LABEL: sil {{.*}}@modifyNewOld : {{.*}} {
-// Neither inlinable nor available before CoroutineAccessors--can use modify2.
-                  // function_ref StructNew.i.modify2
+// Neither inlinable nor available before CoroutineAccessors--can use yielding_mutate.
+                  // function_ref StructNew.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructNewV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyNewOld'
   if #available(SwiftStdlib 9999, *) {
@@ -335,8 +335,8 @@ func modifyNewOld() {
 @_silgen_name("modifyNewNew")
 func modifyNewNew() {
 // CHECK-LABEL: sil {{.*}}@modifyNewNew : {{.*}} {
-// Neither inlinable nor available before CoroutineAccessors--can use modify2.
-                  // function_ref StructNew.i.modify2
+// Neither inlinable nor available before CoroutineAccessors--can use yielding_mutate.
+                  // function_ref StructNew.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructNewV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyNewNew'
   var n = getNew()
@@ -350,8 +350,8 @@ func modifyOldNew() {
 // CHECK-LABEL: sil {{.*}}@modifyOldNew : {{.*}} {
 // Although this module could be back-deployed to before CoroutineAccessors were
 // available, it can only run in environments where the feature is available--
-// can use modify2.
-                  // function_ref StructOld.i.modify2
+// can use yielding_mutate.
+                  // function_ref StructOld.i.yielding_mutate
 // CHECK:         function_ref @$s7Library9StructOldV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyOldNew'
   var n = getOld()
@@ -370,7 +370,7 @@ func modifyOldOld() {
 // This module cannot be back-deployed (the deployment target is
 // available, and nothing ensures the function is available only after the
 // feature is available--must use modify.
-                  // function_ref StructOld.i.modify2
+                  // function_ref StructOld.i.yielding_mutate
 // CHECK-NEW:     function_ref @$s7Library9StructOldV1iSivx
 // CHECK-LABEL: } // end sil function 'modifyOldOld'
   var n = getOld()
@@ -387,8 +387,8 @@ func readGlobalOld() -> Int {
 // Deployment target predates the feature--must use the old read.
                   // function_ref gOld.read
 // CHECK-OLD:     function_ref @$s7Library4gOldSivr
-// Deployment target postdates the feature--can use read2.
-                  // function_ref gOld.read2
+// Deployment target postdates the feature--can use yielding_borrow.
+                  // function_ref gOld.yielding_borrow
 // CHECK-NEW:     function_ref @$s7Library4gOldSivy
 // CHECK-LABEL: } // end sil function 'readGlobalOld'
   return gOld
@@ -400,7 +400,7 @@ func modifyGlobalOld() {
 // CHECK-LABEL: sil {{.*}}@modifyGlobalOld : {{.*}} {
                   // function_ref gOld.modify
 // CHECK-OLD:     function_ref @$s7Library4gOldSivM
-                  // function_ref gOld.modify2
+                  // function_ref gOld.yielding_mutate
 // CHECK-NEW:     function_ref @$s7Library4gOldSivx
 // CHECK-LABEL: } // end sil function 'modifyGlobalOld'
   gOld.increment()
@@ -412,7 +412,7 @@ func modifyGlobalOld() {
 @_silgen_name("readGlobalNew")
 func readGlobalNew() -> Int {
 // CHECK-LABEL: sil {{.*}}@readGlobalNew : {{.*}} {
-                  // function_ref gOld.read2
+                  // function_ref gOld.yielding_borrow
 // CHECK:         function_ref @$s7Library4gOldSivy
 // CHECK-LABEL: } // end sil function 'readGlobalNew'
   return gOld
@@ -422,7 +422,7 @@ func readGlobalNew() -> Int {
 @_silgen_name("modifyGlobalNew")
 func modifyGlobalNew() {
 // CHECK-LABEL: sil {{.*}}@modifyGlobalNew : {{.*}} {
-                  // function_ref gOld.modify2
+                  // function_ref gOld.yielding_mutate
 // CHECK:         function_ref @$s7Library4gOldSivx
 // CHECK-LABEL: } // end sil function 'modifyGlobalNew'
   gOld.increment()

--- a/test/SILGen/coroutine_accessors_getter_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_getter_synthesis.swift
@@ -27,11 +27,13 @@
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefix=NO-GETTER
 
 // RUN: %target-swift-emit-silgen %s                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -enable-callee-allocated-coro-abi                 \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
 // RUN:   | %FileCheck %s --check-prefixes=NO-GETTER,NO-GETTER-RESILIENT

--- a/test/SILGen/coroutine_accessors_getter_synthesis.swift
+++ b/test/SILGen/coroutine_accessors_getter_synthesis.swift
@@ -34,7 +34,7 @@
 // RUN:     -enable-experimental-feature CoroutineAccessors   \
 // RUN:     -enable-library-evolution                         \
 // RUN:     -module-name m                                    \
-// RUN:   | %FileCheck %s --check-prefix=NO-GETTER
+// RUN:   | %FileCheck %s --check-prefixes=NO-GETTER,NO-GETTER-RESILIENT
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
@@ -49,6 +49,7 @@ public struct StructYB {
 }
 // GETTER-DAG: sil{{.*}} @$s1m8StructYBV1iSivg :
 // GETTER-DAG: sil{{.*}} @$s1m8StructYBV1iSivy : $@yield_once_2
+// GETTER-DAG: sil{{.*}} @$s1m8StructYBV1iSivx : $@yield_once_2
 
 open class ClassYB {
   var _s = 0
@@ -59,6 +60,7 @@ open class ClassYB {
 }
 // GETTER-DAG: sil{{.*}} @$s1m7ClassYBC1iSivg :
 // GETTER-DAG: sil{{.*}} @$s1m7ClassYBC1iSivy : $@yield_once_2
+// GETTER-DAG: sil{{.*}} @$s1m7ClassYBC1iSivx : $@yield_once_2
 
 var _g = 0
 public var globalYB: Int {
@@ -67,6 +69,7 @@ public var globalYB: Int {
 }
 // GETTER-DAG: sil{{.*}} @$s1m8globalYBSivg :
 // GETTER-DAG: sil{{.*}} @$s1m8globalYBSivy : $@yield_once_2
+// GETTER-DAG: sil{{.*}} @$s1m8globalYBSivx : $@yield_once_2
 
 // Spelling invariance: the '_read'/'_modify' spelling produces the same getter
 // (the feature remaps it to 'yielding borrow'/'yielding mutate').
@@ -79,6 +82,7 @@ public struct StructRM {
 }
 // GETTER-DAG: sil{{.*}} @$s1m8StructRMV1iSivg :
 // GETTER-DAG: sil{{.*}} @$s1m8StructRMV1iSivy : $@yield_once_2
+// GETTER-DAG: sil{{.*}} @$s1m8StructRMV1iSivx : $@yield_once_2
 
 // The synthesized getter delegates to the coroutine, running its full body: the
 // front half up to the yield (begin_apply) and the back half (end_apply).
@@ -98,6 +102,7 @@ public struct NCHolder: ~Copyable {
   }
 }
 // NO-GETTER-NOT: @$s1m8NCHolderV1nAA5NCValVvg
+// NO-GETTER-DAG: sil{{.*}} @$s1m8NCHolderV1nAA5NCValVvy : $@yield_once_2
 
 // A protocol requirement stays a borrowing opaque read (no getter requirement),
 // so the '@_borrowed' and 'yielding borrow' spellings keep the same witness
@@ -110,3 +115,5 @@ public protocol ProtoB {
 }
 // NO-GETTER-NOT: #ProtoYB.i!getter
 // NO-GETTER-NOT: #ProtoB.i!getter
+// NO-GETTER-RESILIENT-DAG: sil{{.*}} @$s1m7ProtoYBP1iSivy : $@yield_once_2
+// NO-GETTER-RESILIENT-DAG: sil{{.*}} @$s1m6ProtoBP1iSivy : $@yield_once_2

--- a/test/SILOptimizer/devirtualize_coroutine_accessors.sil
+++ b/test/SILOptimizer/devirtualize_coroutine_accessors.sil
@@ -29,7 +29,7 @@ sil [ossa] @utilize_begin_apply : $@convention(thin) () -> () {
 bb0:
   %derived = alloc_ref $Derived
   %base = upcast %derived : $Derived to $Base
-  %reader = class_method %base : $Base, #Base.x!read2 : (Base) -> () -> (), $@yield_once_2 @convention(method) (@guaranteed Base) -> @yields Int
+  %reader = class_method %base : $Base, #Base.x!yielding_borrow : (Base) -> () -> (), $@yield_once_2 @convention(method) (@guaranteed Base) -> @yields Int
   (%value, %token, %allocation) = begin_apply %reader(%base) : $@yield_once_2 @convention(method) (@guaranteed Base) -> @yields Int
   end_apply %token as $()
   dealloc_stack %allocation : $*Builtin.SILToken
@@ -38,14 +38,14 @@ bb0:
   return %retval : $()
 }
 
-sil [ossa] @Base_x_read2 : $@yield_once_2 @convention(method) (@guaranteed Base) -> @yields Int
+sil [ossa] @Base_x_yielding_borrow : $@yield_once_2 @convention(method) (@guaranteed Base) -> @yields Int
 
-sil [ossa] @Derived_x_read2 : $@yield_once_2 @convention(method) (@guaranteed Base) -> @yields Int
+sil [ossa] @Derived_x_yielding_borrow : $@yield_once_2 @convention(method) (@guaranteed Base) -> @yields Int
 
 sil_vtable Base {
-  #Base.x!read2: @Base_x_read2
+  #Base.x!yielding_borrow: @Base_x_yielding_borrow
 }
 
 sil_vtable Derived {
-  #Base.x!read2: @Derived_x_read2 [override]
+  #Base.x!yielding_borrow: @Derived_x_yielding_borrow [override]
 }


### PR DESCRIPTION
A follow-on to #90745 with a number of comment and internal naming changes that were incomplete in that earlier PR.

General cleanup, but nothing functional here.