### PR TITLE
serialization: emit proper diagnostics for conformance witnesses that reference unloaded modules instead of crashing

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1452,6 +1452,18 @@ public:
   std::vector<MissingWitness>
   takeDelayedMissingWitnesses(NormalProtocolConformance *conformance);
 
+  /// Record that a witness of a conformance of \p nominal could not be fully
+  /// deserialized because \p moduleName was never loaded. Used to add an
+  /// actionable note ("add 'import <module>'") to the later requirement-failure
+  /// diagnostic at the use site.
+  void recordUnloadedModuleForConformingType(const NominalTypeDecl *nominal,
+                                              Identifier moduleName);
+
+  /// Retrieve the modules that were not loaded while deserializing conformances
+  /// of \p nominal, or an empty list if there were none.
+  ArrayRef<Identifier>
+  getUnloadedModulesForConformingType(const NominalTypeDecl *nominal) const;
+
   /// Produce a specialized conformance, which takes a generic
   /// conformance and substitutions written in terms of the generic
   /// conformance's signature.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3148,6 +3148,9 @@ ERROR(type_does_not_conform_anyobject_in_decl_ref,none,
 ERROR(type_does_not_conform_decl_owner,none,
       "%kind0 requires that %1 conform to %2",
       (const ValueDecl *, Type, Type))
