### PR TITLE
AST: Don't consider import access level when potentially suppressing `override`

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1087,14 +1087,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DeclAttrKind::Override: {
     if (!Options.IsForSwiftInterface)
       break;
-    // When we are printing Swift interface, we have to skip the override keyword
-    // if the overridden decl is invisible from the interface. Otherwise, an error
-    // will occur while building the Swift module because the overriding decl
-    // doesn't override anything.
-    // We couldn't skip every `override` keywords because they change the
-    // ABI if the overridden decl is also publicly visible.
-    // For public-override-internal case, having `override` doesn't have ABI
-    // implication. Thus we can skip them.
+    // Skip printing 'override' if it would result in a broken swiftinterface.
+    // For example, 'override' should be suppressed if the base decl is internal
+    // or if the base decl is SPI and the public swiftinterface is being
+    // printed.
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (auto *BD = VD->getOverriddenDecl()) {
         // If the overridden decl won't be printed, printing override will fail
@@ -1103,7 +1099,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
           return false;
         if (!BD->hasClangNode() &&
             !BD->getFormalAccessScope(VD->getDeclContext(),
-                                      /*treatUsableFromInlineAsPublic*/ true)
+                                      /*treatUsableFromInlineAsPublic=*/true,
+                                      /*ignoreImportAccessLevel=*/true)
                  .isPublicOrPackage()) {
           return false;
         }

--- a/test/ModuleInterface/skip-override-keyword-access-level-import.swift
+++ b/test/ModuleInterface/skip-override-keyword-access-level-import.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+
+// RUN: %target-swift-frontend -typecheck %t/PublicImport.swift \
+// RUN:   %t/InternalImport.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 -module-name Client \
+// RUN:   -enable-upcoming-feature InternalImportsByDefault \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) \
+// RUN:   -I %t -module-name Client
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \
+// RUN:   -I %t -module-name Client
+
+// RUN: %FileCheck %s < %t/Client.swiftinterface
+// RUN: %FileCheck %s < %t/Client.private.swiftinterface
+
+// REQUIRES: swift_feature_InternalImportsByDefault
+
+//--- Lib.swift
+
+open class Base {
+  public init() {}
+  open func overrideMe() { }
+}
+
+//--- PublicImport.swift
+
+public import Lib
+
+open class Middle: Base {
+  public override init() { super.init() }
+}
+
+//--- InternalImport.swift
+
+internal import Lib
+
+// CHECK: open class Bottom : Client::Middle
+open class Bottom: Middle {
+  // CHECK: override public func overrideMe(){{$}}
+  override public func overrideMe() { }
+}


### PR DESCRIPTION
Methods should be printed in swiftinterface files without `override` when the overridden method would not be visible from the swiftinterface. However, determining the visibility of the base declaration should not take import access level into account, since that base declaration may come from a module that is imported as `internal` in one file while being imported publicly in another.

Resolves rdar://184888792.
