### PR TITLE
[ClangImporter] Import C functions with an error out-parameter as throwing

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -534,6 +534,7 @@ class AbstractionPattern {
                      Kind kind = Kind::Type) {
     assert(signature || !origType->hasTypeParameter());
     TheKind = unsigned(kind);
+    OtherData = 0;
     OrigType = origType;
     GenericSig = CanGenericSignature();
     GenericSubs = subs;
@@ -898,6 +899,12 @@ public:
   getObjCMethod(CanType origType, const clang::ObjCMethodDecl *method,
                 const std::optional<ForeignErrorConvention> &foreignError,
                 const std::optional<ForeignAsyncConvention> &foreignAsync);
+
+  /// Return an abstraction pattern for a C function with a foreign error
+  /// convention.
+  static AbstractionPattern
+  getCFunction(CanType origType, const clang::Type *clangType,
+               const std::optional<ForeignErrorConvention> &foreignError);
 
 private:
   /// Return an abstraction pattern for the uncurried type of an

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4224,6 +4224,63 @@ namespace {
                            result);
       }
 
+      // Produce a throwing variant alongside the non-throwing import when an
+      // error convention applies.
+      //
+      // This covers C functions only. The variant builds its parameters from
+      // the full Clang parameter list and is imported at module scope, which
+      // does not account for 'self', generic parameters, or an enclosing
+      // context, so everything else keeps its error parameter instead.
+      bool isCFunction =
+          !decl->getASTContext().getLangOpts().CPlusPlus || decl->isExternC();
+      if (isCFunction && dc->isModuleScopeContext()) {
+        auto *funcResult = cast<FuncDecl>(result);
+        if (auto errorInfo =
+                Impl.getNameImporter().considerErrorImportForFunction(
+                    decl, decl->parameters())) {
+          ParameterList *throwingBodyParams = nullptr;
+          std::optional<ForeignErrorConvention> foreignErrorConvention;
+          auto throwingResultType = Impl.importFunctionParamsAndReturnType(
+              dc, decl, decl->parameters(), decl->isVariadic(),
+              isInSystemModule(dc), name, throwingBodyParams,
+              /*genericParams=*/{}, *errorInfo, &foreignErrorConvention);
+
+          if (throwingBodyParams && throwingResultType.getType()) {
+            DeclName throwingName(Impl.SwiftContext, name.getBaseName(),
+                                  throwingBodyParams);
+
+            auto *throwingFunc = createFuncOrAccessor(
+                Impl, loc, accessorInfo, throwingName, nameLoc,
+                getGenericParams(), throwingBodyParams,
+                throwingResultType.getType(),
+                /*async=*/false, /*throws=*/true, dc, clangNode);
+
+            throwingFunc->setAccess(
+                importer::convertClangAccess(decl->getAccess()));
+            throwingFunc->setIsObjC(false);
+            throwingFunc->setIsDynamic(false);
+
+            Impl.recordImplicitUnwrapForDecl(
+                throwingFunc, throwingResultType.isImplicitlyUnwrapped());
+
+            if (foreignErrorConvention)
+              throwingFunc->setForeignErrorConvention(*foreignErrorConvention);
+
+            if (dc->getSelfClassDecl())
+              throwingFunc->addAttribute(new (Impl.SwiftContext)
+                                             FinalAttr(/*IsImplicit=*/true));
+
+            finishFuncDecl(decl, throwingFunc);
+
+            // Disfavor the non-throwing variant.
+            funcResult->addAttribute(new (
+                Impl.SwiftContext) DisfavoredOverloadAttr(/*implicit=*/true));
+
+            Impl.addAlternateDecl(funcResult, throwingFunc);
+          }
+        }
+      }
+
       return result;
     }
 
