### PR TITLE
SSAUpdater: fix identifying the phi which was inserted into a block

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/SSAUpdater.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SSAUpdater.swift
@@ -234,9 +234,9 @@ public struct SSAUpdater<Context: MutatingContext> {
 
   /// Returns true if `value` is a phi argument which _this updater_ inserted into `block`.
   private func isInsertedPhi(_ value: Value, in block: BasicBlock) -> Bool {
-    if let arg = value as? Argument,
-       arg.parentBlock == block,
-       blocksWithInsertedPhis.contains(block)
+    if blocksWithInsertedPhis.contains(block),
+       let lastArg = block.arguments.last,
+       value == lastArg
     {
       return true
     }
@@ -389,19 +389,19 @@ let ssaUpdaterTest = Test("ssa_updater") {
     return
   }
 
-  var ssaUpdater = SSAUpdater(type: firstValue.type, ownership: firstValue.ownership, context)
+  var ssaUpdater = SSAUpdater(type: firstValue.0.type, ownership: firstValue.0.ownership, context)
   defer { ssaUpdater.deinitialize() }
 
-  var availableValuesInBlocks = Dictionary<BasicBlock, IntegerLiteralInst>()
+  var availableValuesInBlocks = Dictionary<BasicBlock, Instruction>()
 
-  for v in availableValues {
-    ssaUpdater.addAvailableValue(v, in: v.parentBlock)
-    availableValuesInBlocks[v.parentBlock] = v
+  for (v, insertionPoint) in availableValues {
+    ssaUpdater.addAvailableValue(v, in: insertionPoint.parentBlock)
+    availableValuesInBlocks[insertionPoint.parentBlock] = insertionPoint
   }
 
   for block in function.blocks {
     for inst in block.instructions {
-      for op in inst.operands where op.value is Undef && op.value.type == firstValue.type {
+      for op in inst.operands where op.value is Undef && op.value.type == firstValue.0.type {
         let v: Value
         if let available = availableValuesInBlocks[block], available.strictlyDominatesInBlock(inst) {
           v = ssaUpdater.getValue(atEndOf: block)
@@ -426,33 +426,60 @@ let instructionBasedSSAUpdaterTest = Test("instruction_based_ssa_updater") {
     return
   }
 
-  var ssaUpdater = InstructionBasedSSAUpdater(type: firstValue.type, ownership: firstValue.ownership, context)
+  var ssaUpdater = InstructionBasedSSAUpdater(type: firstValue.0.type, ownership: firstValue.0.ownership, context)
   defer { ssaUpdater.deinitialize() }
 
-  for v in availableValues {
-    for user in v.users {
-      ssaUpdater.addAvailableValue(v, after: user)
-    }
+  for (v, insertionPoint) in availableValues {
+    ssaUpdater.addAvailableValue(v, after: insertionPoint)
   }
 
   for inst in function.instructions {
-    for op in inst.operands where op.value is Undef && op.value.type == firstValue.type {
+    for op in inst.operands where op.value is Undef && op.value.type == firstValue.0.type {
       let v = ssaUpdater.getValue(before: inst)
       op.set(to: v, context)
     }
   }
 }
 
-private func getTestAvailableValues(in function: Function) -> [IntegerLiteralInst] {
-  var availableValues = [IntegerLiteralInst]()
+/// Returns the available values of a test function, together with the instruction after which
+/// each value becomes available. Available values are:
+/// - `integer_literal` instructions: available after each of their users, or after the literal
+///   itself if it has no users
+/// - block arguments which have `fix_lifetime` users: available after each such `fix_lifetime`.
+///   This allows tests to use a pre-existing block argument as an available value.
+///
+private func getTestAvailableValues(in function: Function) -> [(Value, insertionPoint: Instruction)] {
+  var availableValues = [(Value, insertionPoint: Instruction)]()
 
-  for inst in function.instructions {
-    if let il = inst as? IntegerLiteralInst {
-      availableValues.append(il)
+  for block in function.blocks {
+    for arg in block.arguments {
+      for fixLifetime in arg.uses.users(ofType: FixLifetimeInst.self) {
+        availableValues.append((arg, insertionPoint: fixLifetime))
+      }
+    }
+    for inst in block.instructions {
+      if let il = inst as? IntegerLiteralInst {
+        if il.uses.isEmpty {
+          availableValues.append((il, insertionPoint: il))
+        } else {
+          for user in il.users {
+            availableValues.append((il, insertionPoint: user))
+          }
+        }
+      }
     }
   }
 
-  availableValues.sort(by: { $0.value! < $1.value! })
+  // Order integer literals by their value (block arguments keep their relative order at the end)
+  // so that available values are added in a deterministic order.
+  availableValues.sort(by: {
+    if let il1 = $0.0 as? IntegerLiteralInst,
+       let il2 = $1.0 as? IntegerLiteralInst
+    {
+      return il1.value! < il2.value!
+    }
+    return $0.0 is IntegerLiteralInst
+  })
 
   return availableValues
 }

--- a/test/SILOptimizer/ssa-updater.sil
+++ b/test/SILOptimizer/ssa-updater.sil
@@ -190,6 +190,11 @@ bb23:
 
 //===----------------------------------------------------------------------===//
 //                      Swift SSAUpdater tests
+//
+// Available values are `integer_literal` instructions - available after each of
+// their users - and block arguments which have a `fix_lifetime` user - available
+// after that `fix_lifetime`. All `undef` operands are then replaced by the value
+// which the SSA-updater computes at that place.
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: sil @single_block :
@@ -441,6 +446,109 @@ bb2:
   br bb3
 
 bb3:
+  return undef : $Builtin.Int64
+}
+
+// A pre-existing block argument can be an available value - here the loop-carried
+// argument %a of the loop header bb1.
+//
+// CHECK-LABEL: sil @available_value_is_block_argument :
+// CHECK:       bb1([[A:%.*]] : $Builtin.Int64):
+// CHECK-NEXT:    fix_lifetime [[A]]
+// CHECK:       bb3:
+// CHECK-NEXT:    return [[A]]
+// CHECK:       } // end sil function 'available_value_is_block_argument'
+sil @available_value_is_block_argument : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $Builtin.Int64):
+  specify_test "ssa_updater"
+  br bb1(%0 : $Builtin.Int64)
+
+bb1(%a : $Builtin.Int64):
+  fix_lifetime %a : $Builtin.Int64
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1(%a : $Builtin.Int64)
+
+bb3:
+  return undef : $Builtin.Int64
+}
+
+// The available value %a is a pre-existing argument of the loop header bb4 and the
+// loop header needs a phi for the value coming from outside the loop. The updater
+// must not mistake %a for the phi which it inserted into bb4: otherwise bb4 is not
+// invalidated when its value changes from %a to the phi, and the stale %a keeps
+// being forwarded to bb8 - a direct successor of the header which is computed
+// before the header in the current iteration.
+// That would make bb9 see different values from its predecessors and insert a
+// superfluous phi. And if the pre-existing argument is mistaken for an inserted
+// phi in general, bb4 doesn't get a phi at all and %a is forwarded on the path
+// through bb3, where it is not defined.
+// Note: the order of the blocks in this function matters, because it determines
+// the order in which the updater computes the block values.
+//
+// CHECK-LABEL: sil @phi_in_block_with_available_argument :
+// CHECK:       bb0(%0 : $Builtin.Int64):
+// CHECK-NEXT:    [[L1:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb10([[L1]])
+// CHECK:       bb3:
+// CHECK-NEXT:    br bb4(%0, [[L1]])
+// CHECK:       bb4([[A:%.*]] : $Builtin.Int64, [[PHI1:%.*]] : $Builtin.Int64):
+// CHECK:       bb6:
+// CHECK-NEXT:    fix_lifetime [[A]]
+// CHECK-NEXT:    br bb4([[A]], [[A]])
+// CHECK:       bb7:
+// CHECK-NEXT:    br bb9
+// CHECK:       bb8:
+// CHECK-NEXT:    br bb9
+// CHECK:       bb9:
+// CHECK-NEXT:    br bb10([[PHI1]])
+// CHECK:       bb10([[PHI2:%.*]] : $Builtin.Int64):
+// CHECK:       bb11:
+// CHECK-NEXT:    return [[PHI2]]
+// CHECK:       } // end sil function 'phi_in_block_with_available_argument'
+sil @phi_in_block_with_available_argument : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $Builtin.Int64):
+  specify_test "ssa_updater"
+  %l1 = integer_literal $Builtin.Int64, 1
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+// Reaches the join block bb10 without going through the loop.
+bb2:
+  br bb10
+
+bb3:
+  br bb4(%0 : $Builtin.Int64)
+
+// The loop header. %a is a pre-existing argument which is also an available value.
+bb4(%a : $Builtin.Int64):
+  cond_br undef, bb8, bb5
+
+bb5:
+  cond_br undef, bb7, bb6
+
+bb6:
+  fix_lifetime %a : $Builtin.Int64
+  br bb4(%a : $Builtin.Int64)
+
+// The two loop exits. Both see the same value, therefore bb9 must not get a phi.
+bb7:
+  br bb9
+
+bb8:
+  br bb9
+
+bb9:
+  br bb10
+
+bb10:
+  br bb11
+
+bb11:
   return undef : $Builtin.Int64
 }
 


### PR DESCRIPTION
The fix in https://github.com/swiftlang/swift/pull/91417 was incomplete: `isInsertedPhi(_:in:)` checked that the value is _some_ argument of a block in which this updater inserted a phi. But if an available value happens to be a pre-existing argument of such a block - e.g. a loop-carried argument of a loop header which also needs a phi - that pre-existing argument was still mistaken for the inserted phi.

Consequently `clearValues` refused to invalidate the block, so successors which merely forwarded the stale value kept doing so. A join block then saw different values from its predecessors and inserted a superfluous phi, tripping `assert(diff, "inserted a phi argument for identical input values")`.

Compare against the block's last argument instead - the inserted phi is always appended last.

Fixes a compile crash
rdar://185081669

