### PR TITLE
[Sema/SIL] Implement `sending` captures in `@called(once)` closures

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1938,12 +1938,12 @@ public:
 };
 
 SWIFT_NAME("BridgedCaptureListEntry.createParsed(_:declContext:ownership:"
-           "ownershipRange:name:nameLoc:equalLoc:initializer:)")
+           "ownershipRange:sending:name:nameLoc:equalLoc:initializer:)")
 BridgedCaptureListEntry BridegedCaptureListEntry_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedReferenceOwnership cOwnershipKind, swift::SourceRange ownershipRange,
-    swift::Identifier name, swift::SourceLoc nameLoc, swift::SourceLoc equalLoc,
-    BridgedExpr cInitializer);
+    bool isSending, swift::Identifier name, swift::SourceLoc nameLoc,
+    swift::SourceLoc equalLoc, BridgedExpr cInitializer);
 
 SWIFT_NAME("BridgedCaptureListExpr.createParsed(_:captureList:closure:)")
 BridgedCaptureListExpr BridgedCaptureListExpr_createParsed(BridgedASTContext cContext,

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -57,7 +57,7 @@ class CapturedValue {
 private:
   llvm::PointerUnion<ValueDecl *, Expr *> Value;
   // This is really unfortunate but we cannot use PointerIntPair here
-  // since flags need 3 bits and only two are available because union
+  // since flags need 4 bits and only two are available because union
   // needs an extra bit for its discriminator.
   unsigned Flags;
   SourceLoc Loc;
@@ -84,6 +84,11 @@ public:
     /// explicit captures are emitted as fresh variables and initialized with an
     /// owned r-value.
     IsConsumed = 1 << 2,
+
+    /// IsSending is set when the vardecl is declared as a `sending` capture
+    /// i.e. `[sending x]`. Such captures are only valid in a `@called(once)`
+    /// closure.
+    IsSending = 1 << 3,
   };
 
   CapturedValue(ValueDecl *Val, unsigned Flags, SourceLoc Loc)
@@ -99,6 +104,7 @@ public:
   bool isDirect() const { return Flags & IsDirect; }
   bool isNoEscape() const { return Flags & IsNoEscape; }
   bool isConsumed() const { return Flags & IsConsumed; }
+  bool isSending() const { return Flags & IsSending; }
 
   bool isDynamicSelfMetadata() const { return !Value; }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -496,12 +496,16 @@ protected:
     IsStatic : 1
   );
 
