### PR TITLE
[Embedded] Don't try to specialize generic requirements of protocols

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2655,6 +2655,16 @@ bool swift::specializeWitnessMethodInst(WitnessMethodInst *wm) {
   if (wm->use_empty())
     return false;
 
+  // In Embedded Swift, refuse to specialize when the requirement is more
+  // generic than the protocol itself. Such calls required unspecialized
+  // generics, which are not permitted in Embedded Swift. They are diagnosed
+  // in the type checker, but only with a warning in some configurations.
+  auto requirementSig =
+      wm->getType().castTo<SILFunctionType>()->getInvocationGenericSignature();
+  auto protocolSig = wm->getConformance().getProtocol()->getGenericSignature();
+  if (requirementSig.isABIMoreGenericThan(protocolSig))
+    return false;
+
   Operand *firstUse = *wm->use_begin();
   ApplySite AI = ApplySite::isa(firstUse->getUser());
   assert(AI && AI.getCalleeOperand() == firstUse && "wrong use of witness_method instruction");

--- a/test/embedded/existential-generic-error.swift
+++ b/test/embedded/existential-generic-error.swift
@@ -15,3 +15,20 @@ public func test_any(p: any MyProtocol) {
   test_some(p: p)
   // expected-warning@-1{{cannot use generic global function 'test_some(p:)' on a value of type 'any MyProtocol' in Embedded Swift}}
 }
+
+// The same, but where the caller of the generic requirement does get
+// specialized: the witness_method must keep the requirement's own generic
+// parameters, because IRGen derives the signature of the call from the
+// unsubstituted requirement and still passes their metadata and witness tables.
+public protocol OtherProtocol: AnyObject {
+  func bar<T: BinaryInteger>(value: T)
+}
+
+func call_bar<T: BinaryInteger>(value: T, p: any OtherProtocol) {
+  p.bar(value: value) // expected-error {{a protocol type cannot contain a generic method 'bar(value:)' in embedded Swift}}
+  // expected-warning@-1 {{cannot use generic instance method 'bar(value:)' on a value of type 'any OtherProtocol' in Embedded Swift}}
+}
+
+public func test_specialized_caller(p: any OtherProtocol) {
+  call_bar(value: 0, p: p) // expected-note {{generic specialization called here}}
+}


### PR DESCRIPTION
This was diagnosed as a warning in the type checker, but crashed later in the SIL pipeline rather than producing a proper error. Fixes rdar://185238587 / https://github.com/swiftlang/swift/issues/91566.
