### PR TITLE
Partially revert "[rebranch] Adjust to "[clang][deps] Simplify by-module-name scan API (#184376)""

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1076,6 +1076,13 @@ class SwiftDependencyScanningService {
   std::optional<clang::dependencies::DependencyScanningService>
       ClangScanningService;
 
+  /// Factory that produces the base file system used by each Clang dependency
+  /// scanning worker. Installed as \c DependencyScanningServiceOptions::MakeVFS
+  /// on \c ClangScanningService. Must be thread-safe as it is invoked
+  /// concurrently by multiple workers.
+  std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()>
+      ClangScanningFSFactory;
+
   /// Shared state mutual-exclusivity lock
   mutable llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
 
@@ -1086,6 +1093,15 @@ public:
   SwiftDependencyScanningService &
   operator=(const SwiftDependencyScanningService &) = delete;
   virtual ~SwiftDependencyScanningService() {}
+
+  /// Install the factory used to create the base file system for each Clang
+  /// dependency scanning worker and (re)create the underlying Clang scanning
+  /// service so that it picks the factory up. Since the Clang scanning service
+  /// now owns the VFS factory (see \c DependencyScanningServiceOptions::MakeVFS)
+  /// rather than each individual scanning tool, this must be called before any
+  /// worker is created.
+  void setClangScanningFSFactory(
+      std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory);
 
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1076,13 +1076,6 @@ class SwiftDependencyScanningService {
   std::optional<clang::dependencies::DependencyScanningService>
       ClangScanningService;
 
-  /// Factory that produces the base file system used by each Clang dependency
-  /// scanning worker. Installed as \c DependencyScanningServiceOptions::MakeVFS
-  /// on \c ClangScanningService. Must be thread-safe as it is invoked
-  /// concurrently by multiple workers.
-  std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()>
-      ClangScanningFSFactory;
-
   /// Shared state mutual-exclusivity lock
   mutable llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
 
@@ -1093,15 +1086,6 @@ public:
   SwiftDependencyScanningService &
   operator=(const SwiftDependencyScanningService &) = delete;
   virtual ~SwiftDependencyScanningService() {}
-
-  /// Install the factory used to create the base file system for each Clang
-  /// dependency scanning worker and (re)create the underlying Clang scanning
-  /// service so that it picks the factory up. Since the Clang scanning service
-  /// now owns the VFS factory (see \c DependencyScanningServiceOptions::MakeVFS)
-  /// rather than each individual scanning tool, this must be called before any
-  /// worker is created.
-  void setClangScanningFSFactory(
-      std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory);
 
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -160,50 +160,6 @@ struct ClangInvocationFileMapping {
   bool requiresBuiltinHeadersInSystemModules = false;
 };
 
-/// An owning, copyable snapshot of everything
-/// \c ClangImporter::computeClangImporterFileSystem needs from an \c ASTContext
-/// and its \c ClangInvocationFileMapping.
-///
-/// This exists so that clients which must build the ClangImporter file system
-/// more than once can do so without holding on to the \c ASTContext (and
-/// therefore the whole \c CompilerInstance) they derived it from. The Clang
-/// dependency scanner is the motivating case: it needs a *separate* file system
-/// instance per scanning worker, because it calls
-/// \c setCurrentWorkingDirectory on whatever file system it is handed, and
-/// several workers do so concurrently.
-struct ClangImporterVFSRecipe {
-  /// One in-memory file overlaid on top of the base file system.
-  struct OverridenFile {
-    std::string path;
-    /// The file's contents, which this recipe does not own.
-    ///
-    /// \c InMemoryFileSystem::addFileNoOwn does not copy contents either, so
-    /// this storage must outlive not just the recipe but every file system
-    /// built from it. It is owned by the \c allocateString callback given to
-    /// \c ClangImporter::computeClangImporterVFSRecipe, or -- if no callback was
-    /// given -- by the originating \c ClangInvocationFileMapping.
-    llvm::MemoryBufferRef contents;
-  };
-
-  /// Whether the base file system is immutable and must be used unmodified.
-  bool hasImmutableFileSystem = false;
-
-  /// Whether to dump the mapping to \c llvm::errs().
-  bool dumpClangDiagnostics = false;
-
-  /// Clang's '-working-directory', if one was specified.
-  std::optional<std::string> workingDirectory;
-
-  /// Redirected file mappings. These are applied to Clang via '-ivfsoverlay'
-  /// rather than by the computed file system; they are recorded here only
-  /// because their presence affects whether a file system is built at all, and
-  /// for diagnostic dumping.
-  SmallVector<std::pair<std::string, std::string>, 2> redirectedFiles;
-
-  /// Files to overlay on top of the base file system.
-  SmallVector<OverridenFile, 2> overridenFiles;
-};
-
 /// Class that imports Clang modules into Swift, mapping directly
 /// from Clang ASTs over to Swift ASTs.
 class ClangImporter final : public ClangModuleLoader {
@@ -272,27 +228,6 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
       bool suppressDiagnostics = false,
       llvm::function_ref<StringRef(StringRef)> allocateString = nullptr);
-
-  /// Snapshot the information needed to build the ClangImporter file system, so
-  /// that it can be built repeatedly and independently of \p ctx.
-  ///
-  /// \param allocateString If provided, the overriden files' contents are copied
-  /// into storage owned by the callback, and the returned recipe may outlive
-  /// \p ctx and \p fileMapping. Otherwise the recipe points into
-  /// \p fileMapping 's buffers and must not outlive them.
-  static ClangImporterVFSRecipe computeClangImporterVFSRecipe(
-      const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
-      llvm::function_ref<StringRef(StringRef)> allocateString = nullptr);
-
-  /// Compute the file system used by the ClangImporter from a recipe.
-  ///
-  /// Each call layers fresh file systems on top of \p baseFS, so callers that
-  /// need independently mutable file systems (notably one per Clang dependency
-  /// scanning worker) get them by passing a freshly created \p baseFS.
-  static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
-  computeClangImporterFileSystem(
-      const ClangImporterVFSRecipe &recipe,
-      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS);
 
   /// Install a helper object that can synthesize Clang Decls from debug
   /// info. Used by LLDB.

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -690,30 +690,18 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
         CASOpts, Instance.getSharedCASInstance(),
         Instance.getSharedCacheInstance()};
 
-    // The base VFS is derived from the ClangImporter of the first invocation.
-    // This is usually fine since the base VFS should be the same for the same
-    // platform.
-    //
-    // Snapshot it into an owning recipe rather than capturing the ASTContext:
-    // the callback is owned by the scanning service and outlives this
-    // per-query CompilerInstance. Just as importantly, the callback must build a
-    // *separate* file system on every call -- the Clang scanner calls
-    // setCurrentWorkingDirectory on the file system it is handed, and several
-    // workers do so concurrently (rdar://184810704).
+    // Compute VFS from the clang importer from the first invocation. This is
+    // usually fine since the base VFS should be the same for the same platform.
     auto &ctx = Instance.getASTContext();
     auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-    auto recipe = ClangImporter::computeClangImporterVFSRecipe(
+    auto fs = ClangImporter::computeClangImporterFileSystem(
         ctx, importer->getClangFileMapping(),
+        llvm::vfs::createPhysicalFileSystem(), true,
         [&](StringRef str) { return save(str); });
     auto cas = Instance.getSharedCASInstance();
 
-    opts.MakeVFS = [recipe = std::move(recipe),
-                    cas]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
-      auto fs = ClangImporter::computeClangImporterFileSystem(
-          recipe, llvm::vfs::createPhysicalFileSystem());
-      if (cas)
-        return llvm::cas::createCASProvidingFileSystem(cas, std::move(fs));
-      return fs;
+    opts.MakeVFS = [=]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+      return llvm::cas::createCASProvidingFileSystem(cas, fs);
     };
 
     ClangScanningService.emplace(std::move(opts));

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -547,22 +547,8 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
   // by-name module lookup to resolve Swift overlay and cross-import overlay
   // dependencies, so opt into having Clang report them.
   opts.ReportVisibleModules = true;
-  opts.MakeVFS = ClangScanningFSFactory;
 
-  ClangScanningService.emplace(std::move(opts));
-}
-
-void SwiftDependencyScanningService::setClangScanningFSFactory(
-    std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory) {
-  ClangScanningFSFactory = std::move(factory);
-  // The Clang scanning service now owns the base VFS factory (via
-  // DependencyScanningServiceOptions::MakeVFS) rather than each scanning tool,
-  // so re-create it to pick up the new factory while preserving all other
-  // options that were configured earlier (e.g. CAS compilation mode).
-  clang::dependencies::DependencyScanningServiceOptions opts =
-      ClangScanningService->getOpts();
-  opts.MakeVFS = ClangScanningFSFactory;
-  ClangScanningService.emplace(std::move(opts));
+  ClangScanningService.emplace(opts);
 }
 
 bool
@@ -701,9 +687,8 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     opts.Compilation = clang::dependencies::IncludeTreeCompilation{
         CASOpts, Instance.getSharedCASInstance(),
         Instance.getSharedCacheInstance()};
-    opts.MakeVFS = ClangScanningFSFactory;
 
-    ClangScanningService.emplace(std::move(opts));
+    ClangScanningService.emplace(opts);
   }
 
   return false;

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -689,19 +689,19 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     opts.Compilation = clang::dependencies::IncludeTreeCompilation{
         CASOpts, Instance.getSharedCASInstance(),
         Instance.getSharedCacheInstance()};