-  SWIFT_INLINE_BITFIELD(VarDecl, AbstractStorageDecl, 2+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(VarDecl, AbstractStorageDecl, 2+1+1+1+1+1+1+1+1,
     /// Encodes whether this is a 'let' binding.
     Introducer : 2,
 
     /// Whether this declaration captures the 'self' param under the same name.
     IsSelfParamCapture : 1,
+
+    /// Whether this declaration represents a `sending` capture i.e.
+    /// `[sending x]` where `x` is this declaration.
+    IsSendingCapture : 1,
 
     /// Whether this is a property used in expressions in the debugger.
     /// It is up to the debugger to instruct SIL how to access this variable.
@@ -7049,6 +7053,11 @@ public:
   bool isSelfParamCapture() const { return Bits.VarDecl.IsSelfParamCapture; }
   void setIsSelfParamCapture(bool IsSelfParamCapture = true) {
       Bits.VarDecl.IsSelfParamCapture = IsSelfParamCapture;
+  }
+
+  bool isSendingCapture() const { return Bits.VarDecl.IsSendingCapture; }
+  void setIsSendingCapture(bool isSending = true) {
+    Bits.VarDecl.IsSendingCapture = isSending;
   }
 
   /// Check whether this capture of the self param is actor-isolated.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2578,6 +2578,13 @@ ERROR(called_once_cannot_be_used_with_borrowing,none,
 ERROR(called_once_function_type_mismatch,none,
       "invalid conversion from '@called(once)' function of type %0 "
       "to function type %1", (Type, Type))
+ERROR(sending_capture_requires_experimental_feature,none,
+      "'sending' capture is only valid when experimental feature "
+      "'CalledAttribute' is enabled",
+      ())
+ERROR(sending_capture_decl_requires_called_once,none,
+      "'sending' capture may only be declared in a '@called(once)' closure",
+      ())
 
 // Alignment attribute
 ERROR(alignment_not_power_of_two,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4652,10 +4652,12 @@ struct CaptureListEntry {
 
   explicit CaptureListEntry(PatternBindingDecl *PBD);
 
-  static CaptureListEntry
-  createParsed(ASTContext &Ctx, ReferenceOwnership ownershipKind,
-               SourceRange ownershipRange, Identifier name, SourceLoc nameLoc,
-               SourceLoc equalLoc, Expr *initializer, DeclContext *DC);
+  static CaptureListEntry createParsed(ASTContext &Ctx,
+                                       ReferenceOwnership ownershipKind,
+                                       SourceRange ownershipRange,
+                                       bool isSending, Identifier name,
+                                       SourceLoc nameLoc, SourceLoc equalLoc,
+                                       Expr *initializer, DeclContext *DC);
 
   VarDecl *getVar() const;
   bool isSimpleSelfCapture(bool excludeWeakCaptures = true) const;

--- a/lib/AST/Bridging/ExprBridging.cpp
+++ b/lib/AST/Bridging/ExprBridging.cpp
@@ -116,11 +116,12 @@ BridgedCallExpr BridgedCallExpr_createParsed(BridgedASTContext cContext,
 BridgedCaptureListEntry BridegedCaptureListEntry_createParsed(
     BridgedASTContext cContext, BridgedDeclContext cDeclContext,
     BridgedReferenceOwnership cOwnershipKind, SourceRange ownershipRange,
-    Identifier name, SourceLoc nameLoc, SourceLoc equalLoc,
+    bool isSending, Identifier name, SourceLoc nameLoc, SourceLoc equalLoc,
     BridgedExpr cInitializer) {
   return CaptureListEntry::createParsed(
-      cContext.unbridged(), unbridged(cOwnershipKind), ownershipRange, name,
-      nameLoc, equalLoc, cInitializer.unbridged(), cDeclContext.unbridged());
+      cContext.unbridged(), unbridged(cOwnershipKind), ownershipRange,
+      isSending, name, nameLoc, equalLoc, cInitializer.unbridged(),
+      cDeclContext.unbridged());
 }
 
 BridgedCaptureListExpr

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -187,6 +187,10 @@ void CaptureInfo::print(raw_ostream &OS) const {
                  OS << "<direct>";
                if (capture.isNoEscape())
                  OS << "<noescape>";
+               if (capture.isConsumed())
+                 OS << "<consumed>";
+               if (capture.isSending())
+                 OS << "<sending>";
              },
              [&] { OS << ", "; });
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1367,8 +1367,8 @@ CaptureListEntry::CaptureListEntry(PatternBindingDecl *PBD) : PBD(PBD) {
 
 CaptureListEntry CaptureListEntry::createParsed(
     ASTContext &Ctx, ReferenceOwnership ownershipKind,
-    SourceRange ownershipRange, Identifier name, SourceLoc nameLoc,
-    SourceLoc equalLoc, Expr *initializer, DeclContext *DC) {
+    SourceRange ownershipRange, bool isSending, Identifier name,
+    SourceLoc nameLoc, SourceLoc equalLoc, Expr *initializer, DeclContext *DC) {
 
   bool forceVar = ownershipKind == ReferenceOwnership::Weak &&
                   !Ctx.LangOpts.hasFeature(Feature::ImmutableWeakCaptures);
@@ -1389,6 +1389,9 @@ CaptureListEntry CaptureListEntry::createParsed(
 
   if (CLE.isSimpleSelfCapture())
     VD->setIsSelfParamCapture();
+
+  if (isSending)
+    VD->setIsSendingCapture();
 
   return CLE;
 }

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -266,6 +266,7 @@ extension ASTGenVisitor {
 
   func generate(closureCapture node: ClosureCaptureSyntax, capturedSelfDecl: inout BridgedVarDecl?) -> BridgedCaptureListEntry {
     let ownership: BridgedReferenceOwnership
+    var sending: Bool = false
     switch node.specifier?.specifier.rawText {
     case nil:
       ownership = .strong
@@ -281,6 +282,9 @@ extension ASTGenVisitor {
         // TODO: Diagnose.
         fatalError("invalid ownership")
       }
+    case "sending":
+      sending = true
+      ownership = .strong
     default:
       // TODO: Diagnose.
       fatalError("invalid ownership")
@@ -302,6 +306,7 @@ extension ASTGenVisitor {
       declContext: self.declContext,
       ownership: ownership,
       ownershipRange: self.generateSourceRange(node.specifier),
+      sending: sending,
       name: nameAndLoc.identifier,
       nameLoc: nameAndLoc.sourceLoc,
       equalLoc: equalLoc,

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -94,6 +94,7 @@ extension Parser.LanguageFeatures {
     mapFeature(.DefaultIsolationPerFile, to: .defaultIsolationPerFile)
     mapFeature(.BorrowAndMutateAccessors, to: .borrowAndMutateAccessors)
     mapFeature(.LiteralExpressions, to: .literalExpressions)
+    mapFeature(.CalledAttribute, to: .calledAttribute)
   }
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2781,6 +2781,8 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
       // "unowned(safe/unsafe)".
       SourceLoc ownershipLocStart, ownershipLocEnd;
       auto ownershipKind = ReferenceOwnership::Strong;
+      // `sending` specifier.
+      bool isSending = false;
       if (Tok.isContextualKeyword("weak")){
         ownershipLocStart = ownershipLocEnd = consumeToken(tok::identifier);
         ownershipKind = ReferenceOwnership::Weak;
@@ -2801,6 +2803,13 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
           if (!consumeIf(tok::r_paren, ownershipLocEnd))
             diagnose(Tok, diag::attr_unowned_expected_rparen);
         }
+        // `sending <<identifier>>` or `self`
+      } else if (Context.LangOpts.hasFeature(Feature::CalledAttribute) &&
+                 Tok.isContextualKeyword("sending") &&
+                 (peekToken().is(tok::identifier) ||
+                  peekToken().is(tok::kw_self))) {
+        (void)consumeToken(tok::identifier);
+        isSending = true;
       } else if (Tok.isAny(tok::identifier, tok::kw_self, tok::code_complete) &&
                  peekToken().isAny(tok::equal, tok::comma, tok::r_square,
                                    tok::period)) {
@@ -2884,8 +2893,8 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
       // closure) since the initializer expression is evaluated before the
       // closure is formed.
       auto CLE = CaptureListEntry::createParsed(
-          Context, ownershipKind, {ownershipLocStart, ownershipLocEnd}, name,
-          nameLoc, equalLoc, initializer, CurDeclContext);
+          Context, ownershipKind, {ownershipLocStart, ownershipLocEnd},
+          isSending, name, nameLoc, equalLoc, initializer, CurDeclContext);
 
       // If we captured something under the name "self", remember that.
       if (name == Context.Id_self)

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2546,7 +2546,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
         convention = ParameterConvention::Direct_Guaranteed;
       }
       SILParameterInfo param(loweredTy.getASTType(), convention, options);
-      if (function.isAsyncLetClosure)
+      if (function.isAsyncLetClosure || capture.isSending())
         param = param.addingOption(SILParameterInfo::Sending);
       inputs.push_back(param);
       break;
@@ -2566,7 +2566,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
           /*mutable*/ true);
       auto convention = ParameterConvention::Direct_Guaranteed;
       auto param = SILParameterInfo(boxTy, convention, options);
-      if (function.isAsyncLetClosure)
+      if (function.isAsyncLetClosure || capture.isSending())
         param = param.addingOption(SILParameterInfo::Sending);
       inputs.push_back(param);
       break;
@@ -2586,7 +2586,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
           /*mutable*/ false);
       auto convention = ParameterConvention::Direct_Guaranteed;
       auto param = SILParameterInfo(boxTy, convention, options);
-      if (function.isAsyncLetClosure)
+      if (function.isAsyncLetClosure || capture.isSending())
         param = param.addingOption(SILParameterInfo::Sending);
       inputs.push_back(param);
       break;
@@ -2597,7 +2597,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       auto param = SILParameterInfo(
           ty.getASTType(), ParameterConvention::Indirect_InoutAliasable,
           options);
-      if (function.isAsyncLetClosure)
+      if (function.isAsyncLetClosure || capture.isSending())
         param = param.addingOption(SILParameterInfo::Sending);
       inputs.push_back(param);
       break;
@@ -2609,7 +2609,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       auto param = SILParameterInfo(ty.getASTType(),
                                     ParameterConvention::Indirect_In_Guaranteed,
                                     options);
-      if (function.isAsyncLetClosure)
+      if (function.isAsyncLetClosure || capture.isSending())
         param = param.addingOption(SILParameterInfo::Sending);
       inputs.push_back(param);
       break;
@@ -2623,6 +2623,8 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       SILType ty =
           loweredTL.isAddressOnly() ? loweredTy.getAddressType() : loweredTy;
       auto param = SILParameterInfo(ty.getASTType(), convention, options);
+      if (capture.isSending())
+        param = param.addingOption(SILParameterInfo::Sending);
       inputs.push_back(param);
       break;
     }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2688,6 +2688,37 @@ public:
       builder.addAssignFresh(lookupResult->value);
   }
 
+  void translateSILCalledOncePartialApply(PartialApplyInst *pai) {
+    ApplySite applySite(pai);
+    REGIONBASEDISOLATION_LOG(llvm::dbgs()
+                             << "Translating `@called(once)` Partial Apply!\n");
+
+    SmallVector<Operand *> operandsToMerge;
+    for (auto &op : applySite.getArgumentOperands()) {
+      auto lookupResult = tryToTrackValue(op.get());
+      if (!lookupResult)
+        continue;
+
+      auto info = applySite.getParamInfoForOperand(op);
+      // If this is an argument to a `sending` parameter, let's mark it as sent.
+      if (info.hasOption(SILParameterInfo::Flag::Sending)) {
+        builder.addRequire(*lookupResult);
+        builder.addSend(lookupResult->value, &op);
+      } else {
+        // Otherwise, it would have to be merged just like in a regular closure.
+        operandsToMerge.push_back(&op);
+      }
+    }
+
+    SmallVector<SILValue, 8> directResults;
+    getApplyResults(pai, directResults);
+    translateSILMultiAssign(
+        directResults,
+        ArrayRef<Operand *>(), // No indirect results for a partial_apply.
+        operandsToMerge,
+        RegionMergeReason::NonisolatedClosure);
+  }
+
   /// Handles the semantics for SIL applies that cross isolation.
   ///
   /// Semantically this causes all arguments of the applysite to be sent.
@@ -2759,6 +2790,12 @@ public:
     if (auto isolationRegionInfo = SILIsolationInfo::get(pai);
         isolationRegionInfo && !isolationRegionInfo.isDisconnected()) {
       return translateIsolatedPartialApply(pai, isolationRegionInfo);
+    }
+
+    // `@called(once)` closures are allowed to have `sending` captures which
+    // need special handling.
+    if (pai->isCalledOnce()) {
+      return translateSILCalledOncePartialApply(pai);
     }
 
     SmallVector<SILValue, 8> directResults;

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -2755,6 +2755,19 @@ void UseAfterSendDiagnosticInferrer::infer() {
     }
   }
 
+  if (auto *pai = dyn_cast<PartialApplyInst>(sendingOp->getUser())) {
+    if (pai->isCalledOnce() && ApplySite(pai)
+                                   .getParamInfoForOperand(*sendingOp)
+                                   .hasOption(SILParameterInfo::Sending)) {
+      if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
+        return diagnosticEmitter.emitNamedUseofStronglySentValue(
+            baseLoc, rootValueAndName->first);
+      }
+      return diagnosticEmitter.emitTypedUseOfStronglySentValue(
+          baseLoc, baseInferredType);
+    }
+  }
+
   auto *autoClosureExpr = loc.getAsASTNode<AutoClosureExpr>();
   if (!autoClosureExpr) {
     return diagnosticEmitter.emitUnknownPatternError();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2955,6 +2955,50 @@ static void diagnoseImplicitWeakToStrongCapture(const Expr *E,
   const_cast<Expr *>(E)->walk(Walker);
 }
 
+/// Diagnose cases where a `sending` capture is associated with a
+/// non-`@called(once)` closure.
+static void diagnoseInvalidSendingCaptureDeclarations(const Expr *E,
+                                                      const DeclContext *DC) {
+  if (!E || isa<ErrorExpr>(E) || !E->getType())
+    return;
+
+  class CaptureWalker : public BaseDiagnosticWalker {
+    ASTContext &Ctx;
+
+  public:
+    CaptureWalker(ASTContext &ctx) : Ctx(ctx) {}
+
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+      if (auto *captureList = dyn_cast<CaptureListExpr>(E)) {
+        for (const auto &capture : captureList->getCaptureList()) {
+          auto *V = capture.getVar();
+          if (!V->isSendingCapture())
+            continue;
+
+          if (!Ctx.LangOpts.hasFeature(Feature::CalledAttribute)) {
+            Ctx.Diags.diagnose(
+                V->getLoc(),
+                diag::sending_capture_requires_experimental_feature);
+            return Action::Stop();
+          }
+
+          if (!captureList->getClosureBody()->isCalledOnce()) {
+            Ctx.Diags.diagnose(V->getLoc(),
+                               diag::sending_capture_decl_requires_called_once);
+            V->setInvalid();
+            continue;
+          }
+        }
+      }
+
+      return Action::Continue(E);
+    }
+  };
+
+  CaptureWalker W(DC->getASTContext());
+  const_cast<Expr *>(E)->walk(W);
+}
+
 bool TypeChecker::getDefaultGenericArgumentsString(
     SmallVectorImpl<char> &buf,
     const swift::GenericTypeDecl *typeDecl,
@@ -6859,6 +6903,7 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   diagnoseDictionaryLiteralDuplicateKeyEntries(E, DC);
   diagnoseMissingMemberImports(E, DC);
   diagnoseCxxFunctionCalls(E, DC);
+  diagnoseInvalidSendingCaptureDeclarations(E, DC);
 }
 
 void swift::performStmtDiagnostics(const Stmt *S, DeclContext *DC) {

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -413,6 +413,9 @@ public:
                                       : AccessKind::Read,
               CurDC->getParentModule(), CurDC->getResilienceExpansion()))
         Flags |= CapturedValue::IsDirect;
