### PR TITLE
[stdlib] Back out recent linux/Glibc and Android changes for output/input streams

### DIFF
--- a/stdlib/public/Platform/Android.swift
+++ b/stdlib/public/Platform/Android.swift
@@ -11,18 +11,3 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import SwiftAndroid // Clang module
-import SwiftOverlayShims
-
-// FILE is opaque on Android (bionic) - the underlying `struct __sFILE` is
-// not exposed in a way that Clang can import into Swift, so use OpaquePointer.
-// Client code that needs to interoperate with <stdio.h> functions can bridge
-// via `typealias File = OpaquePointer` under `#if os(Android)`.
-nonisolated(unsafe) public var stdin: OpaquePointer {
-  OpaquePointer(_swift_stdlib_stdin())
-}
-nonisolated(unsafe) public var stdout: OpaquePointer {
-  OpaquePointer(_swift_stdlib_stdout())
-}
-nonisolated(unsafe) public var stderr: OpaquePointer {
-  OpaquePointer(_swift_stdlib_stderr())
-}

--- a/stdlib/public/Platform/Glibc.swift.gyb
+++ b/stdlib/public/Platform/Glibc.swift.gyb
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import SwiftGlibc // Clang module
-import SwiftOverlayShims
 
 public let MAP_FAILED: UnsafeMutableRawPointer! = UnsafeMutableRawPointer(bitPattern: -1)
 
@@ -70,16 +69,3 @@ public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 #endif
 % end
 %end
-
-// OpenBSD, FreeBSD, and PS4 define stdin/stdout/stderr in Platform.swift
-#if !os(OpenBSD) && !os(FreeBSD) && !os(PS4)
-nonisolated(unsafe) public var stdin: UnsafeMutablePointer<FILE>! {
-  _swift_stdlib_stdin().assumingMemoryBound(to: FILE.self)
-}
-nonisolated(unsafe) public var stdout: UnsafeMutablePointer<FILE>! {
-  _swift_stdlib_stdout().assumingMemoryBound(to: FILE.self)
-}
-nonisolated(unsafe) public var stderr: UnsafeMutablePointer<FILE>! {
-  _swift_stdlib_stderr().assumingMemoryBound(to: FILE.self)
-}
-#endif

--- a/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
@@ -20,7 +20,7 @@
 
 #include "Visibility.h"
 
-#if defined(__OpenBSD__) || defined(__linux__) || defined(__wasi__)
+#if defined(__OpenBSD__) || defined(__wasi__)
 #include <stdio.h>
 #endif
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -120,7 +120,7 @@ int static inline _swift_stdlib_openat(int fd, const char *path, int oflag,
 }
 #endif
 
-#if defined(__OpenBSD__) || defined(__linux__) || defined(__wasi__)
+#if defined(__OpenBSD__) || defined(__wasi__)
 static inline void *_swift_stdlib_stdin(void) {
   return stdin;
 }

--- a/test/stdlib/StdioSendable.swift
+++ b/test/stdlib/StdioSendable.swift
@@ -12,22 +12,27 @@
 
 // RUN: %target-swift-frontend -swift-version 6 -emit-sil -o /dev/null -verify %s
 // REQUIRES: concurrency
-// REQUIRES: OS=linux-gnu || OS=linux-musl || OS=linux-android || OS=linux-androideabi || OS=wasip1 || OS=openbsd || OS=freebsd
+
+// Module collision errors meant we couldn't add the stdio shims needed for linux
+// and Android, see #43103.
+// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
 
 // Regression test: stdin/stdout/stderr must be usable from concurrent contexts
-// on Linux, Android, WASI, OpenBSD, and FreeBSD. They are computed vars marked
-// nonisolated(unsafe): get-only on Linux/Android/WASI/OpenBSD, and get/set on
-// FreeBSD. Either way they must not trip "global shared mutable state" errors in
-// Swift 6 mode.
+// on most platforms, except linux and Android because of module errors. They are either
+// computed vars marked nonisolated(unsafe)- get-only on WASI/OpenBSD, and get/set
+// on FreeBSD- or imported const/let on Musl. Either way, try not to trip
+// "global shared mutable state" errors in Swift 6 mode.
 
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
 #elseif canImport(WASILibc)
 import WASILibc
+#elseif os(Windows)
+import CRT
 #else
 #error("Unsupported platform")
 #endif
@@ -54,15 +59,9 @@ nonisolated func useFromNonisolatedContext() {
 
 // Make sure we can pass stdout/stderr to `FILE *` parameters of stdio functions
 // imported from the same overlay.
-//
-// On Android and WASI `FILE *` imports as OpaquePointer, so those platforms
-// require a bridging typealias at each call site (see swift-inspect for the
-// pattern). This check therefore runs only where FILE is a nominal type.
-#if !os(Android) && !os(WASI)
 func passToStdioFunctions() {
     setvbuf(stdout, nil, _IOLBF, 0)
     setvbuf(stderr, nil, _IOLBF, 0)
     fflush(stdout)
     fputs("hi", stderr)
 }
-#endif


### PR DESCRIPTION
Extend the test to work on all CI platforms except linux/Glibc and Android, making sure this concurrency typing works everywhere else.