### PR TITLE
[any ~Copyable] Support type(of:) on non-copyable values

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3136,6 +3136,32 @@ static SILValue emitMetatypeOfDelegatingInitExclusivelyBorrowedSelf(
   return SGF.B.createValueMetatype(loc, metaTy, selfValue.getValue());
 }
 
+/// Emit the operand of a `value_metatype` or `existential_metatype`
+/// instruction.
+///
+/// Neither instruction consumes its operand; they only inspect the type of the
+/// value it designates. So when the operand names existing storage, borrow that
+/// storage in place instead of loading a copy out of it. That avoids a needless
+/// retain/release, and it's what lets `type(of:)` apply to a noncopyable value,
+/// where the copy would otherwise be diagnosed as a consume.
+///
+/// The caller must have established a `FormalEvaluationScope` covering the use
+/// of the returned value.
+static ManagedValue emitMetatypeOperand(SILGenFunction &SGF, Expr *baseExpr) {
+  if (auto *load = dyn_cast<LoadExpr>(baseExpr)) {
+    auto accessKind = SGF.getTypeLowering(load->getType()).isAddressOnly()
+                          ? SGFAccessKind::BorrowedAddressRead
+                          : SGFAccessKind::BorrowedObjectRead;
+    LValue lv = SGF.emitLValue(load->getSubExpr(), accessKind);
+    return SGF.emitBorrowedLValue(load, std::move(lv));
+  }
+
+  // Otherwise the operand produces a temporary of its own, which we can just
+  // read from.
+  return SGF.emitRValueAsSingleValue(baseExpr,
+                                     SGFContext::AllowImmediatePlusZero);
+}
+
 SILValue SILGenFunction::emitMetatypeOfValue(SILLocation loc, Expr *baseExpr) {
   Type formalBaseType = baseExpr->getType()->getWithoutSpecifierType();
   CanType baseTy = formalBaseType->getCanonicalType();
@@ -3144,8 +3170,8 @@ SILValue SILGenFunction::emitMetatypeOfValue(SILLocation loc, Expr *baseExpr) {
   if (baseTy.isAnyExistentialType()) {
     SILType metaTy = getLoweredLoadableType(
                                       CanExistentialMetatypeType::get(baseTy));
-    auto base = emitRValueAsSingleValue(baseExpr,
-                                  SGFContext::AllowImmediatePlusZero).getValue();
+    FormalEvaluationScope scope(*this);
+    auto base = emitMetatypeOperand(*this, baseExpr).getValue();
     return B.createExistentialMetatype(loc, metaTy, base);
   }
   SILType metaTy = getLoweredLoadableType(CanMetatypeType::get(baseTy));
@@ -3165,9 +3191,11 @@ SILValue SILGenFunction::emitMetatypeOfValue(SILLocation loc, Expr *baseExpr) {
     }
 
     Scope S(*this, loc);
-    auto base = emitRValueAsSingleValue(baseExpr, SGFContext::AllowImmediatePlusZero);
-    return S.popPreservingValue(B.createValueMetatype(loc, metaTy, base))
-        .getValue();
+    FormalEvaluationScope scope(*this);
+    auto base = emitMetatypeOperand(*this, baseExpr);
+    auto result = B.createValueMetatype(loc, metaTy, base);
+    scope.pop();
+    return S.popPreservingValue(result).getValue();
   }
   // Otherwise, ignore the base and return the static thin metatype.
   emitIgnoredExpr(baseExpr);

--- a/test/Interpreter/moveonly_type_of.swift
+++ b/test/Interpreter/moveonly_type_of.swift
@@ -1,0 +1,101 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
+
+// REQUIRES: executable_test
+
+// `type(of:)` reads the dynamic type of its operand without consuming it, so it
+// must neither destroy the operand early nor perturb its lifetime.
+
+import StdlibUnittest
+
+defer { runAllTests() }
+
+var Tests = TestSuite("TypeOfNoncopyable")
+
+protocol P: ~Copyable {}
+
+struct NC: ~Copyable, P {
+  var tracked = LifetimeTracked(0)
+}
+
+struct OtherNC: ~Copyable, P {
+  var tracked = LifetimeTracked(0)
+}
+
+func borrow<T: ~Copyable>(_: borrowing T) {}
+
+Tests.test("concrete operand is not consumed") {
+  do {
+    let v = NC()
+    expectTrue(type(of: v) == NC.self)
+    expectEqual(1, LifetimeTracked.instances)
+    borrow(v)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("generic operand is not consumed") {
+  func check<T: ~Copyable>(_ v: consuming T, is expected: T.Type) {
+    expectTrue(type(of: v) == expected)
+    // The operand is still live here, and only destroyed on return.
+    expectEqual(1, LifetimeTracked.instances)
+    borrow(v)
+  }
+
+  do {
+    check(NC(), is: NC.self)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("existential operand reports its dynamic type") {
+  func dynamicType(of box: consuming any P & ~Copyable) -> any (P & ~Copyable).Type {
+    let t = type(of: box)
+    expectEqual(1, LifetimeTracked.instances)
+    borrow(box)
+    return t
+  }
+
+  do {
+    let t = dynamicType(of: NC())
+    expectEqual(0, LifetimeTracked.instances)
+    expectTrue(t == NC.self)
+  }
+
+  do {
+    let t = dynamicType(of: OtherNC())
+    expectEqual(0, LifetimeTracked.instances)
+    expectTrue(t == OtherNC.self)
+  }
+}
+
+Tests.test("existential metatype outlives the operand") {
+  func consumeAfterQuery(_ box: consuming any P & ~Copyable) -> any (P & ~Copyable).Type {
+    let t = type(of: box)
+    // Consume the operand; the metatype must remain valid.
+    let moved = consume box
+    borrow(moved)
+    return t
+  }
+
+  do {
+    expectTrue(consumeAfterQuery(NC()) == NC.self)
+    expectTrue(consumeAfterQuery(OtherNC()) == OtherNC.self)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("repeated queries do not consume") {
+  func check<T: ~Copyable>(_ v: consuming T, is expected: T.Type) {
+    for _ in 0 ..< 3 {
+      expectTrue(type(of: v) == expected)
+    }
+    expectEqual(1, LifetimeTracked.instances)
+    borrow(v)
+  }
+
+  do {
+    check(NC(), is: NC.self)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -60,9 +60,9 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
-  // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
-  // CHECK: end_access [[READ]]
-  // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[OBJCOPY]] : $AnyObject
+  // -- 'type(of:)' only reads its operand, so it borrows the storage in place.
+  // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[READ]] : $*AnyObject
+  // CHECK-NEXT: end_access [[READ]]
   // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick any AnyObject.Type to $@thick (@opened([[UUID:.*]], AnyObject) Self).Type
   // CHECK-NEXT: [[METHOD:%[0-9]+]] = objc_method [[OPENMETA]] : $@thick (@opened([[UUID]], AnyObject) Self).Type, #X.staticF!foreign : (X.Type) -> () -> (), $@convention(objc_method) (@thick (@opened([[UUID]], AnyObject) Self).Type) -> ()
   // CHECK: apply [[METHOD]]([[OPENMETA]]) : $@convention(objc_method) (@thick (@opened([[UUID]], AnyObject) Self).Type) -> ()
@@ -157,8 +157,9 @@ func opt_to_static_method(_ obj: AnyObject) {
   // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OPTBOX]]
   // CHECK:   [[PBO:%.*]] = project_box [[OPTLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
-  // CHECK:   [[OBJCOPY:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
-  // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[OBJCOPY]] : $AnyObject
+  // -- 'type(of:)' only reads its operand, so it borrows the storage in place.
+  // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[READ]] : $*AnyObject
+  // CHECK:   end_access [[READ]]
   // CHECK:   [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick any AnyObject.Type to $@thick (@opened
   // CHECK:   [[OBJCMETA:%[0-9]+]] = thick_to_objc_metatype [[OPENMETA]]
   // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<@callee_guaranteed () -> ()>

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -173,10 +173,11 @@ func calls(_ i:Int, j:Int, k:Int) {
   SomeClass.method(c)(i)
 
   // -- Curry the Type onto static method argument lists.
-  
+
+  // -- 'type(of:)' only reads its operand, so it borrows the storage in place.
   // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
-  // CHECK: [[META:%.*]] = value_metatype $@thick SomeClass.Type, [[C]]
+  // CHECK: [[META:%.*]] = value_metatype $@thick SomeClass.Type, [[READC]]
+  // CHECK: end_access [[READC]]
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[META]] : {{.*}}, #SomeClass.static_method :

--- a/test/SILGen/moveonly_type_of.swift
+++ b/test/SILGen/moveonly_type_of.swift
@@ -1,0 +1,63 @@
+// RUN: %target-swift-emit-silgen -module-name type_of -Xllvm -sil-print-types %s | %FileCheck %s
+
+// `type(of:)` lowers to `value_metatype`/`existential_metatype`, neither of
+// which consumes its operand. So for an address-only operand we borrow the
+// storage in place rather than copying it into a temporary to form an rvalue.
+// The copy would be a consume, which is what made `type(of:)` unusable on
+// noncopyable values.
+
+protocol P: ~Copyable {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s7type_of16genericBorrowingyxmxRi_zlF : $@convention(thin) <T where T : ~Copyable> (@in_guaranteed T) -> @thick T.Type {
+// CHECK:       bb0([[V:%.*]] : $*T):
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:         [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[V]]
+// CHECK-NEXT:    [[META:%.*]] = value_metatype $@thick T.Type, [[MARK]]
+// CHECK-NEXT:    return [[META]]
+// CHECK:       } // end sil function '$s7type_of16genericBorrowingyxmxRi_zlF'
+func genericBorrowing<T: ~Copyable>(_ v: borrowing T) -> T.Type {
+  return type(of: v)
+}
+
+// A `consuming` parameter gets a box, so the read goes through an access scope
+// -- but still no copy, and the access ends right after the metatype is derived.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s7type_of16genericConsumingyxmxnRi_zlF : $@convention(thin) <T where T : ~Copyable> (@in T) -> @thick T.Type {
+// CHECK:         [[BOX:%.*]] = project_box
+// CHECK:         [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX]]
+// CHECK-NEXT:    [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS]]
+// CHECK-NEXT:    [[META:%.*]] = value_metatype $@thick T.Type, [[MARK]]
+// CHECK-NEXT:    end_access [[ACCESS]]
+// CHECK:       } // end sil function '$s7type_of16genericConsumingyxmxnRi_zlF'
+func genericConsuming<T: ~Copyable>(_ v: consuming T) -> T.Type {
+  return type(of: v)
+}
+
+// A noncopyable existential goes through `existential_metatype` instead, and is
+// likewise only borrowed.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s7type_of20existentialBorrowingyAA1P_pRi_s_XPXpAaC_pRi_s_XPF : $@convention(thin) (@in_guaranteed any P & ~Copyable) -> @thick any (P & ~Copyable).Type {
+// CHECK:       bb0([[B:%.*]] : $*any P & ~Copyable):
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:         [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[B]]
+// CHECK-NEXT:    [[META:%.*]] = existential_metatype $@thick any (P & ~Copyable).Type, [[MARK]]
+// CHECK-NEXT:    return [[META]]
+// CHECK:       } // end sil function '$s7type_of20existentialBorrowingyAA1P_pRi_s_XPXpAaC_pRi_s_XPF'
+func existentialBorrowing(
+  _ b: borrowing any P & ~Copyable
+) -> any (P & ~Copyable).Type {
+  return type(of: b)
+}
+
+// A copyable class operand is loadable, but reading its type still doesn't need
+// a retain: the metatype is derived from the borrowed storage.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s7type_of12classOperandyyXlXpyXlF : $@convention(thin) (@guaranteed AnyObject) -> @thick any AnyObject.Type {
+// CHECK-NOT:     copy_value
+// CHECK:         existential_metatype $@thick any AnyObject.Type
+// CHECK:       } // end sil function '$s7type_of12classOperandyyXlXpyXlF'
+func classOperand(_ o: AnyObject) -> AnyObject.Type {
+  return type(of: o)
+}

--- a/test/SILOptimizer/moveonly_type_of.swift
+++ b/test/SILOptimizer/moveonly_type_of.swift
@@ -1,0 +1,174 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify -enable-sil-opaque-values %s
+
+// `type(of:)` only reads the type of its operand, so it must not consume it.
+
+struct NC: ~Copyable {
+  var x: Int = 0
+  deinit {}
+}
+
+struct Wrapper: ~Copyable {
+  var nc = NC()
+  var copyable = 0
+}
+
+func consume<T: ~Copyable>(_: consuming T) {}
+func borrow<T: ~Copyable>(_: borrowing T) {}
+
+// MARK: concrete noncopyable operands
+
+func concreteConsumingParam(_ v: consuming NC) {
+  _ = type(of: v)
+  consume(v)
+}
+
+func concreteBorrowingParam(_ v: borrowing NC) {
+  _ = type(of: v)
+  borrow(v)
+}
+
+func concreteInoutParam(_ v: inout NC) {
+  _ = type(of: v)
+  v.x = 1
+}
+
+func concreteLocalVar() {
+  var v = NC()
+  _ = type(of: v)
+  v.x = 1
+  consume(v)
+}
+
+func concreteLocalLet() {
+  let v = NC()
+  _ = type(of: v)
+  consume(v)
+}
+
+func concreteStoredProperty(_ w: consuming Wrapper) {
+  _ = type(of: w.nc)
+  consume(w)
+}
+
+// MARK: generic noncopyable operands
+//
+// These are the interesting cases: an address-only operand used to be copied
+// into a temporary to form an rvalue, which counts as a consume.
+
+func genericConsumingParam<T: ~Copyable>(_ v: consuming T) {
+  _ = type(of: v)
+  consume(v)
+}
+
+func genericBorrowingParam<T: ~Copyable>(_ v: borrowing T) {
+  _ = type(of: v)
+  borrow(v)
+}
+
+func genericInoutParam<T: ~Copyable>(_ v: inout T) {
+  _ = type(of: v)
+  borrow(v)
+}
+
+func genericLocalVar<T: ~Copyable>(_ v: consuming T, _ other: consuming T) {
+  var local = consume v
+  _ = type(of: local)
+  borrow(local)
+  local = consume other
+  consume(local)
+}
+
+func genericLocalLet<T: ~Copyable>(_ v: consuming T) {
+  let local = consume v
+  _ = type(of: local)
+  consume(local)
+}
+
+// Repeated queries must not each consume the operand.
+func genericRepeated<T: ~Copyable>(_ v: consuming T) {
+  _ = type(of: v)
+  _ = type(of: v)
+  _ = type(of: v)
+  consume(v)
+}
+
+// MARK: noncopyable existential operands
+//
+// These go through `existential_metatype` rather than `value_metatype`, but it
+// likewise only reads its operand.
+
+protocol P: ~Copyable {}
+
+struct ConformsToP: ~Copyable, P {
+  deinit {}
+}
+
+func existentialConsumingParam(_ box: consuming any P & ~Copyable) {
+  _ = type(of: box)
+  consume(box)
+}
+
+func existentialBorrowingParam(_ box: borrowing any P & ~Copyable) {
+  _ = type(of: box)
+  borrow(box)
+}
+
+func existentialInoutParam(_ box: inout any P & ~Copyable) {
+  _ = type(of: box)
+  box = ConformsToP()
+}
+
+// Local `var`/`let` bindings of noncopyable existential type are omitted here:
+// any use of one crashes the move-only address checker even without
+// `type(of:)`, so they can't be tested yet. The parameter cases above and below
+// exercise the same `existential_metatype` emission path.
+
+func existentialRepeated(_ box: consuming any P & ~Copyable) {
+  _ = type(of: box)
+  _ = type(of: box)
+  consume(box)
+}
+
+func existentialStillDiagnosed(_ box: consuming any P & ~Copyable) { // expected-error {{'box' used after consume}}
+  consume(box) // expected-note {{consumed here}}
+  _ = type(of: box) // expected-note {{used here}}
+}
+
+// MARK: noncopyable existential metatypes
+//
+// `type(of:)` on a noncopyable existential yields the existential metatype
+// `any (P & ~Copyable).Type`, which is itself copyable and trivial.
+
+func existentialMetatypeResult(
+  _ box: borrowing any P & ~Copyable
+) -> any (P & ~Copyable).Type {
+  return type(of: box)
+}
+
+// The metatype outlives the borrow of the value it was derived from.
+func existentialMetatypeOutlivesOperand(_ box: consuming any P & ~Copyable) {
+  let m = type(of: box)
+  consume(box)
+  _ = m
+}
+
+// An existential metatype is copyable, so `type(of:)` on one is unrestricted.
+func metatypeOfExistentialMetatype(_ box: borrowing any P & ~Copyable) {
+  let m: any (P & ~Copyable).Type = type(of: box)
+  _ = type(of: m)
+  _ = m
+}
+
+func genericMetatypeOutlivesOperand<T: ~Copyable>(_ v: consuming T) {
+  let m = type(of: v)
+  consume(v)
+  _ = m
+}
+
+// MARK: consuming the operand is still diagnosed when it really happens
+
+func stillDiagnosed<T: ~Copyable>(_ v: consuming T) { // expected-error {{'v' used after consume}}
+  consume(v) // expected-note {{consumed here}}
+  _ = type(of: v) // expected-note {{used here}}
+}


### PR DESCRIPTION
This changes SILGen to borrow the argument of `type(of:)` instead of copying it.  This allows `type(of:)` to be used for non-copyable values and non-copyable existentials.