### PR TITLE
[IRGen] NFC: Adjust `@called(once)` thunk emission test to account fo…

### DIFF
--- a/test/IRGen/called_once_thunk.swift
+++ b/test/IRGen/called_once_thunk.swift
@@ -19,7 +19,7 @@ final class Tracker {
 // CHECK-LABEL: define{{.*}} swiftcc void @"$s4test33calledThroughThunkReleasesCaptureyyF"()
 // CHECK: [[TRACKER:%.*]] = call swiftcc ptr @"$s4test7TrackerCACycfC"
 // CHECK: call ptr @swift_retain(ptr returned [[TRACKER]])
-// CHECK: [[CLOSURE:%.*]] = call swiftcc { ptr, ptr } @"$s4test14makeCalledOnceyySiXOySicF"(ptr @"$s4test33calledThroughThunkReleasesCaptureyyFySicfU_TA", ptr [[TRACKER]])
+// CHECK: [[CLOSURE:%.*]] = call swiftcc { ptr, ptr } @"$s4test14makeCalledOnceyySiXOySicF"(ptr @"$s4test33calledThroughThunkReleasesCaptureyyFySicfU_TA{{.*}}", ptr [[TRACKER]])
 // CHECK: [[CLOSURE_FN:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 0
 // CHECK: [[CLOSURE_CTX:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 1
 // CHECK: call void @swift_release(ptr [[TRACKER]])
@@ -34,7 +34,7 @@ public func calledThroughThunkReleasesCapture() {
 // CHECK-LABEL: define{{.*}} swiftcc void @"$s4test38neverCalledThroughThunkReleasesCaptureyyF"()
 // CHECK: [[TRACKER:%.*]] = call swiftcc ptr @"$s4test7TrackerCACycfC"
 // CHECK: call ptr @swift_retain(ptr returned [[TRACKER]])
-// CHECK: [[CLOSURE:%.*]] = call swiftcc { ptr, ptr } @"$s4test14makeCalledOnceyySiXOySicF"(ptr @"$s4test38neverCalledThroughThunkReleasesCaptureyyFySicfU_TA", ptr [[TRACKER]])
+// CHECK: [[CLOSURE:%.*]] = call swiftcc { ptr, ptr } @"$s4test14makeCalledOnceyySiXOySicF"(ptr @"$s4test38neverCalledThroughThunkReleasesCaptureyyFySicfU_TA{{.*}}", ptr [[TRACKER]])
 // CHECK: [[CLOSURE_FN:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 0
 // CHECK: [[CLOSURE_CTX:%.*]] = extractvalue { ptr, ptr } [[CLOSURE]], 1
 // CHECK: call void @swift_release(ptr [[TRACKER]])


### PR DESCRIPTION
…r ptrauth

This is arm64e specific fix that accounts for the fact that the symbol can have `.ptrauth` postfix.

Resolves: rdar://184739123

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