@@ -4293,6 +4350,12 @@ namespace {
       if (!isClangNamespace(result->getDeclContext()) &&
           result->getImportAsMemberStatus().isImportAsMember() &&
           !isa<clang::CXXMethodDecl, clang::ObjCMethodDecl>(decl))
+        return;
+
+      // FIXME: support C functions imported as throwing. The indices below come
+      // from the Clang parameter list, but the vectors they index are sized
+      // from the Swift parameter list, which omits the error parameter.
+      if (result->getForeignErrorConvention())
         return;
 
       bool hasSkippedLifetimeAnnotation = false;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -141,8 +141,71 @@ static bool isBlockParameter(const clang::ParmVarDecl *param) {
   return param->getType()->isBlockPointerType();
 }
 
+bool importer::isRecordBridgedToNSError(const clang::RecordDecl *decl) {
+  if (decl->getTagKind() != clang::TagTypeKind::Struct)
+    return false;
+
+  // Read the attribute off the canonical declaration, as CFPointeeInfo does,
+  // so that a bridging attribute on a redeclaration is ignored consistently.
+  decl = cast<clang::RecordDecl>(decl->getCanonicalDecl());
+
+  const clang::IdentifierInfo *bridgedType = nullptr;
+  if (auto bridgeAttr = decl->getAttr<clang::ObjCBridgeAttr>())
+    bridgedType = bridgeAttr->getBridgedType();
+  else if (auto bridgeMutableAttr =
+               decl->getAttr<clang::ObjCBridgeMutableAttr>())
+    bridgedType = bridgeMutableAttr->getBridgedType();
+
+  return bridgedType && bridgedType->getName() == "NSError";
+}
+
+/// Check if a parameter is a CFErrorRef* out-parameter.
+static bool
+isCFErrorOutParameter(const clang::ParmVarDecl *param,
+                      ForeignErrorConvention::IsOwned_t &isErrorOwned,
+                      bool &hasExplicitOwnership) {
+  clang::QualType type = param->getType();
+
+  // Must be a pointer (to CFErrorRef, which is itself a pointer).
+  auto outerPtrType = type->getAs<clang::PointerType>();
+  if (!outerPtrType)
+    return false;
+  auto innerPtrType =
+      outerPtrType->getPointeeType()->getAs<clang::PointerType>();
+  if (!innerPtrType)
+    return false;
+
+  // The inner pointee must be a struct bridged to NSError.
+  auto recordType = innerPtrType->getPointeeType()->getAs<clang::RecordType>();
+  if (!recordType)
+    return false;
+  if (!importer::isRecordBridgedToNSError(recordType->getDecl()))
+    return false;
+
+  // Determine ownership from explicit CF attributes on the parameter.
+  if (param->hasAttr<clang::CFReturnsRetainedAttr>()) {
+    isErrorOwned = ForeignErrorConvention::IsOwned;
+    hasExplicitOwnership = true;
+    return true;
+  }
+  if (param->hasAttr<clang::CFReturnsNotRetainedAttr>()) {
+    isErrorOwned = ForeignErrorConvention::IsNotOwned;
+    hasExplicitOwnership = true;
+    return true;
+  }
+
+  // CFErrorRef* without explicit ownership annotation.
+  hasExplicitOwnership = false;
+  return true;
+}
+
+/// Check if a parameter is an error out-parameter (NSError** or CFErrorRef*).
 static bool isErrorOutParameter(const clang::ParmVarDecl *param,
-                         ForeignErrorConvention::IsOwned_t &isErrorOwned) {
+                                ForeignErrorConvention::IsOwned_t &isErrorOwned,
+                                bool &isCFError, bool &hasExplicitOwnership) {
+  isCFError = false;
+  hasExplicitOwnership = true; // NSError always has known ownership via ARC
+
   clang::QualType type = param->getType();
 
   // Must be a pointer.
@@ -174,7 +237,27 @@ static bool isErrorOutParameter(const clang::ParmVarDecl *param,
       llvm_unreachable("bad error ownership");
     }
   }
+
+  // Check for CFErrorRef*.
+  if (isCFErrorOutParameter(param, isErrorOwned, hasExplicitOwnership)) {
+    isCFError = true;
+    return true;
+  }
+
   return false;
+}
+
+/// Check if a parameter is an NSError** out-parameter.
+static bool
+isErrorOutParameter(const clang::ParmVarDecl *param,
+                    ForeignErrorConvention::IsOwned_t &isErrorOwned) {
+  bool isCFError = false;
+  bool hasExplicitOwnership = false;
+  if (!isErrorOutParameter(param, isErrorOwned, isCFError,
+                           hasExplicitOwnership))
+    return false;
+  // The ObjC path only recognizes NSError**, not CFErrorRef*.
+  return !isCFError;
 }
 
 static bool isBoolType(clang::ASTContext &ctx, clang::QualType type) {
@@ -212,14 +295,22 @@ static bool isIntegerType(clang::QualType clangType) {
   return false;
 }
 
-static std::optional<ForeignErrorConvention::Kind>
-classifyMethodErrorHandling(const clang::ObjCMethodDecl *clangDecl,
-                            OptionalTypeKind resultOptionality) {
-  // TODO: opt out any non-standard methods here?
-  clang::ASTContext &clangCtx = clangDecl->getASTContext();
+/// Classify error handling for a Clang declaration based on its return type
+/// and an optional swift_error attribute. With \p allowsNativeBool true,
+/// recognizes the C-native _Bool/bool builtin in addition to the BOOL/Boolean
+/// typedefs; ObjC import keeps it false to preserve source compatibility for
+/// methods returning bare bool.
+static std::optional<ForeignErrorConvention::Kind> classifyErrorByReturnType(
+    clang::ASTContext &clangCtx, clang::QualType returnType,
+    OptionalTypeKind resultOptionality, const clang::SwiftErrorAttr *attr,
+    bool allowsNativeBool) {
+  auto isBoolish = [&] {
+    return isBoolType(clangCtx, returnType) ||
+           (allowsNativeBool && returnType->isBooleanType());
+  };
 
   // Check for an explicit attribute.
-  if (auto attr = clangDecl->getAttr<clang::SwiftErrorAttr>()) {
+  if (attr) {
     switch (attr->getConvention()) {
     case clang::SwiftErrorAttr::None:
       return std::nullopt;
@@ -231,25 +322,23 @@ classifyMethodErrorHandling(const clang::ObjCMethodDecl *clangDecl,
     // non-optional type.
     case clang::SwiftErrorAttr::NullResult:
       if (resultOptionality != OTK_None &&
-          swift::canImportAsOptional(
-            clangDecl->getReturnType().getTypePtrOrNull()))
+          swift::canImportAsOptional(returnType.getTypePtrOrNull()))
         return ForeignErrorConvention::NilResult;
       return std::nullopt;
 
     // Preserve the original result type on a zero_result unless we
     // imported it as Bool.
     case clang::SwiftErrorAttr::ZeroResult:
-      if (isBoolType(clangCtx, clangDecl->getReturnType())) {
+      if (isBoolish())
         return ForeignErrorConvention::ZeroResult;
-      } else if (isIntegerType(clangDecl->getReturnType())) {
+      if (isIntegerType(returnType))
         return ForeignErrorConvention::ZeroPreservedResult;
-      }
       return std::nullopt;
 
     // There's no reason to do the same for nonzero_result because the
     // only meaningful value remaining would be zero.
     case clang::SwiftErrorAttr::NonZeroResult:
-      if (isIntegerType(clangDecl->getReturnType()))
+      if (isIntegerType(returnType))
         return ForeignErrorConvention::NonZeroResult;
       return std::nullopt;
     }
@@ -259,35 +348,48 @@ classifyMethodErrorHandling(const clang::ObjCMethodDecl *clangDecl,
   // Otherwise, apply the default rules.
 
   // For bool results, a zero value is an error.
-  if (isBoolType(clangCtx, clangDecl->getReturnType())) {
+  if (isBoolish())
     return ForeignErrorConvention::ZeroResult;
-  }
 
   // For optional reference results, a nil value is normally an error.
   if (resultOptionality != OTK_None &&
-      swift::canImportAsOptional(
-        clangDecl->getReturnType().getTypePtrOrNull())) {
+      swift::canImportAsOptional(returnType.getTypePtrOrNull()))
     return ForeignErrorConvention::NilResult;
-  }
 
   return std::nullopt;
+}
+
+static std::optional<ForeignErrorConvention::Kind>
+classifyMethodErrorHandling(const clang::ObjCMethodDecl *clangDecl,
+                            OptionalTypeKind resultOptionality) {
+  // TODO: opt out any non-standard methods here?
+  return classifyErrorByReturnType(
+      clangDecl->getASTContext(), clangDecl->getReturnType(), resultOptionality,
+      clangDecl->getAttr<clang::SwiftErrorAttr>(),
+      /*allowsNativeBool=*/false);
+}
+
+static std::optional<ForeignErrorConvention::Kind>
+classifyFunctionErrorHandling(const clang::FunctionDecl *clangDecl,
+                              OptionalTypeKind resultOptionality) {
+  return classifyErrorByReturnType(
+      clangDecl->getASTContext(), clangDecl->getReturnType(), resultOptionality,
+      clangDecl->getAttr<clang::SwiftErrorAttr>(),
+      /*allowsNativeBool=*/true);
 }
 
 static const char ErrorSuffix[] = "AndReturnError";
 static const char AltErrorSuffix[] = "WithError";
 
-/// Determine the optionality of the given Objective-C method.
-///
-/// \param method The Clang method.
-static OptionalTypeKind getResultOptionality(
-                          const clang::ObjCMethodDecl *method) {
+/// Determine the optionality of the given declaration's return type.
+template <typename DeclT>
+static OptionalTypeKind getResultOptionality(const DeclT *decl) {
   // If nullability is available on the type, use it.
-  if (auto nullability = method->getReturnType()->getNullability()) {
+  if (auto nullability = decl->getReturnType()->getNullability())
     return translateNullability(*nullability);
-  }
 
   // If there is a returns_nonnull attribute, non-null.
-  if (method->hasAttr<clang::ReturnsNonNullAttr>())
+  if (decl->template hasAttr<clang::ReturnsNonNullAttr>())
     return OTK_None;
 
   // Default to implicitly unwrapped optionals.
@@ -1326,6 +1428,47 @@ NameImporter::considerErrorImport(const clang::ObjCMethodDecl *clangDecl,
     ForeignErrorConvention::Info errorInfo(
         *errorKind, index, isErrorOwned,
         (ForeignErrorConvention::IsReplaced_t)replaceParamWithVoid);
+    return errorInfo;
+  }
+
+  // Didn't find an error parameter.
+  return std::nullopt;
+}
+
+std::optional<ForeignErrorConvention::Info>
+NameImporter::considerErrorImportForFunction(
+    const clang::FunctionDecl *clangDecl,
+    ArrayRef<const clang::ParmVarDecl *> params) {
+  // C++ methods import via a different path; refuse them defensively so the
+  // public API doesn't depend on every caller filtering.
+  if (isa<clang::CXXMethodDecl>(clangDecl))
+    return std::nullopt;
+
+  auto errorKind =
+      classifyFunctionErrorHandling(clangDecl, getResultOptionality(clangDecl));
+  if (!errorKind)
+    return std::nullopt;
+
+  // Find the error parameter (scan from the end, skip trailing blocks).
+  for (unsigned index = params.size(); index-- != 0;) {
+    if (isBlockParameter(params[index]))
+      continue;
+
+    auto isErrorOwned = ForeignErrorConvention::IsNotOwned;
+    bool isCFError = false;
+    bool hasExplicitOwnership = false;
+    if (!isErrorOutParameter(params[index], isErrorOwned, isCFError,
+                             hasExplicitOwnership))
+      break;
+
+    // For CFErrorRef* on C functions, require explicit ownership annotation.
+    if (isCFError && !hasExplicitOwnership)
+      return std::nullopt;
+
+    // For C functions, don't replace the parameter with Void --
+    // the throwing variant simply omits it.
+    ForeignErrorConvention::Info errorInfo(
+        *errorKind, index, isErrorOwned, ForeignErrorConvention::IsNotReplaced);
     return errorInfo;
   }
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -510,6 +510,20 @@ public:
   static std::optional<StringRef>
   findCustomName(const clang::Decl *decl, ImportNameVersion version);
 
+  /// For a C function with an error out-parameter, find that parameter and
+  /// build the ForeignErrorConvention::Info. Uses default heuristics (bool →
+  /// ZeroResult, nullable pointer → NilResult) unless overridden by a
+  /// swift_error attribute. For CFErrorRef* parameters, explicit ownership
+  /// (CF_RETURNS_RETAINED or CF_RETURNS_NOT_RETAINED) is required. Returns
+  /// nullopt for C++ methods.
+  ///
+  /// Called externally from ImportDecl when synthesizing a throwing variant
+  /// alongside the non-throwing import; the ObjC analog (private, below) runs
+  /// only inside the name-importing path.
+  std::optional<ForeignErrorConvention::Info>
+  considerErrorImportForFunction(const clang::FunctionDecl *clangDecl,
+                                 ArrayRef<const clang::ParmVarDecl *> params);
+
 private:
   bool enableObjCInterop() const { return swiftCtx.LangOpts.EnableObjCInterop; }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2463,78 +2463,6 @@ findGenericTypeInGenericDecls(ClangImporter::Implementation &impl,
                                    addDiag);
 }
 
-ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
-    DeclContext *dc, const clang::FunctionDecl *clangDecl,
-    ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
-    bool isFromSystemModule, DeclName name, ParameterList *&parameterList,
-    ArrayRef<GenericTypeParamDecl *> genericParams) {
-
-  bool allowNSUIntegerAsInt =
-      shouldAllowNSUIntegerAsInt(isFromSystemModule, clangDecl);
-
-  // Only eagerly import the return type if it's not too expensive (the current
-  // heuristic for that is if it's not a record type).
-  ImportDiagnosticAdder addDiag(*this, clangDecl,
-                                clangDecl->getSourceRange().getBegin());
-  clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
-  returnType = desugarIfBoundsAttributed(returnType);
-
-  ImportedType importedType = importer::findOptionSetEnum(returnType, *this);
-
-  if (auto templateType =
-          dyn_cast<clang::TemplateTypeParmType>(returnType)) {
-    importedType = {findGenericTypeInGenericDecls(
-                        *this, templateType, genericParams,
-                        getImportTypeAttrs(clangDecl), addDiag),
-                    false};
-  } else if ((isa<clang::PointerType>(returnType) ||
-          isa<clang::ReferenceType>(returnType)) &&
-         isa<clang::TemplateTypeParmType>(returnType->getPointeeType())) {
-    auto pointeeType = returnType->getPointeeType();
-    auto templateParamType = cast<clang::TemplateTypeParmType>(pointeeType);
-    PointerTypeKind pointerKind = pointeeType.getQualifiers().hasConst()
-                                      ? PTK_UnsafePointer
-                                      : PTK_UnsafeMutablePointer;
-    auto genericType =
-        findGenericTypeInGenericDecls(*this, templateParamType, genericParams,
-                                      getImportTypeAttrs(clangDecl), addDiag);
-    auto genericPointerType = genericType->wrapInPointer(pointerKind);
-    if (!genericPointerType)
-      addDiag(Diagnostic(diag::bridged_pointer_type_not_found, pointerKind));
-    importedType = {genericPointerType, false};
-  } else if (!(isa<clang::RecordType>(returnType) ||
-               isa<clang::TemplateSpecializationType>(returnType)) ||
-             // TODO: we currently don't lazily load operator return types, but
-             // this should be trivial to add.
-             clangDecl->isOverloadedOperator() ||
-             // Dependant types are trivially mapped as Any.
-             returnType->isDependentType()) {
-    // If importedType is already initialized, it means we found the enum that
-    // was supposed to be used (instead of the typedef type).
-    if (!importedType) {
-      importedType =
-          importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt);
-      if (!importedType) {
-        addDiag(Diagnostic(diag::return_type_not_imported));
-        return {Type(), false};
-      }
-    }
-  }
-
-  Type swiftResultTy = importedType.getType();
-  ArrayRef<Identifier> argNames = name.getArgumentNames();
-  parameterList = importFunctionParameterList(dc, clangDecl, params, isVariadic,
-                                              allowNSUIntegerAsInt, argNames,
-                                              genericParams, swiftResultTy);
-  if (!parameterList)
-    return {Type(), false};
-
-  if (clangDecl->isNoReturn())
-    swiftResultTy = SwiftContext.getNeverType();
-
-  return {swiftResultTy, importedType.isImplicitlyUnwrapped()};
-}
-
 static bool isParameterContextGlobalActorIsolated(DeclContext *dc,
                                                   const clang::Decl *parent) {
   if (getActorIsolationOfContext(dc).isGlobalActor())
@@ -2858,11 +2786,54 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
   return paramInfo;
 }
 
+/// If \p param is a CFErrorRef* out-parameter, substitute NSError for CFError
+/// in \p errorTy.
+///
+/// The error parameter type has the form
+///   Optional<SomePointer<Optional<T>>>
+/// CFError shares NSError's representation, and SILGen reaches the Error
+/// existential through an entry point typed on NSError.
+static CanType substituteCFErrorWithNSError(CanType errorTy,
+                                            const clang::ParmVarDecl *param) {
+  // Decide from the Clang type, so this agrees with the check that recognized
+  // the parameter as an error out-parameter in the first place.
+  auto outerPtrType = param->getType()->getAs<clang::PointerType>();
+  if (!outerPtrType)
+    return errorTy;
+  auto innerPtrType =
+      outerPtrType->getPointeeType()->getAs<clang::PointerType>();
+  if (!innerPtrType)
+    return errorTy;
+  auto recordType = innerPtrType->getPointeeType()->getAs<clang::RecordType>();
+  if (!recordType || !importer::isRecordBridgedToNSError(recordType->getDecl()))
+    return errorTy;
+
+  auto outerOpt = errorTy.getOptionalObjectType();
+  if (!outerOpt)
+    return errorTy;
+  auto ptrBGT = dyn_cast<BoundGenericType>(outerOpt);
+  if (!ptrBGT)
+    return errorTy;
+  auto innerOpt = ptrBGT.getGenericArgs()[0]->getOptionalObjectType();
+  if (!innerOpt)
+    return errorTy;
+  auto &ctx = errorTy->getASTContext();
+  auto nsErrorTy = ctx.getNSErrorType();
+  if (!nsErrorTy)
+    return errorTy;
+  auto newInnerOpt = OptionalType::get(nsErrorTy)->getCanonicalType();
+  auto newPtr = BoundGenericType::get(ptrBGT->getDecl(), ptrBGT.getParent(),
+                                      {newInnerOpt});
+  return OptionalType::get(newPtr)->getCanonicalType();
+}
+
 ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     DeclContext *dc, const clang::FunctionDecl *clangDecl,
     ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
     bool allowNSUIntegerAsInt, ArrayRef<Identifier> argNames,
-    ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType) {
+    ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType,
+    std::optional<ForeignErrorConvention::Info> errorInfo,
+    CanType *errorParamType) {
   // Import the parameters.
   SmallVector<ParamDecl *, 4> parameters;
   unsigned index = 0;
@@ -2875,6 +2846,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
       continue;
     }
 
+    bool paramIsError = errorInfo && index == errorInfo->ErrorParameterIndex;
     bool knownNonNull = !nonNullArgs.empty() && nonNullArgs[index];
 
     // Check nullability of the parameter.
@@ -2886,7 +2858,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     auto swiftParamTyOpt = importParameterType(
         dc, clangDecl, param, optionalityOfParam, allowNSUIntegerAsInt,
         /*isNSDictionarySubscriptGetter=*/false,
-        /*paramIsError=*/false,
+        /*paramIsError=*/paramIsError,
         /*paramIsCompletionHandler=*/false,
         /*completionHandlerErrorParamIndex=*/std::nullopt, genericParams,
         paramAddDiag);
@@ -2897,6 +2869,16 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
       return nullptr;
     }
     auto swiftParamTy = swiftParamTyOpt->swiftTy;
+
+    if (paramIsError) {
+      if (errorParamType) {
+        *errorParamType = substituteCFErrorWithNSError(
+            swiftParamTy->getCanonicalType(), param);
+      }
+      ++index;
+      continue;
+    }
+
     bool isInOut = swiftParamTyOpt->isInOut;
     bool isConsuming = swiftParamTyOpt->isConsuming;
     bool isParamTypeImplicitlyUnwrapped =
@@ -3167,6 +3149,97 @@ getForeignErrorInfo(ForeignErrorConvention::Info errorInfo,
                                errorParamTy);
   }
   llvm_unreachable("bad error convention");