+    opts.MakeVFS = [&]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+      auto &ctx = Instance.getASTContext();
+      auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+      // Dependency scanner needs to create its own file system per worker.
+      auto fs = ClangImporter::computeClangImporterFileSystem(
+          ctx, importer->getClangFileMapping(),
+          llvm::vfs::createPhysicalFileSystem(), true,
+          [&](StringRef str) { return save(str); });
 
-    // Compute VFS from the clang importer from the first invocation. This is
-    // usually fine since the base VFS should be the same for the same platform.
-    auto &ctx = Instance.getASTContext();
-    auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-    auto fs = ClangImporter::computeClangImporterFileSystem(
-        ctx, importer->getClangFileMapping(),
-        llvm::vfs::createPhysicalFileSystem(), true,
-        [&](StringRef str) { return save(str); });
-    auto cas = Instance.getSharedCASInstance();
-
-    opts.MakeVFS = [=]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
-      return llvm::cas::createCASProvidingFileSystem(cas, fs);
+      auto cas = Instance.getSharedCASInstance();
+      if (cas)
+        return llvm::cas::createCASProvidingFileSystem(cas, fs);
+      return fs;
     };
 
     ClangScanningService.emplace(std::move(opts));

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -24,7 +24,6 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Strings.h"
 #include "clang/Lex/HeaderSearchOptions.h"
