### PR TITLE
[Test] Derive lit's Swift-release OS versions from availability-macros.def.

### DIFF
--- a/test/Availability/availability_scopes_target_min_inlining.swift
+++ b/test/Availability/availability_scopes_target_min_inlining.swift
@@ -13,8 +13,8 @@
 // CHECK-xros: {{^}}(root version=1.0
 
 // CHECK-macosx-NEXT: {{^}}  (decl_implicit version=10.15 decl=foo()
-// CHECK-ios-NEXT: {{^}}  (decl_implicit version=13 decl=foo()
-// CHECK-tvos-NEXT: {{^}}  (decl_implicit version=13 decl=foo()
-// CHECK-watchos-NEXT: {{^}}  (decl_implicit version=6 decl=foo()
+// CHECK-ios-NEXT: {{^}}  (decl_implicit version=13.0 decl=foo()
+// CHECK-tvos-NEXT: {{^}}  (decl_implicit version=13.0 decl=foo()
+// CHECK-watchos-NEXT: {{^}}  (decl_implicit version=6.0 decl=foo()
 
 func foo() {}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -537,53 +537,6 @@ swift_version = lit_config.params.get('swift-version',
 lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
-# Loads availability macros for known stdlib releases.
-def load_availability_macros():
-    path = os.path.join(os.path.dirname(__file__), "../utils/availability-macros.def")
-    lines = open(path, 'r').read().splitlines()
-    pattern = re.compile(r"\s*(#.*)?")
-    return filter(lambda l: pattern.fullmatch(l) is None, lines)
-
-# Returns a tuple with the Swift ABI version (e.g. '5.0') and the corresponding
-# target triple (e.g. 'arm64-apple-ios12.2')
-def availability_macro_to_swift_abi_target_triple(macro):
-    # Use a regex and split to pull out the components of an availability macro
-    # that is formatted like this:
-    #    SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2
-    matches = re.search(r'^[\s]*Swift(?:Stdlib|CompatibilitySpan)[\s]+([0-9\.]+)[\s]*:[\s]*(.+)', macro)
-    if not matches:
-      return None
-
-    stdlib_vers = matches.group(1)
-    vers_by_platform = {}
-    for platform_vers in matches.group(2).split(', '):
-        components = platform_vers.split(' ')
-        vers_by_platform[components[0]] = components[1]
-
-    platform = {
-        'macosx': 'macOS',
-        'ios': 'iOS',
-        'maccatalyst': 'iOS',
-        'tvos': 'tvOS',
-        'watchos': 'watchOS',
-        'xros': 'visionOS'
-    }.get(run_os)
-
-    if platform is None:
-        return stdlib_vers, config.variant_triple
-
-    os_vers = vers_by_platform.get(platform)
-    if os_vers is None:
-        os_vers = vers_by_platform.get('anyAppleOS')
-    if os_vers is None:
-        return stdlib_vers, config.variant_triple
-
-    if run_os == 'maccatalyst':
-        return stdlib_vers, '%s-%s-ios%s-macabi' % (run_cpu, run_vendor, os_vers)
-
-    return stdlib_vers, '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
-                                          os_vers, run_environment)
-
 # Compare two version numbers
 def version_gt(a, b):
   a_int = list(map(int, a.split(".")))
@@ -595,14 +548,125 @@ def version_gt(a, b):
     b_int += [0] * (vlen - len(b_int))
   return a_int > b_int
 
