### PR TITLE
Ensure Span subscripting always uses borrow instead of get

### DIFF
--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -522,43 +522,6 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
-  /// Accesses the element at the specified index in the `Span`.
-  ///
-  /// - Parameter position: The offset of the element to access. `position`
-  ///     must be greater or equal to zero, and less than `count`.
-  ///
-  /// - Complexity: O(1)
-  @export(implementation)
-  public subscript(_ position: Index) -> Element {
-    @_transparent
-    get {
-      _checkIndex(position)
-      return unsafe self[unchecked: position]
-    }
-  }
-
-  /// Accesses the element at the specified index in the `Span`.
-  ///
-  /// This subscript does not validate `position`. Using this subscript
-  /// with an invalid `position` results in undefined behaviour.
-  ///
-  /// - Parameter position: The offset of the element to access. `position`
-  ///     must be greater or equal to zero, and less than `count`.
-  ///
-  /// - Complexity: O(1)
-  @unsafe
-  @export(implementation)
-  public subscript(unchecked position: Index) -> Element {
-    get {
-      let address = unsafe _unsafeAddressOfElement(unchecked: position)
-      return unsafe UnsafeRawPointer(address).loadUnaligned(as: Element.self)
-    }
-  }
-}
-
-@available(SwiftCompatibilitySpan 5.0, *)
-@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: Copyable {
 
   /// Construct a raw span over the memory represented by this span.

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -8,6 +8,9 @@
 //
 // REQUIRES: executable_test
 
+// Blocked by rdar://181604244 (opaque values borrow accessors)
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 import StdlibUnittest
 import CxxStdlib
 #if USE_CUSTOM_STRING_API

--- a/test/SILOptimizer/span.swift
+++ b/test/SILOptimizer/span.swift
@@ -1,8 +1,22 @@
-// RUN: %target-swift-frontend %s -parse-as-library -disable-availability-checking -emit-ir -o /dev/null
+// RUN: %target-swift-frontend %s -parse-as-library -disable-availability-checking -emit-ir -O | %FileCheck %s --check-prefix=CHECK
 
 // Check that the MoveOnlyWrappedTypeEliminator doesn't crash
 func consumingArray(_ arr: consuming [Int]) {
   let s = arr.mutableSpan;
   _ = consume s
+}
+
+
+// Check that the span element is borrowed, not copied.
+// rdar://183793878
+// CHECK:      define {{.*}} @"$s{{.*}}9s_dynamic{{.*}} {
+// CHECK-NOT:    alloca
+// CHECK:        getelementptr
+// CHECK-NEXT:   getelementptr
+// CHECK-NEXT:   load
+// CHECK-NEXT:   ret
+// CHECK:      }
+public func s_dynamic(_ a: inout [10 of [10 of UInt64]], i: Int) -> UInt64 {
+  a.span[i][i]
 }
 

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -14,6 +14,9 @@
 
 // REQUIRES: executable_test
 
+// Blocked by rdar://181604244 (opaque values borrow accessors)
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 import StdlibUnittest
 
 var suite = TestSuite("MutableRawSpan Tests")

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -14,6 +14,9 @@
 
 // REQUIRES: executable_test
 
+// Blocked by rdar://181604244 (opaque values borrow accessors)
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 import StdlibUnittest
 
 var suite = TestSuite("Span Tests")

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -14,6 +14,9 @@
 
 // REQUIRES: executable_test
 
+// Blocked by rdar://181604244 (opaque values borrow accessors)
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 import StdlibUnittest
 
 var suite = TestSuite("StringUTF8StorageProperty")

--- a/validation-test/stdlib/rdar165231596.swift
+++ b/validation-test/stdlib/rdar165231596.swift
@@ -1,0 +1,189 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-feature -Xfrontend Lifetimes -disable-availability-checking) | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+// Ensure we don't crash
+
+struct MyBuffer: ~Copyable {
+    private let buffer: UnsafeMutableRawBufferPointer
+
+    var length: Int { buffer.count }
+    func contents() -> UnsafeMutableRawPointer {
+        buffer.baseAddress!
+    }
+
+    init(buffer: UnsafeMutableRawBufferPointer)
+    {
+        self.buffer = buffer
+    }
+
+    init<T>(of type: T.Type) where T: BitwiseCopyable {
+        self.buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: MemoryLayout<T>.size, alignment: MemoryLayout<T>.alignment)
+    }
+}
+
+extension RawSpan {
+    @_lifetime(borrow buffer)
+    init(buffer: borrowing MyBuffer) {
+        let span = unsafe RawSpan(_unsafeStart: buffer.contents(), byteCount: buffer.length)
+        self = unsafe _overrideLifetime(span, borrowing: buffer)
+    }
+}
+
+extension MutableRawSpan {
+    @_lifetime(borrow buffer)
+    init(buffer: borrowing MyBuffer) {
+        let span = unsafe MutableRawSpan(_unsafeStart: buffer.contents(), byteCount: buffer.length)
+        self = unsafe _overrideLifetime(span, borrowing: buffer)
+    }
+}
+
+extension OutputRawSpan {
+    @_lifetime(borrow buffer)
+    init(buffer: borrowing MyBuffer) {
+        let raw = unsafe UnsafeMutableRawBufferPointer(start: buffer.contents(), count: buffer.length)
+        let span = unsafe OutputRawSpan(buffer: raw, initializedCount: 0)
+        self = unsafe _overrideLifetime(span, borrowing: buffer)
+    }
+}
+
+extension Span where Element: BitwiseCopyable {
+    @_lifetime(borrow buffer)
+    init(buffer: borrowing MyBuffer) {
+        precondition(buffer.length.isMultiple(of: MemoryLayout<Element>.size), "buffer size must be a multiple of the element size.")
+        let span = unsafe buffer.rawSpan._unsafeView(as: Element.self)
+        assert(span.count == buffer.length / MemoryLayout<Element>.size, "Extraction of contiguous storage failed.")
+        self = unsafe _overrideLifetime(span, borrowing: buffer)
+    }
+}
+
+extension MutableSpan where Element: BitwiseCopyable {
+    @_lifetime(borrow buffer)
+    init(buffer: borrowing MyBuffer) {
+        precondition(buffer.length.isMultiple(of: MemoryLayout<Element>.size), "buffer buffer size (\(buffer.length)) must be a multiple of the element size \(MemoryLayout<Element>.size).")
+        var raw = buffer.mutableRawSpan
+        let span = unsafe raw._unsafeMutableView(as: Element.self)
+        assert(span.count == buffer.length / MemoryLayout<Element>.size, "Extraction of contiguous storage failed.")
+        self = unsafe _overrideLifetime(span, borrowing: buffer)
+    }
+}
+
+extension MyBuffer {
+    var rawSpan: RawSpan { .init(buffer: self) }
+    var mutableRawSpan: MutableRawSpan { .init(buffer: self) }
+    var outputRawSpan: OutputRawSpan { .init(buffer: self) }
+
+    @_lifetime(borrow self)
+    func span<T>(of type: T.Type) -> Span<T> where T: BitwiseCopyable { .init(buffer: self) }
+
+    @_lifetime(borrow self)
+    func mutableSpan<T>(of type: T.Type) -> MutableSpan<T> where T: BitwiseCopyable { .init(buffer: self) }
+}
+
+struct MyData: BitwiseCopyable {
+    var storage: InlineArray<262144, UInt32>
+}
+
+func fillBuffer(buffer: borrowing MyBuffer)
+{
+    var mutableSpan = buffer.mutableSpan(of: MyData.self)
+    for i in 0..<262144 {
+        mutableSpan[0].storage[i] = UInt32(1 + i)
+    }
+}
+
+func accessFirstElement(buffer: borrowing MyBuffer)
+{
+    if buffer.length > 4 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        // CHECK: nextValue: 2
+        print("nextValue: \(nextValue)")
+    }
+    if buffer.length <= 4 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    }
+}
+
+func calculateNextValue(value: UInt32) -> UInt32
+{
+    return value + 1
+}
+
+func explodeStack(buffer: borrowing MyBuffer)
+{
+    if buffer.length <= 1024 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 1020 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 1016 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 1012 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 1008 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 1004 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 1000 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 996 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 992 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else if buffer.length <= 988 {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        print("nextValue: \(nextValue)")
+    } else {
+        let span = buffer.span(of: MyData.self)
+        let firstElement = span[0].storage[0]
+        let nextValue = calculateNextValue(value: firstElement)
+        // CHECK: nextValue: 2
+        print("nextValue: \(nextValue)")
+    }
+}
+
+//MARK: - main
+
+func main() {
+    let myBuffer = MyBuffer(of: MyData.self)
+    fillBuffer(buffer: myBuffer)
+
+    accessFirstElement(buffer: myBuffer)
+
+    explodeStack(buffer: myBuffer)
+}
+
+main()


### PR DESCRIPTION
Remove Span's `subscript get` accessors.

Borrowing accessors are preferred whenever possible. In some cases, switching from the get to the borrow accessor allows the compiler to eliminate a temporary copy of the indexed Span element. This is important when the element type is something large, such as an InlineArray.

We do not need to retain these accessors for backwards compatibility because they are @export(implementation), so they are not part of Span's ABI.

For example:
```swift
func get_ii_bad(_ a: inout [10 of [10 of Int]], i: Int) -> Int {
  a.span[i][i] // Copies 80B == sizeof([10 of Int]) onto the stack.
}
```

Since InlineArray is BitwiseCopyable, Span's `subscript get` accessor is used here. This introduces a stack-allocated copy of the entire InlineArray at a.span[i] that the optimizer cannot eliminate.

We do not see this issue when indexing the outer InlineArray directly, since it only has borrow/mutate subscript accessors. Removing Span's `get` accessor lets us achieve this when accessing the element via the span.

```swift
func get_ii_good(_ a: inout [10 of [10 of Int]], i: Int) -> Int {
  a[i][i] // Loads 8B, no stack allocations.
}
```

Partially fixes: rdar://183793878
Fixes: rdar://165231596
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
