### PR TITLE
Forward -sanitize flags to -compile-module-from-interface subinvocations

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -602,6 +602,7 @@ public:
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
       const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
       const ClangImporterOptions &ClangOpts, const CASOptions &CASOpts,
+      const SILOptions &SILOpts,
       StringRef CacheDir, StringRef PrebuiltCacheDir,
       StringRef BackupInterfaceDir, StringRef ModuleName, StringRef InPath,
       StringRef OutPath, StringRef ABIOutputPath,
@@ -679,6 +680,7 @@ private:
                                      const LangOptions &LangOpts,
                                      const ClangImporterOptions &clangImporterOpts,
                                      const CASOptions &casOpts,
+                                     const SILOptions &silOpts,
                                      bool suppressNotes, bool suppressRemarks,
                                      PrintDiagnosticNamesMode diagnosticNamesMode);
   bool extractSwiftInterfaceVersionAndArgs(CompilerInvocation &subInvocation,
@@ -692,6 +694,7 @@ public:
       SourceManager &SM, DiagnosticEngine *Diags,
       const SearchPathOptions &searchPathOpts, const LangOptions &langOpts,
       const ClangImporterOptions &clangImporterOpts, const CASOptions &casOpts,
+      const SILOptions &silOpts,
       ModuleInterfaceLoaderOptions LoaderOpts, bool buildModuleCacheDirIfAbsent,
       StringRef moduleCachePath, StringRef prebuiltCachePath,
       StringRef backupModuleInterfaceDir,

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -254,6 +254,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
       workerASTContext->SourceMgr, workerDiagnosticEngine.get(),
       workerASTContext->SearchPathOpts, workerASTContext->LangOpts,
       workerASTContext->ClangImporterOpts, workerASTContext->CASOpts,
+      workerASTContext->SILOpts,
       workerCompilerInvocation->getFrontendOptions(),
       /* buildModuleCacheDirIfAbsent */ false,
       getModuleCachePathFromClang(

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -950,6 +950,7 @@ bool CompilerInstance::setUpModuleLoaders() {
     InterfaceSubContextDelegateImpl ASTDelegate(
         Context->SourceMgr, &Context->Diags, Context->SearchPathOpts,
         Context->LangOpts, Context->ClangImporterOpts, Context->CASOpts,
+        Context->SILOpts,
         LoaderOpts,
         /*buildModuleCacheDirIfAbsent*/ false, ClangModuleCachePath,
         FEOpts.PrebuiltModuleCachePath, FEOpts.BackupModuleInterfaceDir,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Platform.h"
+#include "swift/Basic/Sanitizers.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/Frontend/CachingUtils.h"
 #include "swift/Frontend/CompileJobCacheResult.h"
@@ -1110,7 +1111,7 @@ class ModuleInterfaceLoaderImpl {
     }
     InterfaceSubContextDelegateImpl astDelegate(
         ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
-        ctx.ClangImporterOpts, ctx.CASOpts, Opts,
+        ctx.ClangImporterOpts, ctx.CASOpts, ctx.SILOpts, Opts,
         /*buildModuleCacheDirIfAbsent*/ true, cacheDir, prebuiltCacheDir,
         backupInterfaceDir, /*replayPrefixMap=*/{},
         /*serializeDependencyHashes*/ false, trackSystemDependencies);
@@ -1481,6 +1482,7 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
     const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
     const ClangImporterOptions &ClangOpts, const CASOptions &CASOpts,
+    const SILOptions &SILOpts,
     StringRef CacheDir, StringRef PrebuiltCacheDir,
     StringRef BackupInterfaceDir, StringRef ModuleName, StringRef InPath,
     StringRef OutPath, StringRef ABIOutputPath,
@@ -1489,7 +1491,7 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
     ModuleInterfaceLoaderOptions LoaderOpts,
     bool silenceInterfaceDiagnostics) {
   InterfaceSubContextDelegateImpl astDelegate(
-      SourceMgr, &Diags, SearchPathOpts, LangOpts, ClangOpts, CASOpts,
+      SourceMgr, &Diags, SearchPathOpts, LangOpts, ClangOpts, CASOpts, SILOpts,
       LoaderOpts,
       /*CreateCacheDirIfAbsent*/ true, CacheDir, PrebuiltCacheDir,
       BackupInterfaceDir, replayPrefixMap, SerializeDependencyHashes,
@@ -1646,6 +1648,7 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     FrontendOptions::ActionType requestedAction,
     const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
     const ClangImporterOptions &clangImporterOpts, const CASOptions &casOpts,
+    const SILOptions &silOpts,
     bool suppressNotes, bool suppressRemarks,
     PrintDiagnosticNamesMode printDiagnosticNames) {
   GenericArgs.push_back("-frontend");
@@ -1699,6 +1702,17 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   GenericArgs.push_back("-swift-version");
   GenericArgs.push_back(ArgSaver.save(genericSubInvocation.getLangOptions()
     .EffectiveLanguageVersion.asAPINotesVersionString()));
+
+  // Forward the parent's sanitizer selection so the child's ClangImporter
+  // propagates the same flags into its Clang cc1 args. This is important because
+  // -sanitize options can add target-features (e.g. MTE). These are checked when
+  // loading a PCM (and mismatches are fatal).
+  genericSubInvocation.getSILOptions().Sanitizers = silOpts.Sanitizers;
+#define SANITIZER(_, kind, name, __)                                           \
+  if (silOpts.Sanitizers & SanitizerKind::kind) {                              \
+    GenericArgs.push_back("-sanitize=" #name);                                 \
+  }
+#include "swift/Basic/Sanitizers.def"
 
   genericSubInvocation.setImportSearchPaths(
       SearchPathOpts.getImportSearchPaths());
@@ -1852,6 +1866,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     SourceManager &SM, DiagnosticEngine *Diags,
     const SearchPathOptions &searchPathOpts, const LangOptions &langOpts,
     const ClangImporterOptions &clangImporterOpts, const CASOptions &casOpts,
+    const SILOptions &silOpts,
     ModuleInterfaceLoaderOptions LoaderOpts, bool buildModuleCacheDirIfAbsent,
     StringRef moduleCachePath, StringRef prebuiltCachePath,
     StringRef backupModuleInterfaceDir,
@@ -1864,6 +1879,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   genericSubInvocation.setMainExecutablePath(LoaderOpts.mainExecutablePath);
   inheritOptionsForBuildingInterface(LoaderOpts.requestedAction, searchPathOpts,
                                      langOpts, clangImporterOpts, casOpts,
+                                     silOpts,
                                      Diags->getSuppressNotes(),
                                      Diags->getSuppressRemarks(),
                                      Diags->getPrintDiagnosticNamesMode());

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -503,6 +503,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
       Instance.getSourceMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
       Invocation.getClangImporterOptions(), Invocation.getCASOptions(),
+      Invocation.getSILOptions(),
       Invocation.getClangModuleCachePath(), PrebuiltCachePath,
       FEOpts.BackupModuleInterfaceDir, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(), ABIPath, FEOpts.CacheReplayPrefixMap,

--- a/test/ScanDependencies/sanitizer-pass-down.swift
+++ b/test/ScanDependencies/sanitizer-pass-down.swift
@@ -1,0 +1,19 @@
+// Verify that a Swift dependency scan propagates the parent's -sanitize=<name>
+// selection into the resolved -compile-module-from-interface command for each
+// swiftinterface dependency.
+
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/Frameworks/E.framework/Modules/E.swiftmodule
+// RUN: cp %S/Inputs/Swift/E.swiftinterface %t/Frameworks/E.framework/Modules/E.swiftmodule/%module-target-triple.swiftinterface
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface %s -o %t/deps.json -F %t/Frameworks/ -sdk %t -sanitize=address
+
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json E > %t/E.cmd
+// RUN: %FileCheck %s -input-file=%t/E.cmd
+
+import E
+
+// CHECK: "-sanitize=address"


### PR DESCRIPTION
#88564 started passing `-fsanitize` flags to the clang importer. This means that compliations via the clang importer may use different LangOpts or target features (e.g. +mte for `-sanitize memtag-stack`).

I ran into an issue where it appears that `-sanitize memtag-stack` and its implied +mte target feature are not being uniformly applied. This causes PCMs to be rejected:

```
error: precompiled file '<redacted>' was compiled with the target feature '+mte'
but the current translation unit is not
```

It looks like this is because -sanitize options are not inherited in `InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface`.

Assisted-by: Claude

rdar://185067740