### PR TITLE
[DependencyScan] Fix race condition in scanner for clang VFS

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1076,13 +1076,6 @@ class SwiftDependencyScanningService {
   std::optional<clang::dependencies::DependencyScanningService>
       ClangScanningService;
 
-  /// Factory that produces the base file system used by each Clang dependency
-  /// scanning worker. Installed as \c DependencyScanningServiceOptions::MakeVFS
-  /// on \c ClangScanningService. Must be thread-safe as it is invoked
-  /// concurrently by multiple workers.
-  std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()>
-      ClangScanningFSFactory;
-
   /// Shared state mutual-exclusivity lock
   mutable llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
 
@@ -1093,15 +1086,6 @@ public:
   SwiftDependencyScanningService &
   operator=(const SwiftDependencyScanningService &) = delete;
   virtual ~SwiftDependencyScanningService() {}
-
-  /// Install the factory used to create the base file system for each Clang
-  /// dependency scanning worker and (re)create the underlying Clang scanning
-  /// service so that it picks the factory up. Since the Clang scanning service
-  /// now owns the VFS factory (see \c DependencyScanningServiceOptions::MakeVFS)
-  /// rather than each individual scanning tool, this must be called before any
-  /// worker is created.
-  void setClangScanningFSFactory(
-      std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory);
 
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -24,6 +24,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Strings.h"
 #include "clang/Lex/HeaderSearchOptions.h"
+#include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/Path.h"
 using namespace swift;
@@ -547,21 +548,8 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
   // by-name module lookup to resolve Swift overlay and cross-import overlay
   // dependencies, so opt into having Clang report them.
   opts.ReportVisibleModules = true;
-  opts.MakeVFS = ClangScanningFSFactory;
+  opts.MakeVFS = [] { return llvm::vfs::createPhysicalFileSystem(); };
 
-  ClangScanningService.emplace(std::move(opts));
-}
-
-void SwiftDependencyScanningService::setClangScanningFSFactory(
-    std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory) {
-  ClangScanningFSFactory = std::move(factory);
-  // The Clang scanning service now owns the base VFS factory (via
-  // DependencyScanningServiceOptions::MakeVFS) rather than each scanning tool,
-  // so re-create it to pick up the new factory while preserving all other
-  // options that were configured earlier (e.g. CAS compilation mode).
-  clang::dependencies::DependencyScanningServiceOptions opts =
-      ClangScanningService->getOpts();
-  opts.MakeVFS = ClangScanningFSFactory;
   ClangScanningService.emplace(std::move(opts));
 }
 
@@ -701,7 +689,20 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     opts.Compilation = clang::dependencies::IncludeTreeCompilation{
         CASOpts, Instance.getSharedCASInstance(),
         Instance.getSharedCacheInstance()};
-    opts.MakeVFS = ClangScanningFSFactory;
+    opts.MakeVFS = [&]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+      auto &ctx = Instance.getASTContext();
+      auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+      // Dependency scanner needs to create its own file system per worker.
+      auto fs = ClangImporter::computeClangImporterFileSystem(
+          ctx, importer->getClangFileMapping(),
+          llvm::vfs::createPhysicalFileSystem(), true,
+          [&](StringRef str) { return save(str); });
+
+      auto cas = Instance.getSharedCASInstance();
+      if (cas)
+        return llvm::cas::createCASProvidingFileSystem(cas, fs);
+      return fs;
+    };
 
     ClangScanningService.emplace(std::move(opts));
   }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -195,22 +195,6 @@ static std::vector<std::string> inputSpecificClangScannerCommand(
   return result;
 }
 
-static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
-getClangScanningFS(SwiftDependencyScanningService &service,
-                   std::shared_ptr<llvm::cas::ObjectStore> cas,
-                   ASTContext &ctx) {
-  auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-  // Dependency scanner needs to create its own file system per worker.
-  auto fs = ClangImporter::computeClangImporterFileSystem(
-      ctx, importer->getClangFileMapping(),
-      llvm::vfs::createPhysicalFileSystem(), true,
-      [&](StringRef str) { return service.save(str); });
-
-  if (cas)
-    return llvm::cas::createCASProvidingFileSystem(cas, fs);
-  return fs;
-}
-
 ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     SwiftDependencyScanningService &globalScanningService,
     const CompilerInvocation &ScanCompilerInvocation,
@@ -624,16 +608,6 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     CacheFS = cast<llvm::cas::CASBackedFileSystem>(
         llvm::cas::createCASProvidingFileSystem(
             CAS, ScanASTContext.SourceMgr.getFileSystem()));
-
-  // The Clang dependency scanning service now owns the factory that produces
-  // each worker's base file system (rather than each scanning tool owning its
-  // own). Install it before creating any worker so that the tools pick it up.
-  // The factory creates a fresh file system per worker, as required for
-  // thread-safety.
-  ScanningService.setClangScanningFSFactory(
-      [&ScanningService, CAS = this->CAS, &ScanASTContext]() {
-        return getClangScanningFS(ScanningService, CAS, ScanASTContext);
-      });
 
   // TODO: Make num threads configurable
   for (size_t i = 0; i < NumThreads; ++i)

--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -22,7 +22,10 @@
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 #include "gtest/gtest.h"
+#include <atomic>
 #include <string>
