### PR TITLE
Restore destroy side-effect for begin_cow_mutation and is_unique

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -253,8 +253,13 @@ private struct CollectedEffects {
     case let bi as BuiltinInst where bi.id == .TSanInoutAccess:
       break
 
-    case is BeginCOWMutationInst, is IsUniqueInst:
+    case is BeginCOWMutationInst:
+      addEffects(.destroy, to: inst.operands[0].value, fromInitialPath: SmallProjectionPath(.anyValueFields))
+
+    case is IsUniqueInst:
       addEffects(.read, to: inst.operands[0].value, fromInitialPath: SmallProjectionPath(.anyValueFields))
+      // The destroy effect is required for the non-ossa ARC optimizer
+      addEffects(.destroy, to: inst.operands[0].value, fromInitialPath: SmallProjectionPath(.anyValueFields))
 
     case isReturnInstruction:
       if inst.parentFunction.convention.hasAddressResult {

--- a/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
+++ b/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
@@ -1,5 +1,6 @@
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | %FileCheck %s
 // RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -compute-side-effects -arc-sequence-opts %s | %FileCheck -check-prefix=CHECK-EFFECTS %s
 
 import Builtin
 import Swift
@@ -129,4 +130,54 @@ bb0(%0 : $@noescape @callee_guaranteed () -> ()):
   %5 = destroy_not_escaped_closure %3 : $@callee_guaranteed () -> ()
   cond_fail %5 : $Builtin.Int1
   return %3 : $@callee_guaranteed () -> ()
+}
+
+class CowBox {
+  init()
+}
+
+sil [noinline] @cowMutate : $@convention(thin) (@guaranteed CowBox) -> () {
+bb0(%0 : $CowBox):
+  (%1, %2) = begin_cow_mutation %0 : $CowBox
+  %3 = end_cow_mutation %2 : $CowBox
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil [noinline] @cowIsUnique : $@convention(thin) (@inout CowBox) -> Builtin.Int1 {
+bb0(%0 : $*CowBox):
+  %1 = is_unique %0 : $*CowBox
+  return %1 : $Builtin.Int1
+}
+
+// CHECK-EFFECTS-LABEL: sil @dont_remove_retain_across_begin_cow_mutation :
+// CHECK-EFFECTS:         strong_retain %0
+// CHECK-EFFECTS:         apply
+// CHECK-EFFECTS:         strong_release %0
+// CHECK-EFFECTS:       } // end sil function 'dont_remove_retain_across_begin_cow_mutation'
+sil @dont_remove_retain_across_begin_cow_mutation : $@convention(thin) (@guaranteed CowBox) -> () {
+bb0(%0 : $CowBox):
+  strong_retain %0 : $CowBox
+  %1 = function_ref @cowMutate : $@convention(thin) (@guaranteed CowBox) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@guaranteed CowBox) -> ()
+  strong_release %0 : $CowBox
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-EFFECTS-LABEL: sil @dont_remove_retain_across_is_unique :
+// CHECK-EFFECTS:         [[L:%.*]] = load %0
+// CHECK-EFFECTS:         strong_retain [[L]]
+// CHECK-EFFECTS:         apply
+// CHECK-EFFECTS:         strong_release [[L]]
+// CHECK-EFFECTS:       } // end sil function 'dont_remove_retain_across_is_unique'
+sil @dont_remove_retain_across_is_unique : $@convention(thin) (@inout CowBox) -> Builtin.Int1 {
+bb0(%0 : $*CowBox):
+  %1 = load %0 : $*CowBox
+  strong_retain %1 : $CowBox
+  %2 = function_ref @cowIsUnique : $@convention(thin) (@inout CowBox) -> Builtin.Int1
+  %3 = apply %2(%0) : $@convention(thin) (@inout CowBox) -> Builtin.Int1
+  fix_lifetime %1 : $CowBox
+  strong_release %1 : $CowBox
+  return %3 : $Builtin.Int1
 }

--- a/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
@@ -1124,7 +1124,7 @@ bb0(%0 : $*MyArray<MyStruct>):
   return %t : $() 
 }
 // CHECK-LABEL: sil [noinline] @refcount_read :
-// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%0: read v**, destroy v**]
 // CHECK-NEXT:  [global: ]
 sil [noinline] @refcount_read : $@convention(thin) (@inout Klass) -> Builtin.Int1 {
 bb0(%0 : $*Klass):

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1149,7 +1149,7 @@ sil [ossa] @callUnknownIsDeinitBarrier : $@convention(thin) () -> () {
 }
 
 // CHECK-LABEL: sil @begin_cow_test
-// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%0: destroy v**]
 // CHECK-NEXT:  [global: ]
 // CHECK-NEXT:  {{^[^[]}}
 sil @begin_cow_test : $@convention(thin) (@guaranteed X) -> () {
@@ -1160,7 +1160,7 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: sil @is_unique_test
-// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%0: read v**, destroy v**]
 // CHECK-NEXT:  [global: ]
 // CHECK-NEXT:  {{^[^[]}}
 sil @is_unique_test : $@convention(thin) (@inout X) -> () {


### PR DESCRIPTION
The destroy effect is required by the non-OSSA ARC optimizer.

