### PR TITLE
Implement typed allocation for opaque existential boxes

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -56,12 +56,30 @@ FUNCTION(AllocBox, Swift, swift_allocBox, SwiftCC, AlwaysAvailable,
          EFFECT(RuntimeEffect::Allocating),
          UNKNOWN_MEMEFFECTS)
 
+// BoxPair swift_allocBoxTyped(Metadata const *type, int64_t typeId);
+FUNCTION(AllocBoxTyped, Swift, swift_allocBoxTyped, SwiftCC, AlwaysAvailable,
+         RETURNS(RefCountedPtrTy, OpaquePtrTy),
+         ARGS(TypeMetadataPtrTy, Int64Ty),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Allocating),
+         UNKNOWN_MEMEFFECTS)
+
 //  BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata *type, size_t alignMask);
 FUNCTION(MakeBoxUnique,
          Swift, swift_makeBoxUnique,
          SwiftCC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy, OpaquePtrTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, SizeTy),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Allocating),
+         UNKNOWN_MEMEFFECTS)
+
+//  BoxPair swift_makeBoxUniqueTyped(OpaqueValue *buffer, Metadata *type, size_t alignMask, int64_t typeId);
+FUNCTION(MakeBoxUniqueTyped,
+         Swift, swift_makeBoxUniqueTyped,
+         SwiftCC, AlwaysAvailable,
+         RETURNS(RefCountedPtrTy, OpaquePtrTy),
+         ARGS(OpaquePtrTy, TypeMetadataPtrTy, SizeTy, Int64Ty),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Allocating),
          UNKNOWN_MEMEFFECTS)
@@ -298,6 +316,14 @@ FUNCTION(NativeStrongReleaseDirect, Swift, swift_releaseDirect, SwiftDirectRR_CC
 FUNCTION(ReleaseBox, Swift, swift_releaseBox, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::RefCounting, RuntimeEffect::Deallocating),
+         UNKNOWN_MEMEFFECTS)
+
+// void swift_releaseBoxTyped(void *ptr, int64_t typeId);
+FUNCTION(ReleaseBoxTyped, Swift, swift_releaseBoxTyped, C_CC, AlwaysAvailable,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy, Int64Ty),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::RefCounting, RuntimeEffect::Deallocating),
          UNKNOWN_MEMEFFECTS)

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -56,6 +56,49 @@
 using namespace swift;
 using namespace irgen;
 
+// For typed allocation, we store the type descriptor of the
+// heap-allocated box in the second word of the opaque existential's
+// 3-word inline buffer (which is unused when the first word holds the
+// heap-allocated box reference) at allocation sites and retrieve it
+// at deallocation sites.
+static bool shouldUseMallocTypeDescriptor(IRGenModule &IGM) {
+  bool available = IGM.isTypedAllocationAvailable();
+  assert((!available || IGM.getPointerSize() == Size(8)) &&
+         "Assume typed allocation is 64-bit-only");
+  return available;
+}
+
+static Address projectMallocTypeDescriptorSlot(IRGenFunction &IGF,
+                                               Address buffer) {
+  return IGF.Builder.CreateElementBitCast(
+      IGF.Builder.CreateConstByteArrayGEP(
+          IGF.Builder.CreateElementBitCast(buffer, IGF.IGM.Int8Ty),
+          IGF.IGM.getPointerSize()),
+      IGF.IGM.Int64Ty);
+}
+
+static void
+storeMallocTypeDescriptor(IRGenFunction &IGF, Address buffer,
+                          std::optional<uint64_t> descriptor) {
+  IGF.Builder.CreateStore(
+      llvm::ConstantInt::get(IGF.IGM.Int64Ty, descriptor.value_or(0)),
+      projectMallocTypeDescriptorSlot(IGF, buffer));
+}
+
+static llvm::Value *loadMallocTypeDescriptor(IRGenFunction &IGF,
+                                             Address buffer) {
+  return IGF.Builder.CreateLoad(
+      projectMallocTypeDescriptorSlot(IGF, buffer));
+}
+
+static void copyMallocTypeDescriptor(IRGenFunction &IGF,
+                                     Address destBuffer,
+                                     Address srcBuffer) {
+  IGF.Builder.CreateStore(
+      loadMallocTypeDescriptor(IGF, srcBuffer),
+      projectMallocTypeDescriptorSlot(IGF, destBuffer));
+}
+
 namespace {
   /// The layout of an existential buffer.  This is intended to be a
   /// small, easily-computed type that can be passed around by value.
@@ -981,6 +1024,14 @@ public:
       Address destBuffer = layout.projectExistentialBuffer(IGF, dest);
       emitInitializeBufferWithCopyOfBufferCall(IGF, metadata, destBuffer,
                                                srcBuffer);
+      // The buffer-copy call above via VMT either copies word 0 only
+      // when it's not inlined or full buffer when it's
+      // inlined. Unconditionally copy the type descriptor here, which
+      // is likely cheaper than doing a conditional branch and is
+      // harmless when it's inlined.
+      if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+        copyMallocTypeDescriptor(IGF, destBuffer, srcBuffer);
+      }
     } else {
       // Create an outlined function to avoid explosion
       OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
@@ -2275,7 +2326,21 @@ static llvm::Function *getAllocateBoxedOpaqueExistentialBufferFunction(
           IGF.Builder.emitBlock(allocateBB);
           ConditionalDominanceScope allocateCondition(IGF);
           llvm::Value *box, *address;
-          IGF.emitAllocBoxCall(metadata, box, address);
+          // For typed allocation, compute the type descriptor of the
+          // heap box but just the header part because this code is
+          // reachable under Embedded Swift but the payload type isn't
+          // concrete at compile time.
+          std::optional<uint64_t> maybeDescriptor;
+          bool useMallocTypeDescriptor = shouldUseMallocTypeDescriptor(IGF.IGM);
+          if (useMallocTypeDescriptor) {
+            auto rawPointerType = SILType::getRawPointerType(IGF.IGM.Context);
+            llvm::SmallVector<SILType> fieldTypes;
+            fieldTypes.push_back(rawPointerType); // metadata pointer
+            fieldTypes.push_back(rawPointerType); // refcount word
+            maybeDescriptor =
+                computeTypedMallocTypeDescriptor(IGF.IGM, fieldTypes);
+          }
+          IGF.emitAllocBoxCall(metadata, maybeDescriptor, box, address);
           addressInBox =
               IGF.Builder.CreateBitCast(address, IGF.IGM.OpaquePtrTy);
           IGF.Builder.CreateStore(
@@ -2283,6 +2348,9 @@ static llvm::Function *getAllocateBoxedOpaqueExistentialBufferFunction(
                                existentialBuffer.getAddress(), IGM.PtrTy),
                            IGF.IGM.RefCountedPtrTy,
                            existLayout.getAlignment(IGF.IGM)));
+          if (useMallocTypeDescriptor) {
+            storeMallocTypeDescriptor(IGF, existentialBuffer, maybeDescriptor);
+          }
           IGF.Builder.CreateRet(addressInBox);
         }
       },
