### PR TITLE
[Swiftify] handle std::span itself being the template arg

### DIFF
--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -217,19 +217,39 @@ private:
   public:
   /// Tracks the set of macro-expansion buffers produced at a single source
   /// location. A location can drive several sibling expansions (e.g. multiple
-  /// peer macros on one declaration); their buffers are ordered by the source
-  /// location of the attached-macro attribute that produced each, so that each
+  /// peer macros on one declaration); their buffers are ordered so that each
   /// expansion has a stable "expansion index" matching source order. The
   /// verifier numbers 'expected-expansion' directives at a location in source
   /// order and matches directive #k to expansion index #k.
   class ExpansionContext {
-    /// Each produced sibling expansion as (sortKey, bufferID), kept sorted so
-    /// the expansion index matches the source order of the macros that produced
-    /// the siblings. sortKey is the source-location pointer of the generating
-    /// attached-macro attribute; SourceManager orders locations by pointer (see
-    /// isBeforeInBuffer), so an earlier attribute sorts first. Ties (e.g. no
-    /// attribute) fall back to buffer-ID order.
-    SmallVector<std::pair<uintptr_t, unsigned>, 2> buffers;
+  public:
+    /// Ordering key for a sibling expansion: siblings sharing a source buffer
+    /// (peer macros, at any nesting depth) are compared by \c anchorOffset;
+    /// siblings in different buffers (a template method's per-instantiation
+    /// synthesized attributes) are compared by \c content.
+    struct ExpansionOrderKey {
+      /// Buffer the generating attribute lives in. Used only to tell whether
+      /// two siblings share a buffer, never to order them, so its unstable
+      /// numeric value does not affect the result.
+      unsigned anchorBufferID = 0;
+      /// Byte offset of the generating attribute within that buffer.
+      unsigned anchorOffset = 0;
+      /// Text of the expansion buffer.
+      StringRef content;
+
+      bool operator<(const ExpansionOrderKey &RHS) const {
+        if (anchorBufferID == RHS.anchorBufferID &&
+            anchorOffset != RHS.anchorOffset)
+          return anchorOffset < RHS.anchorOffset;
+        return content.compare(RHS.content) < 0;
+      }
+    };
+
+  private:
+    /// Produced sibling expansions as (orderKey, bufferID), kept sorted so the
+    /// expansion index follows ExpansionOrderKey. Equal keys fall back to
+    /// buffer-ID order.
+    SmallVector<std::pair<ExpansionOrderKey, unsigned>, 2> buffers;
     /// Number of directives already routed to a buffer during verification.
     size_t verifiedCount = 0;
     /// Number of directives already routed to a buffer during parsing.
@@ -238,14 +258,33 @@ private:
   public:
     ExpansionContext() = default;
 
-    void addBuffer(unsigned ID, uintptr_t sortKey) {
+    void addBuffer(unsigned ID, ExpansionOrderKey key) {
       assert(verifiedCount == 0 && parsedCount == 0 &&
              "added buffer after routing began");
       for (const auto &Buffer : buffers)
         if (Buffer.second == ID)
           return;
-      buffers.emplace_back(sortKey, ID);
+      buffers.emplace_back(key, ID);
       llvm::sort(buffers);
+
+#ifndef NDEBUG
+      // operator< orders same-buffer siblings by offset and different-buffer
+      // siblings by content, which is a valid strict weak ordering only if the
+      // group never mixes the two -- i.e. anchor buffers are all equal or all
+      // distinct. Peer macros share a buffer; per-instantiation synthesized
+      // attributes are all distinct. Guard against a future role breaking this.
+      bool sawEqual = false, sawDistinct = false;
+      for (size_t I = 0, E = buffers.size(); I != E; ++I)
+        for (size_t J = I + 1; J != E; ++J) {
+          if (buffers[I].first.anchorBufferID ==
+              buffers[J].first.anchorBufferID)
+            sawEqual = true;
+          else
+            sawDistinct = true;
+        }
+      assert(!(sawEqual && sawDistinct) &&
+             "expansion siblings mix shared and distinct anchor buffers");
+#endif
     }
 
     size_t expansionIndex(unsigned ID) const {

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -534,7 +534,7 @@ struct UnaliasedInstantiationVisitor
         clangType = ArgTy;
       } else {
         assert(0 && "unknown std::span representation");
-        return false;
+        return true;
       }
     }
     UnaliasedInstantiationVisitor checker;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -500,9 +500,31 @@ struct UnaliasedInstantiationVisitor
       // std::span is transformed to Swift Span, so the std::span template
       // instantiation won't show up in the macro expansion's signature. The
       // element type still needs to be checked.
-      const auto *TST = clangType->getAs<clang::TemplateSpecializationType>();
-      ASSERT(TST && "std::span is not specialized?");
-      clangType = TST->template_arguments()[0].getAsType();
+      auto getTemplateArg = [](clang::QualType Ty) {
+        const auto *STTPT = Ty->getAs<clang::SubstTemplateTypeParmType>();
+        if (!STTPT)
+          return clang::QualType();
+        const auto *RT =
+            dyn_cast<clang::RecordType>(STTPT->getReplacementType());
+        if (!RT)
+          return clang::QualType();
+        const auto *CD =
+            dyn_cast<clang::ClassTemplateSpecializationDecl>(RT->getDecl());
+        if (!CD)
+          return clang::QualType();
+        auto Args = CD->getTemplateArgs().asArray();
+        return Args[0].getAsType();
+      };
+      if (const auto *TST =
+              clangType->getAs<clang::TemplateSpecializationType>())
+        clangType = TST->template_arguments()[0].getAsType();
+      else if (clang::QualType ArgTy = getTemplateArg(clangType);
+               !ArgTy.isNull()) {
+        clangType = ArgTy;
+      } else {
+        assert(0 && "unknown std::span representation");
+        return false;
+      }
     }
     UnaliasedInstantiationVisitor checker;
     checker.TraverseType(clangType);

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -44,6 +44,7 @@
 #include "clang/Sema/Overload.h"
 #include "llvm-c/Types.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/Casting.h"
 #include <optional>
 
 using namespace swift;
