### PR TITLE
[TEST-ONLY] Update test/CAS/binary_module_deps.swift

### DIFF
--- a/test/CAS/binary_module_deps.swift
+++ b/test/CAS/binary_module_deps.swift
@@ -11,7 +11,7 @@
 
 /// Test binary module key: binary module key is the CASID of itself.
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json swiftPrebuiltExternal:A moduleCacheKey > %t/A.key.casid
-// RUN: llvm-cas --cas %t/cas --cat-blob @%t/A.key.casid > %t/Loaded.swiftmodule
+// RUN: llvm-cas --cas %t/cas --cat-node-data @%t/A.key.casid > %t/Loaded.swiftmodule
 // RUN: diff %t/A.swiftmodule %t/Loaded.swiftmodule
 
 import A


### PR DESCRIPTION
Update test on rebranch for deprecated llvm-cas command.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
