### PR TITLE
[cxx-interop] Relax unavailability of abstract C++ classes into a deprecation warning

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2908,9 +2908,12 @@ namespace {
           // If this class is abstract, any of its methods might use a pure
           // virtual method.
           if (cxxRecordDecl->isAbstract()) {
-            Impl.markUnavailable(
-                result,
-                "abstract C++ classes cannot be used as values in Swift");
+            // In the future, this should be a hard error instead of a
+            // deprecation warning.
+            auto attr = AvailableAttr::createUniversallyDeprecated(
+                Impl.SwiftContext,
+                "abstract C++ classes cannot be used as values in Swift", "");
+            result->addAttribute(attr);
           }
 
           // Address-only type is a type that can't be passed in registers.

--- a/test/Interop/Cxx/class/inheritance/abstract-class-value-type-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/abstract-class-value-type-typechecker.swift
@@ -2,12 +2,12 @@
 
 import AbstractClassValueType
 
-func takesAbstractByValue(_ x: AbstractBase) {} // expected-error {{'AbstractBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
-func returnsAbstract() -> AbstractBase {} // expected-error {{'AbstractBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+func takesAbstractByValue(_ x: AbstractBase) {} // expected-warning {{'AbstractBase' is deprecated: abstract C++ classes cannot be used as values in Swift}}
+func returnsAbstract() -> AbstractBase {} // expected-warning {{'AbstractBase' is deprecated: abstract C++ classes cannot be used as values in Swift}}
 
-_ = AbstractBase.self // expected-error {{'AbstractBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+_ = AbstractBase.self // expected-warning {{'AbstractBase' is deprecated: abstract C++ classes cannot be used as values in Swift}}
 
-func takesStillAbstract(_ x: StillAbstractDerived) {} // expected-error {{'StillAbstractDerived' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+func takesStillAbstract(_ x: StillAbstractDerived) {} // expected-warning {{'StillAbstractDerived' is deprecated: abstract C++ classes cannot be used as values in Swift}}
 
 let a = ConcreteDerived()
 let b = a

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=default -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x | %FileCheck %s
 
-// CHECK:      @available(*, unavailable, message: "abstract C++ classes cannot be used as values in Swift")
+// CHECK:      @available(*, deprecated, message: "abstract C++ classes cannot be used as values in Swift")
 // CHECK-NEXT: struct Base {
 // CHECK-NEXT:   @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
 // CHECK-NEXT:   init()
@@ -19,7 +19,7 @@
 // CHECK-NEXT:  @_addressableSelf mutating func foo()
 // CHECK-NEXT: }
 
-// CHECK:      @available(*, unavailable, message: "abstract C++ classes cannot be used as values in Swift")
+// CHECK:      @available(*, deprecated, message: "abstract C++ classes cannot be used as values in Swift")
 // CHECK-NEXT: struct Base2 {
 // CHECK-NEXT:    @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
 // CHECK-NEXT:    init()
@@ -73,7 +73,7 @@
 // CHECK-NEXT:    @_addressableSelf func swiftName() -> CInt
 // CHECK-NEXT:  }
 //
-// CHECK:      @available(*, unavailable, message: "abstract C++ classes cannot be used as values in Swift")
+// CHECK:      @available(*, deprecated, message: "abstract C++ classes cannot be used as values in Swift")
 // CHECK-NEXT: struct PureVirtualRenamedBase {
 // CHECK-NEXT:    @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
 // CHECK-NEXT:    init()

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -3,11 +3,11 @@
 import VirtualMethods
 
 let _ = Base() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
-// expected-error@-1 {{'Base' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+// expected-warning@-1 {{'Base' is deprecated: abstract C++ classes cannot be used as values in Swift}}
 let _ = DerivedInt()
 
 let _ = Base2() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
-// expected-error@-1 {{'Base2' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+// expected-warning@-1 {{'Base2' is deprecated: abstract C++ classes cannot be used as values in Swift}}
 
 let _ = Derived2()
 let _ = Derived3()
@@ -24,11 +24,11 @@ let vro = VirtualRenamedOverridden()
 let _ = vro.cxxName() // expected-error {{has no member 'cxxName'}}
 let _ = vro.swiftName()
 
-func check(pvrb: PureVirtualRenamedBase) { // expected-error {{'PureVirtualRenamedBase' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+func check(pvrb: PureVirtualRenamedBase) { // expected-warning {{'PureVirtualRenamedBase' is deprecated: abstract C++ classes cannot be used as values in Swift}}
   let _ = pvrb.cxxName() // expected-error {{has no member 'cxxName'}}
   let _ = pvrb.swiftName() // expected-error {{virtual function is not available in Swift because it is pure}}
 }
-func check(pvri: PureVirtualRenamedInherited) { // expected-error {{'PureVirtualRenamedInherited' is unavailable: abstract C++ classes cannot be used as values in Swift}}
+func check(pvri: PureVirtualRenamedInherited) { // expected-warning {{'PureVirtualRenamedInherited' is deprecated: abstract C++ classes cannot be used as values in Swift}}
   let _ = pvri.cxxName() // expected-error {{has no member 'cxxName'}}
   let _ = pvri.swiftName() // expected-error {{virtual function is not available in Swift because it is pure}}
 }


### PR DESCRIPTION
This is in response to source breakages in several adopter projects.

Previously, C++ classes with pure virtual methods would be marked unavailable in Swift.

Note that marking an abstract C++ type as an FRT still makes it fully available in Swift.

rdar://185081412

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
