### PR TITLE
Serialization: tolerate a missing Clang function type in XREF near-match. rdar://184955778

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -371,6 +371,12 @@ enum class TypeMatchFlags {
   IgnoreFunctionGlobalActorIsolation = 1 << 8,
   /// Require parameter labels to match.
   RequireMatchingParameterLabels = 1 << 9,
+  /// When comparing function types, treat a missing Clang function type on
+  /// either side as compatible with a present one. Used by deserialization's
+  /// cross-reference near-match to tolerate module build skew where an older
+  /// module didn't record the Clang function type; two present-but-different
+  /// Clang types still mismatch.
+  AllowMissingClangType = 1 << 10,
 };
 using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3743,7 +3743,16 @@ static bool matchesFunctionType(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
     if (!ext2.isNoEscape())
       ext1 = ext1.withNoEscape(false);
   }
-  if (!ext1.isEqualTo(ext2, useClangTypes(fn1)))
+  bool compareClangTypes = useClangTypes(fn1);
+  // Under AllowMissingClangType (set for deserialization near-matches), a
+  // function type that carries a Clang type is compatible with one that lacks
+  // it — module build skew where an older module didn't record the Clang
+  // function type. Two present-but-different Clang types still mismatch.
+  if (compareClangTypes &&
+      matchMode.contains(TypeMatchFlags::AllowMissingClangType) &&
+      (ext1.getClangTypeInfo().empty() || ext2.getClangTypeInfo().empty()))
+    compareClangTypes = false;
+  if (!ext1.isEqualTo(ext2, compareClangTypes))
     return false;
 
   return paramsAndResultMatch();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2028,6 +2028,7 @@ namespace {
       options |= TypeMatchFlags::IgnoreFunctionSendability;
       options |= TypeMatchFlags::IgnoreSendability;
       options |= TypeMatchFlags::IgnoreFunctionGlobalActorIsolation;
+      options |= TypeMatchFlags::AllowMissingClangType;
       if (type1->matches(type2, options))
         return TypeComparison::NearMatch;
     }

--- a/test/Serialization/xref-clang-function-type-skew.swift
+++ b/test/Serialization/xref-clang-function-type-skew.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Middle library WITHOUT clang function types: the serialized cross-reference
+/// to S.fp records a function type with NO Clang type.
+// RUN: %target-swift-frontend -emit-module %t/LibWithXRef.swift -I %t \
+// RUN:   -module-name LibWithXRef -o %t/LibWithXRef.swiftmodule -swift-version 5
+
+/// Client WITH clang function types: re-importing S.fp yields a function type
+/// that DOES carry a Clang type. Expected (no cType) vs found (cType present)
+/// differ only in Clang-type presence — the relaxed near-match must tolerate it
+/// instead of aborting deserialization.
+// RUN: %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN:   -use-clang-function-types -validate-tbd-against-ir=none -swift-version 5 2>&1 \
+// RUN:   | %FileCheck %s --allow-empty
+
+// CHECK-NOT: *** DESERIALIZATION FAILURE ***
+// CHECK-NOT: broken by a context change
+
+//--- module.modulemap
+module A {
+    header "A.h"
+}
+
+//--- A.h
+struct S {
+    int (*fp)(struct S *, unsigned long, void *);
+};
+
+//--- LibWithXRef.swift
+import A
+
+@inlinable
+public func bar(_ s: inout S) {
+    _ = s.fp
+}
+
+//--- Client.swift
+import LibWithXRef
+import A
+
+public func drive(_ s: inout S) {
+    bar(&s)
+}


### PR DESCRIPTION
Cross-module optimization can deserialize a cross-reference to an imported @convention(c) function-pointer member whose serialized type lacks a Clang function type while the reader's re-import carries one. matchesFunctionType treats empty != present as a mismatch, so the candidate is filtered out and deserialization aborts. This is overly strict and developers have no project-side solutions.

Add TypeMatchFlags::AllowMissingClangType, set it only in the deserialization near-match, and honor it in matchesFunctionType so a missing Clang type on either side is compatible. Two present-but-different Clang types still mismatch.

Resolves: rdar://184955778