### PR TITLE
[cherry-pick rebranch][IRGen] Fix the storage size of builtin float types in debug info

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2100,9 +2100,8 @@ private:
     }
 
     case TypeKind::BuiltinFloat: {
-      auto *FloatTy = BaseTy->castTo<BuiltinFloatType>();
-      // Assuming that the bitwidth and FloatTy->getFPKind() are identical.
-      SizeInBits = FloatTy->getBitWidth();
+      SizeInBits = IGM.DataLayout.getTypeAllocSizeInBits(
+          IGM.getStorageTypeForUnlowered(BaseTy));
       Encoding = llvm::dwarf::DW_ATE_float;
       break;
     }

--- a/test/DebugInfo/float80-size.swift
+++ b/test/DebugInfo/float80-size.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend %s -Onone -emit-ir -gdwarf-types -o - | %FileCheck %s
+
+// REQUIRES: CPU=i386 || CPU=x86_64
+//
+// Windows and Android do not expose Float80.
+// UNSUPPORTED: OS=windows-msvc, OS=linux-android
+
+// Builtin.FPIEEE80 holds an 80-bit value in wider storage: 128 bits on x86_64,
+// 96 bits on i386. The debug info describes the storage, so that a consumer
+// laying out a type that contains it (Float80 here) arrives at the same size
+// the runtime does.
+
+let float80 = Float80(1.0625)
+
+// CHECK-DAG: !DIBasicType(name: "$sBf80_D", size: {{96|128}}, encoding: DW_ATE_float)
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Float80", {{.*}}size: {{96|128}},


### PR DESCRIPTION
Builtin.FPIEEE80 holds an 80-bit value in 128 bits of storage, but the
debug info described it as 80 bits wide, so DWARF said 10 bytes for a
16-byte field. Emit the storage size instead.

Assisted-by: claude

(cherry picked from commit 9e8d18799a29809732424ba148b78671257e07c4)
