### PR TITLE
[6.4] MoveChecker: diagnose use and consume within one instruction

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2935,6 +2935,19 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
   for (auto takeInstAndValue : instsToTest) {
     LLVM_DEBUG(llvm::dbgs() << "    Checking: " << *takeInstAndValue.first);
 
+    // The value is consumed and used at the same instruction (e.g. passed both
+    // @in and @in_guaranteed to one apply).
+    if (addressUseState.isLivenessUse(takeInstAndValue.first,
+                                      takeInstAndValue.second)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "        Consumed and used at the same instruction!\n");
+      hadAnyErrorUsers = true;
+      diagnosticEmitter.emitAddressInstConsumesAndUsesValue(
+          addressUseState.address, takeInstAndValue.first);
+      emittedDiagnostic = true;
+      continue;
+    }
+
     // Check if we are in the boundary...
 
     // If the bit vector does not contain any set bits, then we know that we did

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -719,6 +719,23 @@ void DiagnosticEmitter::emitObjectInstConsumesAndUsesValue(
   registerDiagnosticEmitted(markedValue);
 }
 
+void DiagnosticEmitter::emitAddressInstConsumesAndUsesValue(
+    MarkUnresolvedNonCopyableValueInst *markedValue, SILInstruction *user) {
+  LLVM_DEBUG(llvm::dbgs() << "Emitting address consumed and used error!\n");
+  LLVM_DEBUG(llvm::dbgs() << "    Mark: " << *markedValue);
+  LLVM_DEBUG(llvm::dbgs() << "    User: " << *user);
+
+  auto &astContext = markedValue->getModule().getASTContext();
+  SmallString<64> varName;
+  getVariableNameForValue(markedValue, varName);
+  diagnose(astContext, markedValue,
+           diag::sil_movechecking_owned_value_consumed_and_used_at_same_time,
+           varName);
+  diagnose(astContext, user,
+           diag::sil_movechecking_consuming_and_non_consuming_uses_here);
+  registerDiagnosticEmitted(markedValue);
+}
+
 bool DiagnosticEmitter::emitGlobalOrClassFieldLoadedAndConsumed(
     MarkUnresolvedNonCopyableValueInst *markedValue) {
   SmallString<64> varName;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -189,6 +189,10 @@ public:
       MarkUnresolvedNonCopyableValueInst *markedValue, Operand *consumingUse,
       Operand *nonConsumingUse);
 
+  /// Address-checker analogue of \c emitObjectInstConsumesAndUsesValue.
+  void emitAddressInstConsumesAndUsesValue(
+      MarkUnresolvedNonCopyableValueInst *markedValue, SILInstruction *user);
+
   /// Emit a diagnostic for a case where we have one of the following cases:
   ///
   /// 1. A partial_apply formed from a borrowed address only value.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -4564,3 +4564,75 @@ func assignableButNotConsumableEndAccessImplicitLifetimeTest(_ x: MyClassWithMov
         x.moveOnlyVarStruct.nonTrivialStruct2 = NonTrivialStruct2()
     }
 }
+
+// A value consumed and used at the same instruction (passed both @in and
+// @in_guaranteed to one apply).
+struct ConsumeUseHolder<T> { let base: T }
+
+func takeConsumingAndBorrowing<T>(
+  _ a: consuming ConsumeUseHolder<T>, _ b: borrowing ConsumeUseHolder<T>
+) {}
+
+func testConsumeAndBorrowSameApply<T>(_ x: consuming ConsumeUseHolder<T>) { // expected-error {{'x' consumed and used at the same time}}
+  takeConsumingAndBorrowing(x, x) // expected-error {{overlapping accesses to 'x', but deinitialization requires exclusive access}} expected-note {{conflicting access is here}} expected-note {{consumed and used here}}
+}
+
+// Resolved by copying either the consumed or the borrowed argument.
+func testConsumeAndBorrowSameApply_copyConsumed<T>(_ x: consuming ConsumeUseHolder<T>) {
+  takeConsumingAndBorrowing(copy x, x)
+}
+func testConsumeAndBorrowSameApply_copyBorrowed<T>(_ x: consuming ConsumeUseHolder<T>) {
+  takeConsumingAndBorrowing(x, copy x)
+}
+
+// inout + borrowing the same value at one apply: exclusivity violation,
+// resolved by copying the borrowed argument.
+func takeInoutAndBorrowing<T>(
+  _ a: inout ConsumeUseHolder<T>, _ b: borrowing ConsumeUseHolder<T>
+) {}
+
+func testInoutAndBorrowSameApply<T>(_ x: consuming ConsumeUseHolder<T>) {
+  takeInoutAndBorrowing(&x, x) // expected-error {{overlapping accesses to 'x', but modification requires exclusive access}} expected-note {{conflicting access is here}}
+}
+func testInoutAndBorrowSameApply_copyBorrowed<T>(_ x: consuming ConsumeUseHolder<T>) {
+  takeInoutAndBorrowing(&x, copy x)
+}
+
+// Same, via a ~Copyable protocol witness.
+protocol Finishable: ~Copyable {
+  consuming func finish(body: (inout Int) -> Void)
+}
+struct WrapFinishable<Base: Finishable & ~Copyable>: Finishable, ~Copyable {
+  var underlying: Base
+  let label: Int
+  consuming func finish(body: (inout Int) -> Void) { // expected-error {{'self' consumed and used at the same time}}
+    self.underlying.finish { (buf: inout Int) -> Void in // expected-note {{consumed and used here}}
+      body(&buf)
+      _ = self.label
+    }
+  }
+}
+
+// Same, via an async ~Copyable protocol witness / try_apply.
+protocol UnderlyingReader: ~Copyable {}
+protocol ConcludingReader<FinalElement>: ~Copyable {
+  associatedtype Underlying: UnderlyingReader, ~Copyable
+  associatedtype FinalElement
+  consuming func consumeAndConclude<Return>(
+    body: (consuming sending Underlying) async throws -> Return
+  ) async throws -> (Return, FinalElement)
+}
+struct WrapConcluding<Base: ConcludingReader & ~Copyable>: ConcludingReader, ~Copyable {
+  typealias Underlying = Base.Underlying
+  typealias FinalElement = Base.FinalElement
+  var base: Base
+  let sizeLimit: Int
+  consuming func consumeAndConclude<Return>( // expected-error {{'self' consumed and used at the same time}}
+    body: (consuming sending Underlying) async throws -> Return
+  ) async throws -> (Return, FinalElement) {
+    try await self.base.consumeAndConclude { reader in // expected-note {{consumed and used here}}
+      _ = self.sizeLimit
+      return try await body(reader)
+    }
+  }
+}


### PR DESCRIPTION
Explanation: We'd crash on invalid programs with calls that both consume and use an address-only type. This plugs that hole by detecting and diagnosing.

Issue: rdar://129636647

Cherry-picked from: https://github.com/swiftlang/swift/pull/91208

Scope: Diagnostics

Testing: CI and tests extracted from bug reports

Risk: Low. The unlikely worst case scenario is we start diagnosing correct programs.

Reviewed by: TBD