@@ -2313,7 +2381,19 @@ Address irgen::emitAllocateBoxedOpaqueExistentialBuffer(
     } else if (IGF.IGM.isEmbeddedWithExistentials()) {
       llvm::Value *box, *address;
       auto *metadata = existLayout.loadMetadataRef(IGF, existentialContainer);
-      IGF.emitAllocBoxCall(metadata, box, address);
+
+      // For typed allocation, compute the type descriptor of the heap box.
+      bool useMallocTypeDescriptor = shouldUseMallocTypeDescriptor(IGF.IGM);
+      std::optional<uint64_t> maybeDescriptor;
+      if (useMallocTypeDescriptor) {
+        auto rawPointerType = SILType::getRawPointerType(IGF.IGM.Context);
+        llvm::SmallVector<SILType> fieldTypes;
+        fieldTypes.push_back(rawPointerType); // metadata pointer
+        fieldTypes.push_back(rawPointerType); // refcount word
+        fieldTypes.push_back(valueType);
+        maybeDescriptor = computeTypedMallocTypeDescriptor(IGF.IGM, fieldTypes);
+      }
+      IGF.emitAllocBoxCall(metadata, maybeDescriptor, box, address);
       llvm::Value *addressInBox =
         IGF.Builder.CreateBitCast(address, IGF.IGM.OpaquePtrTy);
       IGF.Builder.CreateStore(
@@ -2321,6 +2401,9 @@ Address irgen::emitAllocateBoxedOpaqueExistentialBuffer(
                                existentialBuffer.getAddress(), IGF.IGM.PtrTy),
                            IGF.IGM.RefCountedPtrTy,
                            existLayout.getAlignment(IGF.IGM)));
+      if (useMallocTypeDescriptor) {
+        storeMallocTypeDescriptor(IGF, existentialBuffer, maybeDescriptor);
+      }
 
       return valueTI.getAddressForPointer(addressInBox);
     }
@@ -2410,9 +2493,17 @@ static llvm::Function *getDeallocateBoxedOpaqueExistentialBufferFunction(
         llvm::Value *pointerAlignMask = llvm::ConstantInt::get(
             IGF.IGM.SizeTy, IGF.IGM.getPointerAlignment().getValue() - 1);
         alignmentMask = Builder.CreateOr(alignmentMask, pointerAlignMask);
-        IGF.emitDeallocRawCall(
-            Builder.CreateBitCast(boxReference, IGF.IGM.Int8PtrTy), size,
-            alignmentMask);
+        auto *boxReferenceI8Ptr =
+            Builder.CreateBitCast(boxReference, IGF.IGM.Int8PtrTy);
+        if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+          // Get the type descriptor from the second word and use it
+          // for typed deallocation.
+          auto *descriptor = loadMallocTypeDescriptor(IGF, existentialBuffer);
+          IGF.emitDeallocRawTypedCall(boxReferenceI8Ptr, size, alignmentMask,
+                                      descriptor);
+        } else {
+          IGF.emitDeallocRawCall(boxReferenceI8Ptr, size, alignmentMask);
+        }
         // We are done. Return.
         Builder.CreateRetVoid();
       },