+NOTE(missing_conformance_unloaded_module,none,
+     "the conformance of %0 to %1 could not be loaded because module %2 was not "
+     "imported; add import of module %2", (Type, Type, Identifier))
 ERROR(type_does_not_conform_anyobject_decl_owner,none,
       "%kind0 requires that %1 be a class type",
       (const ValueDecl *, Type, Type))

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -488,6 +488,12 @@ struct ASTContext::Implementation {
   llvm::DenseMap<NormalProtocolConformance *, ::DelayedConformanceDiags>
     DelayedConformanceDiags;
 
+  /// Modules that were never loaded while deserializing a conformance's
+  /// witnesses, keyed by the conforming nominal type. Used to add an
+  /// "add 'import <module>'" note to the later requirement-failure diagnostic.
+  llvm::DenseMap<const NominalTypeDecl *, llvm::SmallSetVector<Identifier, 2>>
+    UnloadedModulesForConformingType;
+
   /// Stores information about lazy deserialization of various declarations.
   llvm::DenseMap<const Decl *, LazyContextData *> LazyContexts;
 
@@ -928,6 +934,7 @@ void ASTContext::Implementation::dump(llvm::raw_ostream &os) const {
   SIZE_AND_BYTES(ForeignAsyncConventions);
   SIZE_AND_BYTES(AssociativityCache);
   SIZE_AND_BYTES(DelayedConformanceDiags);
+  SIZE_AND_BYTES(UnloadedModulesForConformingType);
   SIZE_AND_BYTES(LazyContexts);
   SIZE_AND_BYTES(ElementSignatures);
   SIZE_AND_BYTES(Overrides);
@@ -3494,6 +3501,19 @@ ASTContext::takeDelayedConformanceDiags(NormalProtocolConformance const* cnfrm){
     std::swap(result, diagnostics.Diags);
   }
   return result;
+}
+
+void ASTContext::recordUnloadedModuleForConformingType(
+    const NominalTypeDecl *nominal, Identifier moduleName) {
+  getImpl().UnloadedModulesForConformingType[nominal].insert(moduleName);
+}
+
+ArrayRef<Identifier> ASTContext::getUnloadedModulesForConformingType(
+    const NominalTypeDecl *nominal) const {
+  auto known = getImpl().UnloadedModulesForConformingType.find(nominal);
+  if (known == getImpl().UnloadedModulesForConformingType.end())
+    return {};
+  return known->second.getArrayRef();
 }
 
 size_t ASTContext::getTotalMemory() const {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -521,6 +521,18 @@ bool RequirementFailure::diagnoseAsError() {
 
   maybeEmitRequirementNote(reqDC->getAsDecl(), lhs, rhs);
 
+  // If this conformance couldn't be satisfied because a witness of a
+  // deserialized conformance referenced a module that was never loaded, tell
+  // the user which import restores it.
+  if (getRequirement().getKind() == RequirementKind::Conformance) {
+    if (auto *nominal = lhs->getAnyNominal()) {
+      for (auto moduleName :
+           getASTContext().getUnloadedModulesForConformingType(nominal))
+        emitDiagnostic(diag::missing_conformance_unloaded_module, lhs, rhs,
+                       moduleName);
+    }
+  }
+
   return true;
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -983,6 +983,7 @@ ProtocolConformanceDeserializer::readNormalProtocolConformanceXRef(
 
   // FIXME: If the module hasn't been loaded, we probably don't want to fall
   // back to the current module like this.
+  bool moduleNotLoaded = !module;
   if (!module)
     module = MF.getAssociatedModule();
 
@@ -1007,6 +1008,14 @@ ProtocolConformanceDeserializer::readNormalProtocolConformanceXRef(
     if (!conformances.empty())
       return conformances.front();
   }
+
+  // If the referenced module was never loaded (e.g. it is hidden behind a
+  // non-public import in a dependency), mirror resolveCrossReference and
+  // return a recoverable error instead of a hard ConformanceXRefError. The
+  // witness-substitution reader recovers by installing an opaque witness.
+  if (moduleNotLoaded)
+    return llvm::make_error<XRefNonLoadedModuleError>(
+        MF.getIdentifier(moduleID));
 
   auto error = llvm::make_error<ConformanceXRefError>(
                  nominal->getName(), proto->getName(), module);
@@ -9399,7 +9408,16 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       if (witnessSubstitutions.errorIsA<XRefNonLoadedModuleError>() ||
           witnessSubstitutions.errorIsA<UnsafeDeserializationError>() ||
           allowCompilerErrors()) {
-        diagnoseAndConsumeError(witnessSubstitutions.takeError());
+        auto errorInfo = takeErrorInfo(witnessSubstitutions.takeError());
+        // Remember which module wasn't loaded so Sema can point the user at
+        // the import to add when the resulting requirement failure surfaces.
+        if (errorInfo->isA<XRefNonLoadedModuleError>()) {
+          auto *modErr = static_cast<XRefNonLoadedModuleError *>(errorInfo.get());
+          if (auto *nominal = conformance->getType()->getAnyNominal())
+            getContext().recordUnloadedModuleForConformingType(
+                nominal, modErr->getName().getBaseIdentifier());
+        }
+        diagnoseAndConsumeError(std::move(errorInfo));
         isOpaque = true;
       }
       else

--- a/test/Serialization/Recovery/conformance-xref-internal-import.swift
+++ b/test/Serialization/Recovery/conformance-xref-internal-import.swift
@@ -1,0 +1,69 @@
+/// A resilient module's PUBLIC conformance is witnessed by a constrained default
+/// whose requirement (Tint: CaseIterable) is only reachable through an
+/// `internal import`. That dependency is not re-exported, so an out-of-module
+/// client that finishes the conformance can't resolve it. This used to abort
+/// deserialization (*** DESERIALIZATION FAILURE ***); it must instead recover
+/// and emit a normal missing-conformance diagnostic, plus a note pointing the
+/// user at the import to add.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Foo \
+// RUN:   -o %t/Foo.swiftmodule -swift-version 6 -enable-library-evolution \
+// RUN:   -package-name P -I %t
+// RUN: %target-swift-frontend -emit-module %t/FooUI.swift -module-name FooUI \
+// RUN:   -o %t/FooUI.swiftmodule -swift-version 6 -enable-library-evolution \
+// RUN:   -package-name P -I %t
+// RUN: %target-swift-frontend -emit-module %t/FooCommands.swift -module-name FooCommands \
+// RUN:   -o %t/FooCommands.swiftmodule -swift-version 6 -enable-library-evolution \
+// RUN:   -package-name P -enable-testing -I %t
+
+/// The client imports Foo + FooCommands but NOT FooUI. Deserializing the
+/// FooCommands witness table cross-references Tint: CaseIterable into FooUI,
+/// which the client never loaded. Recover instead of aborting.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -module-name Client \
+// RUN:   -swift-version 6 -enable-library-evolution -I %t -verify \
+// RUN:   -verify-ignore-unrelated
+
+//--- Foo.swift
+public enum Tint {
+  case red
+  case blue
+}
+
+//--- FooUI.swift
+import Foo
+
+// Legal same-package retroactive conformance.
+extension Tint: CaseIterable {
+  public static var allCases: [Tint] { [.red, .blue] }
+}
+
+//--- FooCommands.swift
+public import Foo
+internal import FooUI
+
+public protocol ExpressibleByArgument {
+  static var allValueStrings: [String] { get }
+}
+extension ExpressibleByArgument where Self: CaseIterable {
+  public static var allValueStrings: [String] { [] }
+}
+
+// Public conformance; its only witness is the CaseIterable-constrained default,
+// so the serialized witness carries the conformance Tint: CaseIterable from the
+// internally-imported FooUI.
+extension Tint: ExpressibleByArgument {}
+
+func useTint() { _ = Tint.allValueStrings }
+
+//--- Client.swift
+import Foo
+import FooCommands
+
+func useTint() {
+  _ = Tint.allValueStrings
+  // expected-error@-1 {{static property 'allValueStrings' requires that 'Tint' conform to 'CaseIterable'}}
+  // expected-note@-2 {{the conformance of 'Tint' to 'CaseIterable' could not be loaded because module 'FooUI' was not imported; add import of module 'FooUI'}}
+}


### PR DESCRIPTION
When a deserialized conformance's witness cross-references a module that was never loaded (e.g. a dependency behind `internal import` that isn't re-exported), deserialization used to abort (*** DESERIALIZATION FAILURE ***). Recover instead by installing an opaque witness and continuing; the failure resurfaces as a normal requirement error at the use site.

Also record the unloaded module name at the recovery site, keyed by the conforming nominal type in an ASTContext side-table (the NormalProtocolConformance isn't reachable at the Sema error site). When the requirement failure is diagnosed, emit a note naming the module and the import to add.

Resolves: rdar://184957828