-# Returns a StdlibDeploymentTarget macro given a SwiftStdlib macro
-def availability_macro_to_current(macro):
-    matches = re.search(r'^\s*SwiftStdlib\s+([0-9\.]*)\s*:\s*(.*)', macro)
+# utils/availability-macros.def is the single source of truth for which OS
+# version shipped which Swift release. Everything below that needs to know a
+# Swift release's OS version derives it from that file rather than repeating
+# the numbers.
+
+# The OS component of a target triple, mapped to the platform name used in
+# availability-macros.def.
+AVAILABILITY_PLATFORM_NAMES = {
+    'macosx': 'macOS',
+    'ios': 'iOS',
+    'maccatalyst': 'iOS',
+    'tvos': 'tvOS',
+    'watchos': 'watchOS',
+    'xros': 'visionOS'
+}
+
+# Mac Catalyst didn't exist before iOS 13.1, so an older iOS version from
+# availability-macros.def can't go in a macabi triple as-is.
+MACCATALYST_OLDEST_VERSION = '13.1'
+
+# The first visionOS shipped with the Swift 5.9 stdlib, so entries at or below
+# 5.9 have no visionOS version and apply to every visionOS.
+VISIONOS_OLDEST_VERSION = '1.0'
+VISIONOS_OLDEST_SWIFT_VERSION = '5.9'
+
+# The placeholder version for a Swift release whose OS versions aren't
+# announced yet.
+UNANNOUNCED_OS_VERSION = '9999'
+
+# An OS version far enough in the future that nothing has shipped with it.
+FUTURE_OS_VERSION = '99.99'
+
+# Loads availability macros for known stdlib releases.
+def load_availability_macros():
+    path = os.path.join(os.path.dirname(__file__), "../utils/availability-macros.def")
+    lines = open(path, 'r').read().splitlines()
+    pattern = re.compile(r"\s*(#.*)?")
+    return filter(lambda l: pattern.fullmatch(l) is None, lines)
+
+# Splits an availability macro into its name, Swift version, and OS versions by
+# platform name. A macro is formatted like this:
+#     SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2
+def parse_availability_macro(macro):
+    matches = re.search(r'^\s*([A-Za-z]+)\s+([0-9.]+)\s*:\s*(.+)', macro)
     if not matches:
         return None
 
-    stdlib_vers = matches.group(1)
-    orig_spec = matches.group(2)
+    vers_by_platform = {}
+    for platform_vers in matches.group(3).split(','):
+        components = platform_vers.split()
+        vers_by_platform[components[0]] = components[1]
+
+    return (matches.group(1), matches.group(2), vers_by_platform)
+
+# Every availability macro, in file order, as (name, Swift version, OS versions
+# by platform name).
+availability_macros = [m for m in map(parse_availability_macro,
+                                     load_availability_macros()) if m]
+
+# Swift versions with a SwiftStdlib macro, in file order.
+swift_stdlib_versions = [vers for (name, vers, _) in availability_macros
+                         if name == 'SwiftStdlib']
+
+# Returns the version of the OS under test that shipped the given Swift
+# release, or None when that isn't known.
+def swift_release_os_version(swift_vers, macro_name='SwiftStdlib'):
+    platform_name = AVAILABILITY_PLATFORM_NAMES.get(run_os)
+    if platform_name is None:
+        return None
+
+    for (name, vers, vers_by_platform) in availability_macros:
+        if name != macro_name or vers != swift_vers:
+            continue
+
+        os_vers = vers_by_platform.get(platform_name,
+                                      vers_by_platform.get('anyAppleOS'))
+        if os_vers is None and platform_name == 'visionOS' \
+           and not version_gt(swift_vers, VISIONOS_OLDEST_SWIFT_VERSION):
+            return VISIONOS_OLDEST_VERSION
+        return os_vers
+
+    return None
+
+# Mac Catalyst uses iOS versions, but didn't exist before iOS 13.1, so an
+# earlier iOS version from availability-macros.def has to be raised to the
+# oldest Catalyst there is.
+def clamp_os_version(os_vers):
+    if run_os == 'maccatalyst' and version_gt(MACCATALYST_OLDEST_VERSION, os_vers):
+        return MACCATALYST_OLDEST_VERSION
+    return os_vers
+
+# Returns a triple matching the target under test but deploying to the given OS
+# version.
+def os_version_triple(os_vers):
+    os_vers = clamp_os_version(os_vers)
+    if run_os == 'maccatalyst':
+        return '%s-%s-ios%s-macabi' % (run_cpu, run_vendor, os_vers)
+
+    return '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os, os_vers,
+                             run_environment)
+
+# Returns an OS version just below the given one, for naming the last release
+# before some feature arrived. Clamps when the last component is 0, as
+# calculating the previous version from there is difficult.
+def previous_os_version_clamped(os_vers):
+    components = os_vers.split('.')
+    if int(components[-1]) == 0:
+        return os_vers
+    components[-1] = str(int(components[-1]) - 1)
+    return '.'.join(components)
+
+# Returns a StdlibDeploymentTarget macro given a SwiftStdlib macro
+def availability_macro_to_current(macro):
+    parsed = parse_availability_macro(macro)
+    if not parsed or parsed[0] != 'SwiftStdlib':
+        return None
+
+    (_, stdlib_vers, _) = parsed
+    orig_spec = macro.split(':', 1)[1]
 
     # In backdeployment test runs (where tests use the OS-shipped stdlib
     # rather than the just-built one) we want to exercise the real