@@ -492,6 +493,16 @@ struct UnaliasedInstantiationVisitor
     hasUnaliasedInstantiation = true;
     DLOG("Signature contains raw template, skipping\n");
     return false;
+  }
+
+  bool VisitRecordType(const clang::RecordType *RT) {
+    if (isa_and_nonnull<clang::ClassTemplateSpecializationDecl>(
+            RT->getDecl())) {
+      hasUnaliasedInstantiation = true;
+      DLOG("Signature contains raw template, skipping\n");
+      return false;
+    }
+    return true;
   }
 
   static bool checkTemplates(clang::QualType clangType, bool hasLifetime,

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1601,7 +1601,7 @@ void DiagnosticVerifier::verifyDiagnostics(
     // again. We do have to do this after checking fix-its, though, because
     // the diagnostic owns its fix-its.
     CapturedDiagnostics.erase(FoundDiagnosticIter);
-    
+
     // We found the diagnostic, so remove it... unless we allow an arbitrary
     // number of diagnostics, in which case we want to reprocess this.
     if (expected.mayAppear)
@@ -2030,7 +2030,7 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
 
   // Diagnose expected diagnostics that didn't appear.
   verifyRemaining(ExpectedDiagnostics, InputFile.data());
-  
+
   // Verify that there are no diagnostics (in MemoryBuffer) left in the list.
   bool HadUnexpectedDiag = false;
   auto CapturedDiagIter = CapturedDiagnostics.begin();
@@ -2119,6 +2119,25 @@ void DiagnosticVerifier::printRemainingDiagnostics() const {
   }
 }
 
+// Build the ordering key for a sibling macro expansion (see ExpansionOrderKey).
+static DiagnosticVerifier::ExpansionContext::ExpansionOrderKey
+computeExpansionOrderKey(SourceManager &SM, const GeneratedSourceInfo &GSI,
+                         unsigned expansionBufferID) {
+  DiagnosticVerifier::ExpansionContext::ExpansionOrderKey Key;
+  Key.content = SM.getEntireTextForBuffer(expansionBufferID);
+
+  SourceLoc AttrLoc;
+  if (GSI.attachedMacroCustomAttr)
+    AttrLoc = GSI.attachedMacroCustomAttr->getLocation();
+  if (AttrLoc.isInvalid())
+    AttrLoc = GSI.originalSourceRange.getStart();
+  if (AttrLoc.isValid()) {
+    Key.anchorBufferID = SM.findBufferContainingLoc(AttrLoc);
+    Key.anchorOffset = SM.getLocOffsetInBuffer(AttrLoc, Key.anchorBufferID);
+  }
+  return Key;
+}
+
 static void
 processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, DiagnosticVerifier::ExpansionContext> &Expansions,
                   std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics) {
@@ -2132,16 +2151,9 @@ processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, DiagnosticVerifie
     SourceLoc ExpansionStart = GSI->originalSourceRange.getStart();
     if (ExpansionStart.isInvalid())
       continue;
-    // Order sibling expansions by the source location of the attached-macro
-    // attribute that produced each, so the first attribute in source order
-    // becomes expansion index 0 (matching the order 'expected-expansion'
-    // directives are written). Buffers with no attribute fall back to
-    // buffer-ID order via a zero key.
-    uintptr_t SortKey = 0;
-    if (GSI->attachedMacroCustomAttr)
-      SortKey = reinterpret_cast<uintptr_t>(
-          GSI->attachedMacroCustomAttr->getLocation().getPointer());
-    Expansions[ExpansionStart].addBuffer(diag.SourceBufferID.value(), SortKey);
+    Expansions[ExpansionStart].addBuffer(
+        diag.SourceBufferID.value(),
+        computeExpansionOrderKey(SM, *GSI, diag.SourceBufferID.value()));
   }
 }
 