+#include <thread>
+#include <vector>
 
 using namespace swift;
 using namespace swift::unittest;
@@ -537,4 +540,105 @@ TEST_F(ScanTest, TestStressConcurrentDiagnostics) {
   auto Diagnostics = Dependencies->diagnostics;
   ASSERT_TRUE(Diagnostics->count >= 1);
   swiftscan_dependency_graph_dispose(Dependencies);
+}
+
+// Ensure that full-scan queries issued concurrently against a single
+// `DependencyScanningTool` do not interfere with one another. Each query gets
+// its own `ModuleDependencyScanner`, and anything that scanner shares with the
+// tool must therefore tolerate being used by several scans at once.
+TEST_F(ScanTest, TestConcurrentQueries) {
+  SmallString<256> tempDir;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "ScanTest.TestConcurrentQueries", tempDir));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
+
+  // Create includes
+  std::string IncludeDirPath = createFilename(tempDir, "include");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(IncludeDirPath));
+  std::string CHeadersDirPath = createFilename(IncludeDirPath, "CHeaders");
+  ASSERT_FALSE(llvm::sys::fs::create_directory(CHeadersDirPath));
+
+  // Create test input file
+  std::string TestPathStr = createFilename(tempDir, "foo.swift");
+
+  // Create enough imported C modules for each query to spend a while in the
+  // Clang dependency scanner, so that the queries actually overlap.
+  std::string modulemapContent = "";
+  std::string testFileContent = "";
+  for (int i = 0; i < 50; ++i) {
+    std::string headerName = "A_" + std::to_string(i) + ".h";
+    std::string headerContent = "void funcA_" + std::to_string(i) + "(void);";
+    ASSERT_FALSE(
+        emitFileWithContents(CHeadersDirPath, headerName, headerContent));
+
+    std::string moduleMapEntry = "module A_" + std::to_string(i) + " {\n";
+    moduleMapEntry.append("header \"A_" + std::to_string(i) + ".h\"\n");
+    moduleMapEntry.append("export *\n");
+    moduleMapEntry.append("}\n");
+    modulemapContent.append(moduleMapEntry);
+    testFileContent.append("import A_" + std::to_string(i) + "\n");
+  }
+
+  ASSERT_FALSE(emitFileWithContents(tempDir, "foo.swift", testFileContent));
+  ASSERT_FALSE(emitFileWithContents(CHeadersDirPath, "module.modulemap",
+                                    modulemapContent));
+
+  // Paths to shims and stdlib
+  llvm::SmallString<128> ShimsLibDir = StdLibDir;
+  llvm::sys::path::append(ShimsLibDir, "shims");
+  auto Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
+  llvm::sys::path::append(StdLibDir, getPlatformNameForTriple(Target));
+
+  std::vector<std::string> CommandStr = {
+      TestPathStr,
+      std::string("-I ") + CHeadersDirPath,
+      std::string("-I ") + StdLibDir.str().str(),
+      std::string("-I ") + ShimsLibDir.str().str(),
+      "-module-name",
+      "testConcurrentQueries",
+  };
+
+  // On Windows we need to add an extra escape for path separator characters
+  // because otherwise the command line tokenizer will treat them as escape
+  // characters.
+  for (size_t i = 0; i < CommandStr.size(); ++i)
+    std::replace(CommandStr[i].begin(), CommandStr[i].end(), '\\', '/');
+  std::vector<const char *> Command;
+  for (auto &command : CommandStr)
+    Command.push_back(command.c_str());
+
+  constexpr unsigned NumQueries = 4;
+  std::atomic<unsigned> NumReady(0);
+  std::atomic<unsigned> NumFailed(0);
+  std::atomic<size_t> ModuleCounts[NumQueries] = {};
+  std::vector<std::thread> Queries;
+  Queries.reserve(NumQueries);
+  for (unsigned i = 0; i < NumQueries; ++i) {
+    Queries.emplace_back([&, i]() {
+      // Start all of the queries at roughly the same time to maximize the
+      // overlap between them.
+      ++NumReady;
+      while (NumReady.load() < NumQueries)
+        std::this_thread::yield();
+
+      auto DependenciesOrErr = ScannerTool.getDependencies(Command, {});
+      if (DependenciesOrErr.getError()) {
+        ++NumFailed;
+        return;
+      }
+      auto Dependencies = DependenciesOrErr.get();
+      ModuleCounts[i].store(Dependencies->dependencies->count);
+      swiftscan_dependency_graph_dispose(Dependencies);
+    });
+  }
+
+  for (auto &Query : Queries)
+    Query.join();
+
+  ASSERT_EQ(NumFailed.load(), 0u);
+
+  // The queries are identical, so they must agree. Disagreement would mean a
+  // query resolved dependencies through another query's file system.
+  for (unsigned i = 1; i < NumQueries; ++i)
+    ASSERT_EQ(ModuleCounts[i].load(), ModuleCounts[0].load());
 }


### PR DESCRIPTION
Fix a race condition that is introduced in e568936 that the clang scanning FS is being updated while the other threads are trying to use it.

With the new clang dependency scanner API, there is no need to hold shared states about clang scanning FS. The callback can be created per DependencyScanner and there is no need to have a global state for VFS.

rdar://184810704

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
