### PR TITLE
[DependencyScan] Give each Clang scanning worker its own base VFS

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -159,6 +159,50 @@ struct ClangInvocationFileMapping {
   bool requiresBuiltinHeadersInSystemModules = false;
 };
 
+/// An owning, copyable snapshot of everything
+/// \c ClangImporter::computeClangImporterFileSystem needs from an \c ASTContext
+/// and its \c ClangInvocationFileMapping.
+///
+/// This exists so that clients which must build the ClangImporter file system
+/// more than once can do so without holding on to the \c ASTContext (and
+/// therefore the whole \c CompilerInstance) they derived it from. The Clang
+/// dependency scanner is the motivating case: it needs a *separate* file system
+/// instance per scanning worker, because it calls
+/// \c setCurrentWorkingDirectory on whatever file system it is handed, and
+/// several workers do so concurrently.
+struct ClangImporterVFSRecipe {
+  /// One in-memory file overlaid on top of the base file system.
+  struct OverridenFile {
+    std::string path;
+    /// The file's contents, which this recipe does not own.
+    ///
+    /// \c InMemoryFileSystem::addFileNoOwn does not copy contents either, so
+    /// this storage must outlive not just the recipe but every file system
+    /// built from it. It is owned by the \c allocateString callback given to
+    /// \c ClangImporter::computeClangImporterVFSRecipe, or -- if no callback was
+    /// given -- by the originating \c ClangInvocationFileMapping.
+    llvm::MemoryBufferRef contents;
+  };
+
+  /// Whether the base file system is immutable and must be used unmodified.
+  bool hasImmutableFileSystem = false;
+
+  /// Whether to dump the mapping to \c llvm::errs().
+  bool dumpClangDiagnostics = false;
+
+  /// Clang's '-working-directory', if one was specified.
+  std::optional<std::string> workingDirectory;
+
+  /// Redirected file mappings. These are applied to Clang via '-ivfsoverlay'
+  /// rather than by the computed file system; they are recorded here only
+  /// because their presence affects whether a file system is built at all, and
+  /// for diagnostic dumping.
+  SmallVector<std::pair<std::string, std::string>, 2> redirectedFiles;
+
+  /// Files to overlay on top of the base file system.
+  SmallVector<OverridenFile, 2> overridenFiles;
+};
+
 /// Class that imports Clang modules into Swift, mapping directly
 /// from Clang ASTs over to Swift ASTs.
 class ClangImporter final : public ClangModuleLoader {
@@ -227,6 +271,27 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
       bool suppressDiagnostics = false,
       llvm::function_ref<StringRef(StringRef)> allocateString = nullptr);
+
+  /// Snapshot the information needed to build the ClangImporter file system, so
+  /// that it can be built repeatedly and independently of \p ctx.
+  ///
+  /// \param allocateString If provided, the overriden files' contents are copied
+  /// into storage owned by the callback, and the returned recipe may outlive
+  /// \p ctx and \p fileMapping. Otherwise the recipe points into
+  /// \p fileMapping 's buffers and must not outlive them.
+  static ClangImporterVFSRecipe computeClangImporterVFSRecipe(
+      const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
+      llvm::function_ref<StringRef(StringRef)> allocateString = nullptr);
+
+  /// Compute the file system used by the ClangImporter from a recipe.
+  ///
+  /// Each call layers fresh file systems on top of \p baseFS, so callers that
+  /// need independently mutable file systems (notably one per Clang dependency
+  /// scanning worker) get them by passing a freshly created \p baseFS.
+  static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+  computeClangImporterFileSystem(
+      const ClangImporterVFSRecipe &recipe,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS);
 
   /// Install a helper object that can synthesize Clang Decls from debug
   /// info. Used by LLDB.

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -690,18 +690,30 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
         CASOpts, Instance.getSharedCASInstance(),
         Instance.getSharedCacheInstance()};
 
