### PR TITLE
[CSApply] Isolation extraction from `@isolated(any)` expects base to …

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3683,7 +3683,7 @@ namespace {
       case OverloadChoiceKind::ExtractFunctionIsolation: {
         auto isolationType = solution.getResolvedType(expr);
         auto *extractExpr = new (ctx)
-          ExtractFunctionIsolationExpr(base,
+          ExtractFunctionIsolationExpr(cs.coerceToRValue(base),
                                        expr->getEndLoc(),
                                        isolationType);
         return cs.cacheType(extractExpr);

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -542,3 +542,37 @@ func testEraseAsyncActorIsolatedPartialApplication(a: MyActor) {
 func extractIsolation(fn: @escaping @isolated(any) @Sendable () -> Void) -> (any Actor)? {
   fn.isolation
 }
+
+final class HasIsolatedAnyStorage {
+  var fn: @isolated(any) @Sendable () -> Void = {}
+  var optFn: (@isolated(any) @Sendable () -> Void)?
+}
+
+// The base of an isolation extraction expression has to be loaded first;
+// used to crash in SILGen on an @lvalue operand.
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test30extractIsolationFromMutableVar1cScA_pSgAA21HasIsolatedAnyStorageC_tF
+// CHECK:         [[ADDR:%.*]] = ref_element_addr %0 : $HasIsolatedAnyStorage, #HasIsolatedAnyStorage.fn
+// CHECK-NEXT:    [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]]
+// CHECK-NEXT:    [[FN:%.*]] = load [copy] [[ACCESS]]
+// CHECK-NEXT:    end_access [[ACCESS]]
+// CHECK-NEXT:    [[FN_BORROW:%.*]] = begin_borrow [[FN]]
+// CHECK-NEXT:    [[ISOLATION:%.*]] = function_extract_isolation [[FN_BORROW]]
+// CHECK-NEXT:    [[RESULT:%.*]] = copy_value [[ISOLATION]] : $Optional<any Actor>
+func extractIsolationFromMutableVar(c: HasIsolatedAnyStorage) -> (any Actor)? {
+  c.fn.isolation
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test36extractIsolationThroughOptionalChain1cScA_pSgAA21HasIsolatedAnyStorageC_tF
+// CHECK:         function_extract_isolation
+func extractIsolationThroughOptionalChain(c: HasIsolatedAnyStorage) -> (any Actor)? {
+  c.optFn?.isolation ?? nil
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test28extractIsolationFromLocalVarScA_pSgyF
+// CHECK:         function_extract_isolation
+func extractIsolationFromLocalVar() -> (any Actor)? {
+  var local: (@isolated(any) @Sendable () -> Void)? = nil
+  defer { local = nil }
+  return local?.isolation ?? nil
+}


### PR DESCRIPTION
…be r-value

This used to crash in SILGen because the base wasn't loaded when `.isolation` is used on a `var`.

Resolves: rdar://178379864

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