@@ -614,34 +678,18 @@ def availability_macro_to_current(macro):
     if 'use_os_stdlib' in lit_config.params:
         return f"StdlibDeploymentTarget {stdlib_vers}:{orig_spec}"
 
-    vers_by_platform = {}
-    for platform_vers in orig_spec.split(', '):
-        components = platform_vers.split(' ')
-        vers_by_platform[components[0]] = components[1]
-
-    platform_name = {
-        'macosx': 'macOS',
-        'ios': 'iOS',
-        'maccatalyst': 'iOS',
-        'tvos': 'tvOS',
-        'watchos': 'watchOS',
-        'xros': 'visionOS'
-    }.get(run_os)
-    
+    platform_name = AVAILABILITY_PLATFORM_NAMES.get(run_os)
     if platform_name is None:
         return None
 
-    orig_vers = vers_by_platform.get(platform_name)
-    if orig_vers is None:
-        orig_vers = vers_by_platform.get('anyAppleOS')
-    if orig_vers is not None and orig_vers != "9999" \
+    orig_vers = swift_release_os_version(stdlib_vers)
+    if orig_vers is not None and orig_vers != UNANNOUNCED_OS_VERSION \
        and version_gt(orig_vers, run_vers):
       return f"StdlibDeploymentTarget {stdlib_vers}:{platform_name} {run_vers}"
 
     return f"StdlibDeploymentTarget {stdlib_vers}:{orig_spec}"
 
-# Add availability macros to the default frontend/driver flags and create target
-# triple substitutions for each stdlib version.
+# Add availability macros to the default frontend/driver flags.
 for macro in load_availability_macros():
     config.swift_frontend_test_options += " -define-availability '{0}'".format(macro)
     config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(macro)
@@ -651,10 +699,17 @@ for macro in load_availability_macros():
       config.swift_frontend_test_options += " -define-availability '{0}'".format(current_macro)
       config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(current_macro)
 
-    vers_info = availability_macro_to_swift_abi_target_triple(macro)
-    if vers_info:
-      (stdlib_vers, triple) = vers_info
-      config.substitutions.append(('%target-swift-{}-abi-triple'.format(stdlib_vers), triple))
+# Create a target triple substitution for each Swift version, deploying to the
+# OS that first shipped that version's stdlib. On platforms where that isn't
+# known, the substitution is the target triple unchanged.
+for (name, swift_vers, _) in availability_macros:
+    if name not in ('SwiftStdlib', 'SwiftCompatibilitySpan'):
+        continue
+
+    os_vers = swift_release_os_version(swift_vers, name)
+    triple = os_version_triple(os_vers) if os_vers else config.variant_triple
+    config.substitutions.append(
+        ('%target-swift-{}-abi-triple'.format(swift_vers), triple))
 
 
 differentiable_programming = lit_config.params.get('differentiable_programming', None)
@@ -1144,69 +1199,25 @@ config.sanitizers = []
 if 'asan' in config.available_features:
     config.sanitizers.append('address')
 