+
+      if (CalledOnce && var->isSendingCapture())
+        Flags |= CapturedValue::IsSending;
     }
 
     // If the closure is noescape, then we can capture the decl as noescape.
@@ -464,9 +467,12 @@ public:
       if (!NoEscape)
         Flags &= ~CapturedValue::IsNoEscape;
 
-      // Regular closures cannot consume their captures.
-      if (!CalledOnce)
+      if (!CalledOnce) {
+        // Regular closures cannot consume their captures.
         Flags &= ~CapturedValue::IsConsumed;
+        // ... or have `sending` captures.
+        Flags &= ~CapturedValue::IsSending;
+      }
 
       addCapture(capture.mergeFlags(Flags));
     }

--- a/test/Parse/called_once.swift
+++ b/test/Parse/called_once.swift
@@ -63,3 +63,28 @@ func testClosure() {
   // expected-forbidden-error@-2 {{'called(once)' attribute is only valid when experimental feature CalledAttribute is enabled}}
   _ = x
 }
+
+func testSendingCaptures() {
+  class NS {
+    func test() {
+      _ = { @called(once) [sending self] in
+        // expected-forbidden-error@-1 {{'@called' attribute is only valid when experimental feature CalledAttribute is enabled}}
+        // expected-forbidden-error@-2 {{expected 'weak', 'unowned', or no specifier in capture list}}
+        _ = self
+      }
+    }
+  }
+
+  let ns = NS()
+  _ = { @called(once) [sending ns] in
+    // expected-forbidden-error@-1 {{'@called' attribute is only valid when experimental feature CalledAttribute is enabled}}
+    // expected-forbidden-error@-2 {{expected 'weak', 'unowned', or no specifier in capture list}}
+    ns
+  }
+  _ = { @called(once) [x = 42, sending ns = NS()] in
+    // expected-forbidden-error@-1 {{'@called' attribute is only valid when experimental feature CalledAttribute is enabled}}
+    // expected-forbidden-error@-2 {{expected 'weak', 'unowned', or no specifier in capture list}}
+    _ = x
+    _ = ns
+  }
+}

