### PR TITLE
Update winsdk_um.modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk_um.modulemap
+++ b/stdlib/public/Platform/winsdk_um.modulemap
@@ -429,6 +429,8 @@ module WinSDK [system] {
   module OLE {
     header "ole2.h"
     export *
+
+    link "Ole32.Lib"
   }
 
   module OLE32 {


### PR DESCRIPTION
Autolink Ole32.Lib when using OLE.

Fixes: #89241