### PR TITLE
[test] Make match in `rdar93460450.swift` slightly more lax

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/rdar93460450.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar93460450.swift
@@ -43,12 +43,10 @@ struct MyView: View {
     }, set: { newValue in
     })) {
       ForEach(data, id: \.id) { v in
-        NavigationLink(value: v.name) {
-          // Note: This is on a single line to ensure we get the correct location
-          // for the diagnostic on all the SDKs we test in CI.
-          HStack { MySettingsView(x: 42, y: v.name) }
-          // expected-error@-1 {{reasonable time}}
-        }
+        // Note: This is on a single line to ensure we get the correct location
+        // for the diagnostic on all the SDKs we test in CI.
+        NavigationLink(value: v.name) { HStack { MySettingsView(x: 42, y: v.name) } }
+        // expected-error@-1 {{reasonable time}}
       }
     }
   }


### PR DESCRIPTION
This fixes a test failure in arm64 PR testing https://ci.swift.org/job/swift-PR-macos-arm64/4056/