-#include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/Path.h"
 using namespace swift;
@@ -548,8 +547,21 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
   // by-name module lookup to resolve Swift overlay and cross-import overlay
   // dependencies, so opt into having Clang report them.
   opts.ReportVisibleModules = true;
-  opts.MakeVFS = [] { return llvm::vfs::createPhysicalFileSystem(); };
+  opts.MakeVFS = ClangScanningFSFactory;
 
+  ClangScanningService.emplace(std::move(opts));
+}
+
+void SwiftDependencyScanningService::setClangScanningFSFactory(
+    std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()> factory) {
+  ClangScanningFSFactory = std::move(factory);
+  // The Clang scanning service now owns the base VFS factory (via
+  // DependencyScanningServiceOptions::MakeVFS) rather than each scanning tool,
+  // so re-create it to pick up the new factory while preserving all other
+  // options that were configured earlier (e.g. CAS compilation mode).
+  clang::dependencies::DependencyScanningServiceOptions opts =
+      ClangScanningService->getOpts();
+  opts.MakeVFS = ClangScanningFSFactory;
   ClangScanningService.emplace(std::move(opts));
 }
 
@@ -689,20 +701,7 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     opts.Compilation = clang::dependencies::IncludeTreeCompilation{
         CASOpts, Instance.getSharedCASInstance(),
         Instance.getSharedCacheInstance()};
-    opts.MakeVFS = [&]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
-      auto &ctx = Instance.getASTContext();
-      auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-      // Dependency scanner needs to create its own file system per worker.
-      auto fs = ClangImporter::computeClangImporterFileSystem(
-          ctx, importer->getClangFileMapping(),
-          llvm::vfs::createPhysicalFileSystem(), true,
-          [&](StringRef str) { return save(str); });
-
-      auto cas = Instance.getSharedCASInstance();
-      if (cas)
-        return llvm::cas::createCASProvidingFileSystem(cas, fs);
-      return fs;
-    };
+    opts.MakeVFS = ClangScanningFSFactory;
 
     ClangScanningService.emplace(std::move(opts));
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1246,94 +1246,65 @@ ClangImporter::getClangSystemOverlayFile(const SearchPathOptions &Opts) {
   return overlayPath.str().str();
 }
 
