### PR TITLE
Fix 9 stale CODEOWNERS paths, remove 4 dead rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,14 +19,12 @@
 /.github/                                 @shahmishal
 /.github/CODEOWNERS                       @AnthonyLatsis @shahmishal
 /.github/ISSUE_TEMPLATE/                  @AnthonyLatsis @hborla @shahmishal @xedin
-/.github/PULL_REQUEST_TEMPLATE.md         @AnthonyLatsis @hborla @shahmishal @xedin
 
 /.gitignore           @shahmishal
 # TODO: /.mailmap
 # TODO: /Brewfile
 /CHANGELOG.md         @hborla
 # TODO: /CMakeLists.txt
-/CODE_OF_CONDUCT.md   @swiftlang/core-team
 /CODE_OWNERS.TXT      @swiftlang/core-team
 /CONTRIBUTING.md      @AnthonyLatsis @xedin
 /LICENSE.txt          @swiftlang/core-team
@@ -128,7 +126,7 @@
 /lib/AST/*Demangl*                                  @rjmccall
 /lib/AST/*Generic*                                  @hborla @slavapestov
 /lib/AST/*Requirement*                              @hborla @slavapestov
-/lib/AST/*Substitution                              @slavapestov
+/lib/AST/*Substitution*                             @slavapestov
 /lib/AST/ASTPrinter.cpp                             @hborla @slavapestov @xedin @tshortli
 /lib/AST/Evaluator*                                 @CodaFi @slavapestov
 /lib/AST/ModuleLoader.cpp                           @artemcm
@@ -180,7 +178,7 @@
 /lib/Sema/CodeSynthesisDistributed*                 @hborla @ktoso
 /lib/Sema/Constraint*                               @hborla @xedin @hamishknight @kathygray-pl
 /lib/Sema/DerivedConformance*                       @slavapestov
-/lib/Sema/DerivedConformanceDistributed*            @ktoso @slavapestov
+/lib/Sema/DerivedConformance/DerivedConformanceDistributed*  @ktoso @slavapestov
 /lib/Sema/OpenedExistentials*                       @AnthonyLatsis @slavapestov
 /lib/Sema/PreCheckTarget.cpp                        @hborla @slavapestov @xedin @hamishknight @kathygray-pl
 /lib/Sema/TypeCheckDistributed*                     @hborla @ktoso @xedin
@@ -263,7 +261,7 @@
 
 # tools
 # TODO: /tools
-/tools/*reflection/                                 @slavapestov
+/tools/*reflection*/                                @slavapestov
 /tools/SourceKit                                    @hamishknight @rintaro
 /tools/driver/                                      @artemcm
 /tools/lldb-moduleimport-test/                      @adrian-prantl
@@ -280,7 +278,6 @@
 /unittests/Frontend*/                     @artemcm @tshortli
 /unittests/Parse/                         @CodaFi @DougGregor @hamishknight @rintaro
 /unittests/Reflection/                    @slavapestov
-/unittests/SIL/                           @jckarter
 /unittests/Sema/                          @hborla @xedin @hamishknight
 /unittests/SourceKit/                     @rintaro @hamishknight
 /unittests/runtime/                       @rjmccall
@@ -303,13 +300,12 @@
 /utils/sourcekit_fuzzer/                                      @hamishknight @rintaro
 /utils/swift-dev-utils/                                       @hamishknight
 /utils/swift_build_support/                                   @etcwilde @justice-adams-apple @shahmishal @edymtt
-/utils/swift_build_support/products/earlyswiftsyntax.py       @hamishknight @rintaro
-/utils/swift_build_support/products/skstresstester.py         @hamishknight @rintaro
-/utils/swift_build_support/products/sourcekitlsp.py           @hamishknight @rintaro
-/utils/swift_build_support/products/swiftformat.py            @allevato @hamishknight @rintaro
-/utils/swift_build_support/products/swiftsyntax.py            @hamishknight @rintaro
-/utils/swift_build_support/products/wasm*                     @MaxDesiatov @kateinoigakukun
-/utils/swift_build_support/products/wasi*                     @MaxDesiatov @kateinoigakukun
+/utils/swift_build_support/swift_build_support/products/skstresstester.py  @hamishknight @rintaro
+/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py    @hamishknight @rintaro
+/utils/swift_build_support/swift_build_support/products/swiftformat.py     @allevato @hamishknight @rintaro
+/utils/swift_build_support/swift_build_support/products/swiftsyntax.py     @hamishknight @rintaro
+/utils/swift_build_support/swift_build_support/products/wasm*              @MaxDesiatov @kateinoigakukun
+/utils/swift_build_support/swift_build_support/products/wasi*              @MaxDesiatov @kateinoigakukun
 /utils/update-checkout*                                       @etcwilde @justice-adams-apple @shahmishal
 /utils/update_checkout/                                       @etcwilde @justice-adams-apple @shahmishal
 /utils/update_checkout/update-checkout-config.json            @shahmishal


### PR DESCRIPTION
## Summary
Resolves stale references in CODEOWNERS. The lines themselves were left unchanged while the paths they referenced disappeared from the tree.

9 one-line edits resolve the stale references:
- Update CODEOWNERS line 131 to: `/lib/AST/*Substitution*`
- Update CODEOWNERS line 183 to: `/lib/Sema/DerivedConformance/DerivedConformanceDistributed*`
- Update CODEOWNERS line 266 to: `/tools/*reflection*/`
- Update CODEOWNERS lines 306-311 to: `/utils/swift_build_support/swift_build_support/products/...` (skstresstester.py, sourcekitlsp.py, swiftformat.py, swiftsyntax.py, wasm*, wasi*)

Removed 4 dead rules, their files no longer exist: `/.github/PULL_REQUEST_TEMPLATE.md`, `/CODE_OF_CONDUCT.md`, `/unittests/SIL/`, `/utils/swift_build_support/products/earlyswiftsyntax.py`

## Test

    # the stale line
    sed -n '131p' .github/CODEOWNERS
    # tracked files under the referenced path, 0 before this PR
    git ls-files -- 'lib/AST/*Substitution*' | wc -l
    git ls-files -- 'utils/swift_build_support/swift_build_support/products/swiftsyntax.py' | wc -l
    git ls-files -- '.github/PULL_REQUEST_TEMPLATE.md' 'CODE_OF_CONDUCT.md' 'unittests/SIL' | wc -l

## Additional information
12 of these references became stale when their directories were moved 123 days ago, /unittests/SIL/ has been stale for 61 days.

I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.