### PR TITLE
fix: improve diagnostic for heterogeneous collection literals

### DIFF
--- a/include/swift/Sema/BindingProducer.h
+++ b/include/swift/Sema/BindingProducer.h
@@ -46,6 +46,14 @@ public:
     // in attempt to produce a solution faster for
     // well-formed expressions.
     if (CS.shouldAttemptFixes()) {
+      // A choice that is only viable with a fix attached to it - i.e. an
+      // overload that requires re-labeling of the arguments - should stay
+      // disabled if it refers to a declaration that is not meant to be
+      // referenced directly, because suggesting it would be confusing e.g.
+      // `Set(["a", 0])` should never mention `init(_immutableCocoaSet:)`.
+      if (hasFix() && isUnderscored())
+        return true;
+
       return !(hasFix() || Choice->isDisabledInPerformanceMode());
     }
 
@@ -54,6 +62,14 @@ public:
 
   bool hasFix() const {
     return bool(Choice->getFix());
+  }
+
+  /// Whether this choice refers to a declaration that is not intended to be
+  /// referenced directly i.e. an underscored standard library declaration.
+  bool isUnderscored() const {
+    if (auto *decl = getOverloadChoiceDecl(Choice))
+      return decl->hasUnderscoredNaming();
+    return false;
   }
 
   bool isUnavailable() const {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2058,6 +2058,38 @@ bool Solution::isValidSolution() const {
           FixedScore.Data[SK_Fix] == 0);
 }
 