+}
+
+ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
+    DeclContext *dc, const clang::FunctionDecl *clangDecl,
+    ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
+    bool isFromSystemModule, DeclName name, ParameterList *&parameterList,
+    ArrayRef<GenericTypeParamDecl *> genericParams,
+    std::optional<ForeignErrorConvention::Info> errorInfo,
+    std::optional<ForeignErrorConvention> *foreignErrorConvention) {
+
+  bool allowNSUIntegerAsInt =
+      shouldAllowNSUIntegerAsInt(isFromSystemModule, clangDecl);
+
+  // Only eagerly import the return type if it's not too expensive (the current
+  // heuristic for that is if it's not a record type).
+  ImportDiagnosticAdder addDiag(*this, clangDecl,
+                                clangDecl->getSourceRange().getBegin());
+  clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
+  returnType = desugarIfBoundsAttributed(returnType);
+
+  ImportedType importedType = importer::findOptionSetEnum(returnType, *this);
+
+  if (auto templateType = dyn_cast<clang::TemplateTypeParmType>(returnType)) {
+    importedType = {
+        findGenericTypeInGenericDecls(*this, templateType, genericParams,
+                                      getImportTypeAttrs(clangDecl), addDiag),
+        false};
+  } else if ((isa<clang::PointerType>(returnType) ||
+              isa<clang::ReferenceType>(returnType)) &&
+             isa<clang::TemplateTypeParmType>(returnType->getPointeeType())) {
+    auto pointeeType = returnType->getPointeeType();
+    auto templateParamType = cast<clang::TemplateTypeParmType>(pointeeType);
+    PointerTypeKind pointerKind = pointeeType.getQualifiers().hasConst()
+                                      ? PTK_UnsafePointer
+                                      : PTK_UnsafeMutablePointer;
+    auto genericType =
+        findGenericTypeInGenericDecls(*this, templateParamType, genericParams,
+                                      getImportTypeAttrs(clangDecl), addDiag);
+    auto genericPointerType = genericType->wrapInPointer(pointerKind);
+    if (!genericPointerType)
+      addDiag(Diagnostic(diag::bridged_pointer_type_not_found, pointerKind));
+    importedType = {genericPointerType, false};
+  } else if (!(isa<clang::RecordType>(returnType) ||
+               isa<clang::TemplateSpecializationType>(returnType)) ||
+             // TODO: we currently don't lazily load operator return types, but
+             // this should be trivial to add (6e9bf509964).
+             clangDecl->isOverloadedOperator() ||
+             // Dependant types are trivially mapped as Any.
+             returnType->isDependentType()) {
+    // If importedType is already initialized, it means we found the enum that
+    // was supposed to be used (instead of the typedef type).
+    if (!importedType) {
+      importedType =
+          importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt);
+      if (!importedType) {
+        addDiag(Diagnostic(diag::return_type_not_imported));
+        return {Type(), false};
+      }
+    }
+  }
+
+  // Adjust the result type for a throwing function.
+  CanType origSwiftResultTy;
+  if (errorInfo && importedType.getType()) {
+    origSwiftResultTy = importedType.getType()->getCanonicalType();
+    importedType =
+        adjustResultTypeForThrowingFunction(*errorInfo, importedType);
+    if (!importedType.getType())
+      return {Type(), false};
+  }
+
+  Type swiftResultTy = importedType.getType();
+  CanType errorParamType;
+  ArrayRef<Identifier> argNames = name.getArgumentNames();
+  parameterList = importFunctionParameterList(
+      dc, clangDecl, params, isVariadic, allowNSUIntegerAsInt, argNames,
+      genericParams, swiftResultTy, errorInfo,
+      errorInfo ? &errorParamType : nullptr);
+  if (!parameterList)
+    return {Type(), false};
+
+  if (clangDecl->isNoReturn())
+    swiftResultTy = SwiftContext.getNeverType();
+
+  if (errorInfo && foreignErrorConvention) {
+    assert(errorParamType && "error parameter not found during import");
+    *foreignErrorConvention =
+        getForeignErrorInfo(*errorInfo, errorParamType, origSwiftResultTy);
+  }
+
+  return {swiftResultTy, importedType.isImplicitlyUnwrapped()};
 }
 
 // 'toDC' must be a subclass or a type conforming to the protocol

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1605,11 +1605,18 @@ public:
   ///   to system APIs.
   /// \param name The name of the function.
   /// \param[out] parameterList The parameters visible inside the function body.
+  /// \param genericParams Generic type parameters for the function.
+  /// \param errorInfo If present, identifies the error out-parameter to skip
+  ///   and the convention used to adjust the return type.
+  /// \param[out] foreignErrorConvention If non-null and errorInfo is present,
+  ///   receives the resulting error convention.
   ImportedType importFunctionParamsAndReturnType(
       DeclContext *dc, const clang::FunctionDecl *clangDecl,
       ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
       bool isFromSystemModule, DeclName name, ParameterList *&parameterList,
-      ArrayRef<GenericTypeParamDecl *> genericParams);
+      ArrayRef<GenericTypeParamDecl *> genericParams,
+      std::optional<ForeignErrorConvention::Info> errorInfo = std::nullopt,
+      std::optional<ForeignErrorConvention> *foreignErrorConvention = nullptr);
 
   /// Import the given function return type.
   ///
@@ -1640,7 +1647,9 @@ public:
       DeclContext *dc, const clang::FunctionDecl *clangDecl,
       ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
       bool allowNSUIntegerAsInt, ArrayRef<Identifier> argNames,