@@ -2532,10 +2623,19 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
         auto *alignmentMask = emitAlignMaskFromFlags(IGF, flags);
 
         llvm::Value *box, *objectAddr;
-        IGF.emitMakeBoxUniqueCall(
-            Builder.CreateBitCast(existentialBuffer.getAddress(),
-                                  IGM.OpaquePtrTy),
-            metadata, alignmentMask, box, objectAddr);
+        if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+          auto *descriptor =
+              loadMallocTypeDescriptor(IGF, existentialBuffer);
+          IGF.emitMakeBoxUniqueTypedCall(
+              Builder.CreateBitCast(existentialBuffer.getAddress(),
+                                    IGM.OpaquePtrTy),
+              metadata, alignmentMask, descriptor, box, objectAddr);
+        } else {
+          IGF.emitMakeBoxUniqueCall(
+              Builder.CreateBitCast(existentialBuffer.getAddress(),
+                                    IGM.OpaquePtrTy),
+              metadata, alignmentMask, box, objectAddr);
+        }
 
         IGF.Builder.CreateRet(objectAddr);
       },
@@ -2705,13 +2805,25 @@ static llvm::Function *getAssignBoxedOpaqueExistentialBufferFunction(
                         srcBuffer.getAlignment()));
             IGF.emitNativeStrongRetain(srcReference, IGF.getDefaultAtomicity());
             if (IGF.IGM.isEmbeddedWithExistentials()) {
-              IGF.emitReleaseBox(destReference);
+              if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+                // Get the type descriptor from the old box and use it
+                // for its typed deallocation.
+                llvm::Value *descriptor =
+                    loadMallocTypeDescriptor(IGF, destBuffer);
+                IGF.emitReleaseBoxTyped(destReference, descriptor);
+              } else {
+                IGF.emitReleaseBox(destReference);
+              }
             } else
               IGF.emitNativeStrongRelease(destReference,
                                         IGF.getDefaultAtomicity());
             IGF.Builder.CreateStore(
                 srcReference, Address(destReferenceAddr, IGM.RefCountedPtrTy,
                                       existLayout.getAlignment(IGF.IGM)));
+            if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+              // Copy the type descriptor from the source to the dest.
+              copyMallocTypeDescriptor(IGF, destBuffer, srcBuffer);
+            }
             Builder.CreateBr(doneBB);
           }
         }
@@ -2782,6 +2894,11 @@ static llvm::Function *getAssignBoxedOpaqueExistentialBufferFunction(
               ConditionalDominanceScope domScope(IGF);
               initBufferWithCopyOfReference(IGF, existLayout, destBuffer,
                                             srcBuffer);
+              // dest is transitioning from inline to boxed here. give
+              // it src's descriptor for the box it now shares.
+              if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+                copyMallocTypeDescriptor(IGF, destBuffer, srcBuffer);
+              }
               Builder.CreateBr(contBB2);
             }
 
@@ -2803,6 +2920,14 @@ static llvm::Function *getAssignBoxedOpaqueExistentialBufferFunction(
             auto *destReference = Builder.CreateLoad(
                 Address(destReferenceAddr, IGM.RefCountedPtrTy,
                         srcBuffer.getAlignment()));
+            // Capture destBuffer's type descriptor now before the
+            // src-inline path below overwrites destBuffer's full
+            // width via the source type's own
+            // initializeWithCopy. This is used when releasing the old
+            // box below.
+            llvm::Value *destDescriptor = shouldUseMallocTypeDescriptor(IGF.IGM)
+                ? loadMallocTypeDescriptor(IGF, destBuffer)
+                : nullptr;
             auto *srcInlineBB = IGF.createBasicBlock("dest-outline-src-inline");
             auto *srcOutlineBB =
                 IGF.createBasicBlock("dest-outline-src-outline");
@@ -2828,6 +2953,10 @@ static llvm::Function *getAssignBoxedOpaqueExistentialBufferFunction(
               ConditionalDominanceScope domScope(IGF);
               initBufferWithCopyOfReference(IGF, existLayout, destBuffer,
                                             srcBuffer);
+              // Copy the type descriptor from the source to the dest.
+              if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+                copyMallocTypeDescriptor(IGF, destBuffer, srcBuffer);
+              }
               Builder.CreateBr(contBB2);
             }
             Builder.emitBlock(contBB2);
@@ -2835,7 +2964,11 @@ static llvm::Function *getAssignBoxedOpaqueExistentialBufferFunction(
               ConditionalDominanceScope domScope(IGF);
               // swift_release(tmpRef)
               if (IGF.IGM.isEmbeddedWithExistentials()) {
-                IGF.emitReleaseBox(destReference);
+                if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+                  IGF.emitReleaseBoxTyped(destReference, destDescriptor);
+                } else {
+                  IGF.emitReleaseBox(destReference);
+                }
               } else
                 IGF.emitNativeStrongRelease(destReference,
                                           IGF.getDefaultAtomicity());