-if run_vendor == 'apple':
-    if run_os == 'maccatalyst':
-        config.stable_abi_triple = '%s-%s-ios13.1-macabi' % (run_cpu, run_vendor)
-        config.pre_stable_abi_triple = config.stable_abi_triple
-        config.next_stable_abi_triple = config.stable_abi_triple
-        config.future_abi_triple = '%s-%s-ios99-macabi' % (run_cpu, run_vendor)
-        config.abi_stability = 'stable'
-        config.available_features.add('swift_stable_abi')
+# ABI stability arrived with the Swift 5.0 stdlib, and class stubs with 5.1.
+stable_version = swift_release_os_version('5.0') if run_vendor == 'apple' else None
+next_stable_version = swift_release_os_version('5.1')
+
+if stable_version and next_stable_version:
+    # iOS 12.2 does not support 32-bit targets, so we cannot run tests that
+    # want to deploy to an iOS that has Swift in the OS.
+    if run_os == 'ios' and run_ptrsize == '32':
+        pre_stable_version = '10'
+        config.abi_stability = 'unstable'
     else:
-        # iOS 12.2 does not support 32-bit targets, so we cannot run tests that
-        # want to deploy to an iOS that has Swift in the OS.
-        if run_os == 'ios' and run_ptrsize == '32':
-            pre_stable_version = '10'
-            config.abi_stability = 'unstable'
-        else:
-            config.available_features.add('swift_stable_abi')
-            PRE_STABLE_VERSION = {
-                'macosx': '10.14.3',
-                'ios': '12.1',
-                'maccatalyst': '12.1',
-                'tvos': '12.1',
-                'watchos': '5.1',
-                'xros': '1.0'
-            }
-            pre_stable_version = PRE_STABLE_VERSION.get(run_os, '')
-
-        config.pre_stable_abi_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
-                                                         pre_stable_version, run_environment)
-        STABLE_VERSION = {
-            'macosx': '10.14.4',
-            'ios': '12.2',
-            'maccatalyst': '12.2',
-            'tvos': '12.2',
-            'watchos': '5.2',
-            'xros': '1.0'
-        }
-        stable_version = STABLE_VERSION.get(run_os, '')
-        config.stable_abi_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
-                                                     stable_version, run_environment)
-
-        NEXT_STABLE_VERSION = {
-            'macosx': '10.15',
-            'ios': '13',
-            'maccatalyst': '13',
-            'tvos': '13',
-            'watchos': '6',
-            'xros': '1.0'
-        }
-        next_stable_version = NEXT_STABLE_VERSION.get(run_os, '')
-        config.next_stable_abi_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
-                                                          next_stable_version, run_environment)
-        FUTURE_VERSION = {
-            'macosx': '99.99',
-            'ios': '99.99',
-            'maccatalyst': '99.99',
-            'tvos': '99.99',
-            'watchos': '99.99',
-            'xros': '99.99'
-        }
-        future_version = FUTURE_VERSION.get(run_os, '')
-        config.future_triple = '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
-                                                 future_version, run_environment)
+        config.available_features.add('swift_stable_abi')
+        pre_stable_version = previous_os_version_clamped(stable_version)
         config.abi_stability = 'stable'
+
+    config.pre_stable_abi_triple = os_version_triple(pre_stable_version)
+    config.stable_abi_triple = os_version_triple(stable_version)
+    config.next_stable_abi_triple = os_version_triple(next_stable_version)
+    config.future_triple = os_version_triple(FUTURE_OS_VERSION)
 
 else:
     config.pre_stable_abi_triple = config.variant_triple
@@ -1803,24 +1814,9 @@ if run_vendor == 'apple':
 
     config.otool_classic = ("%s otool-classic" % (xcrun_prefix))
 