-      ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType);
+      ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType,
+      std::optional<ForeignErrorConvention::Info> errorInfo = std::nullopt,
+      CanType *errorParamType = nullptr);
 
   struct ImportParameterTypeResult {
     /// The imported parameter Swift type.
@@ -2159,6 +2168,12 @@ bool isForwardDeclOfType(const clang::Decl *decl);
 /// Checks whether this type is bool or is a C++ enum with a bool underlying
 /// type.
 bool isBoolOrBoolEnumType(Type ty);
+
+/// Whether \p decl is a struct that is toll-free bridged to NSError, which
+/// makes a pointer to it usable as an error out-parameter. Clang applies the
+/// same struct tag and bridging attribute check when it validates the
+/// swift_error attribute, but records only the first such struct it sees.
+bool isRecordBridgedToNSError(const clang::RecordDecl *decl);
 
 /// Whether we should suppress the import of the given Clang declaration.
 bool shouldSuppressDeclImport(const clang::Decl *decl);

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -180,6 +180,15 @@ AbstractionPattern AbstractionPattern::getCurriedObjCMethod(
   return getCurriedObjCMethod(origType, method, errorInfo);
 }
 
+AbstractionPattern AbstractionPattern::getCFunction(
+    CanType origType, const clang::Type *clangType,
+    const std::optional<ForeignErrorConvention> &foreignError) {
+  auto errorInfo = EncodedForeignInfo::encode(foreignError, std::nullopt);
+  AbstractionPattern pattern(origType, clangType);
+  pattern.OtherData = errorInfo.getOpaqueValue();
+  return pattern;
+}
+
 AbstractionPattern
 AbstractionPattern::getCurriedCFunctionAsMethod(CanType origType,
                                          const AbstractFunctionDecl *function) {
@@ -1709,10 +1718,23 @@ AbstractionPattern::getFunctionParamType(unsigned index) const {
     LLVM_FALLTHROUGH;
   case Kind::ClangType: {
     auto params = cast<AnyFunctionType>(getType()).getParams();
-    return AbstractionPattern(getGenericSubstitutions(),
-                              getGenericSignatureForFunctionComponent(),
-                              params[index].getParameterType(),
-                          getClangFunctionParameterType(getClangType(), index));
+    auto paramType = params[index].getParameterType();
+
+    // Adjust the Clang parameter index for a foreign error convention,
+    // which removes the error parameter from the Swift function type.
+    unsigned clangIndex = index;
+    if (getKind() == Kind::ClangType && OtherData != 0) {
+      auto errorInfo = EncodedForeignInfo::fromOpaqueValue(OtherData);
+      if (errorInfo.hasValue() &&
+          !errorInfo.hasErrorParameterReplacedWithVoid()) {
+        if (clangIndex >= errorInfo.getForeignParamIndex())
+          ++clangIndex;
+      }
+    }
+
+    return AbstractionPattern(
+        getGenericSubstitutions(), getGenericSignatureForFunctionComponent(),
+        paramType, getClangFunctionParameterType(getClangType(), clangIndex));
   }
   case Kind::OpaqueFunction:
     return getOpaque();

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4427,7 +4427,8 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
         foreignInfo.self.isImportAsMember()
             ? AbstractionPattern::getCFunctionAsMethod(origType, clangType,
                                                        foreignInfo.self)
-            : AbstractionPattern(origType, clangType);
+            : AbstractionPattern::getCFunction(origType, clangType,
+                                               foreignInfo.error);
     return getSILFunctionType(
         TC, TypeExpansionContext::minimal(), origPattern, substInterfaceType,
         extInfoBuilder, CFunctionConventions(func, TC.Context), foreignInfo,
@@ -5357,7 +5358,9 @@ getAbstractionPatternForConstant(TypeConverter &converter, ASTContext &ctx,
   } else if (auto value = dyn_cast<clang::ValueDecl>(clangDecl)) {
     if (numParameterLists == 1) {
       // C function imported as a function.
-      return AbstractionPattern(fnType, value->getType().getTypePtr());
+      return AbstractionPattern::getCFunction(
+          fnType, value->getType().getTypePtr(),
+          bridgedFn->getForeignErrorConvention());
     } else {
       assert(numParameterLists == 2);
       if (isa<clang::CXXMethodDecl>(clangDecl)) {

--- a/test/ClangImporter/Inputs/custom-modules/SwiftErrorCxxFunctions.h
+++ b/test/ClangImporter/Inputs/custom-modules/SwiftErrorCxxFunctions.h
@@ -1,0 +1,25 @@
+#ifndef SWIFT_ERROR_CXX_FUNCTIONS_H
+#define SWIFT_ERROR_CXX_FUNCTIONS_H
+
+@import Foundation;
+
+// The throwing variant covers C functions only, so each of these keeps its
+// error parameter.
+
+bool sec_cxx_global(int x, NSError **err);
+
+namespace SECNS {
+bool sec_in_namespace(int x, NSError **err);
+}
+
+template <class T>
+bool sec_template(T *out, NSError **err);
+
+struct SECStruct {
+  bool sec_method(int x, NSError **err);
+};
+
+// A declaration with C language linkage is a C function even in a C++ header.
+extern "C" bool sec_extern_c(int x, NSError **err);
+
+#endif

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -312,3 +312,9 @@ module RawIdentifierSwiftNames {
   header "RawIdentifierSwiftNames.h"
   export *
 }
+
+module SwiftErrorCxxFunctions {
+  requires objc
+  header "SwiftErrorCxxFunctions.h"
+  export *
+}

--- a/test/ClangImporter/test_swift_error_c_functions.swift
+++ b/test/ClangImporter/test_swift_error_c_functions.swift
@@ -1,0 +1,234 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -parse-as-library -verify -verify-ignore-unrelated %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -O -parse-as-library -DEMIT_SIL %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+import swift_error_c_functions
+
+// Test swift_error conventions on C functions.
+// Each case mirrors the ObjC method tests in foreign_errors.swift / errors.h.
+
+func testSwiftError() throws {
+  let _: Bool = try c_error_bound()
+  let _: Float = try c_error_bounce()
+  let _: () = try c_error_flounce()
+  let _: CInt = try c_error_ounce()
+  let _: () = try c_error_once()
+  let _: () = try c_error_sconce()
+  let _: () = try c_error_scotch()
+
+  var err: NSError?
+  let _: Bool = c_error_scout(&err)
+}
+
+// All boolean-like C types should produce ZeroResult (throwing returns Void).
+func testBooleanTypes() throws {
+  let _: () = try c_error_zero_bool()
+  let _: () = try c_error_zero_BOOL()
+  let _: () = try c_error_zero_Boolean()
+
+  let _: () = try c_error_nonzero_bool()
+  let _: () = try c_error_nonzero_BOOL()
+  let _: () = try c_error_nonzero_Boolean()
+}
+
+func testCFError() throws {
+  let _: UnsafeMutableRawPointer = try c_error_cf_null()
+  let _: () = try c_error_cf_nonnull()
+}
+
+func testNullResultNSError() throws {
+  let _: UnsafeMutableRawPointer = try c_error_ns_null()
+}
+
+func testTrailingBlock() throws {
+  try c_error_trailing_block {}
+}
+
+func testBlockBefore() throws {
+  try c_error_block_before(1) {}
+}
+
+func testMultiTrailingBlocks() throws {
+  try c_error_multi_trailing_blocks({}, {})
+}
+
+func testMultiBlocksBefore() throws {
+  try c_error_multi_blocks_before({}, {})
+}
+
+func testBlocksBothSides() throws {
+  try c_error_blocks_both_sides({}) {}
+}
+
+func testMultiParam() throws {
+  try c_error_multi_param(1, 2)
+}
+
+func testNonThrowingVariants() {
+  var nserr: NSError?
+  var cferr: CFError?
+
+  let _: Bool = c_error_bound(&nserr)
+  let _: Float = c_error_bounce(&nserr)
+  c_error_flounce(&nserr)
+  let _: CInt = c_error_ounce(&nserr)
+  let _: CInt = c_error_once(&nserr)
+  let _: Bool = c_error_sconce(&nserr)
+  let _: Bool = c_error_scotch(&nserr)
+
+  let _: UnsafeMutableRawPointer? = c_error_cf_null(&cferr)
+  c_error_cf_nonnull(&cferr)
+
+  let _: UnsafeMutableRawPointer? = c_error_ns_null(&nserr)
+
+  let _: Bool = c_error_trailing_block(&nserr) {}
+  let _: Bool = c_error_block_before(1, {}, &nserr)
+  let _: Bool = c_error_multi_trailing_blocks(&nserr, {}, {})
+  let _: Bool = c_error_multi_blocks_before({}, {}, &nserr)
+  let _: Bool = c_error_blocks_both_sides({}, &nserr) {}
+  let _: Bool = c_error_multi_param(1, 2, &nserr)
+}
+
+// --- Default heuristics (no swift_error attribute) ---
+
+func testDefaultBoolNSError() throws {
+  let _: () = try c_default_bool_nserror()
+}
+
+func testDefaultNullableNSError() throws {
+  let _: UnsafeMutableRawPointer = try c_default_nullable_nserror()
+}
+
+func testDefaultUnannotatedPtrNSError() throws {
+  let _: UnsafeMutableRawPointer = try c_default_unannotated_ptr_nserror()
+}
+
+func testDefaultBoolCFError() throws {
+  let _: () = try c_default_bool_cferror()
+}
+
+// c_no_attr now gets a throwing variant via default heuristics.
+func testNoAttrNowThrows() throws {
+  try c_no_attr(42)
+}
+
+func testDefaultNonThrowingVariants() {
+  var nserr: NSError?
+  var cferr: CFError?
+
+  let _: Bool = c_default_bool_nserror(&nserr)
+  let _: UnsafeMutableRawPointer? = c_default_nullable_nserror(&nserr)
+  let _: UnsafeMutableRawPointer! = c_default_unannotated_ptr_nserror(&nserr)
+  let _: Bool = c_default_bool_cferror(&cferr)
+  let _: Bool = c_no_attr(42, &nserr)
+
+  // swift_error(null_result) on _Nonnull falls back to non-throwing.
+  let _: UnsafeMutableRawPointer = c_error_null_nonnull(&nserr)
+}
+
+// A C function mapped onto a type by swift_name keeps its error parameter.
+func testMemberKeepsErrorParameter() {
+  let widget = CErrorWidget()
+  var nserr: NSError?
+  let _: Bool = widget.doIt(error: &nserr)
+
+  var point = CErrorPoint(x: 0, y: 0)
+  let _: Bool = point.doIt(error: &nserr)
+}
+
+// The ObjC error convention covers NSError** only, so a CFErrorRef*
+// out-parameter on a method stays an ordinary unmanaged parameter.
+func testObjCMethodCFErrorKeepsParameter() {
+  let widget = CErrorObjCWidget()
+  var cferr: Unmanaged<CFError>?
+  let _: Bool = widget.doIt(&cferr)
+}
+
+// Dropping the error parameter keeps the remaining argument labels aligned.
+func testLabelsAfterErrorParameter() throws {
+  try labeledTrailingBlock(callback: {})
+}
+
+// A lifetime annotation on the dropped error parameter is not carried over.
+func testLifetimeboundErrorParameter() throws {
+  let _: UnsafeMutableRawPointer = try c_error_lifetimebound()
+}
+
+// Any CF type bridged to NSError carries the error convention, not just CFError.
+func testCustomCFErrorType() throws {
+  let _: () = try c_default_bool_custom_cferror()
+}
+
+#if !EMIT_SIL
+func testNoneNoThrow() throws {
+  try c_error_scout() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+func testCFBareNoThrow() throws {
+  try c_error_cf_bare() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+func testNoAttrCFNoThrow() throws {
+  try c_no_attr_cf(42) // expected-error {{missing argument for parameter #2 in call}}
+}
+
+func testDefaultNegativeInt() throws {
+  try c_default_int_nserror(42) // expected-error {{cannot convert value of type 'Int' to expected argument type 'AutoreleasingUnsafeMutablePointer<NSError?>'}}
+}
+
+func testDefaultNegativeCFBare() throws {
+  try c_default_bool_cferror_bare() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+func testDefaultNegativeErrorUnion() throws {
+  try c_default_bool_error_union() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+// A throwing variant that takes the name of another declaration leaves both
+// visible, so the name is ambiguous rather than silently resolved.
+func testCollidingName() throws {
+  try collide(x: 1) // expected-error {{ambiguous use of 'collide(x:)'}}
+}
+
+func testDefaultNegativeOverrideNone() throws {
+  try c_default_override_none() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+func testDefaultNegativeNonnull() throws {
+  try c_default_nonnull_nserror() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+func testDefaultNegativeVoid() {
+  c_default_void_nserror() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+// --- swift_error(null_result) on a non-optional pointer ---
+// Clang accepts the attribute (the return is still a pointer), but the Swift
+// importer rejects it because the result is non-optional. The function should
+// still be callable as the non-throwing import.
+
+func testNullResultNonnullFallback() throws {
+  try c_error_null_nonnull() // expected-error {{missing argument for parameter #1 in call}}
+}
+
+func testUnhandledError() {
+  try c_error_sconce() // expected-error {{errors thrown from here are not handled}}
+}
+
+func testDefaultUnhandledError() {
+  try c_default_bool_nserror() // expected-error {{errors thrown from here are not handled}}
+}
+
+func testZeroResultIsVoid() throws {
+  let _: Bool = try c_error_sconce() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+  let _: Bool = try c_error_zero_bool() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+  let _: Bool = try c_error_zero_BOOL() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+  let _: Bool = try c_error_zero_Boolean() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+  let _: Bool = try c_error_nonzero_bool() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+  let _: Bool = try c_error_nonzero_BOOL() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+  let _: Bool = try c_error_nonzero_Boolean() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+  let _: Bool = try c_default_bool_nserror() // expected-error {{cannot convert value of type '()' to specified type 'Bool'}}
+}
+#endif

--- a/test/ClangImporter/test_swift_error_cxx_functions.swift
+++ b/test/ClangImporter/test_swift_error_cxx_functions.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -verify-ignore-unrelated -I %S/Inputs/custom-modules -cxx-interoperability-mode=default %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+import SwiftErrorCxxFunctions
+
+// A C++ declaration keeps its error parameter. The throwing variant builds its
+// parameters from the full Clang parameter list at module scope, which accounts
+// for neither 'self', generic parameters, nor an enclosing context.
+
+func useGlobal() throws {
+  try sec_cxx_global(1) // expected-error {{missing argument for parameter #2 in call}}
+}
+
+func useNamespaceMember() throws {
+  try SECNS.sec_in_namespace(1) // expected-error {{missing argument for parameter #2 in call}}
+}
+
+func useTemplate(_ p: UnsafeMutablePointer<Int32>) throws {
+  try sec_template(p) // expected-error {{missing argument for parameter #2 in call}}
+}
+
+func useMethod(_ s: inout SECStruct) throws {
+  try s.sec_method(1) // expected-error {{missing argument for parameter #2 in call}}
+}
+
+// A declaration with C language linkage still gets the throwing variant.
+func useExternC() throws {
+  let _: () = try sec_extern_c(1)
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/CoreFoundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/CoreFoundation.h
@@ -16,6 +16,8 @@ typedef struct __attribute__((objc_bridge(NSDictionary))) __CFDictionary const *
 typedef struct __attribute__((objc_bridge(NSArray))) __CFArray const *CFArrayRef;
 typedef struct __attribute__((objc_bridge(NSSet))) __CFSet const *CFSetRef;
 
+typedef struct __attribute__((objc_bridge_mutable(NSError))) __CFError *CFErrorRef;
+
 typedef CFTypeRef CFAliasForTypeRef;
 
 #if __LLP64__
@@ -39,6 +41,8 @@ extern CFIndex CFIndex_test;
 #define CF_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
 
 #define CF_NOESCAPE __attribute__((noescape))
+#define CF_RETURNS_RETAINED __attribute__((cf_returns_retained))
+#define CF_RETURNS_NOT_RETAINED __attribute__((cf_returns_not_retained))
 
 #ifdef CGFLOAT_IN_COREFOUNDATION
 #if defined(__LP64__) && __LP64__

--- a/test/Inputs/clang-importer-sdk/usr/include/module.modulemap
+++ b/test/Inputs/clang-importer-sdk/usr/include/module.modulemap
@@ -1,4 +1,8 @@
 module cfuncs { header "cfuncs.h" }
+module swift_error_c_functions {
+  header "swift_error_c_functions.h"
+  export *
+}
 module ctypes {
   header "ctypes.h"
   explicit module bits {

--- a/test/Inputs/clang-importer-sdk/usr/include/swift_error_c_functions.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/swift_error_c_functions.h
@@ -1,0 +1,215 @@
+/* -*- ObjC -*- */
+@import Foundation;
+@import CoreFoundation;
+#include <MacTypes.h>
+#include <stdbool.h>
+
+// --- swift_error conventions on C functions ---
+
+// nonnull_error: _Bool return preserved.
+_Bool c_error_bound(NSError **err)
+  __attribute__((swift_error(nonnull_error)));
+
+// nonnull_error: float return preserved.
+float c_error_bounce(NSError **err)
+  __attribute__((swift_error(nonnull_error)));
+
+// nonnull_error: void return.
+void c_error_flounce(NSError **err)
+  __attribute__((swift_error(nonnull_error)));
+
+// zero_result: int return → ZeroPreservedResult, return preserved.
+int c_error_ounce(NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// nonzero_result: int return → Void.
+int c_error_once(NSError **err)
+  __attribute__((swift_error(nonzero_result)));
+
+// zero_result: _Bool return → ZeroResult, Void.
+_Bool c_error_sconce(NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// nonzero_result: _Bool return → Void.
+_Bool c_error_scotch(NSError **err)
+  __attribute__((swift_error(nonzero_result)));
+
+// none: no throwing variant.
+_Bool c_error_scout(NSError **err)
+  __attribute__((swift_error(none)));
+
+// --- Boolean type variants for zero_result ---
+// All boolean-like types should produce ZeroResult (throwing returns Void).
+
+// bool (stdbool.h macro for _Bool).
+bool c_error_zero_bool(NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// BOOL (ObjC typedef).
+BOOL c_error_zero_BOOL(NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// Boolean (Carbon/MacTypes.h typedef to unsigned char).
+Boolean c_error_zero_Boolean(NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// --- Boolean type variants for nonzero_result ---
+
+bool c_error_nonzero_bool(NSError **err)
+  __attribute__((swift_error(nonzero_result)));
+
+BOOL c_error_nonzero_BOOL(NSError **err)
+  __attribute__((swift_error(nonzero_result)));
+
+Boolean c_error_nonzero_Boolean(NSError **err)
+  __attribute__((swift_error(nonzero_result)));
+
+// --- null_result with NSError** ---
+
+void * _Nullable c_error_ns_null(NSError **err)
+  __attribute__((swift_error(null_result)));
+
+// --- Additional cases ---
+
+// null_result: nullable pointer return with CFErrorRef* CF_RETURNS_RETAINED.
+void * _Nullable c_error_cf_null(CFErrorRef *err CF_RETURNS_RETAINED)
+  __attribute__((swift_error(null_result)));
+
+// nonnull_error: void return with CFErrorRef* CF_RETURNS_NOT_RETAINED.
+void c_error_cf_nonnull(CFErrorRef *err CF_RETURNS_NOT_RETAINED)
+  __attribute__((swift_error(nonnull_error)));
+
+// Trailing block parameter after error.
+_Bool c_error_trailing_block(NSError **err, void (^callback)(void))
+  __attribute__((swift_error(zero_result)));
+
+// Explicit argument labels with a block parameter after the error parameter.
+_Bool c_error_labeled_trailing_block(NSError **err, void (^callback)(void))
+  __attribute__((swift_name("labeledTrailingBlock(err:callback:)")))
+  __attribute__((swift_error(zero_result)));
+
+// Block parameter before error (error is last).
+_Bool c_error_block_before(int x, void (^callback)(void), NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// Multiple trailing blocks after error.
+_Bool c_error_multi_trailing_blocks(NSError **err,
+    void (^first)(void), void (^second)(void))
+  __attribute__((swift_error(zero_result)));
+
+// Multiple blocks before error (error is last).
+_Bool c_error_multi_blocks_before(void (^first)(void),
+    void (^second)(void), NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// Blocks on both sides of error.
+_Bool c_error_blocks_both_sides(void (^before)(void),
+    NSError **err, void (^after)(void))
+  __attribute__((swift_error(zero_result)));
+
+// Multiple parameters before error.
+_Bool c_error_multi_param(int x, int y, NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// A lifetime annotation on the error parameter, which the throwing variant
+// omits from its parameter list.
+void * _Nullable c_error_lifetimebound(NSError **err __attribute__((lifetimebound)));
+
+// --- Negative cases ---
+
+// CFErrorRef* without ownership annotation.
+_Bool c_error_cf_bare(CFErrorRef *err)
+  __attribute__((swift_error(zero_result)));
+
+// No swift_error attribute with CFErrorRef* (no ownership).
+_Bool c_no_attr_cf(int x, CFErrorRef *err);
+
+// --- Default heuristics (no swift_error attribute) ---
+
+// bool + NSError** → ZeroResult.
+bool c_default_bool_nserror(NSError **err);
+
+// _Nullable pointer + NSError** → NilResult.
+void * _Nullable c_default_nullable_nserror(NSError **err);
+
+// Unannotated pointer + NSError** → NilResult (IUO default).
+void *c_default_unannotated_ptr_nserror(NSError **err);
+
+// bool + CFErrorRef* with ownership → ZeroResult.
+bool c_default_bool_cferror(CFErrorRef *err CF_RETURNS_RETAINED);
+
+// _Bool + int param + NSError** → ZeroResult via default heuristic.
+_Bool c_no_attr(int x, NSError **err);
+
+// --- Default heuristic negative cases ---
+
+// int return → no default heuristic (not bool, not pointer).
+int c_default_int_nserror(NSError **err);
+
+// CFErrorRef* without ownership → still blocked.
+bool c_default_bool_cferror_bare(CFErrorRef *err);
+
+// A union bridged to NSError is not CFError, which Clang identifies by a
+// struct tag, so no error convention applies.
+typedef union __attribute__((objc_bridge(NSError))) __CFErrorUnion *CFErrorUnionRef;
+
+bool c_default_bool_error_union(CFErrorUnionRef *err CF_RETURNS_RETAINED);
+
+// A CF type bridged to NSError that is not CFError itself.
+typedef struct __attribute__((objc_bridge_mutable(NSError))) __CFCustomError *CFCustomErrorRef;
+
+bool c_default_bool_custom_cferror(CFCustomErrorRef *err CF_RETURNS_RETAINED);
+
+// The throwing variant drops the error parameter, giving it the same name as
+// another declaration.
+_Bool c_collide_source(int x, NSError **err)
+  __attribute__((swift_name("collide(x:err:)")))
+  __attribute__((swift_error(zero_result)));
+
+void c_collide_target(int x)
+  __attribute__((swift_name("collide(x:)")));
+
+// swift_error(none) overrides default heuristic.
+bool c_default_override_none(NSError **err)
+  __attribute__((swift_error(none)));
+
+// _Nonnull pointer + NSError** → no NilResult (non-optional return).
+void * _Nonnull c_default_nonnull_nserror(NSError **err);
+
+// void return + NSError** → no default heuristic.
+void c_default_void_nserror(NSError **err);
+
+// --- swift_error attribute / return type mismatches accepted by Clang ---
+// Clang rejects most return-type mismatches at parse time (e.g.,
+// zero_result/nonzero_result require an integral return). The remaining case
+// Clang allows but the Swift importer must still reject is null_result on a
+// non-optional pointer return: classifyFunctionErrorHandling returns nullopt
+// because OTK_None blocks the NilResult convention.
+void * _Nonnull c_error_null_nonnull(NSError **err)
+  __attribute__((swift_error(null_result)));
+
+// --- Imported as a member of a type ---
+// swift_name can map a C function onto a type, turning one parameter into
+// 'self'. The error parameter is preserved for these; the throwing variant
+// covers module-scope functions only.
+
+@interface CErrorWidget : NSObject
+@end
+
+// The error convention on ObjC methods covers NSError** only, so a CFErrorRef*
+// out-parameter stays an ordinary parameter even with the attribute.
+@interface CErrorObjCWidget : NSObject
+- (BOOL)doIt:(CFErrorRef *)err __attribute__((swift_error(zero_result)));
+@end
+
+_Bool c_member_zero_result(CErrorWidget *widget, NSError **err)
+  __attribute__((swift_name("CErrorWidget.doIt(self:error:)")))
+  __attribute__((swift_error(zero_result)));
+
+struct CErrorPoint {
+  double x, y;
+};
+
+_Bool c_member_struct_zero_result(struct CErrorPoint *point, NSError **err)
+  __attribute__((swift_name("CErrorPoint.doIt(self:error:)")))
+  __attribute__((swift_error(zero_result)));

--- a/test/Interpreter/Inputs/SwiftErrorCFunctions/SwiftErrorCFunctions.h
+++ b/test/Interpreter/Inputs/SwiftErrorCFunctions/SwiftErrorCFunctions.h
@@ -1,0 +1,34 @@
+#import <Foundation/Foundation.h>
+#import <CoreFoundation/CoreFoundation.h>
+
+// zero_result: _Bool return → throws, Void.
+_Bool c_error_zero(_Bool shouldFail, NSError **err)
+  __attribute__((swift_error(zero_result)));
+
+// nonzero_result: int32_t return → throws, Void.
+int32_t c_error_nonzero(int32_t code, NSError **err)
+  __attribute__((swift_error(nonzero_result)));
+
+// nonnull_error: void return → throws, Void.
+void c_error_nonnull(_Bool shouldFail, NSError **err)
+  __attribute__((swift_error(nonnull_error)));
+
+// null_result: nullable pointer → throws, non-optional pointer.
+void * _Nullable c_error_null(_Bool shouldFail, NSError **err)
+  __attribute__((swift_error(null_result)));
+
+// null_result with CFErrorRef*, CF_RETURNS_RETAINED.
+void * _Nullable c_error_cf_null(_Bool shouldFail,
+    CFErrorRef *err CF_RETURNS_RETAINED)
+  __attribute__((swift_error(null_result)));
+
+// nonnull_error with CFErrorRef*, CF_RETURNS_NOT_RETAINED.
+void c_error_cf_nonnull(_Bool shouldFail,
+    CFErrorRef *err CF_RETURNS_NOT_RETAINED)
+  __attribute__((swift_error(nonnull_error)));
+
+// zero_result with blocks on both sides of the error parameter.
+// Exercises the parameter-index plumbing for non-trivial layouts.
+_Bool c_error_blocks_both_sides(_Bool shouldFail,
+    void (^before)(int), NSError **err, void (^after)(int))
+  __attribute__((swift_error(zero_result)));

--- a/test/Interpreter/Inputs/SwiftErrorCFunctions/SwiftErrorCFunctions.m
+++ b/test/Interpreter/Inputs/SwiftErrorCFunctions/SwiftErrorCFunctions.m
@@ -1,0 +1,64 @@
+#import "SwiftErrorCFunctions.h"
+
+static NSError *makeError(int code) {
+  return [NSError errorWithDomain:@"TestDomain" code:code userInfo:nil];
+}
+
+_Bool c_error_zero(_Bool shouldFail, NSError **err) {
+  if (shouldFail) {
+    if (err) *err = makeError(1);
+    return false;
+  }
+  return true;
+}
+
+int32_t c_error_nonzero(int32_t code, NSError **err) {
+  if (code != 0) {
+    if (err) *err = makeError(code);
+    return code;
+  }
+  return 0;
+}
+
+void c_error_nonnull(_Bool shouldFail, NSError **err) {
+  if (shouldFail) {
+    if (err) *err = makeError(3);
+  }
+}
+
+void * _Nullable c_error_null(_Bool shouldFail, NSError **err) {
+  if (shouldFail) {
+    if (err) *err = makeError(4);
+    return NULL;
+  }
+  static int sentinel = 42;
+  return &sentinel;
+}
+
+void * _Nullable c_error_cf_null(_Bool shouldFail,
+    CFErrorRef *err CF_RETURNS_RETAINED) {
+  if (shouldFail) {
+    if (err) *err = (__bridge_retained CFErrorRef)makeError(5);
+    return NULL;
+  }
+  static int sentinel = 99;
+  return &sentinel;
+}
+
+void c_error_cf_nonnull(_Bool shouldFail,
+    CFErrorRef *err CF_RETURNS_NOT_RETAINED) {
+  if (shouldFail) {
+    if (err) *err = (__bridge CFErrorRef)makeError(6);
+  }
+}
+
+_Bool c_error_blocks_both_sides(_Bool shouldFail,
+    void (^before)(int), NSError **err, void (^after)(int)) {
+  before(10);
+  after(20);
+  if (shouldFail) {
+    if (err) *err = makeError(7);
+    return false;
+  }
+  return true;
+}

--- a/test/Interpreter/Inputs/SwiftErrorCFunctions/module.modulemap
+++ b/test/Interpreter/Inputs/SwiftErrorCFunctions/module.modulemap
@@ -1,0 +1,3 @@
+module SwiftErrorCFunctions {
+  header "SwiftErrorCFunctions.h"
+}

--- a/test/Interpreter/swift_error_c_functions.swift
+++ b/test/Interpreter/swift_error_c_functions.swift
@@ -1,0 +1,172 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-clang -fobjc-arc %S/Inputs/SwiftErrorCFunctions/SwiftErrorCFunctions.m -c -o %t/SwiftErrorCFunctions.o
+// RUN: %target-build-swift -I %S/Inputs/SwiftErrorCFunctions/ %t/SwiftErrorCFunctions.o %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import SwiftErrorCFunctions
+import Foundation
+import StdlibUnittest
+
+var SwiftErrorCFunctionTests = TestSuite("SwiftErrorCFunctions")
+
+// --- zero_result ---
+
+SwiftErrorCFunctionTests.test("zero_result/success") {
+  do {
+    try c_error_zero(false)
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+SwiftErrorCFunctionTests.test("zero_result/failure") {
+  do {
+    try c_error_zero(true)
+    expectUnreachable()
+  } catch let error as NSError {
+    expectEqual("TestDomain", error.domain)
+    expectEqual(1, error.code)
+  }
+}
+
+// --- nonzero_result ---
+
+SwiftErrorCFunctionTests.test("nonzero_result/success") {
+  do {
+    try c_error_nonzero(0)
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+SwiftErrorCFunctionTests.test("nonzero_result/failure") {
+  do {
+    try c_error_nonzero(7)
+    expectUnreachable()
+  } catch let error as NSError {
+    expectEqual("TestDomain", error.domain)
+    expectEqual(7, error.code)
+  }
+}
+
+// --- nonnull_error ---
+
+SwiftErrorCFunctionTests.test("nonnull_error/success") {
+  do {
+    try c_error_nonnull(false)
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+SwiftErrorCFunctionTests.test("nonnull_error/failure") {
+  do {
+    try c_error_nonnull(true)
+    expectUnreachable()
+  } catch let error as NSError {
+    expectEqual("TestDomain", error.domain)
+    expectEqual(3, error.code)
+  }
+}
+
+// --- null_result (NSError) ---
+
+SwiftErrorCFunctionTests.test("null_result/success") {
+  do {
+    let ptr = try c_error_null(false)
+    expectNotNil(ptr)
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+SwiftErrorCFunctionTests.test("null_result/failure") {
+  do {
+    _ = try c_error_null(true)
+    expectUnreachable()
+  } catch let error as NSError {
+    expectEqual("TestDomain", error.domain)
+    expectEqual(4, error.code)
+  }
+}
+
+// --- null_result (CFErrorRef) ---
+
+SwiftErrorCFunctionTests.test("cf_null_result/success") {
+  do {
+    let ptr = try c_error_cf_null(false)
+    expectNotNil(ptr)
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+SwiftErrorCFunctionTests.test("cf_null_result/failure") {
+  do {
+    _ = try c_error_cf_null(true)
+    expectUnreachable()
+  } catch let error as NSError {
+    expectEqual("TestDomain", error.domain)
+    expectEqual(5, error.code)
+  }
+}
+
+// --- nonnull_error (CFErrorRef) ---
+
+SwiftErrorCFunctionTests.test("cf_nonnull_error/success") {
+  do {
+    try c_error_cf_nonnull(false)
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+SwiftErrorCFunctionTests.test("cf_nonnull_error/failure") {
+  do {
+    try c_error_cf_nonnull(true)
+    expectUnreachable()
+  } catch let error as NSError {
+    expectEqual("TestDomain", error.domain)
+    expectEqual(6, error.code)
+  }
+}
+
+// --- zero_result with blocks on both sides of error param ---
+
+SwiftErrorCFunctionTests.test("blocks_both_sides/success") {
+  var beforeArg: Int32 = 0
+  var afterArg: Int32 = 0
+  do {
+    try c_error_blocks_both_sides(false,
+                                  { beforeArg = $0 },
+                                  { afterArg = $0 })
+    expectEqual(10, beforeArg)
+    expectEqual(20, afterArg)
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
+SwiftErrorCFunctionTests.test("blocks_both_sides/failure") {
+  var beforeArg: Int32 = 0
+  var afterArg: Int32 = 0
+  do {
+    try c_error_blocks_both_sides(true,
+                                  { beforeArg = $0 },
+                                  { afterArg = $0 })
+    expectUnreachable()
+  } catch let error as NSError {
+    expectEqual("TestDomain", error.domain)
+    expectEqual(7, error.code)
+    // Both blocks ran before the error was raised.
+    expectEqual(10, beforeArg)
+    expectEqual(20, afterArg)
+  }
+}
+
+runAllTests()

--- a/test/SILGen/foreign_errors_c_functions.swift
+++ b/test/SILGen/foreign_errors_c_functions.swift
@@ -1,0 +1,334 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -module-name foreign_errors_c -parse-as-library %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+import swift_error_c_functions
+
+// --- nonnull_error: _Bool return, result discarded after error check ---
+// Mirrors testNonNilError() in foreign_errors.swift (nonnull_error convention).
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c20testNonnullErrorBoolyyKF : $@convention(thin) () -> @error any Error
+func testNonnullErrorBool() throws {
+  //   Allocate error temp and initialize to nil.
+  // CHECK: [[ERR_TEMP:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
+  // CHECK: inject_enum_addr [[ERR_TEMP]] : $*Optional<NSError>, #Optional.none!enumelt
+
+  //   Get the C function reference (not objc_method).
+  // CHECK: [[FN:%.*]] = function_ref @$sSo13c_error_boundSbyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+
+  //   Prepare the error pointer and call.
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+
+  //   For nonnull_error, check the error pointer directly (no result comparison).
+  // CHECK: switch_enum {{%.*}} : $Optional<NSError>, case #Optional.some!enumelt: [[ERROR_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NORMAL_BB:bb[0-9]+]]
+
+  //   Normal: discard result.
+  // CHECK: [[NORMAL_BB]]:
+  // CHECK: ignored_use [[RESULT]] : $Bool
+  try c_error_bound()
+}
+
+// --- nonnull_error: Float return ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c21testNonnullErrorFloatSfyKF : $@convention(thin) () -> (Float, @error any Error)
+func testNonnullErrorFloat() throws -> Float {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo14c_error_bounceSfyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Float
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Float
+  // CHECK: switch_enum {{%.*}} : $Optional<NSError>, case #Optional.some!enumelt: [[ERROR_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NORMAL_BB:bb[0-9]+]]
+  // CHECK: [[NORMAL_BB]]:
+  // CHECK-NOT: destroy_value
+  // CHECK: return [[RESULT]] : $Float
+  return try c_error_bounce()
+}
+
+// --- nonnull_error: Void return ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c20testNonnullErrorVoidyyKF : $@convention(thin) () -> @error any Error
+func testNonnullErrorVoid() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo15c_error_flounceyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> ()
+  // CHECK: apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> ()
+  // CHECK: switch_enum {{%.*}} : $Optional<NSError>, case #Optional.some!enumelt: [[ERROR_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NORMAL_BB:bb[0-9]+]]
+  try c_error_flounce()
+}
+
+// --- zero_result: int return → ZeroPreservedResult (result preserved) ---
+// Mirrors testPreservedResult() in foreign_errors.swift for ObjC ounce().
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c19testPreservedResults5Int32VyKF : $@convention(thin) () -> (Int32, @error any Error)
+func testPreservedResult() throws -> CInt {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo13c_error_ounces5Int32VyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Int32
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Int32
+
+  //   Compare result against zero.
+  // CHECK: [[T0:%.*]] = struct_extract [[RESULT]]
+  // CHECK: [[ZERO:%.*]] = integer_literal $[[PRIM:Builtin.Int[0-9]+]], 0
+  // CHECK: [[CMP:%.*]] = builtin "cmp_ne_Int32"([[T0]] : $[[PRIM]], [[ZERO]] : $[[PRIM]])
+  // CHECK: cond_br [[CMP]], [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+
+  //   Normal: return preserved result.
+  // CHECK: [[NORMAL_BB]]:
+  // CHECK-NOT: destroy_value
+  // CHECK: return [[RESULT]] : $Int32
+  return try c_error_ounce()
+}
+
+// --- nonzero_result: int return → inverted branch ---
+// Mirrors testPreservedResultInverted() in foreign_errors.swift for ObjC once().
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c27testPreservedResultInvertedyyKF : $@convention(thin) () -> @error any Error
+func testPreservedResultInverted() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo12c_error_onceyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Int32
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Int32
+
+  //   Compare result against zero — note INVERTED branch targets.
+  // CHECK: [[T0:%.*]] = struct_extract [[RESULT]]
+  // CHECK: [[ZERO:%.*]] = integer_literal $[[PRIM:Builtin.Int[0-9]+]], 0
+  // CHECK: [[CMP:%.*]] = builtin "cmp_ne_Int32"([[T0]] : $[[PRIM]], [[ZERO]] : $[[PRIM]])
+  // CHECK: cond_br [[CMP]], [[ERROR_BB:bb[0-9]+]], [[NORMAL_BB:bb[0-9]+]]
+
+  // CHECK: [[NORMAL_BB]]:
+  // CHECK-NOT: destroy_value
+  // CHECK: return {{%.+}} : $()
+  try c_error_once()
+}
+
+// --- zero_result: _Bool return → ZeroResult (Void) ---
+// Mirrors test0() in foreign_errors.swift for ObjC fail().
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c15testZeroResultByyKF : $@convention(thin) () -> @error any Error
+func testZeroResultB() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo14c_error_sconceyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+
+  //   Bool result: extract _value and branch directly.
+  // CHECK: [[BVAL:%.*]] = struct_extract [[RESULT]] : $Bool, #Bool._value
+  // CHECK: cond_br [[BVAL]], [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+
+  // CHECK: [[NORMAL_BB]]:
+  try c_error_sconce()
+}
+
+// --- nonzero_result: _Bool return → inverted branch ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c23testNonzeroResultScotchyyKF : $@convention(thin) () -> @error any Error
+func testNonzeroResultScotch() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo14c_error_scotchyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+
+  //   Bool result with inverted semantics.
+  // CHECK: [[BVAL:%.*]] = struct_extract [[RESULT]] : $Bool, #Bool._value
+  // CHECK: cond_br [[BVAL]], [[ERROR_BB:bb[0-9]+]], [[NORMAL_BB:bb[0-9]+]]
+
+  // CHECK: [[NORMAL_BB]]:
+  try c_error_scotch()
+}
+
+// --- Error conversion: verify NSError → Error bridging on error path ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c20testErrorConversionByyKF : $@convention(thin) () -> @error any Error
+func testErrorConversionB() throws {
+  // CHECK: [[ERR_TEMP:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
+  // CHECK: inject_enum_addr [[ERR_TEMP]] : $*Optional<NSError>, #Optional.none!enumelt
+
+  // CHECK: [[FN:%.*]] = function_ref @$sSo14c_error_sconceyyKFTo
+
+  // CHECK: [[UNMANAGED_TEMP:%.*]] = alloc_stack $@sil_unmanaged Optional<NSError>
+  // CHECK: [[T0:%.*]] = load_borrow [[ERR_TEMP]]
+  // CHECK: [[T1:%.*]] = ref_to_unmanaged [[T0]]
+  // CHECK: store [[T1]] to [trivial] [[UNMANAGED_TEMP]]
+  // CHECK: address_to_pointer [stack_protection] [[UNMANAGED_TEMP]]
+
+  // CHECK: apply [[FN]]
+
+  //   Writeback to error temp.
+  // CHECK: [[T0:%.*]] = load [trivial] [[UNMANAGED_TEMP]]
+  // CHECK: [[T1:%.*]] = unmanaged_to_ref [[T0]]
+  // CHECK: [[T1_COPY:%.*]] = copy_value [[T1]]
+  // CHECK: [[T1_COPY_DEP:%.*]] = mark_dependence [[T1_COPY]] : $Optional<NSError> on [[ERR_TEMP]]
+  // CHECK: assign [[T1_COPY_DEP]] to [[ERR_TEMP]]
+
+  //   Branch on result.
+  // CHECK: cond_br {{%.*}}, [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+
+  //   Error path: convert NSError → Error and throw.
+  // CHECK: [[ERROR_BB]]:
+  // CHECK: [[T0:%.*]] = load [take] [[ERR_TEMP]]
+  // CHECK: [[CONVERT:%.*]] = function_ref @$s10Foundation22_convertNSErrorToErrorys0E0_pSo0C0CSgF
+  // CHECK: [[ERR:%.*]] = apply [[CONVERT]]([[T0]])
+  // CHECK: "willThrow"([[ERR]] : $any Error)
+  // CHECK: throw [[ERR]] : $any Error
+  try c_error_sconce()
+}
+
+// --- null_result: nullable pointer return with CFErrorRef ---
+// Mirrors NilResult convention (no ObjC equivalent with CFError).
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c19testNullResultCFRefSvyKF : $@convention(thin) () -> (UnsafeMutableRawPointer, @error any Error)
+func testNullResultCFRef() throws -> UnsafeMutableRawPointer {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo15c_error_cf_nullSvyKFTo : $@convention(c) (Optional<UnsafeMutablePointer<Optional<NSError>>>) -> Optional<UnsafeMutableRawPointer>
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<UnsafeMutablePointer<Optional<NSError>>>) -> Optional<UnsafeMutableRawPointer>
+
+  //   null_result: check result for nil.
+  // CHECK: switch_enum [[RESULT]] : $Optional<UnsafeMutableRawPointer>, case #Optional.some!enumelt: [[NORMAL_BB:bb[0-9]+]], case #Optional.none!enumelt: [[ERROR_BB:bb[0-9]+]]
+  return try c_error_cf_null()
+}
+
+// --- nonnull_error: Void return with CFErrorRef ---
+// Verify CFError param is bridged to NSError in the SIL signature.
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c22testNonnullErrorCFRefByyKF : $@convention(thin) () -> @error any Error
+func testNonnullErrorCFRefB() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo18c_error_cf_nonnullyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> ()
+  // CHECK: apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> ()
+  // CHECK: switch_enum {{%.*}} : $Optional<NSError>, case #Optional.some!enumelt: [[ERROR_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NORMAL_BB:bb[0-9]+]]
+  try c_error_cf_nonnull()
+}
+
+// --- Trailing block parameter after error ---
+// Verify block param is passed correctly when error param is skipped.
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c17testTrailingBlockyyKF : $@convention(thin) () -> @error any Error
+func testTrailingBlock() throws {
+  //   C function takes (NSError**, block) — verify both params in apply.
+  // CHECK: [[FN:%.*]] = function_ref @$sSo22c_error_trailing_blockyyyycSgKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, Optional<@convention(block) () -> ()>) -> Bool
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}, {{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, Optional<@convention(block) () -> ()>) -> Bool
+
+  //   Bool result with zero_result convention.
+  // CHECK: [[BVAL:%.*]] = struct_extract [[RESULT]] : $Bool, #Bool._value
+  // CHECK: cond_br [[BVAL]], [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+  try c_error_trailing_block {}
+}
+
+// --- Block parameter before error (error is last) ---
+// Verify block param and int param are passed, error param is at the end.
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c15testBlockBeforeyyKF : $@convention(thin) () -> @error any Error
+func testBlockBefore() throws {
+  //   C function takes (int, block, NSError**) — verify 3 params in apply.
+  // CHECK: [[FN:%.*]] = function_ref @$sSo20c_error_block_beforeyys5Int32V_yycSgtKFTo : $@convention(c) (Int32, Optional<@convention(block) () -> ()>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: apply [[FN]]({{%.*}}, {{%.*}}, {{%.*}}) : $@convention(c) (Int32, Optional<@convention(block) () -> ()>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: cond_br
+  try c_error_block_before(1) {}
+}
+
+// --- Multiple trailing blocks after error ---
+// Verify both block params are passed after the error param.
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c23testMultiTrailingBlocksyyKF : $@convention(thin) () -> @error any Error
+func testMultiTrailingBlocks() throws {
+  //   C function takes (NSError**, block, block) — verify 3 params.
+  // CHECK: [[FN:%.*]] = function_ref @$sSo29c_error_multi_trailing_blocksyyyycSg_ABtKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, Optional<@convention(block) () -> ()>, Optional<@convention(block) () -> ()>) -> Bool
+  // CHECK: apply [[FN]]({{%.*}}, {{%.*}}, {{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, Optional<@convention(block) () -> ()>, Optional<@convention(block) () -> ()>) -> Bool
+  // CHECK: cond_br
+  try c_error_multi_trailing_blocks({}, {})
+}
+
+// --- Multiple blocks before error (error is last) ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c21testMultiBlocksBeforeyyKF : $@convention(thin) () -> @error any Error
+func testMultiBlocksBefore() throws {
+  //   C function takes (block, block, NSError**) — verify 3 params.
+  // CHECK: function_ref @$sSo27c_error_multi_blocks_beforeyyyycSg_ABtKFTo
+  // CHECK: cond_br
+  try c_error_multi_blocks_before({}, {})
+}
+
+// --- Blocks on both sides of error ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c19testBlocksBothSidesyyKF : $@convention(thin) () -> @error any Error
+func testBlocksBothSides() throws {
+  //   C function takes (block, NSError**, block) — verify 3 params.
+  // CHECK: function_ref @$sSo25c_error_blocks_both_sidesyyyycSg_ABtKFTo
+  // CHECK: cond_br
+  try c_error_blocks_both_sides({}) {}
+}
+
+// --- Multiple parameters before error ---
+// Verify non-error params come first, error param in the middle.
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c14testMultiParamyyKF : $@convention(thin) () -> @error any Error
+func testMultiParam() throws {
+  //   C function takes (int, int, NSError**) — verify 3 params.
+  // CHECK: [[FN:%.*]] = function_ref @$sSo19c_error_multi_paramyys5Int32V_ACtKFTo : $@convention(c) (Int32, Int32, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: apply [[FN]]({{%.*}}, {{%.*}}, {{%.*}}) : $@convention(c) (Int32, Int32, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: cond_br
+  try c_error_multi_param(1, 2)
+}
+
+// --- Boolean type variants: all produce ZeroResult → cond_br on Bool._value ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c18testZeroResultBoolyyKF : $@convention(thin) () -> @error any Error
+func testZeroResultBool() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo17c_error_zero_boolyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[BVAL:%.*]] = struct_extract [[RESULT]] : $Bool, #Bool._value
+  // CHECK: cond_br [[BVAL]], [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+  try c_error_zero_bool()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c18testZeroResultBOOLyyKF : $@convention(thin) () -> @error any Error
+func testZeroResultBOOL() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo17c_error_zero_BOOLyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[BVAL:%.*]] = struct_extract [[RESULT]] : $Bool, #Bool._value
+  // CHECK: cond_br [[BVAL]], [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+  try c_error_zero_BOOL()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c21testZeroResultBooleanyyKF : $@convention(thin) () -> @error any Error
+func testZeroResultBoolean() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo20c_error_zero_BooleanyyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[BVAL:%.*]] = struct_extract [[RESULT]] : $Bool, #Bool._value
+  // CHECK: cond_br [[BVAL]], [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+  try c_error_zero_Boolean()
+}
+
+// --- Default heuristic: bool + NSError** → ZeroResult (no swift_error attr) ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c20testDefaultBoolNSErryyKF : $@convention(thin) () -> @error any Error
+func testDefaultBoolNSErr() throws {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo22c_default_bool_nserroryyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: [[BVAL:%.*]] = struct_extract [[RESULT]] : $Bool, #Bool._value
+  // CHECK: cond_br [[BVAL]], [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+  try c_default_bool_nserror()
+}
+
+// --- Default heuristic: _Nullable pointer + NSError** → NilResult ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c24testDefaultNullableNSErrSvyKF : $@convention(thin) () -> (UnsafeMutableRawPointer, @error any Error)
+func testDefaultNullableNSErr() throws -> UnsafeMutableRawPointer {
+  // CHECK: [[FN:%.*]] = function_ref @$sSo26c_default_nullable_nserrorSvyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Optional<UnsafeMutableRawPointer>
+  // CHECK: [[RESULT:%.*]] = apply [[FN]]({{%.*}}) : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Optional<UnsafeMutableRawPointer>
+  // CHECK: switch_enum [[RESULT]] : $Optional<UnsafeMutableRawPointer>, case #Optional.some!enumelt: [[NORMAL_BB:bb[0-9]+]], case #Optional.none!enumelt: [[ERROR_BB:bb[0-9]+]]
+  return try c_default_nullable_nserror()
+}
+
+// --- Default heuristic: unannotated pointer + NSError** → NilResult (IUO) ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c27testDefaultUnannotatedNSErrSvyKF : $@convention(thin) () -> (UnsafeMutableRawPointer, @error any Error)
+func testDefaultUnannotatedNSErr() throws -> UnsafeMutableRawPointer {
+  // CHECK: function_ref @$sSo33c_default_unannotated_ptr_nserrorSvyKFTo : $@convention(c) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Optional<UnsafeMutableRawPointer>
+  // CHECK: switch_enum {{%.*}} : $Optional<UnsafeMutableRawPointer>, case #Optional.some!enumelt: [[NORMAL_BB:bb[0-9]+]], case #Optional.none!enumelt: [[ERROR_BB:bb[0-9]+]]
+  return try c_default_unannotated_ptr_nserror()
+}
+
+// --- Default heuristic: bool + CFErrorRef* with ownership → ZeroResult ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c23testDefaultBoolCFErrOwnyyKF : $@convention(thin) () -> @error any Error
+func testDefaultBoolCFErrOwn() throws {
+  // CHECK: function_ref @$sSo22c_default_bool_cferroryyKFTo : $@convention(c) (Optional<UnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: cond_br {{%.*}}, [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+  try c_default_bool_cferror()
+}
+
+// --- Default heuristic: _Bool + int params + NSError** → ZeroResult (c_no_attr) ---
+
+// CHECK-LABEL: sil hidden [ossa] @$s16foreign_errors_c17testNoAttrDefaultyyKF : $@convention(thin) () -> @error any Error
+func testNoAttrDefault() throws {
+  // CHECK: function_ref @$sSo9c_no_attryys5Int32VKFTo : $@convention(c) (Int32, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>) -> Bool
+  // CHECK: cond_br {{%.*}}, [[NORMAL_BB:bb[0-9]+]], [[ERROR_BB:bb[0-9]+]]
+  try c_no_attr(42)
+}


### PR DESCRIPTION
Extend `swift_error` support from ObjC methods to C functions. A function annotated `__attribute__((swift_error(...)))`, or one matching the default heuristics with a trailing `NSError**` or an ownership-annotated `CFErrorRef*` out-parameter, now also imports as a throwing Swift function alongside its non-throwing form.

- ImportName: recognize `swift_error` on `FunctionDecl` and classify error handling for C functions, sharing the return-type classification with the ObjC path.
- ImportDecl: build the throwing variant and register it as an alternate decl.
- ImportType: thread the error convention through parameter and result import, and substitute `NSError` for `CFError` in the error parameter type.
- AbstractionPattern / SILFunctionType: carry the error convention into ClangType abstraction patterns so the Clang-to-SIL parameter mapping accounts for the omitted error parameter.

C++ declarations do not get a throwing variant, and neither do C functions that `swift_name` maps onto a type. The variant's parameters are built from the full Clang parameter list, which does not match how those are imported.

Tests cover the imported interface, the generated SIL, and execution.