@@ -2900,7 +3033,12 @@ static llvm::Function *getDestroyBoxedOpaqueExistentialBufferFunction(
           auto *reference = Builder.CreateLoad(Address(
               referenceAddr, IGM.RefCountedPtrTy, buffer.getAlignment()));
           if (IGF.IGM.isEmbeddedWithExistentials()) {
-            IGF.emitReleaseBox(reference);
+            if (shouldUseMallocTypeDescriptor(IGF.IGM)) {
+              llvm::Value *descriptor = loadMallocTypeDescriptor(IGF, buffer);
+              IGF.emitReleaseBoxTyped(reference, descriptor);
+            } else {
+              IGF.emitReleaseBox(reference);
+            }
           } else
             IGF.emitNativeStrongRelease(reference, IGF.getDefaultAtomicity());
 

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1379,6 +1379,16 @@ void IRGenFunction::emitReleaseBox(llvm::Value *value) {
   emitUnaryRefCountCall(*this, IGM.getReleaseBoxFn(), value);
 }
 
+void IRGenFunction::emitReleaseBoxTyped(llvm::Value *value,
+                                        llvm::Value *typeDescriptor) {
+  if (doesNotRequireRefCounting(value))
+    return;
+  auto *call = Builder.CreateCall(IGM.getReleaseBoxTypedFunctionPointer(),
+                                  {value, typeDescriptor});
+  call->setCallingConv(IGM.DefaultCC);
+  call->addFnAttr(llvm::Attribute::NoUnwind);
+}
+
 void IRGenFunction::emitNativeSetDeallocating(llvm::Value *value) {
   if (doesNotRequireRefCounting(value)) return;
   emitUnaryRefCountCall(*this, IGM.getNativeSetDeallocatingFn(), value);
@@ -1653,7 +1663,8 @@ public:
     // Use the runtime to allocate a box of the appropriate size.
     auto metadata = IGF.emitTypeMetadataRefForLayout(boxedType);
     llvm::Value *box, *address;
-    IGF.emitAllocBoxCall(metadata, box, address);
+    IGF.emitAllocBoxCall(metadata, /*mallocTypeId*/ std::nullopt, box,
+                         address);
     address = IGF.Builder.CreateBitCast(address, IGF.IGM.PtrTy);
     return {ti.getAddressForPointer(address), box};
   }

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -280,7 +280,8 @@ static Address emitDefaultAllocateBuffer(IRGenFunction &IGF, Address buffer,
   case FixedPacking::Allocate: {
     llvm::Value *box, *address;
     auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
-    IGF.emitAllocBoxCall(metadata, box, address);
+    IGF.emitAllocBoxCall(metadata, /*mallocTypeId*/ std::nullopt, box,
+                         address);
     IGF.Builder.CreateStore(
         box,
         Address(IGF.Builder.CreateBitCast(buffer.getAddress(), IGF.IGM.PtrTy),

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -220,10 +220,29 @@ llvm::Value *IRGenFunction::emitVerifyEndOfLifetimeCall(llvm::Value *object,
 }
 
 void IRGenFunction::emitAllocBoxCall(llvm::Value *typeMetadata,
+                                      std::optional<uint64_t> mallocTypeId,
                                       llvm::Value *&box,
                                       llvm::Value *&valueAddress) {
+  if (mallocTypeId) {
+    auto *descriptorConst =
+        llvm::ConstantInt::get(IGM.Int64Ty, *mallocTypeId);
+    return emitAllocBoxTypedCall(typeMetadata, descriptorConst, box,
+                                 valueAddress);
+  }
   llvm::CallInst *call =
       Builder.CreateCall(IGM.getAllocBoxFunctionPointer(), typeMetadata);
+  call->addFnAttr(llvm::Attribute::NoUnwind);
+
+  box = Builder.CreateExtractValue(call, 0);
+  valueAddress = Builder.CreateExtractValue(call, 1);
+}
+
+void IRGenFunction::emitAllocBoxTypedCall(llvm::Value *typeMetadata,
+                                          llvm::Value *typeDescriptor,
+                                          llvm::Value *&box,
+                                          llvm::Value *&valueAddress) {
+  llvm::CallInst *call = Builder.CreateCall(
+      IGM.getAllocBoxTypedFunctionPointer(), {typeMetadata, typeDescriptor});
   call->addFnAttr(llvm::Attribute::NoUnwind);
 
   box = Builder.CreateExtractValue(call, 0);
@@ -237,6 +256,21 @@ void IRGenFunction::emitMakeBoxUniqueCall(llvm::Value *box,
                                           llvm::Value *&outValueAddress) {
   llvm::CallInst *call = Builder.CreateCall(
       IGM.getMakeBoxUniqueFunctionPointer(), {box, typeMetadata, alignMask});
+  call->addFnAttr(llvm::Attribute::NoUnwind);
+
+  outBox = Builder.CreateExtractValue(call, 0);
+  outValueAddress = Builder.CreateExtractValue(call, 1);
+}
+
+void IRGenFunction::emitMakeBoxUniqueTypedCall(llvm::Value *box,
+                                               llvm::Value *typeMetadata,
+                                               llvm::Value *alignMask,
+                                               llvm::Value *typeDescriptor,
+                                               llvm::Value *&outBox,
+                                               llvm::Value *&outValueAddress) {
+  llvm::CallInst *call = Builder.CreateCall(
+      IGM.getMakeBoxUniqueTypedFunctionPointer(),
+      {box, typeMetadata, alignMask, typeDescriptor});
   call->addFnAttr(llvm::Attribute::NoUnwind);
 
   outBox = Builder.CreateExtractValue(call, 0);

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -496,12 +496,24 @@ public:
                                llvm::Value *typeDescriptor);
 
   void emitAllocBoxCall(llvm::Value *typeMetadata,
+                         std::optional<uint64_t> mallocTypeId,
                          llvm::Value *&box,
                          llvm::Value *&valueAddress);
+
+  void emitAllocBoxTypedCall(llvm::Value *typeMetadata,
+                             llvm::Value *typeDescriptor,
+                             llvm::Value *&box,
+                             llvm::Value *&valueAddress);
 
   void emitMakeBoxUniqueCall(llvm::Value *box, llvm::Value *typeMetadata,
                              llvm::Value *alignMask, llvm::Value *&outBox,
                              llvm::Value *&outValueAddress);
+
+  void emitMakeBoxUniqueTypedCall(llvm::Value *box, llvm::Value *typeMetadata,
+                                  llvm::Value *alignMask,
+                                  llvm::Value *typeDescriptor,
+                                  llvm::Value *&outBox,
+                                  llvm::Value *&outValueAddress);
 
   void emitDeallocBoxCall(llvm::Value *box, llvm::Value *typeMetadata);
 
@@ -751,6 +763,7 @@ public:
 
   // Routines to deal with box (embedded) runtime calls.
   void emitReleaseBox(llvm::Value *value);
+  void emitReleaseBoxTyped(llvm::Value *value, llvm::Value *typeDescriptor);
 
   // Routines for the ObjC reference-counting style.
   void emitObjCStrongRetain(llvm::Value *value);

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -425,6 +425,25 @@ public func swift_allocBox(_ metadata: Builtin.RawPointer) -> (Builtin.RawPointe
   return (object._rawValue, boxedValueAddr._rawValue)
 }
 
+@_silgen_name("swift_allocBoxTyped")
+public func swift_allocBoxTyped(_ metadata: Builtin.RawPointer, _ typeId: UInt64) -> (Builtin.RawPointer, Builtin.RawPointer) {
+  let layout = unsafe _boxAllocationLayout(metadata: UnsafeMutableRawPointer(metadata))
+
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+  let p = unsafe _swift_typedAllocate(layout.size, layout.alignMask, 0, typeId)!
+#else
+  let p = unsafe swift_slowAlloc(layout.size, layout.alignMask)!
+#endif
+  let object = unsafe p.assumingMemoryBound(to: HeapObject.self)
+
+  unsafe _swift_embedded_set_heap_object_metadata_pointer(object, UnsafeMutableRawPointer(metadata))
+  unsafe object.pointee.refcount = 1
+
+  let boxedValueAddr = unsafe UnsafeMutableRawPointer(p).advanced(by: layout.startOfBoxedValue)
+
+  return (object._rawValue, boxedValueAddr._rawValue)
+}
+
 @c
 public func swift_deallocBox(_ pointer: UnsafeMutableRawPointer) {
   let object = unsafe pointer.bindMemory(to: HeapObject.self, capacity: 1)
@@ -640,6 +659,25 @@ public func swifft_makeBoxUnique(buffer: Builtin.RawPointer, metadata: Builtin.R
   }
 }
 
+@_silgen_name("swift_makeBoxUniqueTyped")
+public func swift_makeBoxUniqueTyped(buffer: Builtin.RawPointer, metadata: Builtin.RawPointer, alignMask: Int, typeId: UInt64) -> (Builtin.RawPointer, Builtin.RawPointer){
+  let addrOfHeapObjectPtr = unsafe UnsafeMutablePointer<Builtin.RawPointer>(buffer)
+  let box = unsafe addrOfHeapObjectPtr.pointee
+  let headerSize = unsafe MemoryLayout<Int>.size + MemoryLayout<UnsafeRawPointer>.size
+  let startOfBoxedValue = ((headerSize + alignMask) & ~alignMask)
+  let oldObjectAddr = unsafe UnsafeMutableRawPointer(box) + startOfBoxedValue
+
+  if !swift_isUniquelyReferenced_native(object: box) {
+    let refAndObjectAddr = swift_allocBoxTyped(metadata, typeId)
+    unsafe _swift_embedded_initialize_box(UnsafeMutableRawPointer(metadata), UnsafeMutableRawPointer(refAndObjectAddr.1), oldObjectAddr)
+    unsafe swift_releaseBoxTyped(UnsafeMutableRawPointer(box), typeId)
+    unsafe addrOfHeapObjectPtr.pointee = refAndObjectAddr.0
+    return refAndObjectAddr
+  } else {
+    return (box, oldObjectAddr._rawValue)
+  }
+}
+
 /// Refcounting
 
 func isValidPointerForNativeRetain(object: Builtin.RawPointer) -> Bool {
@@ -766,7 +804,7 @@ public func swift_nonatomic_release_n(object: Builtin.RawPointer, n: UInt32) {
   swift_release_n(object: object, n: n)
 }
 
-func swift_release_n_(object: UnsafeMutablePointer<HeapObject>?, n: UInt32, isBoxRelease: Bool = false) {
+func swift_release_n_(object: UnsafeMutablePointer<HeapObject>?, n: UInt32, isBoxRelease: Bool = false, typeId: UInt64 = 0) {
   guard let object = unsafe object else {
     return
   }
@@ -792,7 +830,22 @@ func swift_release_n_(object: UnsafeMutablePointer<HeapObject>?, n: UInt32, isBo
     unsafe storeRelaxed(refcount, newValue: HeapObject.immortalRefCount | (doNotFree ? HeapObject.doNotFreeBit : 0))
 
     if isBoxRelease {
+        // _swift_embedded_invoke_box_destroy only runs the boxed payload's
+        // destroy witness and doesn't deallocate the box (a memory leak
+        // otherwise). We deallocate it here.
         unsafe _swift_embedded_invoke_box_destroy(object)
+
+        let metadata = unsafe _swift_embedded_get_heap_object_metadata_pointer(object)
+        let layout = unsafe _boxAllocationLayout(metadata: metadata)
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+        if typeId != 0 {
+          unsafe _swift_typedDeallocate(UnsafeMutableRawPointer(object), layout.size, layout.alignMask, 0, typeId)
+        } else {
+          unsafe _swift_deallocate(UnsafeMutableRawPointer(object), layout.size, layout.alignMask, 0)
+        }
+#else
+        unsafe swift_slowDealloc(UnsafeMutableRawPointer(object), layout.size, layout.alignMask)
+#endif
     } else {
         unsafe _swift_embedded_invoke_heap_object_destroy(object)
     }
@@ -809,6 +862,16 @@ public func swift_releaseBox(_ box: UnsafeMutableRawPointer) {
   }
   let o = unsafe UnsafeMutablePointer<HeapObject>(object)
   unsafe swift_release_n_(object: o, n: 1, isBoxRelease: true)
+}
+
+@c
+public func swift_releaseBoxTyped(_ box: UnsafeMutableRawPointer, _ typeId: UInt64) {
+  let object = box._rawValue
+  if !isValidPointerForNativeRetain(object: object) {
+    fatalError("not a valid pointer for releaseBox")
+  }
+  let o = unsafe UnsafeMutablePointer<HeapObject>(object)
+  unsafe swift_release_n_(object: o, n: 1, isBoxRelease: true, typeId: typeId)
 }
 
 @c

--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -134,3 +134,178 @@ public func deallocateMyClasses(_ ptr: UnsafeMutablePointer<MyClass>) {
 
 // CHECK-LABEL: define {{.*}}swiftcc void @"$eSp10deallocateyyFSi_Tg5"
 // CHECK:   call void @swift_deallocRawTyped(ptr %0, i64 {{.*}}, i64 {{.*}}, i64 [[INT_ARRAY_TYPEID]])
+
+
+// --- Boxed opaque existential cases (typed alloc_box) ---
+
+public protocol Existential {}
+
+// Bigger than the 3-word inline existential buffer, so boxing is required.
+public struct NotInlineFixed: Existential {
+  var x1: Double
+  var x2: Double
+  var x3: Double
+  var x4: Double
+}
+
+public struct NotInlineFixed2: Existential {
+  var y1: Double
+  var y2: Double
+  var y3: Double
+  var y4: Double
+}
+
+public protocol SelfReturningThrows {
+  func upgrade() throws -> Self
+}
+
+extension NotInlineFixed: SelfReturningThrows {
+  public func upgrade() throws -> NotInlineFixed { self }
+}
+
+@inline(never)
+public func useSelfReturningThrows(_ p: any SelfReturningThrows) {}
+
+
+// emitAllocateBoxedOpaqueExistentialBuffer.
+@inline(never)
+public func abandonGeneric<T: SelfReturningThrows>(_ v: T) throws {
+  try useSelfReturningThrows(v.upgrade())
+}
+
+@inline(never)
+public func runAbandonGeneric() throws {
+  try abandonGeneric(NotInlineFixed(x1: 1, x2: 2, x3: 3, x4: 4))
+}
+// CHECK-LABEL: define {{.*}} @"$e{{[0-9]+}}typed_allocation14abandonGeneric{{.*}}"
+// CHECK:   [[CALL:%[0-9]+]] = call swiftcc { ptr, ptr } @swift_allocBoxTyped(ptr {{.*}}, i64 [[TYPEID:[0-9]+]])
+// CHECK:   [[BOX:%[0-9]+]] = extractvalue { ptr, ptr } [[CALL]], 0
+// CHECK:   store ptr [[BOX]], ptr [[BUFFER:%[0-9]+]]
+// CHECK:   [[DESCRIPTOR_SLOT:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[BUFFER]], {{i64|i32}} 8
+// CHECK:   store i64 [[TYPEID]], ptr [[DESCRIPTOR_SLOT]]
+// CHECK:   br i1 {{%[0-9]+}}, label %[[ERRBB:[0-9]+]], label %[[OKBB:[0-9]+]]
+//
+// CHECK: [[OKBB]]:
+// CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(ptr {{%[0-9]+}})
+//
+// CHECK: [[ERRBB]]:
+// CHECK:   call void @__swift_deallocate_boxed_opaque_existential_1(ptr {{%[0-9]+}})
+
+
+// getAllocateBoxedOpaqueExistentialBufferFunction.
+@inline(never)
+public func abandonExistential(_ p: any SelfReturningThrows) throws {
+  try useSelfReturningThrows(p.upgrade())
+}
+// CHECK-LABEL: define {{.*}} @"$e{{[0-9]+}}typed_allocation18abandonExistential{{.*}}"
+// CHECK:   call ptr @__swift_allocate_boxed_opaque_existential_1(ptr {{%[0-9]+}})
+// CHECK-LABEL: define {{.*}} @__swift_allocate_boxed_opaque_existential_1(ptr %0)
+// CHECK: allocateBox:
+// CHECK:   call swiftcc { ptr, ptr } @swift_allocBoxTyped(ptr {{.*}}, i64 [[HEADERID:[0-9]+]])
+// CHECK:   store i64 [[HEADERID]], ptr {{.*}}
+
+
+// getDeallocateBoxedOpaqueExistentialBufferFunction.
+
+// CHECK-LABEL: define {{.*}} @__swift_deallocate_boxed_opaque_existential_1(ptr %0)
+// CHECK: deallocateBox:
+// CHECK:   [[REFERENCE:%[0-9]+]] = load ptr, ptr {{.*}}
+// CHECK:   [[DESCRIPTOR3:%[0-9]+]] = load i64, ptr {{.*}}
+// CHECK:   call void @swift_deallocRawTyped(ptr [[REFERENCE]], {{i64|i32}} {{.*}}, {{i64|i32}} {{.*}}, i64 [[DESCRIPTOR3]])
+
+
+// getDestroyBoxedOpaqueExistentialBufferFunction.
+
+// CHECK-LABEL: define {{.*}} @__swift_destroy_boxed_opaque_existential_1(ptr %0)
+// CHECK: outline:
+// CHECK:   [[REF2:%[0-9]+]] = load ptr, ptr {{.*}}
+// CHECK:   [[DESCRIPTOR4:%[0-9]+]] = load i64, ptr {{.*}}
+// CHECK:   call void @swift_releaseBoxTyped(ptr [[REF2]], i64 [[DESCRIPTOR4]])
+
+
+// initializeWithCopy (OpaqueExistentialTypeInfo).
+@inline(never)
+public func copyExistential() -> any Existential {
+  let x: any Existential = NotInlineFixed(x1: 1, x2: 2, x3: 3, x4: 4)
+  let y = x
+  return y
+}
+// CHECK-LABEL: define {{.*}} @"$e{{[0-9]+}}typed_allocation11Existential_pWOc"(ptr %0, ptr %1)
+// CHECK:   [[SRC_BUFFER:%[0-9]+]] = getelementptr inbounds{{.*}} %T{{[0-9]+}}typed_allocation11ExistentialP, ptr %0, i32 0, i32 0
+// CHECK:   [[DEST_BUFFER:%[0-9]+]] = getelementptr inbounds{{.*}} %T{{[0-9]+}}typed_allocation11ExistentialP, ptr %1, i32 0, i32 0
+// CHECK:   {{%[0-9]+}} = call ptr {{%.*}}(ptr noalias [[DEST_BUFFER]], ptr noalias [[SRC_BUFFER]], ptr {{%[0-9]+}})
+// CHECK:   [[SRC_DESCRIPTOR_SLOT:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[SRC_BUFFER]], {{i64|i32}} 8
+// CHECK:   [[DESCRIPTOR:%[0-9]+]] = load i64, ptr [[SRC_DESCRIPTOR_SLOT]]
+// CHECK:   [[DEST_DESCRIPTOR_SLOT:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[DEST_BUFFER]], {{i64|i32}} 8
+// CHECK:   store i64 [[DESCRIPTOR]], ptr [[DEST_DESCRIPTOR_SLOT]]
+
+// getProjectBoxedOpaqueExistentialFunction.
+public protocol MutableSelfSized {
+  mutating func bump()
+  var value: Double { get }
+}
+extension NotInlineFixed: MutableSelfSized {
+  public mutating func bump() { x1 += 1 }
+  public var value: Double { x1 }
+}
+@inline(never)
+public func mutateSharedExistential() -> Double {
+  var x: any MutableSelfSized = NotInlineFixed(x1: 1, x2: 2, x3: 3, x4: 4)
+  let y = x
+  x.bump()
+  return x.value + y.value
+}
+// CHECK-LABEL: define {{.*}} @__swift_mutable_project_boxed_opaque_existential_1(ptr %0, ptr %1)
+// CHECK: boxed:
+// CHECK:   [[DESCRIPTOR_SLOT7:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr %0, {{i64|i32}} 8
+// CHECK:   [[DESCRIPTOR7:%[0-9]+]] = load i64, ptr [[DESCRIPTOR_SLOT7]]
+// CHECK:   {{%[0-9]+}} = call swiftcc { ptr, ptr } @swift_makeBoxUniqueTyped(ptr %0, ptr %1, i64 {{.*}}, i64 [[DESCRIPTOR7]])
+
+
+// getAssignBoxedOpaqueExistentialBufferFunction (match-outline).
+@inline(never)
+func genericAssign<T>(_ dest: inout T, _ value: T) {
+  dest = value
+}
+@inline(never)
+public func reassignSameType() -> any Existential {
+  var y: any Existential = NotInlineFixed(x1: 1, x2: 2, x3: 3, x4: 4)
+  genericAssign(&y, NotInlineFixed(x1: 5, x2: 6, x3: 7, x4: 8))
+  return y
+}
+// CHECK-LABEL: define {{.*}} @__swift_assign_boxed_opaque_existential_1(ptr %0, ptr %1)
+// CHECK: match-outline:
+// CHECK:   [[OLD_DEST_REF:%[0-9]+]] = load ptr, ptr [[DEST_BUFFER4:%[0-9]+]]
+// CHECK:   [[SRC_REF:%[0-9]+]] = load ptr, ptr [[SRC_BUFFER4:%[0-9]+]]
+// CHECK:   call ptr @swift_retain(ptr returned [[SRC_REF]])
+// CHECK:   [[OLD_DESCRIPTOR_SLOT:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[DEST_BUFFER4]], {{i64|i32}} 8
+// CHECK:   [[OLD_DESCRIPTOR:%[0-9]+]] = load i64, ptr [[OLD_DESCRIPTOR_SLOT]]
+// CHECK:   call void @swift_releaseBoxTyped(ptr [[OLD_DEST_REF]], i64 [[OLD_DESCRIPTOR]])
+// CHECK:   store ptr [[SRC_REF]], ptr [[DEST_BUFFER4]]
+// CHECK:   [[SRC_DESCRIPTOR_SLOT:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[SRC_BUFFER4]], {{i64|i32}} 8
+// CHECK:   [[NEW_DESCRIPTOR:%[0-9]+]] = load i64, ptr [[SRC_DESCRIPTOR_SLOT]]
+// CHECK:   [[NEW_DESCRIPTOR_SLOT:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[DEST_BUFFER4]], {{i64|i32}} 8
+// CHECK:   store i64 [[NEW_DESCRIPTOR]], ptr [[NEW_DESCRIPTOR_SLOT]]
+
+
+// getAssignBoxedOpaqueExistentialBufferFunction (no-match/dest-outline)
+@inline(never)
+public func reassignDifferentType() -> any Existential {
+  var y: any Existential = NotInlineFixed(x1: 1, x2: 2, x3: 3, x4: 4)
+  genericAssign(&y, NotInlineFixed2(y1: 5, y2: 6, y3: 7, y4: 8))
+  return y
+}
+// CHECK: dest-outline:
+// CHECK:   [[OLD_DEST_REF2:%[0-9]+]] = load ptr, ptr [[DEST_BUFFER5:%[0-9]+]]
+// CHECK:   [[OLD_DESCRIPTOR_SLOT2:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[DEST_BUFFER5]], {{i64|i32}} 8
+// CHECK:   [[OLD_DESCRIPTOR2:%[0-9]+]] = load i64, ptr [[OLD_DESCRIPTOR_SLOT2]]
+// CHECK: dest-outline-src-outline:
+// CHECK:   [[SRC_REF2:%[0-9]+]] = load ptr, ptr [[SRC_BUFFER5:%[0-9]+]]
+// CHECK:   call ptr @swift_retain(ptr returned [[SRC_REF2]])
+// CHECK:   store ptr [[SRC_REF2]], ptr [[DEST_BUFFER5]]
+// CHECK:   [[SRC_DESCRIPTOR_SLOT2:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[SRC_BUFFER5]], {{i64|i32}} 8
+// CHECK:   [[NEW_DESCRIPTOR2:%[0-9]+]] = load i64, ptr [[SRC_DESCRIPTOR_SLOT2]]
+// CHECK:   [[NEW_DESCRIPTOR_SLOT2:%[0-9]+]] = getelementptr inbounds{{.*}} i8, ptr [[DEST_BUFFER5]], {{i64|i32}} 8
+// CHECK:   store i64 [[NEW_DESCRIPTOR2]], ptr [[NEW_DESCRIPTOR_SLOT2]]
+// CHECK: dest-outline-cont:
+// CHECK:   call void @swift_releaseBoxTyped(ptr [[OLD_DEST_REF2]], i64 [[OLD_DESCRIPTOR2]])


### PR DESCRIPTION
We store the type descriptors of the heap allocated existential boxes in the otherwise unused second word of the inlined buffer and propagate them to the deallocation sites.

There are a few places that required additional code that copies the type descriptor slot where the original code only copied only the first word (the heap reference) where it knows that it's in the non-inlined shape.

There are two reachable emitAllocBoxCall sites under Embedded Swift, one in emitAllocateBoxedOpaqueExistentialBuffer and another in getAllocateBoxedOpaqueExistentialBufferFunction. For the former, we compute the type descriptor of the box header + payload. For the latter, we only include the box header because the concrete payload type isn't available at compile time.

This includes a fix for an existing memory leak in swift_releaseBox (those alloc boxes weren't actually deallocated) under Embedded Swift.
