### PR TITLE
[Concurrency] Fix AsyncStream finish(throwing:) behavior in onTermination

### DIFF
--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -184,8 +184,22 @@ internal final class _AsyncStreamStorage<
       // to set a failure.
       struct Terminating: ~Copyable {
         var buffer: Buffer
-        var failure: Failure?
+        private(set) var failure: Failure?
         var terminationHandler: TerminationHandler?
+
+        /// Returns true if the value was set, false otherwise.
+        @export(implementation)
+        mutating func setFailureOnce(_ failure: Failure?) -> Bool {
+          guard self.failure == nil else {
+            return false
+          }
+          self.failure = failure
+          return true
+        }
+        @export(implementation)
+        mutating func takeFailure() -> Failure? {
+          self.failure.take()
+        }
       }
 
       struct Terminated: ~Copyable {
@@ -587,8 +601,8 @@ extension _AsyncStreamStorage.StateMachine {
 
     case .terminating(var terminating):
       // A re-entrant `finish(throwing:)` from within the termination handler,
-      // while the cancellation outcome is not yet final. Adopt the failure
-      terminating.failure = failure
+      // while the cancellation outcome is not yet final.
+      terminating.setFailureOnce(failure)
       unsafe self = .init(state: .terminating(terminating))
       return unsafe .none
 
@@ -633,7 +647,7 @@ extension _AsyncStreamStorage.StateMachine {
 
     case .terminating(var terminating):
       // Already terminating: adopt the failure, matching `terminate`
-      terminating.failure = failure
+      terminating.setFailureOnce(failure)
       unsafe self = .init(state: .terminating(terminating))
       return unsafe .none
 
@@ -658,15 +672,14 @@ extension _AsyncStreamStorage.StateMachine {
       preconditionFailure("takeTerminalFailure() called in a non-terminal state")
 
     case .terminating(var terminating):
-      let failure = terminating.failure
+      let failure = terminating.takeFailure()
       unsafe self = .init(state: .terminated(.init(
         terminationHandler: terminating.terminationHandler.take()
       )))
       return failure
 
     case .terminated(var terminated):
-      let failure = terminated.failure
-      terminated.failure = nil
+      let failure = terminated.failure.take()
       unsafe self = .init(state: .terminated(terminated))
       return failure
     }

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -617,9 +617,7 @@ extension _AsyncStreamStorage.StateMachine {
   ///
   /// Enters the transient `terminating` state so the termination handler can
   /// still supply a failure via `finish(throwing:)`.
-  mutating func beginTerminating(
-    _ failure: consuming Failure?
-  ) -> TerminateAction {
+  mutating func beginTerminating() -> TerminateAction {
     switch unsafe consume self.state {
     case .idle(var idle):
       unsafe self = .init(state: .terminating(.init(
@@ -790,7 +788,7 @@ extension _AsyncStreamStorage {
         // Only "begin" terminating here, next we'll trigger the cancellation handler,
         // which must be allowed to `finish(throwing:)` to finalize the termination with an error.
         withLock { state in
-         return unsafe state.beginTerminating(nil)
+         return unsafe state.beginTerminating()
         }
       }
 

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -80,6 +80,8 @@ fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, @unchecked Sendabl
 ///   and new elements are directly delivered to the next consumer.
 ///   - `draining`: The stream **no longer accepts new elements**,
 ///   new consumers drain the buffered elements.
+///   - `terminating`: The stream is terminating,
+///   and is currently running the termination handler, before moving on to terminated.
 ///   - `terminated`: The stream is in a terminal state,
 ///   **no new elements are accepted**, and **new consumers return immediately**.
 ///
@@ -88,9 +90,10 @@ fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, @unchecked Sendabl
 /// ```text
 /// Current State   Possible Next State
 /// -------------   -------------------
-/// idle          ->  idle, waiting, draining, terminated
-/// waiting       ->  idle, waiting, terminated
-/// draining      ->  draining, terminated
+/// idle          ->  idle, waiting, draining, terminating
+/// waiting       ->  idle, waiting, terminating
+/// draining      ->  draining, terminating
+/// terminating   ->  terminated
 /// terminated    ->  terminated
 /// ```
 ///
@@ -175,6 +178,16 @@ internal final class _AsyncStreamStorage<
         var terminationHandler: TerminationHandler?
       }
 
+      // A transient state entered on the cancellation path.
+      // The stream is terminating but the outcome is not yet finalized:
+      // the termination handler still has to run and may call `finish(throwing:)`
+      // to set a failure.
+      struct Terminating: ~Copyable {
+        var buffer: Buffer
+        var failure: Failure?
+        var terminationHandler: TerminationHandler?
+      }
+
       struct Terminated: ~Copyable {
         var failure: Failure?
         var terminationHandler: TerminationHandler? // TODO: Remove this in a follow-up PR
@@ -185,6 +198,8 @@ internal final class _AsyncStreamStorage<
       case waiting(Waiting)
 
       case draining(Draining)
+
+      case terminating(Terminating)
 
       case terminated(Terminated)
     }
@@ -220,7 +235,6 @@ internal final class _AsyncStreamStorage<
       @unsafe
       struct CallAndResume: ~Copyable {
         var consumers: Consumers
-        let failure: Failure?
         let terminationHandler: TerminationHandler?
       }
 
@@ -294,6 +308,9 @@ extension _AsyncStreamStorage.StateMachine {
     case .draining(let draining):
       return draining.terminationHandler
 
+    case .terminating(let terminating):
+      return terminating.terminationHandler
+
     case .terminated(let terminated):
       return terminated.terminationHandler
     }
@@ -317,6 +334,11 @@ extension _AsyncStreamStorage.StateMachine {
       previous = draining.terminationHandler
       draining.terminationHandler = newValue
       unsafe self = .init(state: .draining(draining))
+
+    case .terminating(var terminating):
+      previous = terminating.terminationHandler
+      terminating.terminationHandler = newValue
+      unsafe self = .init(state: .terminating(terminating))
 
     case .terminated(var terminated):
       previous = terminated.terminationHandler
@@ -408,6 +430,10 @@ extension _AsyncStreamStorage.StateMachine {
       unsafe self = .init(state: .draining(draining))
       return unsafe .none(yieldResult: .terminated)
 
+    case .terminating(let terminating):
+      unsafe self = .init(state: .terminating(terminating))
+      return unsafe .none(yieldResult: .terminated)
+
     case .terminated(let terminated):
       unsafe self = .init(state: .terminated(terminated))
       return unsafe .none(yieldResult: .terminated)
@@ -480,6 +506,37 @@ extension _AsyncStreamStorage.StateMachine {
         )
       }
 
+    case .terminating(var terminating):
+      // The stream is terminating but the outcome is not yet final.
+      // Deliver any remaining buffered elements just like `draining`; the failure thrown
+      // once the buffer empties is finalized by the caller of `terminate` after
+      // the handler returns
+      guard let element = terminating.buffer.popFirst() else {
+        unsafe self = .init(state: .terminated(.init(
+          terminationHandler: terminating.terminationHandler.take()
+        )))
+
+        switch terminating.failure {
+        case .some(let failure):
+          return unsafe .throw(
+            consumer: consumer,
+            failure: failure
+          )
+
+        case .none:
+          return unsafe .resume(
+            consumer: consumer,
+            element: nil
+          )
+        }
+      }
+
+      unsafe self = .init(state: .terminating(terminating))
+      return unsafe .resume(
+        consumer: consumer,
+        element: element
+      )
+
     case .terminated(let terminated):
       unsafe self = .init(state: .terminated(.init()))
 
@@ -499,30 +556,28 @@ extension _AsyncStreamStorage.StateMachine {
     }
   }
 
-  mutating func terminate(_ failure: consuming Failure?) -> TerminateAction {
+  /// Terminates the stream with a final outcome.
+  mutating func terminate(
+    _ failure: consuming Failure?
+  ) -> TerminateAction {
     switch unsafe consume self.state {
     case .idle(var idle):
       if idle.buffer.isEmpty {
         unsafe self = .init(state: .terminated(.init(failure: failure)))
-        return unsafe .call(
-          terminationHandler: idle.terminationHandler.take()
-        )
-
       } else {
         unsafe self = .init(state: .draining(.init(
           buffer: idle.buffer,
           failure: failure,
         )))
-        return unsafe .call(
-          terminationHandler: idle.terminationHandler.take()
-        )
       }
+      return unsafe .call(
+        terminationHandler: idle.terminationHandler.take()
+      )
 
     case .waiting(var waiting):
-      unsafe self = .init(state: .terminated(.init()))
+      unsafe self = .init(state: .terminated(.init(failure: failure)))
       return unsafe .callAndResume(.init(
         consumers: waiting.consumers,
-        failure: failure,
         terminationHandler: waiting.terminationHandler.take(),
       ))
 
@@ -530,9 +585,122 @@ extension _AsyncStreamStorage.StateMachine {
       unsafe self = .init(state: .draining(draining))
       return unsafe .none
 
+    case .terminating(var terminating):
+      // A re-entrant `finish(throwing:)` from within the termination handler,
+      // while the cancellation outcome is not yet final. Adopt the failure
+      terminating.failure = failure
+      unsafe self = .init(state: .terminating(terminating))
+      return unsafe .none
+
     case .terminated(let terminated):
+      // Already final: later terminations are ignored (first finish wins)
       unsafe self = .init(state: .terminated(terminated))
       return unsafe .none
+    }
+  }
+
+  /// Begins terminating the stream on the cancellation path.
+  ///
+  /// Enters the transient `terminating` state so the termination handler can
+  /// still supply a failure via `finish(throwing:)`.
+  mutating func beginTerminating(
+    _ failure: consuming Failure?
+  ) -> TerminateAction {
+    switch unsafe consume self.state {
+    case .idle(var idle):
+      unsafe self = .init(state: .terminating(.init(
+        buffer: idle.buffer,
+        failure: failure,
+      )))
+      return unsafe .call(
+        terminationHandler: idle.terminationHandler.take()
+      )
+
+    case .waiting(var waiting):
+      unsafe self = .init(state: .terminating(.init(
+        buffer: [],
+        failure: failure
+      )))
+      return unsafe .callAndResume(.init(
+        consumers: waiting.consumers,
+        terminationHandler: waiting.terminationHandler.take(),
+      ))
+
+    case .draining(let draining):
+      // Already final: later terminations are ignored (first finish wins)
+      unsafe self = .init(state: .draining(draining))
+      return unsafe .none
+
+    case .terminating(var terminating):
+      // Already terminating: adopt the failure, matching `terminate`
+      terminating.failure = failure
+      unsafe self = .init(state: .terminating(terminating))
+      return unsafe .none
+
+    case .terminated(let terminated):
+      // Already final: later terminations are ignored (first finish wins)
+      unsafe self = .init(state: .terminated(terminated))
+      return unsafe .none
+    }
+  }
+
+  /// Reads the failure recorded in the terminal state after the termination
+  /// handler has run, and finalizes to `terminated`.
+  mutating func takeTerminalFailure() -> Failure? {
+    switch unsafe consume self.state {
+    case .idle:
+      preconditionFailure("takeTerminalFailure() called in a non-terminal state")
+
+    case .waiting:
+      preconditionFailure("takeTerminalFailure() called in a non-terminal state")
+
+    case .draining:
+      preconditionFailure("takeTerminalFailure() called in a non-terminal state")
+
+    case .terminating(var terminating):
+      let failure = terminating.failure
+      unsafe self = .init(state: .terminated(.init(
+        terminationHandler: terminating.terminationHandler.take()
+      )))
+      return failure
+
+    case .terminated(var terminated):
+      let failure = terminated.failure
+      terminated.failure = nil
+      unsafe self = .init(state: .terminated(terminated))
+      return failure
+    }
+  }
+
+  /// Finalizes the `terminating` state to `terminated` preserving any recorded failure.
+  mutating func finalizeTermination() {
+    switch unsafe consume self.state {
+    case .idle:
+      preconditionFailure("finalizeTermination() called in a non-terminal state")
+
+    case .waiting:
+      preconditionFailure("finalizeTermination() called in a non-terminal state")
+
+    case .draining(let draining):
+      // `finish` with buffered elements left us draining
+      unsafe self = .init(state: .draining(draining))
+
+    case .terminating(var terminating):
+      if terminating.buffer.isEmpty {
+        unsafe self = .init(state: .terminated(.init(
+          failure: terminating.failure,
+          terminationHandler: terminating.terminationHandler.take()
+        )))
+      } else {
+        unsafe self = .init(state: .draining(.init(
+          buffer: terminating.buffer,
+          failure: terminating.failure,
+          terminationHandler: terminating.terminationHandler.take()
+        )))
+      }
+
+    case .terminated(let terminated):
+      unsafe self = .init(state: .terminated(terminated))
     }
   }
 }
@@ -598,25 +766,31 @@ extension _AsyncStreamStorage {
   }
 
   func terminate(_ terminationReason: Continuation.Termination) {
-    let failure: Failure?
+    let action =
+      switch terminationReason {
+      case .finished(let withFailure):
+        withLock { state in
+          return unsafe state.terminate(withFailure)
+        }
 
-    switch terminationReason {
-    case .finished(let withFailure):
-      failure = withFailure
-
-    case .cancelled:
-      failure = nil
-    }
-
-    let action = withLock { state in
-      return unsafe state.terminate(failure)
-    }
+      case .cancelled:
+        // Only "begin" terminating here, next we'll trigger the cancellation handler,
+        // which must be allowed to `finish(throwing:)` to finalize the termination with an error.
+        withLock { state in
+         return unsafe state.beginTerminating(nil)
+        }
+      }
 
     switch unsafe consume action {
     case .callAndResume(var callAndResume):
       unsafe callAndResume.terminationHandler?.invoke(terminationReason)
 
-      if let failure = unsafe callAndResume.failure {
+      let failure = withLock { state in
+        // Reload the failure, in case the termination handler has set one using `finish(throwing:)`.
+        return state.takeTerminalFailure()
+      }
+
+      if let failure {
         let consumer = unsafe callAndResume.consumers.removeFirst()
         unsafe consumer.resume(returning: .failure(failure))
       }
@@ -627,6 +801,9 @@ extension _AsyncStreamStorage {
 
     case .call(let terminationHandler):
       terminationHandler?.invoke(terminationReason)
+      withLock { state in
+        state.finalizeTermination()
+      }
 
     case .none:
       return

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -552,6 +552,9 @@ extension _AsyncStreamStorage.StateMachine {
       )
 
     case .terminated(let terminated):
+      // Reaching the terminal state drops the termination handler, per the
+      // documented `onTermination` contract: the handler is released once the
+      // stream has terminated
       unsafe self = .init(state: .terminated(.init()))
 
       switch terminated.failure {
@@ -602,7 +605,7 @@ extension _AsyncStreamStorage.StateMachine {
     case .terminating(var terminating):
       // A re-entrant `finish(throwing:)` from within the termination handler,
       // while the cancellation outcome is not yet final.
-      terminating.setFailureOnce(failure)
+      _ = terminating.setFailureOnce(failure)
       unsafe self = .init(state: .terminating(terminating))
       return unsafe .none
 
@@ -622,7 +625,7 @@ extension _AsyncStreamStorage.StateMachine {
     case .idle(var idle):
       unsafe self = .init(state: .terminating(.init(
         buffer: idle.buffer,
-        failure: failure,
+        failure: nil,
       )))
       return unsafe .call(
         terminationHandler: idle.terminationHandler.take()
@@ -631,7 +634,7 @@ extension _AsyncStreamStorage.StateMachine {
     case .waiting(var waiting):
       unsafe self = .init(state: .terminating(.init(
         buffer: [],
-        failure: failure
+        failure: nil
       )))
       return unsafe .callAndResume(.init(
         consumers: waiting.consumers,
@@ -643,9 +646,9 @@ extension _AsyncStreamStorage.StateMachine {
       unsafe self = .init(state: .draining(draining))
       return unsafe .none
 
-    case .terminating(var terminating):
-      // Already terminating: adopt the failure, matching `terminate`
-      terminating.setFailureOnce(failure)
+    case .terminating(let terminating):
+      // Already terminating: nothing to do, the cancellation path carries no
+      // failure of its own (a failure can only be set via `finish(throwing:)`)
       unsafe self = .init(state: .terminating(terminating))
       return unsafe .none
 

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -16,7 +16,7 @@ import _Concurrency
 import StdlibUnittest
 
 struct SomeError: Error, Equatable {
-  var value = Int.random(in: 0..<100)
+  var value: Int = 0
 }
 
 class NotSendable {}
@@ -473,9 +473,8 @@ class NotSendable {}
       }
 
       tests.test("finish(throwing:) from onTermination keeps the first error when called twice") {
-        let firstError = SomeError()
-        let secondError = SomeError()
-        expectTrue(firstError != secondError)
+        let firstError = SomeError(value: 1)
+        let secondError = SomeError(value: 2)
 
         let (controlStream, controlContinuation) = AsyncStream<Int>.makeStream()
         var controlIterator = controlStream.makeAsyncIterator()
@@ -508,6 +507,26 @@ class NotSendable {}
         } else {
           expectUnreachable("expected SomeError, got \(String(describing: caught))")
         }
+      }
+
+      tests.test("onTermination handler is released after the stream terminates") {
+        let (stream, continuation) = AsyncStream<Int>.makeStream()
+
+        // Terminate the stream first
+        continuation.finish()
+
+        // Setting the handler now stores it in the terminal state, but never calls it
+        continuation.onTermination = { @Sendable _ in
+          fatalError("Unexpectedly triggered termination handler")
+        }
+
+        var iterator = stream.makeAsyncIterator()
+        let value = await iterator.next()
+        expectNil(value)
+
+        // Per the documented `onTermination` contract, the handler is released
+        // once the stream has reached its terminal state
+        expectTrue(continuation.onTermination == nil)
       }
 
       tests.test("continuation equality") {

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -438,6 +438,40 @@ class NotSendable {}
         expectTrue(expectation.fulfilled)
       }
 
+      tests.test("finish(throwing:) from onTermination on cancellation throws the error passed to finish") {
+        let thrownError = SomeError()
+
+        let (controlStream, controlContinuation) = AsyncStream<Int>.makeStream()
+        var controlIterator = controlStream.makeAsyncIterator()
+
+        let task = Task { () -> Error? in
+          let stream = AsyncThrowingStream<Int, Error> { continuation in
+            continuation.onTermination = { @Sendable termination in
+              if case .cancelled = termination {
+                continuation.finish(throwing: thrownError)
+              }
+            }
+          }
+          controlContinuation.yield(1)
+          do {
+            for try await _ in stream {}
+            return nil
+          } catch {
+            return error
+          }
+        }
+
+        expectEqual(await controlIterator.next(), 1)
+        task.cancel()
+
+        let caught = await task.value
+        if let failure = caught as? SomeError {
+          expectEqual(failure, thrownError)
+        } else {
+          expectUnreachable("expected SomeError, got \(String(describing: caught))")
+        }
+      }
+
       tests.test("continuation equality") {
         let (_, continuation1) = AsyncStream<Int>.makeStream()
         let (_, continuation2) = AsyncStream<Int>.makeStream()

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -472,6 +472,44 @@ class NotSendable {}
         }
       }
 
+      tests.test("finish(throwing:) from onTermination keeps the first error when called twice") {
+        let firstError = SomeError()
+        let secondError = SomeError()
+        expectTrue(firstError != secondError)
+
+        let (controlStream, controlContinuation) = AsyncStream<Int>.makeStream()
+        var controlIterator = controlStream.makeAsyncIterator()
+
+        let task = Task { () -> Error? in
+          let stream = AsyncThrowingStream<Int, Error> { continuation in
+            continuation.onTermination = { @Sendable termination in
+              if case .cancelled = termination {
+                // Only the first finish(throwing:) should decide the outcome
+                continuation.finish(throwing: firstError)
+                continuation.finish(throwing: secondError)
+              }
+            }
+          }
+          controlContinuation.yield(1)
+          do {
+            for try await _ in stream {}
+            return nil
+          } catch {
+            return error
+          }
+        }
+
+        expectEqual(await controlIterator.next(), 1)
+        task.cancel()
+
+        let caught = await task.value
+        if let failure = caught as? SomeError {
+          expectEqual(failure, firstError)
+        } else {
+          expectUnreachable("expected SomeError, got \(String(describing: caught))")
+        }
+      }
+
       tests.test("continuation equality") {
         let (_, continuation1) = AsyncStream<Int>.makeStream()
         let (_, continuation2) = AsyncStream<Int>.makeStream()


### PR DESCRIPTION
This fixes a behavior break of AsyncStream.onTermination due to the recent internals rewrite.

Previously, it was allowed to resume finish the continuation from the onTermination handler and potentially provide a more detailed error this way. Some adopters rely on this behavior and we should keep this working; The internals rewrite caused this finish-throwing to be ignored.

I think we should solve this by entering a "terminating" state while we invoke the handler, and only once it's completed enter a "final" "terminated" state.

resolves rdar://183522041