-ClangImporterVFSRecipe ClangImporter::computeClangImporterVFSRecipe(
-    const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
-    llvm::function_ref<StringRef(StringRef)> allocateString) {
-  ClangImporterVFSRecipe recipe;
-  recipe.hasImmutableFileSystem = ctx.CASOpts.HasImmutableFileSystem;
-
-  const auto &importerOpts = ctx.ClangImporterOpts;
-  recipe.dumpClangDiagnostics = importerOpts.DumpClangDiagnostics;
-
-  // Record the working directory, if one was specified.
-  auto workingDirPos =
-      std::find(importerOpts.ExtraArgs.rbegin(), importerOpts.ExtraArgs.rend(),
-                "-working-directory");
-  if (workingDirPos != importerOpts.ExtraArgs.rend() &&
-      workingDirPos != importerOpts.ExtraArgs.rbegin())
-    recipe.workingDirectory = *(workingDirPos - 1);
-
-  recipe.redirectedFiles.assign(fileMapping.redirectedFiles.begin(),
-                                fileMapping.redirectedFiles.end());
-
-  for (const auto &file : fileMapping.overridenFiles) {
-    // Note MemoryBuffer is guaranteeed to be null-terminated.
-    auto content = file->getMemBufferRef();
-    // If allocateString callback is provided, it means the life-time of the
-    // file buffer needs to be extended by saving into the string saver.
-    if (allocateString)
-      content = llvm::MemoryBufferRef(allocateString(content.getBuffer()), "");
-    recipe.overridenFiles.push_back(
-        {file->getBufferIdentifier().str(), content});
-  }
-
-  return recipe;
-}
-
-llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
-ClangImporter::computeClangImporterFileSystem(
-    const ClangImporterVFSRecipe &recipe,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS) {
-  // Configure ClangImporter file system. There are two situations:
-  // * If caching is used, thus file system is immutable, the one immutable file
-  //   system is shared between swift frontend and ClangImporter.
-  // * Otherwise, ClangImporter file system is configure from scratch from
-  //   VFS in SourceMgr using ivfsoverlay options.
-  if (recipe.hasImmutableFileSystem)
-    return baseFS;
-
-  // If no file mapping, nothing to update.
-  if (recipe.redirectedFiles.empty() && recipe.overridenFiles.empty())
-    return baseFS;
-
-  // Set the working directory.
-  if (recipe.workingDirectory)
-    baseFS->setCurrentWorkingDirectory(*recipe.workingDirectory);
-
-  if (!recipe.redirectedFiles.empty() && recipe.dumpClangDiagnostics) {
-    llvm::errs() << "clang importer redirected file mappings:\n";
-    for (const auto &mapping : recipe.redirectedFiles) {
-      llvm::errs() << "   mapping real file '" << mapping.second
-                   << "' to virtual file '" << mapping.first << "'\n";
-    }
-    llvm::errs() << "\n";
-  }
-
-  auto overridenVFS =
-      llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
-  for (const auto &file : recipe.overridenFiles) {
-    if (recipe.dumpClangDiagnostics) {
-      llvm::errs() << "clang importer overriding file '" << file.path
-                   << "' with the following contents:\n";
-      llvm::errs() << file.contents.getBuffer() << "\n";
-    }
-    overridenVFS->addFileNoOwn(file.path, 0, file.contents);
-  }
-  auto overlayVFS = llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(
-      std::move(baseFS));
-  overlayVFS->pushOverlay(std::move(overridenVFS));
-  return overlayVFS;
-}
-
 llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 ClangImporter::computeClangImporterFileSystem(
     const ASTContext &ctx, const ClangInvocationFileMapping &fileMapping,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> baseFS,
     bool suppressDiagnostics,
     llvm::function_ref<StringRef(StringRef)> allocateString) {
-  return computeClangImporterFileSystem(
-      computeClangImporterVFSRecipe(ctx, fileMapping, allocateString),
-      std::move(baseFS));
+  // Configure ClangImporter file system. There are two situations:
+  // * If caching is used, thus file system is immutable, the one immutable file
+  //   system is shared between swift frontend and ClangImporter.
+  // * Otherwise, ClangImporter file system is configure from scratch from
+  //   VFS in SourceMgr using ivfsoverlay options.
+  if (ctx.CASOpts.HasImmutableFileSystem)
+    return baseFS;
+
+  // If no file mapping, nothing to update.
+  if (fileMapping.redirectedFiles.empty() && fileMapping.overridenFiles.empty())
+    return baseFS;
+
+  // Compute and set working directory.
+  const auto &importerOpts = ctx.ClangImporterOpts;
+  auto workingDirPos =
+      std::find(importerOpts.ExtraArgs.rbegin(), importerOpts.ExtraArgs.rend(),
+                "-working-directory");
+  if (workingDirPos != importerOpts.ExtraArgs.rend() &&
+      workingDirPos != importerOpts.ExtraArgs.rbegin())
+    baseFS->setCurrentWorkingDirectory(*(workingDirPos - 1));
+
+  if (!fileMapping.redirectedFiles.empty()) {
+    if (importerOpts.DumpClangDiagnostics) {
+      llvm::errs() << "clang importer redirected file mappings:\n";
+      for (const auto &mapping : fileMapping.redirectedFiles) {
+        llvm::errs() << "   mapping real file '" << mapping.second
+                     << "' to virtual file '" << mapping.first << "'\n";
+      }
+      llvm::errs() << "\n";
+    }
+  }
+
+  auto overridenVFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  for (auto &file : fileMapping.overridenFiles) {
+    if (importerOpts.DumpClangDiagnostics) {
+      llvm::errs() << "clang importer overriding file '"
+                   << file->getBufferIdentifier()
+                   << "' with the following contents:\n";
+      llvm::errs() << file->getBuffer() << "\n";
+    }
+    // Note MemoryBuffer is guaranteeed to be null-terminated.
+    auto content = file->getMemBufferRef();
+    // If allocateString callback is provided, it means the life-time of the
+    // file buffer needs to be extended by saving into the string saver.
+    if (allocateString)
+      content = llvm::MemoryBufferRef(allocateString(content.getBuffer()), "");
+    overridenVFS->addFileNoOwn(file->getBufferIdentifier(), 0, content);
+  }
+  auto overlayVFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(baseFS);
+  overlayVFS->pushOverlay(std::move(overridenVFS));
+  return overlayVFS;
 }
 
 std::vector<std::string>

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -195,6 +195,22 @@ static std::vector<std::string> inputSpecificClangScannerCommand(
   return result;
 }
 
