### PR TITLE
CrossModuleOptimization: fix a crash with local archetypes

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -23,6 +23,7 @@
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILUndef.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/FunctionOrder.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -167,13 +168,21 @@ public:
     Builder.getFunction().setNeedCompleteLifetimes(false);
   }
 
-  SILType remapType(SILType Ty) {
-    if (Ty.hasLocalArchetype()) {
-      Ty = Ty.subst(getBuilder().getModule(),
+  /// Replaces local archetypes with the local archetypes of the new generic
+  /// environments which the cloner created for cloned instructions which
+  /// define local archetypes (e.g. `open_existential_addr`).
+  SILType substLocalArchetypes(SILType Ty) {
+    if (!Ty.hasLocalArchetype())
+      return Ty;
+
+    return Ty.subst(getBuilder().getModule(),
                     Functor, Functor, CanGenericSignature(),
                     SubstFlags::SubstitutePrimaryArchetypes |
-                    SubstFlags::SubstituteLocalArchetypes);
-    }
+                        SubstFlags::SubstituteLocalArchetypes);
+  }
+
+  SILType remapType(SILType Ty) {
+    Ty = substLocalArchetypes(Ty);
 
     switch (mode) {
       case VisitMode::DetectSerializableInst:
@@ -270,6 +279,20 @@ public:
     case VisitMode::SerializeInst:
       break;
     }
+
+    // If the operand type contains local archetypes, the cloner re-mapped
+    // those archetypes to newly created generic environments (see
+    // `substLocalArchetypes`). But because we don't really clone - the cloned
+    // instructions are deleted immediately in `postProcess` - operands are not
+    // re-mapped and their types still refer to the original local archetypes.
+    // That would create instructions whose (re-mapped) type doesn't match the
+    // type of its operands, which some SILBuilder APIs check, e.g.
+    // `createValueMetatype`.
+    // Therefore use an undef value with the re-mapped type in this case.
+    SILType substTy = substLocalArchetypes(Value->getType());
+    if (substTy != Value->getType())
+      return SILUndef::get(&getBuilder().getFunction(), substTy);
+
     return Value;
   }
 

--- a/test/SILOptimizer/cmo_and_local_archetypes.swift
+++ b/test/SILOptimizer/cmo_and_local_archetypes.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -O -cross-module-optimization -sil-verify-all
+
+// Check that the cross-module-optimization pass can handle instructions which
+// operate on local archetypes, like `value_metatype` on an opened existential
+// or on an opened pack element.
+
+public protocol P {
+  static var name: String { get }
+}
+
+public struct S1: P { public static var name: String { "S1" } }
+public struct S2: P { public static var name: String { "S2" } }
+
+// The `value_metatype` operates on an opened pack element archetype.
+public func namesOfPack<each T: P>(_ values: repeat each T) -> String {
+  var s = ""
+  for value in repeat each values {
+    s += type(of: value).name
+  }
+  return s
+}
+
+public func callNamesOfPack() -> String {
+  return namesOfPack(S1(), S2())
+}
+
+@inline(__always)
+func nameOfValue<T: P>(_ value: T) -> String {
+  return type(of: value).name
+}
+
+// After inlining `nameOfValue`, the `value_metatype` operates on an opened
+// existential archetype.
+public func nameOfExistential(_ value: any P) -> String {
+  return nameOfValue(value)
+}


### PR DESCRIPTION
The pass' InstructionVisitor uses the SILCloner just to visit the types of instructions - the created instructions are deleted immediately. Therefore operands are not re-mapped, while `remapType` does substitute local archetypes with the archetypes of the new generic environments which the cloner creates for `open_existential_addr`, `open_pack_element`, etc.

This resulted in instructions whose re-mapped type didn't match the type of its un-mapped operands, which triggered an assert in `SILBuilder::createValueMetatype` for a `value_metatype` on an opened pack element or existential.

Use an undef value with the re-mapped type for such operands.

https://github.com/swiftlang/swift/issues/91480
rdar://184910222
