### PR TITLE
Fix testing with Xcode 27 beta

### DIFF
--- a/validation-test/SILGen/SwiftUI/opaque_result_type_erasure.swift
+++ b/validation-test/SILGen/SwiftUI/opaque_result_type_erasure.swift
@@ -5,8 +5,26 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises SILGen of
+// opaque result types, not `@State` itself; the box reproduces `@State`'s
+// nonmutating setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct MyView: View {
-    @State private var isPresented = false
+    @FakeState private var isPresented = false
 
     var body: some View {
         NavigationView {

--- a/validation-test/Sema/SwiftUI/builder_requirement_errors_should_not_shadow_errors_in_code.swift
+++ b/validation-test/Sema/SwiftUI/builder_requirement_errors_should_not_shadow_errors_in_code.swift
@@ -5,6 +5,24 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 extension [UInt8] {
   var toASCII : String? { nil }
 }
@@ -82,7 +100,7 @@ do {
   }
 
   struct InvalidRef: View {
-    @State private var isLoading = true
+    @FakeState private var isLoading = true
 
     var body: some View {
       Group {
@@ -142,7 +160,7 @@ do {
 // rdar://118374670
 do {
   struct MissingWrapperInnerView: View {
-    @State var cond = false
+    @FakeState var cond = false
 
     var body: some View {
       Group {

--- a/validation-test/Sema/SwiftUI/builder_with_implicit_property_wrapper_inference.swift
+++ b/validation-test/Sema/SwiftUI/builder_with_implicit_property_wrapper_inference.swift
@@ -5,6 +5,24 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct Example: View {
   struct Item: Identifiable {
     var id: Int
@@ -12,7 +30,7 @@ struct Example: View {
     var isOn: Bool = .random()
   }
 
-  @State var items = [
+  @FakeState var items = [
     Item(id: 0, title: "")
   ]
 

--- a/validation-test/Sema/SwiftUI/issue-56479.swift
+++ b/validation-test/Sema/SwiftUI/issue-56479.swift
@@ -8,8 +8,26 @@
 import SwiftUI
 import Foundation
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct ContentView: View {
-  @State private var date = Date()
+  @FakeState private var date = Date()
 
   var body: some View {
     Group {

--- a/validation-test/Sema/SwiftUI/rdar148350982.swift
+++ b/validation-test/Sema/SwiftUI/rdar148350982.swift
@@ -4,6 +4,24 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 final class Item: Identifiable, ObservableObject {
   var id = 42
   var text: String
@@ -21,7 +39,7 @@ enum MessageKind: CaseIterable, Hashable, Identifiable {
 }
 
 struct ContentView: View {
-  @State var items = (0..<100).map { Item(index: $0) }
+  @FakeState var items = (0..<100).map { Item(index: $0) }
   var body: some View {
     List {
       ForEach($items) { $item in

--- a/validation-test/Sema/SwiftUI/rdar169041434.swift
+++ b/validation-test/Sema/SwiftUI/rdar169041434.swift
@@ -3,8 +3,26 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct TestView: View {
-  @State var angle: Angle = Angle(radians: Double.pi/1.5)
+  @FakeState var angle: Angle = Angle(radians: Double.pi/1.5)
   let size = CGSize(width: 800, height: 600)
   var body: some View {
     Path { path in

--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -6,8 +6,26 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct ContentView : View {
-  @State var foo: [String] = Array(repeating: "", count: 5)
+  @FakeState var foo: [String] = Array(repeating: "", count: 5)
 
   var body: some View {
     VStack {

--- a/validation-test/Sema/SwiftUI/rdar57410798.swift
+++ b/validation-test/Sema/SwiftUI/rdar57410798.swift
@@ -4,6 +4,24 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 enum ColorScheme: CaseIterable, Hashable, Equatable, Identifiable {
 // expected-error@-1 {{type 'ColorScheme' does not conform to protocol 'Identifiable'}}
 // expected-note@-2 {{add stubs for conformance}}
@@ -27,8 +45,8 @@ struct IconPicker : View {
 }
 
 struct CountdownEditor : View {
-  @State var symbol: String = "timer"
-  @State var selectedColor: ColorScheme = ColorScheme.pink
+  @FakeState var symbol: String = "timer"
+  @FakeState var selectedColor: ColorScheme = ColorScheme.pink
 
   var body: some View {
     NavigationLink(destination: IconPicker()) {

--- a/validation-test/Sema/SwiftUI/rdar58972627.swift
+++ b/validation-test/Sema/SwiftUI/rdar58972627.swift
@@ -5,6 +5,24 @@
 import SwiftUI
 import Combine
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises the SIL
+// verifier, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct A: View {
   var body: some View {
     Spacer()
@@ -18,7 +36,7 @@ struct B: View {
 }
 
 class Context: ObservableObject {
-  @State var flag: Bool
+  @FakeState var flag: Bool
 
   init() {
     self.flag = false

--- a/validation-test/Sema/SwiftUI/rdar70256351.swift
+++ b/validation-test/Sema/SwiftUI/rdar70256351.swift
@@ -4,8 +4,26 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct ContentView: View {
-  @State private var currentPage = "1"
+  @FakeState private var currentPage = "1"
 
   var body: some View {
     switch currentPage {

--- a/validation-test/Sema/SwiftUI/rdar80630127.swift
+++ b/validation-test/Sema/SwiftUI/rdar80630127.swift
@@ -4,8 +4,26 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// performance, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct FullScreenView<Content>: View where Content: View {
-  @State private var showFullScreen: Bool = false
+  @FakeState private var showFullScreen: Bool = false
 
   var x: Double = 0
   var y: Double = 0

--- a/validation-test/Sema/SwiftUI/rdar87407899.swift
+++ b/validation-test/Sema/SwiftUI/rdar87407899.swift
@@ -4,6 +4,24 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct AStruct {
   let aField: MyEnum = .aCase // expected-note {{change 'let' to 'var' to make it mutable}}
 }
@@ -21,7 +39,7 @@ extension EmptyView {
 struct SegFaultingView: View {
   @Binding var aStruct: AStruct
   @Binding var showImport: Bool
-  @State var importMessage: String = "none"
+  @FakeState var importMessage: String = "none"
 
   var body: some View {
     EmptyView()

--- a/validation-test/Sema/SwiftUI/rdar98862079.swift
+++ b/validation-test/Sema/SwiftUI/rdar98862079.swift
@@ -4,6 +4,24 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// diagnostics, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct NewBounds {
   var minBinding: Binding<Double>!
   var maxBinding: Binding<Double>!
@@ -17,7 +35,7 @@ func test<V>(
 }
 
 struct MyView : View {
-  @State var newBounds: NewBounds
+  @FakeState var newBounds: NewBounds
   var bounds: ClosedRange<Double>
 
   var body: some View {

--- a/validation-test/Sema/SwiftUI/too_complex_source_location.swift
+++ b/validation-test/Sema/SwiftUI/too_complex_source_location.swift
@@ -13,12 +13,21 @@
 
 import SwiftUI
 
-struct ContentView: View {
-    @State var selection = ""
+// A trivial stand-in for `@State` that avoids depending on the SwiftUI macro
+// plugin. This test only exercises a type-checking pattern, not `@State`
+// itself; all it needs is a `Binding` projected value for the `Picker`.
+@propertyWrapper
+struct FakeState<T> {
+  var wrappedValue: T
+  var projectedValue: Binding<T> { .constant(wrappedValue) }
+}
 
-    @State var a: Int?
-    @State var b: Int?
-    @State var c: Int?
+struct ContentView: View {
+    @FakeState var selection = ""
+
+    @FakeState var a: Int?
+    @FakeState var b: Int?
+    @FakeState var c: Int?
 
     var body: some View {
         ScrollView {

--- a/validation-test/Sema/type_checker_perf/fast/issue-54795.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-54795.swift
@@ -8,10 +8,28 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// performance, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct Breathe: View {
     static private let colors: [Color] = [Color(#colorLiteral(red: 0.3529411765, green: 0.662745098, blue: 0.6745098039, alpha: 1)), Color(#colorLiteral(red: 0.4078431373, green: 0.7450980392, blue: 0.6549019608, alpha: 1)), Color(#colorLiteral(red: 0.4666666667, green: 0.8196078431, blue: 0.631372549, alpha: 1)), Color(#colorLiteral(red: 0.5179253817, green: 0.8318992257, blue: 0.6992306113, alpha: 1)), Color(#colorLiteral(red: 0.4078431373, green: 0.7333333333, blue: 0.6509803922, alpha: 1)), Color(#colorLiteral(red: 0.3568627451, green: 0.6666666667, blue: 0.6745098039, alpha: 1))]
 
-    @State private var leafSize: CGFloat = 50
+    @FakeState private var leafSize: CGFloat = 50
 
     var body: some View {
         ZStack {

--- a/validation-test/Sema/type_checker_perf/fast/rdar97631072.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar97631072.swift
@@ -4,10 +4,28 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// performance, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 // Invalid expression
 
 struct MaskingView: View {
-	@State var xOffset: CGFloat = 0.0
+	@FakeState var xOffset: CGFloat = 0.0
 	let count = 10
 	
 	var body: some View {

--- a/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar120225470.swift
@@ -5,8 +5,26 @@
 import Photos
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// performance, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct AssetBrowserView: View {
-	@State private var assetsFetchResult: PHFetchResult = { () -> PHFetchResult<PHAsset> in
+	@FakeState private var assetsFetchResult: PHFetchResult = { () -> PHFetchResult<PHAsset> in
     fatalError()
 	}()
 	

--- a/validation-test/Sema/type_checker_perf/slow/rdar134901556.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar134901556.swift
@@ -6,6 +6,24 @@
 
 import SwiftUI
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// performance, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct SubView: View {
     var body: some View {
         EmptyView()
@@ -13,7 +31,7 @@ struct SubView: View {
 }
 
 struct TestView: View {
-    @State private var value: (row: Int, column: Int)? = nil
+    @FakeState private var value: (row: Int, column: Int)? = nil
     
     var body: some View {
         Grid {

--- a/validation-test/Sema/type_checker_perf/slow/rdar93460450.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar93460450.swift
@@ -5,6 +5,24 @@
 import SwiftUI
 import Foundation
 
+// Stand-in for SwiftUI's `@State`, which became a macro in recent SDKs and would
+// otherwise require the SwiftUIMacros plugin. This test exercises type-checking
+// performance, not `@State` itself; the box reproduces `@State`'s nonmutating
+// setter and `Binding` projected value.
+@propertyWrapper
+struct FakeState<Value> {
+  final class Box { var value: Value; init(_ value: Value) { self.value = value } }
+  private let box: Box
+  init(wrappedValue: Value) { box = Box(wrappedValue) }
+  var wrappedValue: Value {
+    get { box.value }
+    nonmutating set { box.value = newValue }
+  }
+  var projectedValue: Binding<Value> {
+    Binding(get: { box.value }, set: { box.value = $0 })
+  }
+}
+
 struct Value: Identifiable {
   var id: UUID
   var name: String
@@ -17,7 +35,7 @@ struct MySettingsView: View {
 
 struct MyView: View {
   var data: [Value]
-  @State var selection: String?
+  @FakeState var selection: String?
 
   var body: some View {
     List(selection: Binding(get: {


### PR DESCRIPTION
- **Explanation**:
A bunch of typechecker tests used the SwiftUI `@State` property wrapper and broke when this changed to a macro.  Since these tests were created to verify typechecking of property wrappers, update them with a local `@FakeState` property wrapper to preserve the original intent.
- **Scope**:
Test changes only.
- **Issues**:
n/a
- **Original PRs**:
https://github.com/swiftlang/swift/pull/90314
- **Risk**:
Low. This is test changes only.
- **Testing**:
Tested in the new CI pipeline being brought up on Xcode 27 beta 2.
- **Reviewers**:
@xedin 