+static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+getClangScanningFS(SwiftDependencyScanningService &service,
+                   std::shared_ptr<llvm::cas::ObjectStore> cas,
+                   ASTContext &ctx) {
+  auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+  // Dependency scanner needs to create its own file system per worker.
+  auto fs = ClangImporter::computeClangImporterFileSystem(
+      ctx, importer->getClangFileMapping(),
+      llvm::vfs::createPhysicalFileSystem(), true,
+      [&](StringRef str) { return service.save(str); });
+
+  if (cas)
+    return llvm::cas::createCASProvidingFileSystem(cas, fs);
+  return fs;
+}
+
 ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     SwiftDependencyScanningService &globalScanningService,
     const CompilerInvocation &ScanCompilerInvocation,
@@ -608,6 +624,16 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     CacheFS = cast<llvm::cas::CASBackedFileSystem>(
         llvm::cas::createCASProvidingFileSystem(
             CAS, ScanASTContext.SourceMgr.getFileSystem()));
+
+  // The Clang dependency scanning service now owns the factory that produces
+  // each worker's base file system (rather than each scanning tool owning its
+  // own). Install it before creating any worker so that the tools pick it up.
+  // The factory creates a fresh file system per worker, as required for
+  // thread-safety.
+  ScanningService.setClangScanningFSFactory(
+      [&ScanningService, CAS = this->CAS, &ScanASTContext]() {
+        return getClangScanningFS(ScanningService, CAS, ScanASTContext);
+      });
 
   // TODO: Make num threads configurable
   for (size_t i = 0; i < NumThreads; ++i)

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -223,7 +223,9 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
       workerSourceMgr(ScanASTContext.SourceMgr.getFileSystem()),