--- a/test/SIL/called_once_sending_captures.swift
+++ b/test/SIL/called_once_sending_captures.swift
@@ -1,0 +1,106 @@
+// RUN: %target-swift-frontend %s \
+// RUN: -emit-sil -target %target-swift-5.1-abi-triple \
+// RUN: -enable-experimental-feature CalledAttribute \
+// RUN: -swift-version 6 \
+// RUN: -verify
+
+// REQUIRES: swift_feature_CalledAttribute
+// REQUIRES: concurrency
+
+class NS {}
+
+struct Box: ~Copyable {
+  let ns: NS
+
+  init(_ ns: NS) {
+    self.ns = ns
+  }
+
+  consuming func takeNS() -> NS { ns }
+}
+
+func sendAgain(_ ns: sending NS) {}
+
+func calledOnce(_: @called(once) () -> Void) {}
+func manyTimes(_: () -> Void) {}
+
+struct CalledOnceTask {
+  init(_ ns: @called(once) () -> Void) {}
+}
+
+func testBasic(_ ns: sending NS) {
+  _ = CalledOnceTask { [sending ns] in
+    sendAgain(ns)
+  }
+}
+
+func testDoubleSend(_ ns: sending NS) {
+  _ = CalledOnceTask { @called(once) [sending ns] in
+    sendAgain(ns)
+    // expected-error@-1 {{sending 'ns' risks causing data races}}
+    // expected-note@-2 {{'ns' used after being passed as a 'sending' parameter; Later uses could race}}
+    sendAgain(ns) // expected-note {{access can happen concurrently}}
+  }
+}
+
+func testMultipleSendingCaptures(_ ns1: sending NS, _ ns2: sending NS) {
+  _ = CalledOnceTask { @called(once) [sending ns1, sending ns2] in
+    sendAgain(ns1)
+    sendAgain(ns2)
+  }
+}
+
+func testMixedSendingAndOrdinary(_ ns1: sending NS, x: Int) {
+  _ = CalledOnceTask { @called(once) [sending ns1] in
+    print(x)
+    sendAgain(ns1)
+  }
+}
+
+func testNestedRejectedThroughNonCalledOnceIntermediate(ns1: sending NS) {
+  let _: @called(once) () -> Void = {
+    manyTimes {
+      calledOnce { [sending ns1] in
+        // expected-error@-1 {{task or actor-isolated value cannot be sent}}
+        sendAgain(ns1)
+      }
+    }
+  }
+  
+  let _: @called(once) () -> Void = { [sending ns1] in
+    manyTimes {
+      calledOnce { [sending ns1] in
+        // expected-error@-1 {{task or actor-isolated value cannot be sent}}
+        sendAgain(ns1)
+      }
+    }
+  }
+}
+
+func testNestedAcceptedWithExplicitChain(ns1: sending NS) {
+  let _: @called(once) () -> Void = { [sending ns1] in
+    calledOnce { [sending ns1] in
+      sendAgain(ns1)
+    }
+  }
+}
+
+func testOuterCalledOnceAloneIsNotEnough(ns1: sending NS) {
+  let _: @called(once) () -> Void = {
+    calledOnce { [sending ns1] in
+      // expected-error@-1 {{task or actor-isolated value cannot be sent}}
+      sendAgain(ns1)
+    }
+  }
+}
+
+func testConsumingWithUseAfterIndirectSend(_ ns: sending NS) {
+  let box = Box(ns)
+
+  _ = CalledOnceTask { [sending box] in // expected-error {{sending 'box' risks causing data races}} expected-note {{'box' used after being passed as a 'sending' parameter; Later uses could race}}
+      let ns = box.takeNS()
+      sendAgain(ns)
+  }
+
+  print(ns) // expected-note {{access can happen concurrently}}
+}

