### PR TITLE
Skip propagating debug_values with reconstruction blocks in async code

### DIFF
--- a/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
+++ b/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
@@ -438,6 +438,17 @@ void DebugInfoPropagator::performInitialLocalDataflow() {
         continue;
       }
 
+      if (debugInst.hasDebugReconstructionBlock()) {
+        // Ideally those should be handled, but this seems to only happen
+        // in embedded swift, when the optimized stdlib is inlined into
+        // unoptimized async code.
+        LLVM_DEBUG(
+            llvm::dbgs()
+            << "    Found a debug value with a debug reconstruction block..."
+                   "continuing!\n");
+        continue;
+      }
+
       LLVM_DEBUG(llvm::dbgs() << "Found DebugValueInst!\n");
 
       // ... and we have a non-empty SILDebugVariable.

--- a/test/SILOptimizer/moved_async_var_dbginfo_propagator.sil
+++ b/test/SILOptimizer/moved_async_var_dbginfo_propagator.sil
@@ -136,3 +136,40 @@ bb3:
   %9999 = tuple()
   return %9999 : $()
 }
+
+// A debug_value with a debug reconstruction block cannot currently be
+// propagated, as it would crash when there is no operand to clone.
+//
+// CHECK-LABEL: sil @testConstantDebugReconstructionBlock : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0(%0 :
+// CHECK:   debug_value [moveable_value_debuginfo] %0 : $Klass, let, name "arg"
+// CHECK:   debug_value (), let, name "const", transform {
+// CHECK:   bb0:
+// CHECK:     %0 = integer_literal $Builtin.Int64, 42
+// CHECK:     return %0 : $Builtin.Int64
+// CHECK:   }
+// CHECK-NOT: name "const"
+// CHECK:   begin_apply
+// CHECK-NEXT:   debug_value [moveable_value_debuginfo] %0 : $Klass, let, name "arg"
+// CHECK-NOT: name "const"
+// CHECK:   end_apply
+// CHECK-NEXT:   debug_value [moveable_value_debuginfo] %0 : $Klass, let, name "arg"
+// CHECK-NOT: name "const"
+// CHECK: } // end sil function 'testConstantDebugReconstructionBlock'
+sil @testConstantDebugReconstructionBlock : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  debug_value [moveable_value_debuginfo] %0 : $Klass, let, name "arg"
+  debug_value [moveable_value_debuginfo] (), let, name "const", transform {
+  bb0:
+    %c = integer_literal $Builtin.Int64, 42
+    return %c : $Builtin.Int64
+  }
+  br bb1
+
+bb1:
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  (%3, %4) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  %9999 = tuple()
+  end_apply %4 as $()
+  return %9999 : $()
+}


### PR DESCRIPTION
This mandatory pass normally only runs at -Onone, where debug reconstruction blocks don't exist, but if the optimized standard library is inlined into unoptimized code in embedded swift, without this guard, it would crash the compiler.

Such debug_values are now left alone and don't get propagated across async edges. Ideally they would be supported, but it would require significant changes to the pass, and it only triggers in a very narrow scenario.

Fixes a crash in the embedded/observation.swift test, introduced by #91394