-      clangScanningTool(*globalScanningService.ClangScanningService),
+      clangScanningTool(
+          *globalScanningService.ClangScanningService,
+          getClangScanningFS(globalScanningService, CAS, ScanASTContext)),
       CAS(CAS), ActionCache(ActionCache),
       diagnosticReporter(DiagnosticReporter),
       ShareClangCompilerInstance(ShareClangCompilerInstance) {
@@ -624,16 +626,6 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     CacheFS = cast<llvm::cas::CASBackedFileSystem>(
         llvm::cas::createCASProvidingFileSystem(
             CAS, ScanASTContext.SourceMgr.getFileSystem()));
-
-  // The Clang dependency scanning service now owns the factory that produces
-  // each worker's base file system (rather than each scanning tool owning its
-  // own). Install it before creating any worker so that the tools pick it up.
-  // The factory creates a fresh file system per worker, as required for
-  // thread-safety.
-  ScanningService.setClangScanningFSFactory(
-      [&ScanningService, CAS = this->CAS, &ScanASTContext]() {
-        return getClangScanningFS(ScanningService, CAS, ScanASTContext);
-      });
 
   // TODO: Make num threads configurable
   for (size_t i = 0; i < NumThreads; ++i)

--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -22,10 +22,7 @@
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 #include "gtest/gtest.h"
-#include <atomic>
 #include <string>
-#include <thread>
-#include <vector>
 
 using namespace swift;
 using namespace swift::unittest;
@@ -540,105 +537,4 @@ TEST_F(ScanTest, TestStressConcurrentDiagnostics) {
   auto Diagnostics = Dependencies->diagnostics;
   ASSERT_TRUE(Diagnostics->count >= 1);
   swiftscan_dependency_graph_dispose(Dependencies);
-}
-
-// Ensure that full-scan queries issued concurrently against a single
-// `DependencyScanningTool` do not interfere with one another. Each query gets
-// its own `ModuleDependencyScanner`, and anything that scanner shares with the
-// tool must therefore tolerate being used by several scans at once.
-TEST_F(ScanTest, TestConcurrentQueries) {
-  SmallString<256> tempDir;
-  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
-      "ScanTest.TestConcurrentQueries", tempDir));
-  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
-
-  // Create includes
-  std::string IncludeDirPath = createFilename(tempDir, "include");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(IncludeDirPath));
-  std::string CHeadersDirPath = createFilename(IncludeDirPath, "CHeaders");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(CHeadersDirPath));
-
-  // Create test input file
-  std::string TestPathStr = createFilename(tempDir, "foo.swift");
-
-  // Create enough imported C modules for each query to spend a while in the
-  // Clang dependency scanner, so that the queries actually overlap.
-  std::string modulemapContent = "";
-  std::string testFileContent = "";
-  for (int i = 0; i < 50; ++i) {
-    std::string headerName = "A_" + std::to_string(i) + ".h";
-    std::string headerContent = "void funcA_" + std::to_string(i) + "(void);";
-    ASSERT_FALSE(
-        emitFileWithContents(CHeadersDirPath, headerName, headerContent));
-
-    std::string moduleMapEntry = "module A_" + std::to_string(i) + " {\n";
-    moduleMapEntry.append("header \"A_" + std::to_string(i) + ".h\"\n");
-    moduleMapEntry.append("export *\n");
-    moduleMapEntry.append("}\n");
-    modulemapContent.append(moduleMapEntry);
-    testFileContent.append("import A_" + std::to_string(i) + "\n");
-  }
-
-  ASSERT_FALSE(emitFileWithContents(tempDir, "foo.swift", testFileContent));
-  ASSERT_FALSE(emitFileWithContents(CHeadersDirPath, "module.modulemap",
-                                    modulemapContent));
-
-  // Paths to shims and stdlib
-  llvm::SmallString<128> ShimsLibDir = StdLibDir;
-  llvm::sys::path::append(ShimsLibDir, "shims");
-  auto Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
-  llvm::sys::path::append(StdLibDir, getPlatformNameForTriple(Target));
-
-  std::vector<std::string> CommandStr = {
-      TestPathStr,
-      std::string("-I ") + CHeadersDirPath,
-      std::string("-I ") + StdLibDir.str().str(),
-      std::string("-I ") + ShimsLibDir.str().str(),
-      "-module-name",
-      "testConcurrentQueries",
-  };
-
-  // On Windows we need to add an extra escape for path separator characters
-  // because otherwise the command line tokenizer will treat them as escape
-  // characters.
-  for (size_t i = 0; i < CommandStr.size(); ++i)
-    std::replace(CommandStr[i].begin(), CommandStr[i].end(), '\\', '/');
-  std::vector<const char *> Command;
-  for (auto &command : CommandStr)
-    Command.push_back(command.c_str());
-
-  constexpr unsigned NumQueries = 4;
-  std::atomic<unsigned> NumReady(0);
-  std::atomic<unsigned> NumFailed(0);
-  std::atomic<size_t> ModuleCounts[NumQueries] = {};
-  std::vector<std::thread> Queries;
-  Queries.reserve(NumQueries);
-  for (unsigned i = 0; i < NumQueries; ++i) {
-    Queries.emplace_back([&, i]() {
-      // Start all of the queries at roughly the same time to maximize the
-      // overlap between them.
-      ++NumReady;
-      while (NumReady.load() < NumQueries)
-        std::this_thread::yield();
-
-      auto DependenciesOrErr = ScannerTool.getDependencies(Command, {});
-      if (DependenciesOrErr.getError()) {
-        ++NumFailed;
-        return;
-      }
-      auto Dependencies = DependenciesOrErr.get();
-      ModuleCounts[i].store(Dependencies->dependencies->count);
-      swiftscan_dependency_graph_dispose(Dependencies);
-    });
-  }
-
-  for (auto &Query : Queries)
-    Query.join();
-
-  ASSERT_EQ(NumFailed.load(), 0u);
-
-  // The queries are identical, so they must agree. Disagreement would mean a
-  // query resolved dependencies through another query's file system.
-  for (unsigned i = 1; i < NumQueries; ++i)
-    ASSERT_EQ(ModuleCounts[i].load(), ModuleCounts[0].load());
 }

