### PR TITLE
[DependencyScan] Fix Swift Instance lifetime issue

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -689,19 +689,19 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     opts.Compilation = clang::dependencies::IncludeTreeCompilation{
         CASOpts, Instance.getSharedCASInstance(),
         Instance.getSharedCacheInstance()};
-    opts.MakeVFS = [&]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
-      auto &ctx = Instance.getASTContext();
-      auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-      // Dependency scanner needs to create its own file system per worker.
-      auto fs = ClangImporter::computeClangImporterFileSystem(
-          ctx, importer->getClangFileMapping(),
-          llvm::vfs::createPhysicalFileSystem(), true,
-          [&](StringRef str) { return save(str); });
 
-      auto cas = Instance.getSharedCASInstance();
-      if (cas)
-        return llvm::cas::createCASProvidingFileSystem(cas, fs);
-      return fs;
+    // Compute VFS from the clang importer from the first invocation. This is
+    // usually fine since the base VFS should be the same for the same platform.
+    auto &ctx = Instance.getASTContext();
+    auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+    auto fs = ClangImporter::computeClangImporterFileSystem(
+        ctx, importer->getClangFileMapping(),
+        llvm::vfs::createPhysicalFileSystem(), true,
+        [&](StringRef str) { return save(str); });
+    auto cas = Instance.getSharedCASInstance();
+
+    opts.MakeVFS = [=]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+      return llvm::cas::createCASProvidingFileSystem(cas, fs);
     };
 
     ClangScanningService.emplace(std::move(opts));


### PR DESCRIPTION
Follow up to #91535 and use a safer implementation that let callback to hold onto the CAS and base VFS via shared_ptr, then hold onto the reference of Swift CompilerInstance.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
