### PR TITLE
Fix crash on plugging concrete-typed closure into generic parameter

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -93,7 +93,8 @@ private func optimizeClosureWithDeadCaptures(of partialApply: PartialApplyInst, 
 private func constantPropagateCaptures(of partialApply: PartialApplyInst, _ context: FunctionPassContext) {
   guard let callee = partialApply.referencedFunction,
         callee.isDefinition,
-        let (constArgs, nonConstArgs) = partialApply.classifyArgumentsForConstness()
+        let (constArgs, nonConstArgs) = partialApply.classifyArgumentsForConstness(),
+        !hasConcreteClosureArgForGenericParam(constArgs, callee: callee, partialApply: partialApply)
   else {
     return
   }
@@ -118,6 +119,17 @@ private func constantPropagateCaptures(of partialApply: PartialApplyInst, _ cont
   }
   let newArguments = Array(nonConstArgs.values)
   rewritePartialApply(partialApply, withSpecialized: specializedCallee, arguments: newArguments, context)
+}
+
+// Propagating a concrete-typed closure into an argument slot whose declared type still has
+// a type parameter would cause a type mismatch and SIL verification failure.
+private func hasConcreteClosureArgForGenericParam(_ constArgs: [Operand], callee: Function,
+                                                  partialApply: PartialApplyInst) -> Bool {
+  constArgs.contains(where: {
+    let calleeArgIdx = partialApply.calleeArgumentIndex(of: $0)!
+    let paramType = callee.argumentConventions[parameter: calleeArgIdx]!.type
+    return paramType.isLoweredFunction && paramType.hasTypeParameter
+  })
 }
 
 private func getSpecializedCalleeWithDeadParams(of partialApply: PartialApplyInst,

--- a/test/SILOptimizer/capture_propagation.sil
+++ b/test/SILOptimizer/capture_propagation.sil
@@ -1043,3 +1043,58 @@ bb0(%1 : $S):
   %3 = struct_extract %2, #Int32._value
   return %3
 }
+
+// The generic reabstraction thunk that converts a direct throw to an
+// indirect throw, matching the shape of the thunk synthesized for
+// `withUnsafeBytes`'s generic result.
+sil shared [reabstraction_thunk] [ossa] @generic_param_thunk : $@convention(thin) <T> (UnsafeRawBufferPointer, @guaranteed @noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out T, @error any Error)) -> (@out T, @error_indirect any Error) {
+bb0(%0 : $*T, %1 : $*any Error, %2 : $UnsafeRawBufferPointer, %3 : @guaranteed $@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out T, @error any Error)):
+  try_apply %3(%0, %2) : $@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out T, @error any Error), normal bb2, error bb1
+
+bb1(%5 : @owned $any Error):
+  store %5 to [init] %1
+  throw_addr
+
+bb2(%8 : $()):
+  %9 = tuple ()
+  return %9
+}
+
+// A concrete closure body.
+sil private [ossa] @generic_param_body : $@convention(thin) (UnsafeRawBufferPointer) -> (@out UInt8, @error any Error) {
+bb0(%0 : $*UInt8, %1 : $UnsafeRawBufferPointer):
+  %2 = integer_literal $Builtin.Int8, 42
+  %3 = struct $UInt8 (%2 : $Builtin.Int8)
+  store %3 to [trivial] %0
+  %4 = tuple ()
+  return %4
+}
+
+// Specializing the thunk (@generic_param_thunk) body with the constant closure
+// (@generic_param_body) would cause a type mismatch because the parameter still has
+// generic type T while the closure does not.
+//
+// CHECK-LABEL: sil [ossa] @generic_param_caller
+// CHECK:         function_ref @generic_param_thunk
+// CHECK:         partial_apply [callee_guaranteed] [on_stack] {{%[0-9]+}}<UInt8>({{%[0-9]+}})
+// CHECK:       } // end sil function 'generic_param_caller'
+sil [ossa] @generic_param_caller : $@convention(thin) (UnsafeRawBufferPointer) -> (@out UInt8, @error_indirect any Error) {
+bb0(%0 : $*UInt8, %1 : $*any Error, %2 : $UnsafeRawBufferPointer):
+  %3 = function_ref @generic_param_body : $@convention(thin) (UnsafeRawBufferPointer) -> (@out UInt8, @error any Error)
+  %4 = thin_to_thick_function %3 to $@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out UInt8, @error any Error)
+  %5 = function_ref @generic_param_thunk : $@convention(thin) <T> (UnsafeRawBufferPointer, @guaranteed @noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out T, @error any Error)) -> (@out T, @error_indirect any Error)
+  %6 = partial_apply [callee_guaranteed] [on_stack] %5<UInt8>(%4) : $@convention(thin) <T> (UnsafeRawBufferPointer, @guaranteed @noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out T, @error any Error)) -> (@out T, @error_indirect any Error)
+  %7 = begin_borrow %6
+  try_apply %7(%0, %1, %2) : $@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out UInt8, @error_indirect any Error), normal bb1, error bb2
+
+bb1(%9 : $()):
+  end_borrow %7
+  destroy_value %6
+  %11 = tuple ()
+  return %11
+
+bb2:
+  end_borrow %7
+  destroy_value %6
+  unreachable
+}

--- a/test/SILOptimizer/constant_capture_propagation_generic_result.swift
+++ b/test/SILOptimizer/constant_capture_propagation_generic_result.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O -Xllvm -sil-disable-pass=generic-specializer -module-name=test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Regression test: ConstantCapturePropagation used to crash the compiler
+// when specializing a partial_apply whose constant-captured closure argument's
+// declared parameter type has a generic parameter, as
+// happens with the reabstraction thunk synthesized for `withUnsafeBytes`'s
+// generic `Result`.
+
+import Foundation
+
+@inline(never)
+func repro() -> Data {
+    let bytes = [UInt8](repeating: 42, count: 4)
+    return bytes.withUnsafeBytes { body in
+        Data(body)
+    }
+}
+
+// CHECK: [42, 42, 42, 42]
+print(Array(repro()))


### PR DESCRIPTION
UnsafeRawBufferPointer.withUnsafeBytes uses a generic reabstraction thunk to convert a direct throw into an indirect
throw. ConstantCapturePropagation attempts to specialize the thunk, which has type

<τ_0_0> (UnsafeRawBufferPointer, @guaranteed @noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out τ_0_0, @error any Error)) -> (@out τ_0_0, @error_indirect any Error)

by plugging a constant closure argument which has type (with no generic type param)

@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out Data._Representation, @error any Error)

through the thunk's second argument into a try_apply in its body, which has type

@convention(thin) @substituted <τ_0_0> (UnsafeRawBufferPointer) -> (@out τ_0_0, @error any Error)

which leads to a type mismatch (Data._Representation vs τ_0_0) and SIL verification error.

GenericSpecializer runs earlier in the pipeline and ordinarily specializes the thunk for its concrete type before ConstantCapturePropagation sees it, which is why this crash requires the thunk to still be generic when this pass runs, e.g. with -sil-disable-pass=generic-specializer.

Fix: bail out of specialization when a concrete-typed constant closure is plugged into a parameter whose type has a generic type parameter. This is conservative in that it never changes behavior except to decline an optimization where it would cause a type error.

rdar://182549575
