### PR TITLE
tests: fix two Foundation tests which fail with an installed Xcode/macOS 27

### DIFF
--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -885,8 +885,6 @@ CastsTests.test("Casting Objects retained from KeyPaths to Protocols is not work
   expectNotNil(value as? SuperProtocol)
 }
 
-// https://github.com/apple/swift/issues/54462
-// FIXME: Known to still be broken, but we can document the issue here.
 #if _runtime(_ObjC)
 public protocol SomeProtocol {}
 extension NSString: SomeProtocol {}
@@ -901,7 +899,12 @@ CastsTests.test("NSDictionary -> Dictionary casting") {
 
   // Test casting of the dictionary
   let b = a as? [String:SomeProtocol]
-  expectFailure { expectNotNil(b) } // Expect non-nil, but see nil
+
+  // This is broken in older Foundation versions in macOS < 27.
+  // https://github.com/apple/swift/issues/54462
+  // TODO: enable this check once CI upgrades to macOS >= 27
+  // expectNotNil(b)
+
   let c = a as? [String:Any]
   expectNotNil(c)  // Non-nil (as expected)
   let d = c as? [String:SomeProtocol]

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -56,10 +56,11 @@ func testAmbiguousStringComparisons(s: String) {
 
 func testStringDeprecation(hello: String) {
   let hello2 = hello
-    .addingPercentEscapes(using: .utf8) // expected-error{{'addingPercentEscapes(using:)' is unavailable}}
+    .addingPercentEscapes(using: .utf8) // expected-error{{addingPercentEscapes}}
 
+  // This error check is optional because different Foundation version behave differently
   _ = hello2?
-    .replacingPercentEscapes(using: .utf8) // expected-error{{'replacingPercentEscapes(using:)' is unavailable}}
+    .replacingPercentEscapes(using: .utf8) // expected-error*{{'replacingPercentEscapes(using:)' is unavailable}}
 }
 
 // Positive and negative tests for String collection types. Testing the complete


### PR DESCRIPTION
- **Explanation**:
  * Casts.swift: disable an x-failed check for a bug which is now fixed: https://github.com/apple/swift/issues/54462, rdar://59274096
  * StringDiagnostics.swift: some diagnostics changed
- **Scope**:
Test changes only.
- **Issues**:
https://github.com/apple/swift/issues/54462, rdar://59274096
- **Original PRs**:
https://github.com/swiftlang/swift/pull/89863
- **Risk**:
Low. This is test change only.
- **Testing**:
Tested in the new CI pipeline being brought up on macOS 27
- **Reviewers**:
@jrflat

