### PR TITLE
Frontend: Introduce `-no-downgrade-typecheck-interface-error`

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -451,10 +451,11 @@ public:
   /// such as `-Xcc` flags, etc.
   bool StrictImplicitModuleContext = false;
 
-  /// Downgrade all errors emitted in the module interface verification phase
-  /// to warnings.
+  /// Whether to downgrade all errors emitted in the module interface
+  /// verification phase to warnings. When this has no value, the blocklists
+  /// decide whether the module's interface verification errors are downgraded.
   /// TODO: remove this after we fix all project-side warnings in the interface.
-  bool DowngradeInterfaceVerificationError = false;
+  std::optional<bool> DowngradeInterfaceVerificationError;
 
   /// True if the "-static" option is set.
   bool Static = false;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -499,7 +499,7 @@ public:
   bool disableInterfaceLock = false;
   bool disableImplicitSwiftModule = false;
   bool disableBuildingInterface = false;
-  bool downgradeInterfaceVerificationError = false;
+  std::optional<bool> downgradeInterfaceVerificationError;
   bool strictImplicitModuleContext = false;
   CompilerDebuggingOptions compilerDebuggingOptions;
   std::string mainExecutablePath;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -982,6 +982,11 @@ def Rmodule_interface_rebuild : Flag<["-"], "Rmodule-interface-rebuild">,
 def downgrade_typecheck_interface_error : Flag<["-"], "downgrade-typecheck-interface-error">,
   HelpText<"Downgrade error to warning when typechecking emitted module interfaces">;
 
+def no_downgrade_typecheck_interface_error
+    : Flag<["-"], "no-downgrade-typecheck-interface-error">,
+      HelpText<"Report errors when typechecking emitted module interfaces, "
+               "even for a module blocklisted as having a broken interface">;
+
 def enable_volatile_modules : Flag<["-"], "enable-volatile-modules">,
   HelpText<"Load Swift modules in memory">;
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -199,8 +199,12 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.RemarkOnRebuildFromModuleInterface |=
     Args.hasArg(OPT_Rmodule_interface_rebuild);
 
-  Opts.DowngradeInterfaceVerificationError |=
-    Args.hasArg(OPT_downgrade_typecheck_interface_error);
+  if (const Arg *A =
+          Args.getLastArg(OPT_downgrade_typecheck_interface_error,
+                          OPT_no_downgrade_typecheck_interface_error)) {
+    Opts.DowngradeInterfaceVerificationError =
+        A->getOption().matches(OPT_downgrade_typecheck_interface_error);
+  }
   computePrintStatsOptions();
   computeDebugTimeOptions();
   computeTBDOptions();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1338,6 +1338,13 @@ bool CompilerInstance::supportCaching() const {
 
 bool CompilerInstance::downgradeInterfaceVerificationErrors() const {
   auto &FrontendOpts = Invocation.getFrontendOptions();
+  // An explicit '-downgrade-typecheck-interface-error' or
+  // '-no-downgrade-typecheck-interface-error' takes precedence over the
+  // blocklists, so that the interface of a blocklisted module can still be
+  // verified.
+  if (FrontendOpts.DowngradeInterfaceVerificationError.has_value())
+    return *FrontendOpts.DowngradeInterfaceVerificationError;
+
   if (Context->blockListConfig.hasBlockListAction(FrontendOpts.ModuleName,
                                              BlockListKeyKind::ModuleName,
                         BlockListAction::DowngradeInterfaceVerificationFailure)) {
@@ -1345,7 +1352,7 @@ bool CompilerInstance::downgradeInterfaceVerificationErrors() const {
                             FrontendOpts.ModuleName);
     return true;
   }
-  return FrontendOpts.DowngradeInterfaceVerificationError;
+  return false;
 }
 
 ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {

--- a/test/ModuleInterface/blocklist_action.swift
+++ b/test/ModuleInterface/blocklist_action.swift
@@ -3,15 +3,17 @@
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test  %s
 // RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
 
-// RUN: echo "<<<<<>>>>>>>>" >> %t/Test.swiftinterface
-// RUN: not %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
+// Break the interface. The diagnostics expected by the '-verify' runs below are
+// annotated in the interface itself.
+// RUN: echo "public func bad() -> DoesNotExist // expected-error {{cannot find type 'DoesNotExist' in scope}} expected-error@1 {{failed to verify module interface of 'Test'}}" >> %t/Test.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -verify -show-diagnostics-after-fatal
 
 // RUN: echo "---" > %t/blocklist.yml
 // RUN: echo "DowngradeInterfaceVerificationFailure:" >> %t/blocklist.yml
 // RUN: echo "  ModuleName:" >> %t/blocklist.yml
 // RUN: echo "    - FooBar" >> %t/blocklist.yml
 
-// RUN: not %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml -verify -show-diagnostics-after-fatal
 
 // RUN: echo "    - Test" >> %t/blocklist.yml
 
@@ -21,5 +23,12 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml &> %t/notes.txt
 // RUN: %FileCheck -check-prefix CHECK-NOTES --input-file %t/notes.txt %s
 // CHECK-NOTES: note: textual interface for Test is blocklisted as broken; interface verification errors are downgraded to warnings
+
+// '-no-downgrade-typecheck-interface-error' disregards the blocklist.
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -blocklist-file %t/blocklist.yml -no-downgrade-typecheck-interface-error -verify -show-diagnostics-after-fatal
+
+// The last of the downgrade flags wins.
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -downgrade-typecheck-interface-error -no-downgrade-typecheck-interface-error -verify -show-diagnostics-after-fatal
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -no-downgrade-typecheck-interface-error -downgrade-typecheck-interface-error
 
 public func foo() {}


### PR DESCRIPTION
When specified, the compiler should report errors during module interface type checking jobs, even for modules on the DowngradeInterfaceVerificationFailure block list.

Resolves rdar://185151497.