-    // Compute VFS from the clang importer from the first invocation. This is
-    // usually fine since the base VFS should be the same for the same platform.
+    // The base VFS is derived from the ClangImporter of the first invocation.
+    // This is usually fine since the base VFS should be the same for the same
+    // platform.
+    //
+    // Snapshot it into an owning recipe rather than capturing the ASTContext:
+    // the callback is owned by the scanning service and outlives this
+    // per-query CompilerInstance. Just as importantly, the callback must build a
+    // *separate* file system on every call -- the Clang scanner calls
+    // setCurrentWorkingDirectory on the file system it is handed, and several
+    // workers do so concurrently (rdar://184810704).
     auto &ctx = Instance.getASTContext();
     auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-    auto fs = ClangImporter::computeClangImporterFileSystem(
+    auto recipe = ClangImporter::computeClangImporterVFSRecipe(
         ctx, importer->getClangFileMapping(),
-        llvm::vfs::createPhysicalFileSystem(), true,
         [&](StringRef str) { return save(str); });
     auto cas = Instance.getSharedCASInstance();
 
-    opts.MakeVFS = [=]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
-      return llvm::cas::createCASProvidingFileSystem(cas, fs);
+    opts.MakeVFS = [recipe = std::move(recipe),
+                    cas]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+      auto fs = ClangImporter::computeClangImporterFileSystem(
+          recipe, llvm::vfs::createPhysicalFileSystem());
+      if (cas)
+        return llvm::cas::createCASProvidingFileSystem(cas, std::move(fs));
+      return fs;
     };
 
     ClangScanningService.emplace(std::move(opts));

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1246,65 +1246,94 @@ ClangImporter::getClangSystemOverlayFile(const SearchPathOptions &Opts) {
   return overlayPath.str().str();
 }
 
-llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
-ClangImporter::computeClangImporterFileSystem(
+ClangImporterVFSRecipe ClangImporter::computeClangImporterVFSRecipe(
     const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
-    bool suppressDiagnostics,
     llvm::function_ref<StringRef(StringRef)> allocateString) {
-  // Configure ClangImporter file system. There are two situations:
-  // * If caching is used, thus file system is immutable, the one immutable file
-  //   system is shared between swift frontend and ClangImporter.
-  // * Otherwise, ClangImporter file system is configure from scratch from
-  //   VFS in SourceMgr using ivfsoverlay options.
-  if (ctx.CASOpts.HasImmutableFileSystem)
-    return baseFS;
+  ClangImporterVFSRecipe recipe;
+  recipe.hasImmutableFileSystem = ctx.CASOpts.HasImmutableFileSystem;
 
-  // If no file mapping, nothing to update.
-  if (fileMapping.redirectedFiles.empty() && fileMapping.overridenFiles.empty())
-    return baseFS;
-
-  // Compute and set working directory.
   const auto &importerOpts = ctx.ClangImporterOpts;
+  recipe.dumpClangDiagnostics = importerOpts.DumpClangDiagnostics;
+
+  // Record the working directory, if one was specified.
   auto workingDirPos =
       std::find(importerOpts.ExtraArgs.rbegin(), importerOpts.ExtraArgs.rend(),
                 "-working-directory");
   if (workingDirPos != importerOpts.ExtraArgs.rend() &&
       workingDirPos != importerOpts.ExtraArgs.rbegin())
-    baseFS->setCurrentWorkingDirectory(*(workingDirPos - 1));
+    recipe.workingDirectory = *(workingDirPos - 1);
 
-  if (!fileMapping.redirectedFiles.empty()) {
-    if (importerOpts.DumpClangDiagnostics) {
-      llvm::errs() << "clang importer redirected file mappings:\n";
-      for (const auto &mapping : fileMapping.redirectedFiles) {
-        llvm::errs() << "   mapping real file '" << mapping.second
-                     << "' to virtual file '" << mapping.first << "'\n";
-      }
-      llvm::errs() << "\n";
-    }
-  }
+  recipe.redirectedFiles.assign(fileMapping.redirectedFiles.begin(),
+                                fileMapping.redirectedFiles.end());
 
-  auto overridenVFS =
-      llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
-  for (auto &file : fileMapping.overridenFiles) {
-    if (importerOpts.DumpClangDiagnostics) {
-      llvm::errs() << "clang importer overriding file '"
-                   << file->getBufferIdentifier()
-                   << "' with the following contents:\n";
-      llvm::errs() << file->getBuffer() << "\n";
-    }
+  for (const auto &file : fileMapping.overridenFiles) {
     // Note MemoryBuffer is guaranteeed to be null-terminated.
     auto content = file->getMemBufferRef();
     // If allocateString callback is provided, it means the life-time of the
     // file buffer needs to be extended by saving into the string saver.
     if (allocateString)
       content = llvm::MemoryBufferRef(allocateString(content.getBuffer()), "");
-    overridenVFS->addFileNoOwn(file->getBufferIdentifier(), 0, content);
+    recipe.overridenFiles.push_back(
+        {file->getBufferIdentifier().str(), content});
   }
-  auto overlayVFS =
-      llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(baseFS);
+
+  return recipe;
+}
+
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+ClangImporter::computeClangImporterFileSystem(
+    const ClangImporterVFSRecipe &recipe,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS) {
+  // Configure ClangImporter file system. There are two situations:
+  // * If caching is used, thus file system is immutable, the one immutable file
+  //   system is shared between swift frontend and ClangImporter.
+  // * Otherwise, ClangImporter file system is configure from scratch from
+  //   VFS in SourceMgr using ivfsoverlay options.
+  if (recipe.hasImmutableFileSystem)
+    return baseFS;
+
+  // If no file mapping, nothing to update.
+  if (recipe.redirectedFiles.empty() && recipe.overridenFiles.empty())
+    return baseFS;
+
+  // Set the working directory.
+  if (recipe.workingDirectory)
+    baseFS->setCurrentWorkingDirectory(*recipe.workingDirectory);
+
+  if (!recipe.redirectedFiles.empty() && recipe.dumpClangDiagnostics) {
+    llvm::errs() << "clang importer redirected file mappings:\n";
+    for (const auto &mapping : recipe.redirectedFiles) {
+      llvm::errs() << "   mapping real file '" << mapping.second
+                   << "' to virtual file '" << mapping.first << "'\n";
+    }
+    llvm::errs() << "\n";
+  }
+
+  auto overridenVFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  for (const auto &file : recipe.overridenFiles) {
+    if (recipe.dumpClangDiagnostics) {
+      llvm::errs() << "clang importer overriding file '" << file.path
+                   << "' with the following contents:\n";
+      llvm::errs() << file.contents.getBuffer() << "\n";
+    }
+    overridenVFS->addFileNoOwn(file.path, 0, file.contents);
+  }
+  auto overlayVFS = llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(
+      std::move(baseFS));
   overlayVFS->pushOverlay(std::move(overridenVFS));
   return overlayVFS;
+}
+
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+ClangImporter::computeClangImporterFileSystem(
+    const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
+    bool suppressDiagnostics,
+    llvm::function_ref<StringRef(StringRef)> allocateString) {
+  return computeClangImporterFileSystem(
+      computeClangImporterVFSRecipe(ctx, fileMapping, allocateString),
+      std::move(baseFS));
 }
 
 std::vector<std::string>

--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -542,16 +542,12 @@ TEST_F(ScanTest, TestStressConcurrentDiagnostics) {
   swiftscan_dependency_graph_dispose(Dependencies);
 }
 
-// Ensure that full-scan queries issued concurrently against a single
-// `DependencyScanningTool` do not interfere with one another. Each query gets
-// its own `ModuleDependencyScanner`, and anything that scanner shares with the
-// tool must therefore tolerate being used by several scans at once.
-TEST_F(ScanTest, TestConcurrentQueries) {
-  SmallString<256> tempDir;
-  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
-      "ScanTest.TestConcurrentQueries", tempDir));
-  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
-
+// Set up a workspace importing enough C modules that each scan spends a while
+// in the Clang dependency scanner, and build the scanner command line for it.
+static void makeConcurrentQueryCommand(StringRef tempDir, StringRef stdLibDir,
+                                       StringRef moduleName,
+                                       ArrayRef<std::string> extraArgs,
+                                       std::vector<std::string> &commandOut) {
   // Create includes
   std::string IncludeDirPath = createFilename(tempDir, "include");
   ASSERT_FALSE(llvm::sys::fs::create_directory(IncludeDirPath));
@@ -584,27 +580,43 @@ TEST_F(ScanTest, TestConcurrentQueries) {
                                     modulemapContent));
 
   // Paths to shims and stdlib
-  llvm::SmallString<128> ShimsLibDir = StdLibDir;
+  llvm::SmallString<128> ShimsLibDir = stdLibDir;
   llvm::sys::path::append(ShimsLibDir, "shims");
+  llvm::SmallString<128> PlatformStdLibDir = stdLibDir;
   auto Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
-  llvm::sys::path::append(StdLibDir, getPlatformNameForTriple(Target));
+  llvm::sys::path::append(PlatformStdLibDir, getPlatformNameForTriple(Target));
 
-  std::vector<std::string> CommandStr = {
+  // Note: '-I' and its value are kept as separate arguments. Combining them
+  // into "-I <path>" leaves a leading space in the path, which breaks search
+  // path resolution once a working directory is in play.
+  commandOut = {
       TestPathStr,
-      std::string("-I ") + CHeadersDirPath,
-      std::string("-I ") + StdLibDir.str().str(),
-      std::string("-I ") + ShimsLibDir.str().str(),
+      "-I",
+      CHeadersDirPath,
+      "-I",
+      PlatformStdLibDir.str().str(),
+      "-I",
+      ShimsLibDir.str().str(),
       "-module-name",
-      "testConcurrentQueries",
+      moduleName.str(),
   };
+  commandOut.insert(commandOut.end(), extraArgs.begin(), extraArgs.end());
 
   // On Windows we need to add an extra escape for path separator characters
   // because otherwise the command line tokenizer will treat them as escape
   // characters.
-  for (size_t i = 0; i < CommandStr.size(); ++i)
-    std::replace(CommandStr[i].begin(), CommandStr[i].end(), '\\', '/');
+  for (auto &arg : commandOut)
+    std::replace(arg.begin(), arg.end(), '\\', '/');
+}
+
+// Issue several identical full-scan queries concurrently through one tool and
+// check that they agree. Disagreement means a query resolved dependencies
+// through another query's file system.
+static void runConcurrentQueries(DependencyScanningTool &tool,
+                                 ArrayRef<std::string> commandStr,
+                                 StringRef workingDir = {}) {
   std::vector<const char *> Command;
-  for (auto &command : CommandStr)
+  for (auto &command : commandStr)
     Command.push_back(command.c_str());
 
   constexpr unsigned NumQueries = 4;
@@ -621,7 +633,7 @@ TEST_F(ScanTest, TestConcurrentQueries) {
       while (NumReady.load() < NumQueries)
         std::this_thread::yield();
 
-      auto DependenciesOrErr = ScannerTool.getDependencies(Command, {});
+      auto DependenciesOrErr = tool.getDependencies(Command, workingDir);
       if (DependenciesOrErr.getError()) {
         ++NumFailed;
         return;
@@ -637,8 +649,84 @@ TEST_F(ScanTest, TestConcurrentQueries) {
 
   ASSERT_EQ(NumFailed.load(), 0u);
 
-  // The queries are identical, so they must agree. Disagreement would mean a
-  // query resolved dependencies through another query's file system.
+  // The queries are identical, so they must agree.
   for (unsigned i = 1; i < NumQueries; ++i)
     ASSERT_EQ(ModuleCounts[i].load(), ModuleCounts[0].load());
 }
+
+// Ensure that full-scan queries issued concurrently against a single
+// `DependencyScanningTool` do not interfere with one another. Each query gets
+// its own `ModuleDependencyScanner`, and anything that scanner shares with the
+// tool must therefore tolerate being used by several scans at once.
+TEST_F(ScanTest, TestConcurrentQueries) {
+  SmallString<256> tempDir;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "ScanTest.TestConcurrentQueries", tempDir));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
+
+  std::vector<std::string> CommandStr;
+  makeConcurrentQueryCommand(tempDir, StdLibDir, "testConcurrentQueries",
+                             /*extraArgs=*/{}, CommandStr);
+  ASSERT_FALSE(CommandStr.empty());
+
+  runConcurrentQueries(ScannerTool, CommandStr);
+}
+
+// As above, but with compiler caching enabled, which installs a different
+// `DependencyScanningServiceOptions::MakeVFS` callback. That callback must also
+// build a separate file system on every call: the Clang dependency scanner calls
+// `setCurrentWorkingDirectory` on whatever file system it is handed, so workers
+// sharing one corrupt each other's working directory (rdar://184810704). Run
+// under ASan/TSan to catch the heap corruption rather than just the disagreeing
+// results.
+TEST_F(ScanTest, TestConcurrentCachingQueries) {
+  SmallString<256> tempDir;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "ScanTest.TestConcurrentCachingQueries", tempDir));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
+
+  // Scan with a deliberately long working directory. `RealFileSystem` stores its
+  // working directory in a `SmallString<128>`, so a shared file system only
+  // corrupts the heap once the path exceeds that inline capacity -- with a short
+  // path the racing writes stay inside the object and the bug hides.
+  std::string LongWorkingDir =
+      createFilename(createFilename(tempDir, std::string(80, 'w')),
+                     std::string(80, 'd'));
+  ASSERT_FALSE(llvm::sys::fs::create_directories(LongWorkingDir));
+  ASSERT_GT(LongWorkingDir.size(), 128u);
+
+  std::vector<std::string> ExtraArgs = {
+      "-cache-compile-job",
+      "-cas-path",
+      createFilename(tempDir, "cas"),
+      "-module-cache-path",
+      createFilename(tempDir, "clang-module-cache"),
+  };
+
+  std::vector<std::string> CommandStr;
+  makeConcurrentQueryCommand(tempDir, StdLibDir, "testConcurrentCachingQueries",
+                             ExtraArgs, CommandStr);
+  ASSERT_FALSE(CommandStr.empty());
+
+  // Confirm that caching really is enabled for this command line, so that this
+  // test cannot silently degrade into a duplicate of TestConcurrentQueries. With
+  // caching on, Clang module dependencies carry an include-tree CASID.
+  std::vector<const char *> Command;
+  for (auto &command : CommandStr)
+    Command.push_back(command.c_str());
+  auto DependenciesOrErr = ScannerTool.getDependencies(Command, LongWorkingDir);
+  ASSERT_FALSE(DependenciesOrErr.getError());
+  auto Dependencies = DependenciesOrErr.get();
+  unsigned NumClangModulesWithIncludeTree = 0;
+  for (size_t i = 0; i < Dependencies->dependencies->count; ++i) {
+    auto *Details = Dependencies->dependencies->modules[i]->details;
+    if (Details->kind == SWIFTSCAN_DEPENDENCY_INFO_CLANG &&
+        Details->clang_details.clang_include_tree.length)
+      ++NumClangModulesWithIncludeTree;
+  }
+  swiftscan_dependency_graph_dispose(Dependencies);
+  ASSERT_GT(NumClangModulesWithIncludeTree, 0u);
+
+  runConcurrentQueries(ScannerTool, CommandStr, LongWorkingDir);
+}
+


