### PR TITLE
[update-checkout] Support per-protocol clone URL overrides

### DIFF
--- a/utils/update_checkout/README.md
+++ b/utils/update_checkout/README.md
@@ -76,6 +76,49 @@ To checkout the commits that most closely match the timestamp of the checked out
 ./swift/utils/update-checkout --scheme release/6.2 --match-timestamp
 ```
 
+## Configuration
+
+### Clone URLs
+
+By default, the URL a repository is cloned from is formed by interpolating its
+`remote` `id` into the top-level `ssh-clone-pattern` or `https-clone-pattern`,
+depending on whether `--clone-with-ssh` was passed:
+
+```json
+"ssh-clone-pattern": "git@github.com:%s.git",
+"https-clone-pattern": "https://github.com/%s.git",
+"repos": {
+    "swift": { "remote": { "id": "swiftlang/swift" } }
+}
+```
+
+A repository that does not live where the clone patterns point can override its
+URL. Use `url` when the same URL should be used for both protocols, or
+`ssh-url` / `https-url` to override only the URL for a given protocol:
+
+```json
+"repos": {
+    "boringssl": {
+        "remote": {
+            "id": "google/boringssl",
+            "url": "https://boringssl.googlesource.com/boringssl"
+        }
+    },
+    "swift-corelibs-xctest": {
+        "remote": {
+            "id": "swiftlang/swift-corelibs-xctest",
+            "ssh-url": "git@github.com:swiftlang/swift-corelibs-xctest.git",
+            "https-url": "https://github.com/swiftlang/swift-corelibs-xctest.git"
+        }
+    }
+}
+```
+
+When both a protocol-specific override and `url` are present, the
+protocol-specific one wins for its protocol. An override for the other protocol
+is still preferred over the interpolated URL, so a repository that only
+specifies `https-url` is cloned over `HTTPS` even with `--clone-with-ssh`.
+
 ## Testing
 
 `update-checkout` has both unit and end to end tests located in the `tests` directory. You can run them with the following command:

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -272,20 +272,24 @@ class SchemeMockTestCase(unittest.TestCase):
     def _compute_remote_path(self, *, repo_name: str):
         remote_info = self.config["repos"][repo_name]["remote"]
         id = remote_info.get("id")
-        url = remote_info.get("url")
         if id is not None:
             return os.path.join(self._remotes_path, remote_info["id"])
-        elif url is not None:
+
+        for url_key in ("url", "https-url", "ssh-url"):
+            url = remote_info.get(url_key)
+            if url is None:
+                continue
             url_path = get_path_from_url(url)
             workspace_path = os.path.dirname(self._remotes_path)
             self.assertEqual(
                 os.path.commonpath((workspace_path, url_path)), workspace_path
             )
             return os.path.join(self._remotes_path, os.path.basename(url_path))
-        else:
-            raise RuntimeError(
-                f"'remote' for '{local_repo_name}' must have an 'id' or 'url' item"
-            )
+
+        raise RuntimeError(
+            f"'remote' for '{repo_name}' must have an 'id', 'url', 'https-url' "
+            "or 'ssh-url' item"
+        )
 
     def remote_path(self, *, repo_name: str):
         return self._compute_remote_path(repo_name=repo_name)

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -315,6 +315,72 @@ class SchemeWithHashTestCase(scheme_mock.SchemeMockTestCase):
         self.assertEqual(current_commit, self.commit_hash)
 
 
+class SchemeWithURLOverrideTestCase(scheme_mock.SchemeMockTestCase):
+    """
+    Test the per-repository clone URL overrides. 'repo1' is given overrides
+    pointing at its own mock remote, plus unusable overrides that must not be
+    selected; 'repo2' is always skipped, since it can only be cloned through
+    the (unusable) ssh clone pattern of the mock config.
+    """
+
+    UNUSABLE_URL = "file:///unusable/repo1"
+
+    def setUp(self):
+        super().setUp()
+        # The https clone pattern of the mock config points at the mock
+        # remotes, so this is a URL that can actually be cloned from.
+        self.usable_url = self.config["https-clone-pattern"] % "repo1"
+
+    def _clone_repo1_with_overrides(self, overrides, additional_flags=[]):
+        import json
+
+        self.config["repos"]["repo1"]["remote"].update(overrides)
+        with open(self.config_path, "w") as f:
+            json.dump(self.config, f)
+
+        self.call(
+            self.base_args
+            + [
+                "--clone",
+                "--skip-repository",
+                "repo2",
+                "--max-retries",
+                "0",
+            ]
+            + additional_flags
+        )
+        self.assertTrue(os.path.isdir(os.path.join(self.source_root, "repo1")))
+
+    def test_clone_with_url_override(self):
+        # A protocol-agnostic override is used for both protocols.
+        self._clone_repo1_with_overrides({"url": self.usable_url})
+
+    def test_clone_with_url_override_and_ssh(self):
+        self._clone_repo1_with_overrides({"url": self.usable_url}, ["--clone-with-ssh"])
+
+    def test_clone_with_https_url_override(self):
+        self._clone_repo1_with_overrides(
+            {"https-url": self.usable_url, "ssh-url": self.UNUSABLE_URL}
+        )
+
+    def test_clone_with_ssh_url_override(self):
+        self._clone_repo1_with_overrides(
+            {"ssh-url": self.usable_url, "https-url": self.UNUSABLE_URL},
+            ["--clone-with-ssh"],
+        )
+
+    def test_clone_with_ssh_url_override_wins_over_url(self):
+        self._clone_repo1_with_overrides(
+            {"ssh-url": self.usable_url, "url": self.UNUSABLE_URL},
+            ["--clone-with-ssh"],
+        )
+
+    def test_clone_with_https_url_override_wins_over_url(self):
+        self._clone_repo1_with_overrides(
+            {"https-url": self.usable_url, "url": self.UNUSABLE_URL}
+        )
+
+
 class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/utils/update_checkout/tests/test_remote_url.py
+++ b/utils/update_checkout/tests/test_remote_url.py
@@ -1,0 +1,126 @@
+# ===--- test_remote_url.py -----------------------------------------------===#
+#
+#  This source file is part of the Swift.org open source project
+#
+#  Copyright (c) 2025 Apple Inc. and the Swift project authors
+#  Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#  See https:#swift.org/LICENSE.txt for license information
+#  See https:#swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+import unittest
+
+from update_checkout.update_checkout import remote_url_for_repo
+
+CONFIG = {
+    "ssh-clone-pattern": "ssh://git@example.com/org/%s.git",
+    "https-clone-pattern": "https://example.com/org/%s.git",
+}
+
+SSH_ONLY_CONFIG = {
+    "ssh-clone-pattern": "ssh://git@example.com/org/%s.git",
+}
+
+
+class RemoteURLTestCase(unittest.TestCase):
+    def _url(self, remote, *, clone_with_ssh, config=CONFIG):
+        return remote_url_for_repo("repo", remote, config, clone_with_ssh)
+
+    def test_interpolated_from_id(self):
+        remote = {"id": "repo"}
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=False),
+            "https://example.com/org/repo.git",
+        )
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=True),
+            "ssh://git@example.com/org/repo.git",
+        )
+
+    def test_interpolated_without_https_clone_pattern(self):
+        # A config that only knows how to form ssh URLs uses them even when
+        # ssh was not requested.
+        remote = {"id": "repo"}
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=False, config=SSH_ONLY_CONFIG),
+            "ssh://git@example.com/org/repo.git",
+        )
+
+    def test_url_override_wins_over_interpolation(self):
+        remote = {"id": "repo", "url": "https://other.example/repo.git"}
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=False),
+            "https://other.example/repo.git",
+        )
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=True),
+            "https://other.example/repo.git",
+        )
+
+    def test_protocol_specific_override(self):
+        remote = {
+            "id": "repo",
+            "ssh-url": "git@other.example:org/repo.git",
+            "https-url": "https://other.example/org/repo.git",
+        }
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=False),
+            "https://other.example/org/repo.git",
+        )
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=True),
+            "git@other.example:org/repo.git",
+        )
+
+    def test_protocol_specific_override_wins_over_url(self):
+        remote = {
+            "id": "repo",
+            "url": "https://other.example/org/repo.git",
+            "ssh-url": "git@other.example:org/repo.git",
+        }
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=True),
+            "git@other.example:org/repo.git",
+        )
+        # No https-specific override, so the protocol-agnostic one is used.
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=False),
+            "https://other.example/org/repo.git",
+        )
+
+    def test_override_for_other_protocol_is_last_resort(self):
+        # An override is always more specific than an interpolated URL, so it
+        # is used even when it does not match the requested protocol.
+        self.assertEqual(
+            self._url(
+                {"id": "repo", "https-url": "https://other.example/org/repo.git"},
+                clone_with_ssh=True,
+            ),
+            "https://other.example/org/repo.git",
+        )
+        self.assertEqual(
+            self._url(
+                {"id": "repo", "ssh-url": "git@other.example:org/repo.git"},
+                clone_with_ssh=False,
+            ),
+            "git@other.example:org/repo.git",
+        )
+
+    def test_protocol_specific_override_without_https_clone_pattern(self):
+        # An ssh-only config picks the ssh override, since it can only clone
+        # over ssh anyway.
+        remote = {
+            "id": "repo",
+            "ssh-url": "git@other.example:org/repo.git",
+            "https-url": "https://other.example/org/repo.git",
+        }
+        self.assertEqual(
+            self._url(remote, clone_with_ssh=False, config=SSH_ONLY_CONFIG),
+            "git@other.example:org/repo.git",
+        )
+
+    def test_remote_without_id_or_url(self):
+        with self.assertRaises(RuntimeError):
+            self._url({}, clone_with_ssh=False)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -848,6 +848,47 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
     Git.run(repo_path, ["submodule", "update", "--recursive"], env=env)
 
 
+def remote_url_for_repo(
+    repo_name: str,
+    remote_repo_info: Dict[str, Any],
+    config: Dict[str, Any],
+    clone_with_ssh: bool,
+) -> str:
+    """Computes the URL to clone the given repository from.
+
+    By default, the URL is interpolated from the top-level clone pattern that
+    matches the requested protocol and the repository's remote "id". A
+    repository can override that URL entirely, either per-protocol
+    ("ssh-url", "https-url") or for both protocols at once ("url"). When both
+    kinds of override are present, the one matching the requested protocol
+    wins; when only the override for the other protocol is present, it is used
+    as a last resort, since an override is always more specific than the
+    interpolated URL.
+    """
+
+    # A configuration that does not provide an https clone pattern only
+    # supports ssh, so pick the ssh overrides in that case as well.
+    use_ssh = clone_with_ssh or "https-clone-pattern" not in config
+
+    if use_ssh:
+        url_keys = ["ssh-url", "url", "https-url"]
+    else:
+        url_keys = ["https-url", "url", "ssh-url"]
+
+    for url_key in url_keys:
+        if url_key in remote_repo_info:
+            return remote_repo_info[url_key]
+
+    if "id" not in remote_repo_info:
+        raise RuntimeError(
+            "'remote' for '{0}' must have an 'id', 'url', 'ssh-url' or "
+            "'https-url' item".format(repo_name)
+        )
+
+    clone_pattern_key = "ssh-clone-pattern" if use_ssh else "https-clone-pattern"
+    return config[clone_pattern_key] % remote_repo_info["id"]
+
+
 def obtain_all_additional_swift_sources(
     args: CliArguments,
     config: Dict[str, Any],
@@ -882,17 +923,9 @@ def obtain_all_additional_swift_sources(
             )
             continue
 
-        # If we have a url override, use that url instead of
-        # interpolating.
-        remote_repo_info = repo_info["remote"]
-        if "url" in remote_repo_info:
-            remote = remote_repo_info["url"]
-        else:
-            remote_repo_id = remote_repo_info["id"]
-            if args.clone_with_ssh is True or "https-clone-pattern" not in config:
-                remote = config["ssh-clone-pattern"] % remote_repo_id
-            else:
-                remote = config["https-clone-pattern"] % remote_repo_id
+        remote = remote_url_for_repo(
+            repo_name, repo_info["remote"], config, args.clone_with_ssh
+        )
 
         repo_branch: Optional[str] = None
         repo_not_in_scheme = False


### PR DESCRIPTION
A repository in an update-checkout config can override the URL that would otherwise be interpolated from the top-level ssh/https clone patterns by specifying a "url" in its "remote" object. That override applies to both protocols, so a downstream config that needs to point a repository at a different host than the rest of its repositories has to pick one protocol for it and force everyone onto that protocol, regardless of whether --clone-with-ssh was passed. In practice this means such repositories end up pinned to ssh URLs even for users cloning over https.

Add two new optional keys to a repository's "remote" object, "ssh-url" and "https-url", so an override can be specified per protocol. The URL selection now goes: the override matching the requested protocol, then the protocol-agnostic "url", then the override for the other protocol, and finally the URL interpolated from the matching clone pattern and the remote "id". An override is preferred over interpolation even when it does not match the requested protocol, since it is the more specific piece of configuration; a repository that only specifies "https-url" is therefore still cloned over https under --clone-with-ssh.

Existing configurations are unaffected: a "remote" with only a "url" continues to use it for both protocols.

While here, factor the URL computation out of
obtain_all_additional_swift_sources into remote_url_for_repo so it can be unit tested, and diagnose a "remote" that specifies none of the recognized keys instead of failing with a KeyError.