-    SDK_2020_VERSION = {
-        'macosx': '11.0',
-        'ios': '14.0',
-        'maccatalyst': '14.0',
-        'tvos': '14.0',
-        'watchos': '7.0',
-        'xros': '1.0'
-    }
-    sdk_2020_version = SDK_2020_VERSION.get(run_os, '')
-    SDK_2021_VERSION = {
-        'macosx': '12.0',
-        'ios': '15.0',
-        'maccatalyst': '15.0',
-        'tvos': '15.0',
-        'watchos': '8.0',
-        'xros': '1.0'
-    }
-    sdk_2021_version = SDK_2021_VERSION.get(run_os, '')
+    # The 2020 and 2021 SDKs shipped the Swift 5.3 and 5.5 stdlibs.
+    sdk_2020_version = swift_release_os_version('5.3') or ''
+    sdk_2021_version = swift_release_os_version('5.5') or ''
     linker_os = {
         'iphoneos': 'ios',
         'appletvos': 'tvos',
@@ -2525,22 +2521,16 @@ if run_vendor == 'apple':
 
 compatibility_span_back_deploy_path = ''
 if run_vendor == 'apple':
-    COMPATIBILITY_SPAN_BACK_DEPLOY_EARLIEST_VERSIONS = {
-        'macosx': '10.14.4',
-        'ios': '12.2',
-        'maccatalyst': '13.1',
-        'tvos': '12.2',
-        'watchos': '5.2',
-        'xros': '1.0',
-    }
+    # Span back-deploys to every OS with a Swift stdlib, and is in the OS as of
+    # the 6.2 stdlib.
+    span_floor_version = swift_release_os_version(
+        '5.0', 'SwiftCompatibilitySpan')
+    span_in_os_version = swift_release_os_version(
+        '6.2', 'SwiftCompatibilitySpan')
 
-    compatibility_span_back_deploy_version = tuple(
-        int(component) for component
-        in COMPATIBILITY_SPAN_BACK_DEPLOY_EARLIEST_VERSIONS.get(run_os, '').split('.'))
-
-    tuple_run_vers=tuple(int(component) for component in run_vers.split('.'))
-
-    if tuple_run_vers >= compatibility_span_back_deploy_version and tuple_run_vers < (26,):
+    if span_floor_version and span_in_os_version \
+       and not version_gt(clamp_os_version(span_floor_version), run_vers) \
+       and version_gt(span_in_os_version, run_vers):
         config.available_features.add('back_deploy_compatibility_span')
         toolchain_swiftc_path = subprocess.check_output(['xcrun', '--find', 'swiftc']).rstrip().decode('utf-8')
         compatibility_span_back_deploy_path = os.path.join(
@@ -2866,29 +2856,16 @@ if 'concurrency' in config.available_features:
     if 'use_os_stdlib' not in lit_config.params:
         config.available_features.add('concurrency_runtime')
     elif run_vendor == 'apple':
-        # OS version in which concurrency was introduced
-        CONCURRENCY_OS_VERSION = {
-            'macosx': '12',
-	    'ios': '15',
-	    'maccatalyst': '15',
-	    'tvos': '15',
-	    'watchos': '8'
-	}
-        concurrency_os_version = CONCURRENCY_OS_VERSION.get(run_os, '')
+        # Concurrency shipped in the OS with the Swift 5.5 stdlib, and back
+        # deploys as far as the 5.1 stdlib.
+        concurrency_os_version = swift_release_os_version('5.5')
+        concurrency_back_deploy_version = clamp_os_version(
+            swift_release_os_version('5.1'))
 
-	# OS version to which concurrency can back-deploy
-        CONCURRENCY_BACK_DEPLOY_VERSION = {
-	    'macosx': '10.15',
-	    'ios': '13',
-	    'maccatalyst': '13',
-	    'tvos': '13',
-	    'watchos': '6'
-	}
-        concurrency_back_deploy_version = CONCURRENCY_BACK_DEPLOY_VERSION.get(run_os, '')
-
-        if run_vers >= concurrency_os_version:
+        if not version_gt(concurrency_os_version, run_vers):
             config.available_features.add('concurrency_runtime')
-        elif 'back_deploy_concurrency' in config.available_features and run_vers >= concurrency_back_deploy_version:
+        elif 'back_deploy_concurrency' in config.available_features \
+             and not version_gt(concurrency_back_deploy_version, run_vers):
             config.available_features.add('concurrency_runtime')
         elif 'back_deploy_concurrency' in config.available_features:
             print('Disabled concurrency runtime tests because run version',
@@ -2900,46 +2877,30 @@ if 'concurrency' in config.available_features:
     else:
         config.available_features.add('concurrency_runtime')
 
-# Add a stdlib_X_Y_runtime feature when the runtime we test against is that
-# version or newer. Some tests need runtime support that can't be version-gated
-# in the test code, because a too-old runtime makes the test fail to launch
-# rather than fail a check. Those tests still have value against older runtimes
-# that are new enough, so UNSUPPORTED: use_os_stdlib isn't what they want.
-def add_stdlib_runtime_feature(stdlib_vers, os_versions):
+# Add a stdlib_X_Y_runtime feature for every Swift release whose stdlib is at
+# most as new as the one we test against. Some tests need runtime support that
+# can't be version-gated in the test code, because a too-old runtime makes the
+# test fail to launch rather than fail a check. Those tests still have value
+# against older runtimes that are new enough, so UNSUPPORTED: use_os_stdlib
+# isn't what they want.
+for stdlib_vers in swift_stdlib_versions:
     feature = 'stdlib_%s_runtime' % stdlib_vers.replace('.', '_')
 
-    # Only the OS stdlib can be older than what we just built.
+    # Only the OS stdlib can be older than the one we just built.
     if 'use_os_stdlib' not in lit_config.params or run_vendor != 'apple':
         config.available_features.add(feature)
-        return
+        continue
 
-    os_version = os_versions.get(run_os, '')
-    if os_version and not version_gt(os_version, run_vers):
+    os_version = swift_release_os_version(stdlib_vers)
+    if os_version is None or os_version == UNANNOUNCED_OS_VERSION:
+        continue
+
+    if not version_gt(clamp_os_version(os_version), run_vers):
         config.available_features.add(feature)
     else:
         lit_config.note(
             'Disabled Swift %s runtime tests because run version %s < %s'
             % (stdlib_vers, run_vers, os_version))
-
-# OS versions corresponding to each stdlib release, per
-# utils/availability-macros.def.
-add_stdlib_runtime_feature('5.8', {
-    'macosx': '13.3',
-    'ios': '16.4',
-    'maccatalyst': '16.4',
-    'tvos': '16.4',
-    'watchos': '9.4',
-    'xros': '1.0'
-})
-
-add_stdlib_runtime_feature('5.9', {
-    'macosx': '14.0',
-    'ios': '17.0',
-    'maccatalyst': '17.0',
-    'tvos': '17.0',
-    'watchos': '10.0',
-    'xros': '1.0'
-})
 
 # Set up testing with the standard libraries coming from either the OS, the back
 # deployment runtime or the just-built libraries. By default, we run tests with

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -11,6 +11,9 @@
 #
 #     @available(SwiftStdlib 5.2, *)
 #
+# These macros are also made available for use in tests. They are converted into
+# %target-swift-X.Y-abi-triple substitutions and stdlib_X_Y_runtime features.
+#
 # Comments in this file start with `#`. Comments and empty lines are ignored.
 # Each of the remaining lines must define an availability macro in the same
 # format used by the `-define-availability` frontend command line option.


### PR DESCRIPTION
Use the version number mapping from availability-macros.def in the lit configuration. Generate stdlib_x_y_runtime conditions and %target-swift-X.Y-abi-triple substitutions from the macros instead of maintaining a separate ad hoc list.

Two fixes fall out of the shared helpers. The Mac Catalyst branch of the ABI stability block used to return one triple for pre-stable, stable, and next-stable alike, and set future_abi_triple where every reader looks at future_triple; Catalyst now gets distinct triples clamped to iOS 13.1 like every other platform. The concurrency runtime comparisons were string compares, where '9.0' > '10.0', and now use version_gt.