--- a/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
+++ b/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
@@ -22,10 +22,17 @@ module Test {
 
 template <typename T>
 struct S {
-    // expected-expansion@+7:10{{
+    // expected-expansion@+14:10{{
     //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
     //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload|}}
     //   expected-remark@3{{macro content: |public borrowing func get() -> Span<CChar> {|}}
+    //   expected-remark@4{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe get()), copying: ())|}}
+    //   expected-remark@5{{macro content: |}|}}
+    // }}
+    // expected-expansion@+7:10{{
+    //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+    //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload|}}
+    //   expected-remark@3{{macro content: |public borrowing func get() -> Span<CInt> {|}}
     //   expected-remark@4{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe get()), copying: ())|}}
     //   expected-remark@5{{macro content: |}|}}
     // }}
@@ -33,10 +40,15 @@ struct S {
 };
 
 using SpanHolder = S<std::span<const char>>;
+using IntSpan = std::span<const int>;
+using UsingSpanHolder = S<IntSpan>;
 
 //--- test.swift
 import Test
 
 public func f(_ holder: SpanHolder) {
+  let _ = holder.get();
+}
+public func g(_ holder: UsingSpanHolder) {
   let _ = holder.get();
 }

--- a/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
+++ b/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
@@ -37,6 +37,7 @@ struct S {
     //   expected-remark@5{{macro content: |}|}}
     // }}
     T get() const [[clang::lifetimebound]];
+    T getNoLifetime() const;
 };
 
 using SpanHolder = S<std::span<const char>>;
@@ -62,15 +63,6 @@ struct S2 {
     // }}
     U getU() const [[clang::lifetimebound]];
 
-    // expected-note@+9{{'getTPassUnrelatedU' declared here}}
-    // expected-expansion@+8:29{{
-    //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-    //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload|}}
-    //   expected-error@3{{cannot find type '__cxxConst' in scope}}
-    //   expected-remark@3{{macro content: |public borrowing func getTPassUnrelatedU(_ u: std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>) -> Span<CChar> {|}}
-    //   expected-remark@4{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe getTPassUnrelatedU(u)), copying: ())|}}
-    //   expected-remark@5{{macro content: |}|}}
-    // }}
     T getTPassUnrelatedU(U u) const [[clang::lifetimebound]];
 };
 
@@ -81,14 +73,14 @@ import Test
 
 public func f(_ holder: SpanHolder) {
   let _ = holder.get();
+  let _ = holder.getNoLifetime();
 }
 public func g(_ holder: UsingSpanHolder) {
   let _ = holder.get();
+  let _ = holder.getNoLifetime();
 }
-public func h(_ holder: SpanHolder2, _ is: IntSpan) {
+public func h(_ holder: SpanHolder2, _ s: IntSpan) {
   let _ = holder.getT();
   let _ = holder.getU();
-  // expected-error@+2{{missing argument for parameter #1 in call}}
-  // expected-error@+1{{expected expression in list of expressions}}
-  let _ = holder.getTPassUnrelatedU(is);
+  let _ = holder.getTPassUnrelatedU(s);
 }

--- a/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
+++ b/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
@@ -1,0 +1,42 @@
+// REQUIRES: std_span
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir \
+// RUN:   -I %t -cxx-interoperability-mode=default -Xcc -std=c++20 \
+// RUN:   -enable-experimental-feature SafeInteropWrappers %t/test.swift \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -verify-ignore-macro-note
+
+//--- module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+    export *
+}
+
+//--- test.h
+#pragma once
+#include <span>
+
+template <typename T>
+struct S {
+    // expected-expansion@+7:10{{
+    //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+    //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload|}}
+    //   expected-remark@3{{macro content: |public borrowing func get() -> Span<CChar> {|}}
+    //   expected-remark@4{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe get()), copying: ())|}}
+    //   expected-remark@5{{macro content: |}|}}
+    // }}
+    T get() const [[clang::lifetimebound]];
+};
+
+using SpanHolder = S<std::span<const char>>;
+
+//--- test.swift
+import Test
+
+public func f(_ holder: SpanHolder) {
+  let _ = holder.get();
+}

--- a/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
+++ b/test/Interop/Cxx/swiftify-import/std-span-template-arg.swift
@@ -43,6 +43,39 @@ using SpanHolder = S<std::span<const char>>;
 using IntSpan = std::span<const int>;
 using UsingSpanHolder = S<IntSpan>;
 
+template <typename T, typename U>
+struct S2 {
+    // expected-expansion@+7:11{{
+    //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+    //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload|}}
+    //   expected-remark@3{{macro content: |public borrowing func getT() -> Span<CChar> {|}}
+    //   expected-remark@4{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe getT()), copying: ())|}}
+    //   expected-remark@5{{macro content: |}|}}
+    // }}
+    T getT() const [[clang::lifetimebound]];
+    // expected-expansion@+7:11{{
+    //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+    //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload|}}
+    //   expected-remark@3{{macro content: |public borrowing func getU() -> Span<CInt> {|}}
+    //   expected-remark@4{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe getU()), copying: ())|}}
+    //   expected-remark@5{{macro content: |}|}}
+    // }}
+    U getU() const [[clang::lifetimebound]];
+
+    // expected-note@+9{{'getTPassUnrelatedU' declared here}}
+    // expected-expansion@+8:29{{
+    //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+    //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload|}}
+    //   expected-error@3{{cannot find type '__cxxConst' in scope}}
+    //   expected-remark@3{{macro content: |public borrowing func getTPassUnrelatedU(_ u: std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>) -> Span<CChar> {|}}
+    //   expected-remark@4{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe getTPassUnrelatedU(u)), copying: ())|}}
+    //   expected-remark@5{{macro content: |}|}}
+    // }}
+    T getTPassUnrelatedU(U u) const [[clang::lifetimebound]];
+};
+
+using SpanHolder2 = S2<std::span<const char>, std::span<const int>>;
+
 //--- test.swift
 import Test
 
@@ -51,4 +84,11 @@ public func f(_ holder: SpanHolder) {
 }
 public func g(_ holder: UsingSpanHolder) {
   let _ = holder.get();
+}
+public func h(_ holder: SpanHolder2, _ is: IntSpan) {
+  let _ = holder.getT();
+  let _ = holder.getU();
+  // expected-error@+2{{missing argument for parameter #1 in call}}
+  // expected-error@+1{{expected expression in list of expressions}}
+  let _ = holder.getTPassUnrelatedU(is);
 }


### PR DESCRIPTION
When a type is specilized as `S<std::span<int>>` the type AST node is different than for a top-level `std::span<int>`. This would crash the compiler when safe wrapper analysis encountered the unexpected std::span representation.

rdar://184914165