### PR TITLE
[IRGen] Give variables holding a global's address a shadow copy

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -840,7 +840,6 @@ public:
     }
   }
 
-  
   /// Account for bugs in LLVM.
   ///
   /// - When a variable is spilled into a stack slot, LiveDebugValues fails to
@@ -852,10 +851,15 @@ public:
   ///   on 32-bit targets as it will also fire for doubles.
   ///
   /// - CodeGen Prepare may drop dbg.values pointing to PHI instruction.
+  ///
+  /// - A dbg_value of a global's address has no location at -O0; only
+  ///   variables backed by a stack slot get one.
   bool needsShadowCopy(llvm::Value *Storage) {
     // If we have a constant data vector, we always need a shadow copy due to
     // bugs in LLVM.
     if (isa<llvm::ConstantDataVector>(Storage))
+      return true;
+    if (isa<llvm::GlobalValue>(Storage))
       return true;
     return !isa<llvm::Constant>(Storage);
   }

--- a/test/DebugInfo/embedded-keypath-shadow-copy.swift
+++ b/test/DebugInfo/embedded-keypath-shadow-copy.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macos14 -emit-ir -g -Onone -enable-experimental-feature Embedded -wmo -disable-availability-checking -o - | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
+// REQUIRES: swift_feature_Embedded
+
+// An embedded key path is a constant global rather than the result of a runtime
+// call, so a variable bound to one is backed by an llvm::Constant. A dbg_value
+// naming a global has no DWARF location at -Onone, so it needs a stack slot.
+
+public func f() -> [Int] {
+  struct S {
+    var values: [[Int]] = [[1, 2]]
+  }
+  let kp = \S.values
+  let s = S()
+  print(s[keyPath: kp][0][0])
+  return [0]
+}
+
+// CHECK: %kp.debug = alloca ptr
+// CHECK: #dbg_declare(ptr %kp.debug, ![[KP:[0-9]+]], !DIExpression()
+// CHECK: store ptr @keypath, ptr %kp.debug
+// CHECK-DAG: ![[KP]] = !DILocalVariable(name: "kp"


### PR DESCRIPTION
A variable whose storage is an llvm::Constant got no shadow copy, on the
grounds that a dbg_value can name a constant directly and no stack slot
is needed. That holds for a constant integer, but not for the address of
a global: LLVM emits no location for such a dbg_value at -O0, so the
variable reads back as optimized out in the debugger.

Assisted-by: claude
rdar://185253667
