### PR TITLE
[Test] Add a stdlib_5_9_runtime lit feature, and fix a few tests that can't run against old runtimes.

### DIFF
--- a/test/Interpreter/objc_protocol_symbolic_reference_nested.swift
+++ b/test/Interpreter/objc_protocol_symbolic_reference_nested.swift
@@ -7,6 +7,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
+// Match the macosx14 target above.
+// REQUIRES: stdlib_5_9_runtime
+
 import Foundation
 
 struct S<T> {}

--- a/test/Interpreter/variadic_generic_vanishing_tuple_resilient_field.swift
+++ b/test/Interpreter/variadic_generic_vanishing_tuple_resilient_field.swift
@@ -7,6 +7,9 @@
 
 // REQUIRES: executable_test
 
+// Match the swift-5.9 target triple above.
+// REQUIRES: stdlib_5_9_runtime
+
 // Storing a pack-expansion tuple property hits an unrelated pre-existing SILGen
 // assertion under SIL opaque values (TupleInitialization::copyOrInitValueInto);
 // the metadata-completion bug this test guards is in IRGen and is exercised by

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2900,32 +2900,46 @@ if 'concurrency' in config.available_features:
     else:
         config.available_features.add('concurrency_runtime')
 
-# Determine whether the runtime we test against is Swift 5.8 or newer. IRGen
-# omits inverted protocol metadata when targeting earlier runtimes, so tests
-# that need that metadata cannot run against them.
-if 'use_os_stdlib' not in lit_config.params:
-    config.available_features.add('stdlib_5_8_runtime')
-elif run_vendor == 'apple':
-    # OS version corresponding to SwiftStdlib 5.8, per
-    # utils/availability-macros.def.
-    STDLIB_5_8_OS_VERSION = {
-        'macosx': '13.3',
-        'ios': '16.4',
-        'maccatalyst': '16.4',
-        'tvos': '16.4',
-        'watchos': '9.4',
-        'xros': '1.0'
-    }
-    stdlib_5_8_os_version = STDLIB_5_8_OS_VERSION.get(run_os, '')
+# Add a stdlib_X_Y_runtime feature when the runtime we test against is that
+# version or newer. Some tests need runtime support that can't be version-gated
+# in the test code, because a too-old runtime makes the test fail to launch
+# rather than fail a check. Those tests still have value against older runtimes
+# that are new enough, so UNSUPPORTED: use_os_stdlib isn't what they want.
+def add_stdlib_runtime_feature(stdlib_vers, os_versions):
+    feature = 'stdlib_%s_runtime' % stdlib_vers.replace('.', '_')
 
-    if stdlib_5_8_os_version and not version_gt(stdlib_5_8_os_version, run_vers):
-        config.available_features.add('stdlib_5_8_runtime')
+    # Only the OS stdlib can be older than what we just built.
+    if 'use_os_stdlib' not in lit_config.params or run_vendor != 'apple':
+        config.available_features.add(feature)
+        return
+
+    os_version = os_versions.get(run_os, '')
+    if os_version and not version_gt(os_version, run_vers):
+        config.available_features.add(feature)
     else:
         lit_config.note(
-            'Disabled Swift 5.8 runtime tests because run version %s < %s'
-            % (run_vers, stdlib_5_8_os_version))
-else:
-    config.available_features.add('stdlib_5_8_runtime')
+            'Disabled Swift %s runtime tests because run version %s < %s'
+            % (stdlib_vers, run_vers, os_version))
+
+# OS versions corresponding to each stdlib release, per
+# utils/availability-macros.def.
+add_stdlib_runtime_feature('5.8', {
+    'macosx': '13.3',
+    'ios': '16.4',
+    'maccatalyst': '16.4',
+    'tvos': '16.4',
+    'watchos': '9.4',
+    'xros': '1.0'
+})
+
+add_stdlib_runtime_feature('5.9', {
+    'macosx': '14.0',
+    'ios': '17.0',
+    'maccatalyst': '17.0',
+    'tvos': '17.0',
+    'watchos': '10.0',
+    'xros': '1.0'
+})
 
 # Set up testing with the standard libraries coming from either the OS, the back
 # deployment runtime or the just-built libraries. By default, we run tests with

--- a/test/stdlib/test_runtime_function_counters.swift
+++ b/test/stdlib/test_runtime_function_counters.swift
@@ -5,6 +5,12 @@
 // REQUIRES: runtime_function_counters
 // REQUIRES: executable_test
 
+// OS and back-deployment runtimes never build with
+// SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS. We can only test a locally built
+// runtime.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 /// Test functionality related to the runtime function counters.
 
 class C {


### PR DESCRIPTION
Generalize the stdlib_5_8_runtime gate into add_stdlib_runtime_feature() and add a 5.9 version.

Gate objc_protocol_symbolic_reference_nested.swift and variadic_generic_vanishing_tuple_resilient_field.swift on stdlib_5_9_runtime.

Mark test_runtime_function_counters.swift unsupported with use_os_stdlib and back_deployment_runtime, since it relies on SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS and that's not set in OS runtimes.

rdar://184417931
rdar://184331976
rdar://184418165