### PR DESCRIPTION
The caching `MakeVFS` callback computed the base VFS once and captured it by value, so every Clang dependency scanning worker shared one `llvm::vfs::RealFileSystem`. Workers call `setCurrentWorkingDirectory` on the file system they are handed, and `RealFileSystem` keeps its working directory in an unsynchronized `optional<ErrorOr<WorkingDirectory>>` holding two `SmallString<128>`, so concurrent scans free each other's buffers. This only corrupts the heap once the path exceeds the 128-character inline capacity, which is why it showed up in Xcode builds and not in local `swiftc` runs.

The callback cannot simply re-run the computation, because it reads an `ASTContext` whose `CompilerInstance` dies with the query that created it -- the reason 90a8ac0d601 hoisted it out to begin with. Instead, snapshot the little that `computeClangImporterFileSystem` actually reads into an owning `ClangImporterVFSRecipe`, and build a fresh chain over a fresh `createPhysicalFileSystem()` on every call. The `ASTContext`-taking overload is now a thin wrapper, so `ClangImporter::create` is unchanged.

This keeps the pre-existing limitation that the recipe comes from the first invocation: Clang scopes `MakeVFS` to the service, while Swift's base VFS is logically per-query.

`TestConcurrentCachingQueries` covers this. Note it needs a >128-character working directory to reproduce at all: 10/10 runs pass with the fix and 10/10 crash without it, with a stack matching the reported crashes.

rdar://184810704

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