--- a/test/SIL/called_once_sending_captures.swift
+++ b/test/SIL/called_once_sending_captures.swift
@@ -7,7 +7,7 @@
 // REQUIRES: swift_feature_CalledAttribute
 // REQUIRES: concurrency
 
-class NS {}
+class NS {} // expected-note {{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct Box: ~Copyable {
   let ns: NS
@@ -103,4 +103,143 @@ func testConsumingWithUseAfterIndirectSend(_ ns: sending NS) {
   }
 
   print(ns) // expected-note {{access can happen concurrently}}
+}
+
+// Make sure that each PartitionOpError kind is exercised through a
+// `@called(once)` closure with a `sending` capture. The goal here is not to
+// pin exact wording (that's covered above) but to make sure each emitter
+// produces *some* real diagnostic for this SIL shape rather than falling
+// through to `emitUnknownPatternError`/`RegionIsolationUnknownPattern`.
+
+actor CalledOnceActor {
+  var ns = NS()
+  func makeNS() -> NS { NS() }
+}
+
+// LocalUseAfterSend: already covered above by
+// testDoubleSend/testConsumingWithUseAfterIndirectSend. No separate case
+// needed here.
+
+// SentNeverSendable: sending an actor-isolated capture (`ns` here resolves
+// to `self.ns`, captured while already inside the actor-isolated method).
+//
+// TODO: Falls through to the generic path for unknown values.
+extension CalledOnceActor {
+  func testSentNeverSendableActorIsolatedCapture() {
+    _ = CalledOnceTask { [sending ns] in // expected-error {{task or actor-isolated value cannot be sent}}
+      sendAgain(ns)
+    }
+  }
+}
+
+// AssignNeverSendableIntoSendingResult: a `@called(once)` closure with a
+// `sending` result, returning a captured value that was never itself sent.
+func calledOnceResult(_ f: @called(once) () -> sending NS) {}
+
+func testAssignNeverSendableIntoSendingResult(ns: NS) {
+  calledOnceResult { ns } // expected-error {{sending 'ns' risks causing data races}} expected-note {{'ns' cannot be a 'sending' result. Code in the current task may race with caller uses}}
+}
+
+// NonSendableIsolationCrossingResult: inside a `@called(once)` closure with
+// a `sending` capture, an isolation-crossing call (actor -> @concurrent)
+// returns a non-Sendable result.
+func testNonSendableIsolationCrossingResult(a: CalledOnceActor) async {
+  _ = CalledOnceTask { [sending a] in
+    Task {
+      let ns = await a.makeNS() // expected-error {{non-Sendable 'NS'-typed result can not be returned from actor-isolated instance method 'makeNS()' to @concurrent context}}
+      print(ns)
+    }
+  }
+}
+
+// InOutSendingParametersInSameRegion: two `inout sending` parameters of
+// the enclosing function end up in the same region.
+func testInOutSendingParametersInSameRegionUnaffected(_ x: inout sending NS, _ y: inout sending NS) {
+  let _: @called(once) () -> Void = {
+    x = y
+  }
+} // expected-error {{'inout sending' parameters 'x' and 'y' can be potentially accessed from each other at function return risking data races in caller}}
+// expected-note@-1 {{caller function assumes on return that 'x' and 'y' cannot be used to access each other implying sending them to different isolation domains does not risk a data race}}
+
+// InOutSendingNotInitializedAtExit: `inout` parameters can be captured by
+// closures, including non-escaping ones, so a `sending` capture of an
+// `inout sending` parameter is reachable -- sending it away via the
+// `@called(once)` closure counts as consuming the parameter, and the
+// function must reinitialize it with a disconnected value before returning,
+// exactly as it would for an ordinary direct send.
+//
+// TODO: note should say "capture" instead of "argument".
+func testInOutSendingCaptureNotReinitialized(_ x: inout sending NS) {
+  _ = CalledOnceTask { [sending x] in
+    // expected-error@-1 {{sending value of non-Sendable type 'NS' risks causing data races}}
+    // expected-note@-2 {{Passing value of non-Sendable type 'NS' as a 'sending' argument risks causing races in between local and caller code}}
+    sendAgain(x)
+  }
+} // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}
+
+// ... and is accepted once `x` is reinitialized with a disconnected value
+// before the function returns.
+func testInOutSendingCaptureReinitialized(_ x: inout sending NS) {
+  _ = CalledOnceTask { [sending x] in
+    sendAgain(x)
+  }
+  x = NS()
+}
+
+// InOutSendingNotDisconnectedAtExit: `x` is reinitialized before return,
+// but with a value (`y`) that isn't itself disconnected -- distinct from
+// the "not reinitialized at all" case above.
+func testInOutSendingCaptureReinitWithNonDisconnectedValue(_ x: inout sending NS, y: NS) {
+  _ = CalledOnceTask { [sending x] in
+    sendAgain(x)
+  }
+  x = y
+} // expected-error {{'inout sending' parameter 'x' is accessible to code in the current isolation context at end of function}}
+// expected-note@-1 {{'x' risks causing races in between code in the current isolation context and caller uses since caller assumes value is not actor isolated}}
+
+// InOutSendingReturned: `x` is properly reinitialized, but the function
+// also returns a value that aliases the region of the reinitialized `x` --
+// distinct from both cases above, and from the underlying send via
+// `[sending x]` itself, which is otherwise fine here.
+func testInOutSendingCaptureAliasedWithReturnValue(_ x: inout sending NS) -> sending NS {
+  _ = CalledOnceTask { [sending x] in
+    sendAgain(x)
+  }
+  let fresh = NS()
+  x = fresh
+  return fresh // expected-error {{'fresh' cannot be returned}}
+  // expected-note@-1 {{returning 'fresh' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+// IncompatibleRegionMerge: two values from different global actors, merged
+// directly (not sent) inside a `@called(once)` closure body. This needs the
+// closure to be neither actor-isolated (which would route through
+// translateIsolatedPartialApply, sending every capture individually) nor
+// have any of its captures marked `sending` (which routes the merge through
+// a send diagnostic instead, via `SentNeverSendable`) -- an `@concurrent`
+// `@called(once)` closure with plain, unmarked captures is what actually
+// reaches `translateSILCalledOncePartialApply`'s `operandsToMerge` path and
+// the underlying `Merge` PartitionOp. This diagnostic warns until a future
+// language mode, not v6 (see also
+// transfernonsendable_isolationhistory_incompatible_merge.swift), so it is
+// a warning even here.
+actor CustomActorInstance {}
+@globalActor struct CustomActor { static let shared = CustomActorInstance() }
+
+struct CalledOnceAsyncTask { init(_ ns: @called(once) () async -> Void) {} }
+
+@MainActor
+struct MergeAcrossGlobalActors {
+  var mainField: NS? = nil
+  @CustomActor var customField: NS? = nil
+
+  init() {
+    let a = mainField! // expected-note {{'a' is exposed to main actor-isolated code}}
+    let b = customField! // expected-note {{'b' is exposed to global actor 'CustomActor'-isolated code}}
+    _ = CalledOnceAsyncTask { @concurrent in
+      // expected-warning@-1 {{executing operation could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races; this will be an error in a future Swift language mode}}
+      _ = a
+      _ = b
+    }
+  }
 }

--- a/test/SILGen/called_once_sending_captures.swift
+++ b/test/SILGen/called_once_sending_captures.swift
@@ -1,0 +1,119 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-feature CalledAttribute -swift-version 6 %s | %FileCheck %s
+
+// REQUIRES: swift_feature_CalledAttribute
+// REQUIRES: concurrency
+
+class NS {}
+
+struct Box: ~Copyable {
+  var ns: NS
+
+  consuming func takeValue() -> NS { ns }
+}
+
+func sendAgain(_ ns: sending NS) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_sending_captures18testSendingCaptureyyAA2NSCnF : $@convention(thin) (@sil_sending @owned NS) -> () {
+// CHECK:  [[NS_PROJ:%.*]] = project_box {{.*}} : ${ var NS }, 0
+// CHECK:  [[NS_READ:%.*]] = begin_access [read] [unknown] [[NS_PROJ]] : $*NS
+// CHECK:  [[NS_VALUE:%.*]] = load [copy] [[NS_READ]] : $*NS
+// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s28called_once_sending_captures18testSendingCaptureyyAA2NSCnFyyXOfU_ : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK:  [[NS_COPY:%.*]] = copy_value {{%.*}} : $NS
+// CHECK:  partial_apply [called_once] [[CLOSURE_REF]]([[NS_COPY]]) : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures18testSendingCaptureyyAA2NSCnF'
+
+// The closure's own captured parameter carries `@sil_sending`, exactly as a
+// genuine `sending` parameter would - this is what makes it eligible to be
+// sent onward via `sendAgain`.
+// CHECK-LABEL: sil private [ossa] @$s28called_once_sending_captures18testSendingCaptureyyAA2NSCnFyyXOfU_ : $@convention(thin) (@sil_sending @guaranteed NS) -> () {
+// CHECK: bb0([[NS_CAPTURE:%.*]] : @closureCapture @guaranteed $NS):
+// CHECK:  [[NS_COPY:%.*]] = copy_value [[NS_CAPTURE]] : $NS
+// CHECK:  // function_ref sendAgain(_:)
+// CHECK:  [[SEND_AGAIN:%.*]] = function_ref @$s28called_once_sending_captures9sendAgainyyAA2NSCnF : $@convention(thin) (@sil_sending @owned NS) -> ()
+// CHECK:  apply [[SEND_AGAIN]]([[NS_COPY]]) : $@convention(thin) (@sil_sending @owned NS) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures18testSendingCaptureyyAA2NSCnFyyXOfU_'
+func testSendingCapture(_ ns: sending NS) {
+  let g = { @called(once) [sending ns] in sendAgain(ns) }
+  g()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_sending_captures21testSendingVarCaptureyyAA2NSCnF : $@convention(thin) (@sil_sending @owned NS) -> () {
+// CHECK:  copy_addr {{%.*}} to [init] [[NS_PROJ:%.*]] : $*NS
+// CHECK:  [[NS_READ:%.*]] = begin_access [read] [unknown] [[NS_PROJ]] : $*NS
+// CHECK:  [[NS_VALUE:%.*]] = load [copy] [[NS_READ]] : $*NS
+// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s28called_once_sending_captures21testSendingVarCaptureyyAA2NSCnFyyXOfU_ : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK:  [[NS_COPY:%.*]] = copy_value {{%.*}} : $NS
+// CHECK:  partial_apply [called_once] [[CLOSURE_REF]]([[NS_COPY]]) : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures21testSendingVarCaptureyyAA2NSCnF'
+func testSendingVarCapture(_ ns: sending NS) {
+  var ns = ns
+  let g = { @called(once) [sending ns] in sendAgain(ns) }
+  g()
+  ns = NS()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_sending_captures23testConsumingAndSending3boxyAA3BoxVn_tF : $@convention(thin) (@sil_sending @owned Box) -> () {
+// CHECK:  [[BOX_PROJ:%.*]] = project_box {{.*}} : ${ let Box }, 0
+// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s28called_once_sending_captures23testConsumingAndSending3boxyAA3BoxVn_tFyyXEfU_ : $@convention(thin) (@sil_sending @owned Box) -> ()
+// CHECK:  [[BOX_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[BOX_PROJ]] : $*Box
+// CHECK:  [[BOX_VALUE:%.*]] = load [take] [[BOX_TAKE_ADDR]] : $*Box
+// CHECK:  partial_apply [called_once] [[CLOSURE_REF]]([[BOX_VALUE]]) : $@convention(thin) (@sil_sending @owned Box) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures23testConsumingAndSending3boxyAA3BoxVn_tF'
+
+// The closure body sees an `@sil_sending @owned` capture, just like a
+// genuine `sending` parameter of noncopyable type would.
+// CHECK-LABEL: sil private [ossa] @$s28called_once_sending_captures23testConsumingAndSending3boxyAA3BoxVn_tFyyXEfU_ : $@convention(thin) (@sil_sending @owned Box) -> () {
+// CHECK: bb0([[BOX_CAPTURE:%.*]] : @closureCapture @owned $Box):
+// CHECK:  [[BOX_STACK:%.*]] = alloc_stack $Box, let, name "box"
+// CHECK:  [[BOX_INIT_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[BOX_STACK]] : $*Box
+// CHECK:  store [[BOX_CAPTURE]] to [init] [[BOX_INIT_ADDR]] : $*Box
+// CHECK:  [[BOX_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[BOX_INIT_ADDR]] : $*Box
+// CHECK:  [[BOX_VALUE:%.*]] = load [copy] [[BOX_ADDR]] : $*Box
+// CHECK:  // function_ref Box.takeValue()
+// CHECK:  [[TAKE_VALUE:%.*]] = function_ref @$s28called_once_sending_captures3BoxV9takeValueAA2NSCyF : $@convention(method) (@owned Box) -> @owned NS
+// CHECK:  [[NS_VALUE:%.*]] = apply [[TAKE_VALUE]]([[BOX_VALUE]]) : $@convention(method) (@owned Box) -> @owned NS
+// CHECK:  // function_ref sendAgain(_:)
+// CHECK:  [[SEND_AGAIN:%.*]] = function_ref @$s28called_once_sending_captures9sendAgainyyAA2NSCnF : $@convention(thin) (@sil_sending @owned NS) -> ()
+// CHECK:  apply [[SEND_AGAIN]]({{%.*}}) : $@convention(thin) (@sil_sending @owned NS) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures23testConsumingAndSending3boxyAA3BoxVn_tFyyXEfU_'
+func testConsumingAndSending(box: consuming sending Box) {
+  func calledOnce(_: @called(once) () -> Void) {}
+
+  calledOnce { [sending box] in
+    let ns = box.takeValue()
+    sendAgain(ns)
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnF : $@convention(thin) (@sil_sending @owned NS) -> () {
+// CHECK:  [[NS_PROJ:%.*]] = project_box {{.*}} : ${ var NS }, 0
+// CHECK:  [[NS_READ:%.*]] = begin_access [read] [unknown] [[NS_PROJ]] : $*NS
+// CHECK:  [[NS_VALUE:%.*]] = load [copy] [[NS_READ]] : $*NS
+// CHECK:  [[OUTER_CLOSURE_REF:%.*]] = function_ref @$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnFyyXOfU_ : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK:  [[NS_COPY:%.*]] = copy_value {{%.*}} : $NS
+// CHECK:  partial_apply [called_once] [[OUTER_CLOSURE_REF]]([[NS_COPY]]) : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnF'
+
+// CHECK-LABEL: sil private [ossa] @$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnFyyXOfU_ : $@convention(thin) (@sil_sending @guaranteed NS) -> () {
+// CHECK: bb0([[NS_OUTER_CAPTURE:%.*]] : @closureCapture @guaranteed $NS):
+// CHECK:  [[INNER_CLOSURE_REF:%.*]] = function_ref @$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnFyyXOfU_yyXEfU_ : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK:  [[NS_COPY:%.*]] = copy_value [[NS_OUTER_CAPTURE]] : $NS
+// CHECK:  partial_apply [called_once] [[INNER_CLOSURE_REF]]([[NS_COPY]]) : $@convention(thin) (@sil_sending @guaranteed NS) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnFyyXOfU_'
+
+// CHECK-LABEL: sil private [ossa] @$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnFyyXOfU_yyXEfU_ : $@convention(thin) (@sil_sending @guaranteed NS) -> () {
+// CHECK: bb0([[NS_INNER_CAPTURE:%.*]] : @closureCapture @guaranteed $NS):
+// CHECK:  [[NS_COPY:%.*]] = copy_value [[NS_INNER_CAPTURE]] : $NS
+// CHECK:  // function_ref sendAgain(_:)
+// CHECK:  [[SEND_AGAIN:%.*]] = function_ref @$s28called_once_sending_captures9sendAgainyyAA2NSCnF : $@convention(thin) (@sil_sending @owned NS) -> ()
+// CHECK:  apply [[SEND_AGAIN]]([[NS_COPY]]) : $@convention(thin) (@sil_sending @owned NS) -> ()
+// CHECK: } // end sil function '$s28called_once_sending_captures22testCapturePropagationyyAA2NSCnFyyXOfU_yyXEfU_'
+func testCapturePropagation(_ ns: sending NS) {
+  func calledOnce(_: @called(once) () -> Void) {}
+
+  let _: @called(once) () -> Void = { [sending ns] in
+    calledOnce {
+      sendAgain(ns)
+    }
+  }
+}

--- a/test/Sema/called_once.swift
+++ b/test/Sema/called_once.swift
@@ -179,6 +179,40 @@ struct TestPlainResultWitness : P_CalledOnceResult {
   func f() -> () -> Void { { } } // Ok
 }
 
+func testSendingCaptures() {
+  class NS {
+    func test() {
+      _ = { @called(once) [sending self] in
+        _ = self
+      }
+    }
+  }
+
+  let ns = NS()
+  _ = { @called(once) [sending ns] in
+    ns
+  }
+  _ = { @called(once) [x = 42, sending ns = NS()] in
+    _ = x
+    _ = ns
+  }
+
+  _ = { [sending ns] in ns }
+  // expected-error@-1 {{'sending' capture may only be declared in a '@called(once)' closure}}
+
+  func calledOnce(_: @called(once) () -> Void) {}
+  func manyTimes(_: () -> Void) {}
+
+  calledOnce { [sending x = NS()] in
+    _ = x // Ok
+  }
+
+  manyTimes { [sending x = NS()] in
+    // expected-error@-1 {{'sending' capture may only be declared in a '@called(once)' closure}}
+    _ = x
+  }
+}
+
 // `@escaping @called(once)` implies `@_implicitSelfCapture`
 do {
   func takeFn(fn: @escaping @called(once) () -> Int) { }


### PR DESCRIPTION
- Adds a new `sending` specifier for a capture declaration. Adds validation that such captures
could only be declared on `@called(once)` closures. 
- Adds a notion of `sending` capture to `CaptureInfo` and makes sure that it's not propagated into non-`@called(once)` closures
- Emits `sending` captured value as `@sil_sending` parameter and handles other non-Sendable captures/results as it does for regular closures.
- Teaches region-based isolation "use after send" diagnostics about existence of `@called(once)` partial_apply.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