+static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
+                                                ArrayRef<Solution> solutions,
+                                                bool onlyUniqueCommonConflict);
+
+/// Determine whether all of the given solutions have fixes and every one of
+/// them is an element mismatch associated with the same collection literal.
+///
+/// This is the case when a literal is heterogeneous and each solution
+/// picks a different type for its elements e.g. `Set(["a", 0])`.
+static bool
+hasElementMismatchesInSameCollectionLiteral(ArrayRef<Solution> solutions) {
+  CollectionExpr *literal = nullptr;
+
+  for (const auto &solution : solutions) {
+    if (solution.Fixes.empty())
+      return false;
+
+    for (const auto *fix : solution.Fixes) {
+      if (fix->getKind() != FixKind::IgnoreCollectionElementContextualMismatch)
+        return false;
+
+      auto *collection = getAsExpr<CollectionExpr>(fix->getAnchor());
+      if (!collection || (literal && literal != collection))
+        return false;
+
+      literal = collection;
+    }
+  }
+
+  return literal != nullptr;
+}
+
 SolutionResult ConstraintSystem::salvage() {
   if (isDebugMode()) {
     llvm::errs() << "---Attempting to salvage and emit diagnostics---\n";
@@ -2116,6 +2148,21 @@ SolutionResult ConstraintSystem::salvage() {
 
     // FIXME: If we were able to actually fix things along the way,
     // we may have to hunt for the best solution. For now, we don't care.
+
+    // If every solution has element mismatches associated with the same
+    // collection literal, the problem is that the literal is heterogeneous
+    // e.g. `Set(["a", 0])`. Such ambiguities cannot be diagnosed through
+    // fixes or overload choices because they are different in each solution
+    // - the fixes are attached to a different element of the literal and
+    // `init(_:)` is `Set.init(_:)` in some solutions and
+    // `SetAlgebra.init(_:)` in others - but all of the solutions do disagree
+    // about the type inferred for a generic parameter they have in common,
+    // which is `Element` of `Set` in this example.
+    if (viable.size() > 1 &&
+        hasElementMismatchesInSameCollectionLiteral(viable) &&
+        diagnoseConflictingGenericArguments(*this, viable,
+                                            /*onlyUniqueCommonConflict=*/true))
+      return SolutionResult::forAmbiguous(viable);
 
     // Remove solutions that require fixes; the fixes in those systems should
     // be diagnosed rather than any ambiguity.
@@ -2290,12 +2337,17 @@ std::string swift::describeGenericType(ValueDecl *GP, bool includeName) {
 ///
 /// It's done by first retrieving all generic parameters from each solution,
 /// filtering bindings into a distinct set and diagnosing any differences.
+///
+/// \param onlyUniqueCommonConflict Consider only type variables that have been
+/// assigned a type by every solution and diagnose only if there is exactly one
+/// conflict among them. This has to be used when solutions disagree about
+/// their overload choices because type variables that represent generic
+/// parameters opened for a particular choice are not comparable across
+/// solutions, and multiple conflicts are much more likely to be a consequence
+/// of the choices rather than the problem itself.
 static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
-                                                const SolutionDiff &diff,
-                                                ArrayRef<Solution> solutions) {
-  if (!diff.overloads.empty())
-    return false;
-
+                                                ArrayRef<Solution> solutions,
+                                                bool onlyUniqueCommonConflict) {
   bool noFixes = llvm::all_of(solutions, [](const Solution &solution) -> bool {
      const auto score = solution.getFixedScore();
      return score.Data[SK_Fix] == 0 && solution.Fixes.empty();
@@ -2356,14 +2408,17 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     auto GP = entry.second;
 
     swift::SmallSetVector<Type, 4> arguments;
+    bool boundByEverySolution = true;
     for (const auto &solution : solutions) {
       auto type = solution.typeBindings.lookup(typeVar);
       // Type variables gathered from a solution's type binding context may not
       // exist in another given solution because some solutions may have
       // additional type variables not present in other solutions due to taking
       // different paths in the solver.
-      if (!type)
+      if (!type) {
+        boundByEverySolution = false;
         continue;
+      }
 
       // Contextual opaque result type is uniquely identified by
       // declaration it's associated with, so we have to compare
@@ -2381,9 +2436,15 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
       arguments.insert(type);
     }
 
+    if (onlyUniqueCommonConflict && !boundByEverySolution)
+      continue;
+
     if (arguments.size() > 1)
       conflicts[GP].append(arguments.begin(), arguments.end());
   }
+
+  if (onlyUniqueCommonConflict && conflicts.size() != 1)
+    return false;
 
   auto getGenericTypeDecl = [&](ArchetypeType *archetype) -> ValueDecl * {
     auto type = archetype->getInterfaceType();
@@ -2986,7 +3047,9 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 
   SolutionDiff solutionDiff(solutions);
 
-  if (diagnoseConflictingGenericArguments(*this, solutionDiff, solutions))
+  if (solutionDiff.overloads.empty() &&
+      diagnoseConflictingGenericArguments(*this, solutions,
+                                          /*onlyUniqueCommonConflict=*/false))
     return true;
 
   if (auto bestScore = solverState->BestScore) {

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -176,6 +176,39 @@ do {
 // rdar://problem/34670592 - Compiler crash on heterogeneous collection literal
 _ = Array([1, "hello"]) // Ok
 
+// A heterogeneous collection literal passed to an initializer that cannot
+// default its element type to `Any`. This used to be diagnosed in terms of
+// `Set.init(_immutableCocoaSet:)` because that (disabled) choice produced a
+// cheaper solution once it was re-enabled to attempt fixes.
+_ = Set(["hello", 1])
+// expected-error@-1 {{conflicting arguments to generic parameter 'Element'}}
+
+// Same, but without relying on the standard library. Solutions here disagree
+// about both the overload choice for `init(_:)` (the one declared in the type
+// vs. the one from the protocol extension) and the element of the literal
+// their fix is attached to, which means that neither could be used to
+// diagnose the ambiguity.
+protocol ContainerProtocol {
+  associatedtype Element: Hashable
+  init(elements: [Element])
+}
+
+extension ContainerProtocol {
+  init<S: Sequence>(_ elements: S) where S.Element == Element {
+    self.init(elements: Array(elements))
+  }
+}
+
+struct Container<Element: Hashable>: ContainerProtocol {
+  init(elements: [Element]) {}
+  init<S: Sequence>(_ elements: S) where S.Element == Element {
+    self.init(elements: Array(elements))
+  }
+}
+
+_ = Container(["hello", 1])
+// expected-error@-1 {{conflicting arguments to generic parameter 'Element'}}
+
 func init_via_non_const_metatype(_ s1: S1.Type) {
   _ = s1(i: 42) // expected-error {{initializing from a metatype value must reference 'init' explicitly}} {{9-9=.init}}
   _ = s1.init(i: 42) // ok


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
Resolves #91518

## Summary

Fix a diagnostic fallback for heterogeneous collection literals passed to generic initializers, for example:

```swift
var stuff = Set(["red", 2])
```

This currently falls through to the generic “failed to produce diagnostic” error instead of reporting the underlying type conflict in the literal.

## Details

During salvage, this expression can produce several fixed solutions. The solutions may differ in both the selected initializer overload and the literal element that gets the contextual mismatch fix, so the existing ambiguity diagnostics do not find a stable place to report the problem.

This patch handles that case by recognizing when all viable salvage solutions are element mismatches for the same collection literal. When those solutions have one common conflicting generic parameter, we diagnose that conflict directly.

It also keeps underscored relabeling overloads disabled during diagnostic salvage, avoiding diagnostics that mention implementation-only entry points such as `Set.init(_immutableCocoaSet:)`.

## Testing

Added regression coverage in `test/Constraints/construction.swift` for:

- `Set(["hello", 1])`
- an equivalent user-defined generic container with competing initializer candidates

I also checked that the reported expression still reproduces the diagnostic failure on the released Swift 6.3.3 toolchain before this source change.

