### PR TITLE
[SourceKit] Accept frontend arguments when generating compiler invocation

### DIFF
--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -162,32 +162,47 @@ bool ide::initCompilerInvocation(
     const std::string &swiftExecutablePath,
     const std::string &runtimeResourcePath, time_t sessionTimestamp,
     std::string &Error) {
+  // Frontend arguments begin with -frontend, otherwise they are treated as
+  // driver arguments.
+  bool ArgsAreFrontend =
+      !OrigArgs.empty() && StringRef(OrigArgs.front()) == "-frontend";
+  ArrayRef<const char *> PassedArgs =
+      ArgsAreFrontend ? OrigArgs.drop_front() : OrigArgs;
+
   SmallVector<const char *, 16> Args;
   // Make sure to put '-resource-dir' at the top to allow overriding them with
   // the passed in arguments.
   Args.push_back("-resource-dir");
   Args.push_back(runtimeResourcePath.c_str());
-  Args.append(OrigArgs.begin(), OrigArgs.end());
+  Args.append(PassedArgs.begin(), PassedArgs.end());
 
   SmallString<32> ErrStr;
   llvm::raw_svector_ostream ErrOS(ErrStr);
   StreamDiagConsumer DiagConsumer(ErrOS);
   Diags.addConsumer(DiagConsumer);
 
-  // Derive 'swiftc' path from 'swift-frontend' path (swiftExecutablePath).
-  SmallString<256> driverPath(swiftExecutablePath);
-  llvm::sys::path::remove_filename(driverPath);
-  llvm::sys::path::append(driverPath, "swiftc");
+  bool InvocationCreationFailed;
+  if (ArgsAreFrontend) {
+    // No need to call the driver here, arguments are parsed directly.
+    InvocationCreationFailed = Invocation.parseArgs(
+        Args, Diags, /*ConfigurationFileBuffers=*/nullptr,
+        /*workingDirectory=*/"", swiftExecutablePath);
+  } else {
+    // Derive 'swiftc' path from 'swift-frontend' path (swiftExecutablePath).
+    SmallString<256> driverPath(swiftExecutablePath);
+    llvm::sys::path::remove_filename(driverPath);
+    llvm::sys::path::append(driverPath, "swiftc");
 
-  bool InvocationCreationFailed =
-      driver::getSingleFrontendInvocationFromDriverArguments(
-          driverPath, Args, Diags,
-          [&](ArrayRef<const char *> FrontendArgs) {
-            return Invocation.parseArgs(
-                FrontendArgs, Diags, /*ConfigurationFileBuffers=*/nullptr,
-                /*workingDirectory=*/"", swiftExecutablePath);
-          },
-          /*ForceNoOutputs=*/true);
+    InvocationCreationFailed =
+        driver::getSingleFrontendInvocationFromDriverArguments(
+            driverPath, Args, Diags,
+            [&](ArrayRef<const char *> FrontendArgs) {
+              return Invocation.parseArgs(
+                  FrontendArgs, Diags, /*ConfigurationFileBuffers=*/nullptr,
+                  /*workingDirectory=*/"", swiftExecutablePath);
+            },
+            /*ForceNoOutputs=*/true);
+  }
 
   // Remove the StreamDiagConsumer as it's no longer needed.
   Diags.removeConsumer(DiagConsumer);

--- a/test/SourceKit/Misc/frontend_compiler_args.swift
+++ b/test/SourceKit/Misc/frontend_compiler_args.swift
@@ -1,0 +1,15 @@
+func demo() -> Int { return 42 }
+
+// This test ensures sourcekitd accepts frontend arguments (a compiler-args
+// list beginning with `-frontend`); the request is sent via
+// -json-request-path rather than the natural because that form has
+// sourcekitd-test prepend `-module-cache-path` to the request's compiler args,
+// which would incorrectly fail this test
+
+// RUN: echo '{ key.request: source.request.cursorinfo, key.sourcefile: "%/s", key.offset: 5, key.compilerargs: [ "-frontend", "-module-name", "Test", "%/s" ] }' > %t.json
+// RUN: %sourcekitd-test -json-request-path %t.json | %FileCheck %s
+
+// The module name `Test` is set only through the frontend args, so seeing it
+// baked into the USR (`4Test`) proves the frontend path parsed and applied them.
+// CHECK: key.kind: source.lang.swift.decl.function.free
+// CHECK: key.usr: "s:4Test4demoSiyF"


### PR DESCRIPTION
SourceKit now accepts frontend arguments in addition to driver arguments. Frontend arguments are detected by the first argument being `-frontend`, they do not require calling legacy driver and are parsed directly into the invocation. Anything that doesn't lead with '-frontend' is still treated as driver arguments.

rdar://185359034