--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -542,12 +542,16 @@ TEST_F(ScanTest, TestStressConcurrentDiagnostics) {
   swiftscan_dependency_graph_dispose(Dependencies);
 }
 
-// Set up a workspace importing enough C modules that each scan spends a while
-// in the Clang dependency scanner, and build the scanner command line for it.
-static void makeConcurrentQueryCommand(StringRef tempDir, StringRef stdLibDir,
-                                       StringRef moduleName,
-                                       ArrayRef<std::string> extraArgs,
-                                       std::vector<std::string> &commandOut) {
+// Ensure that full-scan queries issued concurrently against a single
+// `DependencyScanningTool` do not interfere with one another. Each query gets
+// its own `ModuleDependencyScanner`, and anything that scanner shares with the
+// tool must therefore tolerate being used by several scans at once.
+TEST_F(ScanTest, TestConcurrentQueries) {
+  SmallString<256> tempDir;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
+      "ScanTest.TestConcurrentQueries", tempDir));
+  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
+
   // Create includes
   std::string IncludeDirPath = createFilename(tempDir, "include");
   ASSERT_FALSE(llvm::sys::fs::create_directory(IncludeDirPath));
@@ -580,43 +584,27 @@ static void makeConcurrentQueryCommand(StringRef tempDir, StringRef stdLibDir,
                                     modulemapContent));
 
   // Paths to shims and stdlib
-  llvm::SmallString<128> ShimsLibDir = stdLibDir;
+  llvm::SmallString<128> ShimsLibDir = StdLibDir;
   llvm::sys::path::append(ShimsLibDir, "shims");
-  llvm::SmallString<128> PlatformStdLibDir = stdLibDir;
   auto Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
-  llvm::sys::path::append(PlatformStdLibDir, getPlatformNameForTriple(Target));
+  llvm::sys::path::append(StdLibDir, getPlatformNameForTriple(Target));
 
