### PR TITLE
IRGen: fix wrong layout of statically initialized objects with padded elements

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -286,6 +286,13 @@ Explosion irgen::emitConstantValue(IRGenModule &IGM, SILValue operand,
     switch (IGM.getSILModule().getBuiltinInfo(BI->getName()).ID) {
       case BuiltinValueKind::ZeroInitializer: {
         auto &resultTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(BI->getType()));
+        if (!flatten) {
+          // The storage type can contain explicit padding which is not part of
+          // the explosion schema, e.g. for imported C structs. Therefore the
+          // zero constant must be created from the storage type - otherwise the
+          // resulting constant would be too small.
+          return llvm::Constant::getNullValue(resultTI.getStorageType());
+        }
         auto schema = resultTI.getSchema();
         Explosion out;
         for (auto &elt : schema) {
@@ -504,7 +511,11 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
     elements[0].add(llvm::Constant::getNullValue(ObjectHeaderTy));
   }
   insertPadding(elements, sTy);
-  return createStructFromExplosion(elements, sTy);
+  llvm::Constant *initVal = createStructFromExplosion(elements, sTy);
+  ASSERT(IGM.DataLayout.getTypeStoreSize(initVal->getType()) ==
+             IGM.DataLayout.getTypeStoreSize(sTy) &&
+         "size of statically initialized object does not match its layout");
+  return initVal;
 }
 
 void ConstantAggregateBuilderBase::addUniqueHash(StringRef data) {

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -22,6 +22,11 @@ public struct S2 {
   var s : S
 }
 
+struct StructWithPadding {
+  var x : Int32
+  var y : Int64
+}
+
 // CHECK: %Ts5Int32V = type <{ i32 }>
 // CHECK: %T18static_initializer2S2V = type <{ %Ts5Int32V, %Ts5Int32V, %T18static_initializer1SV }>
 // CHECK: %T18static_initializer1SV = type <{ %Ts5Int32V }>
@@ -136,6 +141,21 @@ sil_global @static_array_with_empty_element : $TestArrayStorage = {
   %initval = object $TestArrayStorage (%2 : $Int32, [tail_elems] %0 : $Empty, %0 : $Empty)
 }
 // CHECK: @static_array_with_empty_element = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems3c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems3 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef, [1 x i8] undef }> }, align 8
+
+// The zero-initialized elements must contain the padding of the struct.
+// Otherwise the elements would be at wrong offsets.
+sil_global @static_array_of_zeroinitialized_elements : $TestArrayStorage = {
+  %0 = integer_literal $Builtin.Int32, 2
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %2 = builtin "zeroInitializer"() : $StructWithPadding
+  %initval = object $TestArrayStorage (%1 : $Int32, [tail_elems] %2 : $StructWithPadding, %2 : $StructWithPadding)
+}
+// CHECK: @static_array_of_zeroinitialized_elements = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems4c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems4 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [4 x i8] undef, %T18static_initializer17StructWithPaddingV zeroinitializer, %T18static_initializer17StructWithPaddingV zeroinitializer }> }, align 8
+
+sil_global @static_zeroinitialized_struct : $StructWithPadding = {
+  %initval = builtin "zeroInitializer"() : $StructWithPadding
+}
+// CHECK: @static_zeroinitialized_struct = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer17StructWithPaddingV zeroinitializer, align 8
 
 struct MyString {
   var buffer: Builtin.BridgeObject

--- a/test/Interpreter/static_array_c_struct_padding.swift
+++ b/test/Interpreter/static_array_c_struct_padding.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+// RUN: %target-build-swift %t/main.swift -O -o %t/a.out -import-objc-header %t/header.h
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// The ObjectOutliner creates statically initialized arrays for the literals
+// below. The element types contain trailing padding, which must be taken into
+// account when IRGen emits the static initializer - otherwise the array
+// elements end up at wrong offsets.
+// https://github.com/swiftlang/swift/issues/91387
+
+//--- header.h
+
+struct CStructWithPadding {
+  long long a;
+  int b;
+  // 4 bytes of trailing padding on 64 bit platforms
+};
+
+//--- main.swift
+
+let structArray = [CStructWithPadding(), CStructWithPadding(a: 1, b: 2), CStructWithPadding(a: 3, b: 4)]
+
+// CHECK: [0, 0, 1, 2, 3, 4]
+print(structArray.flatMap { [Int($0.a), Int($0.b)] })
+
+let tupleArray: [(Int, CStructWithPadding)] = [(1, CStructWithPadding()), (2, CStructWithPadding()), (3, CStructWithPadding())]
+
+// CHECK: [1, 2, 3]
+print(tupleArray.map { $0.0 })
+
+let dict: [Int: CStructWithPadding] = [1: CStructWithPadding(), 2: CStructWithPadding(), 3: CStructWithPadding()]
+
+// CHECK: 3
+print(dict.count)
+
+// CHECK: [1, 2, 3]
+print(dict.keys.sorted())


### PR DESCRIPTION
`emitConstantValue` created the constant for `builtin "zeroInitializer"` from the type's explosion schema, which does not contain the explicit padding of the storage type - e.g. the trailing padding of an imported C struct.

The resulting constant was too small, which put the tail allocated elements of a statically initialized array at wrong offsets.

Also add an assert which verifies that the size of a statically initialized object matches its layout.

Fixes a mis-compile
https://github.com/swiftlang/swift/issues/91387
rdar://184625433
