### PR TITLE
[Concurrency] Persist onTermination handler across next() calls when set after stream was terminated

### DIFF
--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -480,8 +480,11 @@ extension _AsyncStreamStorage.StateMachine {
         )
       }
 
-    case .terminated(let terminated):
-      unsafe self = .init(state: .terminated(.init()))
+    case .terminated(var terminated):
+      unsafe self = .init(state: .terminated(.init(
+        failure: nil,
+        terminationHandler: terminated.terminationHandler.take()
+      )))
 
       switch terminated.failure {
       case .some(let failure):


### PR DESCRIPTION
-- WIP --

Persist the `onTermination` handler across `next()` calls if the handler was set after the stream was terminated.

Should we cover this behavior with a test case for now?

-- WIP --