### PR TITLE
[stdlib] adjust assertion levels in UnsafeBufferPointer.extracting()

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -518,7 +518,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   @export(implementation)
   @safe
   public func extracting(_ bounds: Range<Int>) -> Self {
-    _precondition(_checkBounds(bounds), "Index out of range")
+    _debugPrecondition(_checkBounds(bounds), "Index out of range")
     guard let start = self.baseAddress else {
       return unsafe Self(start: nil, count: 0)
     }
@@ -592,6 +592,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   /// - Returns: A new buffer pointer over the items at `bounds`.
   @export(implementation)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
+    _internalInvariant(_checkBounds(bounds), "Index out of range")
     let newStart = unsafe _position?.advanced(by: bounds.lowerBound)
     return unsafe Self(start: newStart, count: bounds.count)
   }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1222,7 +1222,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   @export(implementation)
   @safe
   public func extracting(_ bounds: Range<Int>) -> Self {
-    _precondition(_checkBounds(bounds), "Byte offset out of range")
+    _debugPrecondition(_checkBounds(bounds), "Byte offset out of range")
     guard let start = baseAddress else {
       return unsafe Self(_uncheckedStart: nil, count: 0)
     }
@@ -1267,6 +1267,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Returns: A new buffer pointer over the bytes at `bounds`.
   @export(implementation)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
+    _internalInvariant(_checkBounds(bounds), "Byte offset out of range")
     let newStart = unsafe baseAddress?.advanced(by: bounds.lowerBound)
     return unsafe Self(_uncheckedStart: newStart, count: bounds.count)
   }

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -417,6 +417,11 @@ ${SelfName}TestSuite.test("extracting() functions")
   expectEqual(sub3[capacity - 1], ${Element}(capacity - 1))
   expectEqual(sub4[0], ${Element}(2))
   expectEqual(sub5[0], ${Element}(1))
+
+  let empty1 = buffer.extracting(0..<0)
+  expectEqual(empty1.count, 0)
+  let empty2 = buffer.extracting(capacity..<capacity)
+  expectEqual(empty2.count, 0)
 }
 
 ${SelfName}TestSuite.test("extracting() bounds checking")
@@ -433,6 +438,7 @@ ${SelfName}TestSuite.test("extracting() bounds checking")
 
 ${SelfName}TestSuite.test("extracting(unchecked:) functions")
 .require(.stdlib_6_5)
+.skip(.custom({ _isStdlibInternalChecksEnabled() }, reason: "Requires a release stdlib."))
 .code {
   let capacity = 32
 %   if IsRaw:
@@ -459,11 +465,6 @@ ${SelfName}TestSuite.test("extracting(unchecked:) functions")
   let beyondClosed = prefix.extracting(unchecked: 16...23)
   expectEqual(beyondClosed.count, 8)
   expectEqual(beyondClosed[0], ${Element}(16))
-
-  let empty1 = buffer.extracting(unchecked: 0..<0)
-  expectEqual(empty1.count, 0)
-  let empty2 = buffer.extracting(unchecked: capacity..<capacity)
-  expectEqual(empty2.count, 0)
 }
 
 ${SelfName}TestSuite.test("prefix extracting() functions")

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -122,8 +122,6 @@ ${SelfName}TestSuite.test("rebasing") {
 ${SelfName}TestSuite.test("_checkBounds(_: Range) helper")
 .require(.minimumStdlib(.stdlib_6_4))
 .code {
-  guard #available(SwiftStdlib 6.4, *) else { return }
-
 %   if IsRaw:
   let allocated = UnsafeMutableRawBufferPointer.allocate(byteCount: 20, alignment: 8)
   let buffer = ${SelfType}(allocated)
@@ -173,8 +171,6 @@ ${SelfName}TestSuite.test("rebasingInvalidMutableSlice")
 .require(.minimumStdlib(.stdlib_6_4))
 .require(.crashTesting)
 .code {
-  guard #available(SwiftStdlib 6.4, *) else { return }
-
   let rawBuffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 32, alignment: 8
   )


### PR DESCRIPTION
Weaken the bounds checks from `_precondition` to `_debugPrecondition`.
Add an `_internalInvariant` in the `unchecked:` variants.

Addresses: rdar://184868565
