### PR TITLE
When cross compiling a multi-arch darwin toolchain, ensure SwiftPM builds using multi-arch toolchain content

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -217,6 +217,23 @@ class Product(object):
         return targets.toolchain_path(install_destdir,
                                       self.args.install_prefix)
 
+    def merged_install_toolchain_path(self, host_target):
+        """merged_install_toolchain_path() -> string or None
+
+        Returns the path to the merged multi-architecture toolchain
+        that is being created as part of the build, if it exists.
+        """
+        if not self.should_include_host_in_lipo(host_target):
+            return None
+
+        toolchain_path = targets.toolchain_path(self.args.install_destdir,
+                                                self.args.install_prefix)
+
+        if not os.path.exists(os.path.join(toolchain_path, 'bin', 'swiftc')):
+            return None
+
+        return toolchain_path
+
     def native_clang_tools_path(self, host_target):
         if self.args.native_clang_tools_path is not None:
             return os.path.split(self.args.native_clang_tools_path)[0]

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -55,6 +55,13 @@ class SwiftPM(product.Product):
 
         toolchain_path = self.native_toolchain_path(host_target)
         clang_tools_path = self.native_clang_tools_path(host_target)
+        merged_toolchain_path = self.merged_install_toolchain_path(host_target)
+        if merged_toolchain_path is not None:
+            # An explicit native toolchain takes precedence.
+            if self.args.native_swift_tools_path is None:
+                toolchain_path = merged_toolchain_path
+            if self.args.native_clang_tools_path is None:
+                clang_tools_path = merged_toolchain_path
         swiftc = os.path.join(toolchain_path, "bin", "swiftc")
         clang = os.path.join(clang_tools_path, "bin", "clang")
 


### PR DESCRIPTION
Right now, SwiftPM builds against the thin toolchain content, causing the non-host slice to fail to discover the just-built copy of testing libraries.

Context:

Swift Testing made a change which broke the build of SwiftPM when using a macOS preset which built a fat binary for SwiftPM. This happened because SwiftPM built a universal binary using the staged thin toolchain for the host arch. Compilation of SwiftPM's host arch slice succeeded, but compilation of the cross-compiled slice failed because the compile failed to find the just-built testing library and fell back to an installed copy instead, which was incompatible with the host macro content