### PR TITLE
[Concurrency] Fix ABI tests, should be in concurrency.swift

### DIFF
--- a/test/abi/macOS/arm64/concurrency-asserts.swift
+++ b/test/abi/macOS/arm64/concurrency-asserts.swift
@@ -40,8 +40,3 @@
 
 // _Concurrency Symbols
 
-// _reasonRawStorage accessors are only emitted with assertions enabled
-Added: _$sScE17_reasonRawStorages5UInt8VvM
-Added: _$sScE17_reasonRawStorages5UInt8Vvg
-Added: _$sScE17_reasonRawStorages5UInt8VvpMV
-Added: _$sScE17_reasonRawStorages5UInt8Vvs

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -492,6 +492,10 @@ Added: _$ss21TaskCancellationScopeVMn
 Added: _$ss21TaskCancellationScopeVN
 Added: _$sScE11descriptionSSvg
 Added: _$sScE11descriptionSSvpMV
+Added: _$sScE17_reasonRawStorages5UInt8VvM
+Added: _$sScE17_reasonRawStorages5UInt8Vvg
+Added: _$sScE17_reasonRawStorages5UInt8VvpMV
+Added: _$sScE17_reasonRawStorages5UInt8Vvs
 Added: _$sScE6ReasonO11descriptionSSvg
 Added: _$sScE6ReasonO11descriptionSSvpMV
 Added: _$sScE6ReasonO11unspecifiedyA2BmFWC

--- a/test/abi/macOS/x86_64/concurrency-asserts.swift
+++ b/test/abi/macOS/x86_64/concurrency-asserts.swift
@@ -40,8 +40,3 @@
 
 // _Concurrency Symbols
 
-// _reasonRawStorage accessors are only emitted with assertions enabled
-Added: _$sScE17_reasonRawStorages5UInt8VvM
-Added: _$sScE17_reasonRawStorages5UInt8Vvg
-Added: _$sScE17_reasonRawStorages5UInt8VvpMV
-Added: _$sScE17_reasonRawStorages5UInt8Vvs

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -492,6 +492,10 @@ Added: _$ss21TaskCancellationScopeVMn
 Added: _$ss21TaskCancellationScopeVN
 Added: _$sScE11descriptionSSvg
 Added: _$sScE11descriptionSSvpMV
+Added: _$sScE17_reasonRawStorages5UInt8VvM
+Added: _$sScE17_reasonRawStorages5UInt8Vvg
+Added: _$sScE17_reasonRawStorages5UInt8VvpMV
+Added: _$sScE17_reasonRawStorages5UInt8Vvs
 Added: _$sScE6ReasonO11descriptionSSvg
 Added: _$sScE6ReasonO11descriptionSSvpMV
 Added: _$sScE6ReasonO11unspecifiedyA2BmFWC


### PR DESCRIPTION
Follow up from https://github.com/swiftlang/swift/pull/91516#issuecomment-5323377449 seems the ABI were added in the wrong file, just the -asserts one.