### PR TITLE
[🍒 6.4] LoopInvariantCodeMotion: don't hoist and sink `store [assign]`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -431,7 +431,10 @@ private extension AnalyzedInstructions {
       switch sideEffect {
       case let storeInst as StoreInst:
         if storeInst.storesTo(accessPath) {
-          return false
+          // TODO: Add support for `store [assign]`. Moving such a store out of the loop
+          //       requires to insert a `destroy_value` for the overwritten value at the
+          //       original store location.
+          return storeInst.storeOwnership == .assign
         }
       case let loadInst as LoadInst:
         if loadInst.loadsFrom(accessPath) {

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -1907,6 +1907,36 @@ bb3:
   return %r : $()
 }
 
+// Hoisting `store [assign]` is currently not supported, because it would require to
+// insert a `destroy_value` for the overwritten value at the original store location.
+// CHECK-LABEL: sil [ossa] @dont_hoist_store_assign :
+// CHECK-NOT:     load [take]
+// CHECK:       bb2:
+// CHECK:         store %{{[0-9]+}} to [assign] %2
+// CHECK:       bb3:
+// CHECK-LABEL: } // end sil function 'dont_hoist_store_assign'
+sil [ossa] @dont_hoist_store_assign : $@convention(thin) (@guaranteed String) -> () {
+bb0(%0 : @guaranteed $String):
+  %1 = alloc_box ${ var String }
+  %2 = project_box %1, 0
+  %3 = copy_value %0
+  store %3 to [init] %2
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %6 = copy_value %0
+  store %6 to [assign] %2
+  br bb1
+
+bb3:
+  destroy_value %1
+  %r = tuple()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil [ossa] @store_and_load_borrow :
 // CHECK:       bb1({{.*}}):
 // CHECK:         store %1 to [trivial]


### PR DESCRIPTION
- **Explanation**:
We're hitting an error (`SIL memory lifetime failure in <symbol>: memory is not initialized, but should be`) when building some of our internal projects in release mode against a 6.4.x snapshot toolchain. I couldn't reproduce with recent main snapshots. I initially thought it was because that mem2reg pass was removed on main, but I was able to narrow this down to being resolved by https://github.com/swiftlang/swift/pull/91219.
We do have a short-term workaround to remove the inlining on the code that triggers this, but it causes a pretty severe performance regression that we can't afford to incur in the longer term.

- **Scope**:
Limited to `LoopInvariantCodeMotion`. The change breaks out of a previously attempted optimization when there's a `store [assign]` in the loop.

- **Issues**:
rdar://183953843

- **Original PRs**:
https://github.com/swiftlang/swift/pull/91219

- **Risk**:
Low. It's a trivial change which makes load-store optimization in LICM more conservative. This drops an optimization opportunity that lead to a crash and failure to compile in release mode.

- **Testing**:
Adds `dont_hoist_store_assign` test case to `test/SILOptimizer/licm.sil`. Locally, I've also built a toolchain from a recent 6.4.x snapshot plus this commit and confirmed that a package which reproduces the failure builds successfully.

- **Reviewers**:
@aidan-hall 