### PR TITLE
[cherry-pick rebranch][DebugInfo] Implement DebugTypeInfo::getDecl() for parametrized protocols

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -161,6 +161,8 @@ TypeDecl *DebugTypeInfo::getDecl() const {
     return UBG->getDecl();
   if (auto *BG = dyn_cast<BoundGenericType>(Type))
     return BG->getDecl();
+  if (auto *PPT = dyn_cast<ParameterizedProtocolType>(Type))
+    return PPT->getProtocol();
   if (auto *E = dyn_cast<ExistentialType>(Type))
     return E->getConstraintType()->getAnyNominal();
   return nullptr;

--- a/test/DebugInfo/existential-typealias-cache-conflict.swift
+++ b/test/DebugInfo/existential-typealias-cache-conflict.swift
@@ -20,4 +20,4 @@ actor A<Value> {
 // CHECK-DAG: ![[ELTS]] = !{![[INNER:[0-9]+]]}
 // CHECK-DAG: ![[INNER]] = !DIDerivedType(tag: DW_TAG_member, name: "$swift.constraint", {{.*}}, baseType: ![[TYPEDEF:[0-9]+]]
 // CHECK-DAG: ![[TYPEDEF]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s12LayeredCache1AC1Tayx_GD", {{.*}}, baseType: ![[PROTO_TY:[0-9]+]])
-// CHECK-DAG: ![[PROTO_TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s12LayeredCache1P_px5ValueAaBPRts_XPD", {{.*}}, identifier: "$s12LayeredCache1P_px5ValueAaBPRts_XPD")
+// CHECK-DAG: ![[PROTO_TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "P", {{.*}}, identifier: "$s12LayeredCache1P_px5ValueAaBPRts_XPD")

--- a/test/DebugInfo/parameterized-existential-protocol-name.swift
+++ b/test/DebugInfo/parameterized-existential-protocol-name.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -parse-as-library -module-name main -o - \
+// RUN:   | %FileCheck %s
+
+public protocol Plain { func f() -> Int }
+public protocol Param<U> { associatedtype U; func g() -> U }
+public protocol ClassParam<U>: AnyObject { associatedtype U; func g() -> U }
+@_marker public protocol Marker {}
+
+public func consume(_ a: any Plain,
+                    _ b: any Param<Int>,
+                    _ c: any ClassParam<Int>,
+                    _ d: any Param<Int> & Marker) {}
+
+// A plain existential is named after its protocol.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Plain",{{.*}}identifier: "$s4main5Plain_pD")
+
+// A parameterized existential keeps the parameterized mangling as its identifier, but
+// takes its name from the protocol.
+// CHECK-DAG: ![[PARAM:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Param",{{.*}}identifier: "$s4main5Param_pSi1UAaBPRts_XPD")
+
+// A class-constrained parameterized existential also keeps the annotation.
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "ClassParam",{{.*}}identifier: "$s4main10ClassParam_pSi1UAaBPRts_XPD", annotations: ![[CP_ANNOTS:[0-9]+]])
+// CHECK-DAG: ![[CP_ANNOTS]] = !{![[CP_FLAG:[0-9]+]]}
+// CHECK-DAG: ![[CP_FLAG]] = !{!"swift.ClassConstrainedProtocol", i1 true}
+
+// A composition is still named by its mangled name -- it has no single decl -- but each
+// member it inherits from is a protocol DIE that must be named, whether or not that
+// member is parameterized.
+// CHECK-DAG: ![[COMP:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s4main6Marker{{.*}}Rts_XPD",{{.*}}elements:
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_inheritance, scope: ![[COMP]], baseType: ![[PARAM]],
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_inheritance, scope: ![[COMP]], baseType: ![[MARKER:[0-9]+]],
+// CHECK-DAG: ![[MARKER]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Marker",{{.*}}annotations: ![[M_ANNOTS:[0-9]+]])
+// CHECK-DAG: ![[M_ANNOTS]] = !{![[M_FLAG:[0-9]+]]}
+// CHECK-DAG: ![[M_FLAG]] = !{!"swift.MarkerProtocol", i1 true}


### PR DESCRIPTION
Without this we won’t attach `swift.MarkerProtocol`,
`swift.ObjCProtocol` or
`swift.ClassConstrainedProtocol` DWARF markers to the type.

Assisted-by: Claude

rdar://184853745

(cherry picked from commit 69b3d803dd94482598284c029c350965df4ed429)