-  // Note: '-I' and its value are kept as separate arguments. Combining them
-  // into "-I <path>" leaves a leading space in the path, which breaks search
-  // path resolution once a working directory is in play.
-  commandOut = {
+  std::vector<std::string> CommandStr = {
       TestPathStr,
-      "-I",
-      CHeadersDirPath,
-      "-I",
-      PlatformStdLibDir.str().str(),
-      "-I",
-      ShimsLibDir.str().str(),
+      std::string("-I ") + CHeadersDirPath,
+      std::string("-I ") + StdLibDir.str().str(),
+      std::string("-I ") + ShimsLibDir.str().str(),
       "-module-name",
-      moduleName.str(),
+      "testConcurrentQueries",
   };
-  commandOut.insert(commandOut.end(), extraArgs.begin(), extraArgs.end());
 
   // On Windows we need to add an extra escape for path separator characters
   // because otherwise the command line tokenizer will treat them as escape
   // characters.
-  for (auto &arg : commandOut)
-    std::replace(arg.begin(), arg.end(), '\\', '/');
-}
-
-// Issue several identical full-scan queries concurrently through one tool and
-// check that they agree. Disagreement means a query resolved dependencies
-// through another query's file system.
-static void runConcurrentQueries(DependencyScanningTool &tool,
-                                 ArrayRef<std::string> commandStr,
-                                 StringRef workingDir = {}) {
+  for (size_t i = 0; i < CommandStr.size(); ++i)
+    std::replace(CommandStr[i].begin(), CommandStr[i].end(), '\\', '/');
   std::vector<const char *> Command;
-  for (auto &command : commandStr)
+  for (auto &command : CommandStr)
     Command.push_back(command.c_str());
 
   constexpr unsigned NumQueries = 4;
@@ -633,7 +621,7 @@ static void runConcurrentQueries(DependencyScanningTool &tool,
       while (NumReady.load() < NumQueries)
         std::this_thread::yield();
 
-      auto DependenciesOrErr = tool.getDependencies(Command, workingDir);
+      auto DependenciesOrErr = ScannerTool.getDependencies(Command, {});
       if (DependenciesOrErr.getError()) {
         ++NumFailed;
         return;
@@ -649,84 +637,8 @@ static void runConcurrentQueries(DependencyScanningTool &tool,
 
   ASSERT_EQ(NumFailed.load(), 0u);
 
-  // The queries are identical, so they must agree.
+  // The queries are identical, so they must agree. Disagreement would mean a
+  // query resolved dependencies through another query's file system.
   for (unsigned i = 1; i < NumQueries; ++i)
     ASSERT_EQ(ModuleCounts[i].load(), ModuleCounts[0].load());
 }
-
-// Ensure that full-scan queries issued concurrently against a single
-// `DependencyScanningTool` do not interfere with one another. Each query gets
-// its own `ModuleDependencyScanner`, and anything that scanner shares with the
-// tool must therefore tolerate being used by several scans at once.
-TEST_F(ScanTest, TestConcurrentQueries) {
-  SmallString<256> tempDir;
-  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
-      "ScanTest.TestConcurrentQueries", tempDir));
-  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
-
-  std::vector<std::string> CommandStr;
-  makeConcurrentQueryCommand(tempDir, StdLibDir, "testConcurrentQueries",
-                             /*extraArgs=*/{}, CommandStr);
-  ASSERT_FALSE(CommandStr.empty());
-
-  runConcurrentQueries(ScannerTool, CommandStr);
-}
-
-// As above, but with compiler caching enabled, which installs a different
-// `DependencyScanningServiceOptions::MakeVFS` callback. That callback must also
-// build a separate file system on every call: the Clang dependency scanner calls
-// `setCurrentWorkingDirectory` on whatever file system it is handed, so workers
-// sharing one corrupt each other's working directory (rdar://184810704). Run
-// under ASan/TSan to catch the heap corruption rather than just the disagreeing
-// results.
-TEST_F(ScanTest, TestConcurrentCachingQueries) {
-  SmallString<256> tempDir;
-  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory(
-      "ScanTest.TestConcurrentCachingQueries", tempDir));
-  SWIFT_DEFER { llvm::sys::fs::remove_directories(tempDir); };
-
-  // Scan with a deliberately long working directory. `RealFileSystem` stores its
-  // working directory in a `SmallString<128>`, so a shared file system only
-  // corrupts the heap once the path exceeds that inline capacity -- with a short
-  // path the racing writes stay inside the object and the bug hides.
-  std::string LongWorkingDir =
-      createFilename(createFilename(tempDir, std::string(80, 'w')),
-                     std::string(80, 'd'));
-  ASSERT_FALSE(llvm::sys::fs::create_directories(LongWorkingDir));
-  ASSERT_GT(LongWorkingDir.size(), 128u);
-
-  std::vector<std::string> ExtraArgs = {
-      "-cache-compile-job",
-      "-cas-path",
-      createFilename(tempDir, "cas"),
-      "-module-cache-path",
-      createFilename(tempDir, "clang-module-cache"),
-  };
-
-  std::vector<std::string> CommandStr;
-  makeConcurrentQueryCommand(tempDir, StdLibDir, "testConcurrentCachingQueries",
-                             ExtraArgs, CommandStr);
-  ASSERT_FALSE(CommandStr.empty());
-
-  // Confirm that caching really is enabled for this command line, so that this
-  // test cannot silently degrade into a duplicate of TestConcurrentQueries. With
-  // caching on, Clang module dependencies carry an include-tree CASID.
-  std::vector<const char *> Command;
-  for (auto &command : CommandStr)
-    Command.push_back(command.c_str());
-  auto DependenciesOrErr = ScannerTool.getDependencies(Command, LongWorkingDir);
-  ASSERT_FALSE(DependenciesOrErr.getError());
-  auto Dependencies = DependenciesOrErr.get();
-  unsigned NumClangModulesWithIncludeTree = 0;
-  for (size_t i = 0; i < Dependencies->dependencies->count; ++i) {
-    auto *Details = Dependencies->dependencies->modules[i]->details;
-    if (Details->kind == SWIFTSCAN_DEPENDENCY_INFO_CLANG &&
-        Details->clang_details.clang_include_tree.length)
-      ++NumClangModulesWithIncludeTree;
-  }
-  swiftscan_dependency_graph_dispose(Dependencies);
-  ASSERT_GT(NumClangModulesWithIncludeTree, 0u);
-
-  runConcurrentQueries(ScannerTool, CommandStr, LongWorkingDir);
-}
-


### PR DESCRIPTION
Backup revert in case https://github.com/swiftlang/swift/pull/91563 fails us.

Paired with https://github.com/swiftlang/llvm-project/pull/13919.