### PR TITLE
[Distributed] Reject executeDistributedTarget when decoders don't match

### DIFF
--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -426,6 +426,9 @@ extension DistributedActorSystem {
     invocationDecoder: inout InvocationDecoder,
     handler: Self.ResultHandler
   ) async throws where Act: DistributedActor {
+    try _validateMatchingInvocationDecoder(Act.self, Self.self)
+    try _validateMatchingResultHandler(Act.self, Self.self)
+
     // NOTE: Implementation could be made more efficient because we still risk
     // demangling a RemoteCallTarget identity (if it is a mangled name) multiple
     // times. We would prefer to store if it is a mangled name, demangle, and
@@ -608,6 +611,58 @@ extension DistributedActorSystem {
     } catch {
       try await handler.onThrow(error: error)
     }
+  }
+}
+
+@export(implementation)
+@available(SwiftStdlib 5.7, *)
+internal func _validateMatchingInvocationDecoder<
+  Act: DistributedActor,
+  System: DistributedActorSystem
+>(_ actorType: Act.Type, _ systemType: System.Type) throws {
+  guard Act.ActorSystem.InvocationDecoder.self
+        == System.InvocationDecoder.self else {
+    let errorCode: ExecuteDistributedTargetError.ErrorCode
+    // This is @available(SwiftStdlib 6.5, *) but can't use SwiftStdlib in an @export(implementation) function
+    if #available(anyAppleOS 9999, *) {
+      errorCode = .incompatibleInvocationDecoder
+    } else {
+      errorCode = .typeDeserializationFailure
+    }
+    throw ExecuteDistributedTargetError(
+      message: """
+               Actor '\(actorType)' uses InvocationDecoder \
+               '\(Act.ActorSystem.InvocationDecoder.self)' which does not \
+               match the receiving system's decoder \
+               '\(System.InvocationDecoder.self)'
+               """,
+      errorCode: errorCode)
+  }
+}
+
+@export(implementation)
+@available(SwiftStdlib 5.7, *)
+internal func _validateMatchingResultHandler<
+  Act: DistributedActor,
+  System: DistributedActorSystem
+>(_ actorType: Act.Type, _ systemType: System.Type) throws {
+  guard Act.ActorSystem.ResultHandler.self
+        == System.ResultHandler.self else {
+    let errorCode: ExecuteDistributedTargetError.ErrorCode
+    // This is @available(SwiftStdlib 6.5, *) but can't use SwiftStdlib in an @export(implementation) function
+    if #available(anyAppleOS 9999, *) {
+      errorCode = .incompatibleResultHandler
+    } else {
+      errorCode = .typeDeserializationFailure
+    }
+    throw ExecuteDistributedTargetError(
+      message: """
+               Actor '\(actorType)' uses ResultHandler \
+               '\(Act.ActorSystem.ResultHandler.self)' which does not match \
+               the receiving system's result handler \
+               '\(System.ResultHandler.self)'
+               """,
+      errorCode: errorCode)
   }
 }
 
@@ -925,6 +980,18 @@ public struct ExecuteDistributedTargetError: DistributedActorSystemError {
 
     // Failed to deserialize type or obtain type information for call.
     case typeDeserializationFailure
+
+    /// The actor passed to `executeDistributedTarget` belongs to an actor
+    /// system whose ``InvocationDecoder`` associated type does not match
+    /// the receiving system's ``InvocationDecoder``.
+    @available(SwiftStdlib 6.5, *)
+    case incompatibleInvocationDecoder
+
+    /// The actor passed to `executeDistributedTarget` belongs to an actor
+    /// system whose ``ResultHandler`` associated type does not match the
+    /// receiving system's ``ResultHandler``.
+    @available(SwiftStdlib 6.5, *)
+    case incompatibleResultHandler
 
     /// A general issue during the execution of the distributed call target occurred.
     case other

--- a/test/Distributed/Runtime/distributed_executeDistributedTarget_crossSystem.swift
+++ b/test/Distributed/Runtime/distributed_executeDistributedTarget_crossSystem.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-future-triple -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+// A distributed actor pinned to a *different* ActorSystem whose associated
+// InvocationDecoder and ResultHandler types differ from the receiving system.
+distributed actor OtherSystemGreeter {
+  typealias ActorSystem = FakeCustomSerializationRoundtripActorSystem
+
+  distributed func hello() {}
+}
+
+@main
+struct Main {
+  static func main() async {
+    let system = FakeActorSystem()
+    let handler = FakeRoundtripResultHandler({ _ in }, onError: { _ in })
+
+    // executeDistributedTarget must reject invocations on an actor whose
+    // declared ActorSystem's associated decoder / result handler types do
+    // not match the receiving system.
+
+    let otherSystem = FakeCustomSerializationRoundtripActorSystem()
+    let otherGreeter = OtherSystemGreeter(actorSystem: otherSystem)
+    var crossSystemDecoder = FakeInvocationDecoder(args: [])
+    do {
+      try await system.executeDistributedTarget(
+        on: otherGreeter,
+        target: RemoteCallTarget("$s4main18OtherSystemGreeterC5helloyyYaKFTE"),
+        invocationDecoder: &crossSystemDecoder,
+        handler: handler)
+      print("UNEXPECTED: cross-system returned")
+    } catch let e as ExecuteDistributedTargetError {
+      print("crossSystem threw errorCode=\(e.errorCode)")
+    } catch {
+      print("crossSystem threw: \(error)")
+    }
+    // CHECK: crossSystem threw errorCode=incompatibleInvocationDecoder
+  }
+}

--- a/test/abi/macOS/arm64/distributed.swift
+++ b/test/abi/macOS/arm64/distributed.swift
@@ -113,3 +113,8 @@ Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_Y
 
 // Distributed.DistributedRemoteActorReferenceExecutor.checkIsolated() -> ()
 Added: _$s11Distributed0A28RemoteActorReferenceExecutorC13checkIsolatedyyF
+
+// Distributed.ExecuteDistributedTargetError.ErrorCode.incompatibleInvocationDecoder
+Added: _$s11Distributed07ExecuteA11TargetErrorV0D4CodeO29incompatibleInvocationDecoderyA2EmFWC
+// Distributed.ExecuteDistributedTargetError.ErrorCode.incompatibleResultHandler
+Added: _$s11Distributed07ExecuteA11TargetErrorV0D4CodeO25incompatibleResultHandleryA2EmFWC

--- a/test/abi/macOS/x86_64/distributed.swift
+++ b/test/abi/macOS/x86_64/distributed.swift
@@ -113,3 +113,8 @@ Added: _$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_Y
 
 // Distributed.DistributedRemoteActorReferenceExecutor.checkIsolated() -> ()
 Added: _$s11Distributed0A28RemoteActorReferenceExecutorC13checkIsolatedyyF
+
+// Distributed.ExecuteDistributedTargetError.ErrorCode.incompatibleInvocationDecoder
+Added: _$s11Distributed07ExecuteA11TargetErrorV0D4CodeO29incompatibleInvocationDecoderyA2EmFWC
+// Distributed.ExecuteDistributedTargetError.ErrorCode.incompatibleResultHandler
+Added: _$s11Distributed07ExecuteA11TargetErrorV0D4CodeO25incompatibleResultHandleryA2EmFWC


### PR DESCRIPTION
executeDistributedTarget<Act> is only constrained by `Act: DistributedActor`, but we need to ensure the decoder and result handler types are compatible -- otherwise we are at risk of invoking methods on a decoder that has the wrong layout. This introduces a runtime check for the system equality, so we don't have a source break here but do protect from such misuse.

Fixes rdar://182990719
