### PR TITLE
Fix unbalanced alloc_stack generated by LoadableByAddress

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -4244,8 +4244,9 @@ void AddressAssignment::finish(DominanceInfo *dominance,
     SmallVector<SILBasicBlock *, 8> boundary;
     computeDominatedBoundaryBlocks(stackLoc->getParent(), dominance, boundary);
     for (auto *block : boundary) {
-      if (deadEnds->isDeadEnd(block))
+      if (DeadEndBlocks::triviallyEndsInUnreachable(block)) {
         continue;
+      }
       auto builder = getBuilder(block->back().getIterator());
       builder.createDeallocStack(getAutoLoc(), stackLoc);
     }

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -531,3 +531,35 @@ bb0(%0 : $*LargeRef, %1 : $*Builtin.NativeObject):
   return %4 : $()
 }
 
+sil @useC1 : $@convention(thin) (@guaranteed C1) -> ()
+
+// CHECK-LABEL: sil @test_alloc_stack_in_loop_no_return
+// CHECK:       bb1:
+// CHECK:         [[STK:%.*]] = alloc_stack $LargeRef
+// CHECK:         copy_addr [take] %0 to [init] [[STK]]
+// CHECK:       bb2:
+// CHECK:         dealloc_stack [[STK]]
+// CHECK:         br bb1
+// CHECK:       bb3:
+// CHECK-NOT:     dealloc_stack
+// CHECK:         unreachable
+// CHECK:       } // end sil function 'test_alloc_stack_in_loop_no_return'
+sil @test_alloc_stack_in_loop_no_return : $@convention(thin) (@in_guaranteed LargeRef, Builtin.Int1) -> () {
+bb0(%0 : $*LargeRef, %1 : $Builtin.Int1):
+  br bb1
+
+bb1:
+  %2 = load %0 : $*LargeRef
+  retain_value %2 : $LargeRef
+  %3 = struct_extract %2 : $LargeRef, #LargeRef.c
+  %4 = function_ref @useC1 : $@convention(thin) (@guaranteed C1) -> ()
+  apply %4(%3) : $@convention(thin) (@guaranteed C1) -> ()
+  cond_br %1, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  unreachable
+}
+


### PR DESCRIPTION
AddressAssignment::finish() sinks each alloc_stack to the least common ancestor of its uses, then emits dealloc_stack at the dominated boundary blocks. It skipped any boundary block for which DeadEndBlocks::isDeadEnd() returned true.

isDeadEnd() is transitive: in a function with no reachable return or throw, every block is a dead-end block. So no dealloc_stack was emitted in some cases causing other verifier errors.

Use triviallyEndsInUnreachable() instead to skip inserting dealloc_stack on boundary blocks ending in unreachable.

rdar://184014468
