### PR TITLE
[cxx-interop] Constructors of C++ FRTs should not satisfy protocol requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3268,6 +3268,10 @@ ERROR(witness_initializer_not_required,none,
       "initializer requirement %0 can only be satisfied by a 'required' "
       "initializer in%select{| the definition of}1 non-final class %2",
       (const ValueDecl *, bool, Type))
+ERROR(witness_initializer_cxx_not_inherited,none,
+      "initializer requirement %0 cannot be satisfied by a C++ constructor of "
+      "non-final foreign reference type %1",
+      (const ValueDecl *, Type))
 ERROR(witness_initializer_failability,none,
       "non-failable initializer requirement %0"
       "%select{| in Objective-C protocol}1 cannot be satisfied by a "

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4421,6 +4421,23 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
     }
   }
 
+  // C++ constructors are not generally inherited by derived classes, unless a
+  // using-decl is used within a derived type. Therefore, a constructor of a C++
+  // foreign reference type cannot satisfy an initializer requirement.
+  if (auto ctor = dyn_cast<ConstructorDecl>(witness)) {
+    if (isa_and_nonnull<clang::CXXMethodDecl>(ctor->getClangDecl())) {
+      getASTContext().addDelayedConformanceDiag(
+          Conformance, false,
+          [ctor, requirement](NormalProtocolConformance *conformance) {
+            auto &diags = ctor->getASTContext().Diags;
+            SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, ctor);
+            diags.diagnose(diagLoc, diag::witness_initializer_cxx_not_inherited,
+                           requirement, conformance->getType());
+            emitDeclaredHereIfNeeded(diags, diagLoc, ctor);
+          });
+    }
+  }
+
   // Check whether this requirement uses Self in a way that might
   // prevent conformance from succeeding.
   const auto selfRefInfo = findExistentialSelfReferences(requirement);

--- a/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking -I %S/Inputs
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking -I %S/Inputs -verify-ignore-unrelated
 
 // REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
@@ -184,3 +184,20 @@ func crtpDowncast(_ b: CRTPBaseOfDerived) -> CRTPDerived {
   return b as! CRTPDerived // expected-error {{downcast from 'CRTPBaseOfDerived' (aka 'CRTPBase<CRTPDerived>') to 'CRTPDerived' is not supported for foreign reference types}}
   // expected-warning@-1 {{cast from 'CRTPBaseOfDerived' (aka 'CRTPBase<CRTPDerived>') to unrelated type 'CRTPDerived' always fails}}
 }
+
+// MARK: - Initializer requirements:
+
+protocol Describable {
+  func getBaseValue() -> Int32
+}
+
+extension RefCountedBase: Describable {}
+
+// Initializers are not inherited in C++, so they can't satisfy protocol requirements.
+protocol Creatable {
+  init()
+}
+
+extension Base: Creatable {} // expected-error {{initializer requirement 'init()' cannot be satisfied by a C++ constructor of non-final foreign reference type 'Base'}}
+extension Unrelated: Creatable {} // expected-error {{initializer requirement 'init()' cannot be satisfied by a C++ constructor of non-final foreign reference type 'Unrelated'}}
+


### PR DESCRIPTION
C++ constructors are not inherited.

With `ForeignReferenceTypeInheritance` feature enabled, Swift represents the inheritance hierarchies of C++ foreign reference types as Swift inheritance. This means that conforming a base FRT to a Swift protocol via an extension would not be sound if the protocol requires a Swift initializer.

Let's diagnose this instead of crashing in SILGen.

rdar://185232029

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
