### PR TITLE
[any ~Copyable] Don't crash when using local ~C existentials

### DIFF
--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -203,16 +203,27 @@ struct SubElementOffset {
   /// elements of \p projectionFromRoot's type and adding this to the result of
   /// this function.
   ///
+  /// That last step only holds when \p projectionFromRoot's leaves really are a
+  /// sub-tree of the root's. Some projections look through a node of the type
+  /// tree that is opaque -- the payload of an existential, or the source of an
+  /// unchecked address cast -- and reach a type that is unrelated to the tree.
+  /// Such a projection affects the whole opaque node instead. If \p
+  /// opaqueBoundaryType is non-null and the walk looked through such a node, it
+  /// is set to that node's type, whose leaf count callers must use in place of
+  /// \p projectionFromRoot's. Otherwise it is left alone; callers should pass a
+  /// null SILType.
+  ///
   /// \returns None if we didn't know how to compute sub-element for this
   /// projection.
-  static std::optional<SubElementOffset> compute(SILValue projectionFromRoot,
-                                                 SILValue root) {
+  static std::optional<SubElementOffset>
+  compute(SILValue projectionFromRoot, SILValue root,
+          SILType *opaqueBoundaryType = nullptr) {
     assert(projectionFromRoot->getType().getCategory() ==
                root->getType().getCategory() &&
            "projectionFromRoot and root must both be objects or address.");
     if (root->getType().isObject())
       return computeForValue(projectionFromRoot, root);
-    return computeForAddress(projectionFromRoot, root);
+    return computeForAddress(projectionFromRoot, root, opaqueBoundaryType);
   }
 
   operator unsigned() const { return number; }
@@ -224,7 +235,8 @@ struct SubElementOffset {
 
 private:
   static std::optional<SubElementOffset>
-  computeForAddress(SILValue projectionFromRoot, SILValue rootAddress);
+  computeForAddress(SILValue projectionFromRoot, SILValue rootAddress,
+                    SILType *opaqueBoundaryType = nullptr);
   static std::optional<SubElementOffset>
   computeForValue(SILValue projectionFromRoot, SILValue rootValue);
 };
@@ -312,11 +324,19 @@ struct TypeTreeLeafTypeRange {
   /// the type tree.
   static void get(SILValue projectedValue, SILValue rootValue,
                   SmallVectorImpl<TypeTreeLeafTypeRange> &ranges) {
-    auto startEltOffset = SubElementOffset::compute(projectedValue, rootValue);
+    SILType opaqueBoundaryType;
+    auto startEltOffset =
+        SubElementOffset::compute(projectedValue, rootValue,
+                                  &opaqueBoundaryType);
     if (!startEltOffset)
       return;
-    ranges.push_back({*startEltOffset,
-                      *startEltOffset + TypeSubElementCount(projectedValue)});
+    // A projection out of an opaque node covers that whole node; its own type's
+    // leaves are not part of the root's type tree at all.
+    auto count = opaqueBoundaryType
+                     ? TypeSubElementCount(opaqueBoundaryType,
+                                           rootValue->getFunction())
+                     : TypeSubElementCount(projectedValue);
+    ranges.push_back({*startEltOffset, *startEltOffset + count});
   }
 
   /// Which bits of \p rootValue are involved in \p op.

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -131,12 +131,22 @@ TypeSubElementCount::TypeSubElementCount(SILValue value) : number(1) {
 
 std::optional<SubElementOffset>
 SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
-                                    SILValue rootAddress) {
+                                    SILValue rootAddress,
+                                    SILType *opaqueBoundaryType) {
   unsigned finalSubElementOffset = 0;
   SILModule &mod = *rootAddress->getModule();
 
   LLVM_DEBUG(llvm::dbgs() << "computing element offset for root:\n";
              rootAddress->print(llvm::dbgs()));
+
+  // Note that we looked through a node of the type tree whose leaves are opaque,
+  // reaching a type that is not a sub-tree of the root's. Anything projected out
+  // of such a node affects the node as a whole. Assigning unconditionally leaves
+  // the outermost such node, which is the one that matters.
+  auto noteOpaqueBoundary = [&](SILValue boundary) {
+    if (opaqueBoundaryType)
+      *opaqueBoundaryType = boundary->getType();
+  };
 
   while (1) {
     LLVM_DEBUG(llvm::dbgs() << "projection: ";
@@ -156,9 +166,12 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
       continue;
     }
 
+    // An unchecked address cast reinterprets its operand as an unrelated type,
+    // so its result covers the operand as a whole.
     if (auto *uaci =
             dyn_cast<UncheckedAddrCastInst>(projectionDerivedFromRoot)) {
       projectionDerivedFromRoot = uaci->getOperand();
+      noteOpaqueBoundary(projectionDerivedFromRoot);
       continue;
     }
 
@@ -173,15 +186,20 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
       continue;
     }
 
+    // The payload of an existential is not part of the existential's type tree:
+    // an existential is a single opaque leaf, while its payload can have any
+    // number of leaves. So a projection of the payload covers that one leaf.
     if (auto *oea =
             dyn_cast<OpenExistentialAddrInst>(projectionDerivedFromRoot)) {
       projectionDerivedFromRoot = oea->getOperand();
+      noteOpaqueBoundary(projectionDerivedFromRoot);
       continue;
     }
 
     if (auto *iea =
             dyn_cast<InitExistentialAddrInst>(projectionDerivedFromRoot)) {
       projectionDerivedFromRoot = iea->getOperand();
+      noteOpaqueBoundary(projectionDerivedFromRoot);
       continue;
     }
 
@@ -603,9 +621,21 @@ void TypeTreeLeafTypeRange::get(
     Operand *op, SILValue rootValue,
     SmallVectorImpl<TypeTreeLeafTypeRange> &ranges) {
   auto projectedValue = op->get();
-  auto startEltOffset = SubElementOffset::compute(projectedValue, rootValue);
+  SILType opaqueBoundaryType;
+  auto startEltOffset =
+      SubElementOffset::compute(projectedValue, rootValue, &opaqueBoundaryType);
   if (!startEltOffset)
     return;
+
+  // If the operand was projected out of an opaque node of the root's type tree,
+  // it affects that whole node. None of the sub-tree reasoning below applies:
+  // the operand's own leaves aren't in the tree, and there is in particular no
+  // separate deinit bit to carve out, since the opaque node is a single leaf.
+  if (opaqueBoundaryType) {
+    auto count = TypeSubElementCount(opaqueBoundaryType, op->getFunction());
+    ranges.push_back({*startEltOffset, *startEltOffset + count});
+    return;
+  }
 
   // A drop_deinit only consumes the deinit bit of its operand.
   if (isa<DropDeinitInst>(op->getUser())) {

--- a/test/Interpreter/moveonly_noncopyable_existential_local.swift
+++ b/test/Interpreter/moveonly_noncopyable_existential_local.swift
@@ -1,0 +1,149 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all)
+
+// REQUIRES: executable_test
+
+// The move-only address checker treats a noncopyable existential as a single
+// opaque leaf of the type tree. Check that the liveness it computes from that is
+// actually right: each payload must be destroyed exactly once, at the right
+// point, whether it is consumed, borrowed, reassigned, or left to go out of
+// scope.
+
+import StdlibUnittest
+
+defer { runAllTests() }
+
+var Tests = TestSuite("NoncopyableExistentialLocal")
+
+protocol P: ~Copyable {}
+
+// Payloads with differing leaf counts, since the leaf count of the payload is
+// what used to be mistaken for the leaf count of the existential.
+struct TwoLeaves: ~Copyable, P {
+  var tracked = LifetimeTracked(0)
+  deinit {}
+}
+
+struct ThreeFields: ~Copyable, P {
+  var a = LifetimeTracked(0)
+  var b = LifetimeTracked(0)
+  var c = LifetimeTracked(0)
+}
+
+struct DeinitOnly: ~Copyable, P {
+  deinit { DeinitOnly.deinitCount += 1 }
+  static var deinitCount = 0
+}
+
+func consume<T: ~Copyable>(_: consuming T) {}
+func borrow<T: ~Copyable>(_: borrowing T) {}
+
+Tests.test("let binding destroyed once at scope exit") {
+  do {
+    let box: any P & ~Copyable = TwoLeaves()
+    borrow(box)
+    expectEqual(1, LifetimeTracked.instances)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("multi-leaf payload destroyed once") {
+  do {
+    let box: any P & ~Copyable = ThreeFields()
+    borrow(box)
+    expectEqual(3, LifetimeTracked.instances)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("consuming the binding destroys the payload once") {
+  do {
+    let box: any P & ~Copyable = ThreeFields()
+    expectEqual(3, LifetimeTracked.instances)
+    consume(box)
+    // `consume` took ownership and dropped it.
+    expectEqual(0, LifetimeTracked.instances)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("reassignment destroys the old payload") {
+  do {
+    var box: any P & ~Copyable = ThreeFields()
+    expectEqual(3, LifetimeTracked.instances)
+    box = TwoLeaves()
+    // Old payload's three trackers are gone, new payload has one.
+    expectEqual(1, LifetimeTracked.instances)
+    borrow(box)
+    consume(box)
+    expectEqual(0, LifetimeTracked.instances)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("deinit runs exactly once") {
+  DeinitOnly.deinitCount = 0
+  do {
+    let box: any P & ~Copyable = DeinitOnly()
+    borrow(box)
+    expectEqual(0, DeinitOnly.deinitCount)
+  }
+  expectEqual(1, DeinitOnly.deinitCount)
+
+  DeinitOnly.deinitCount = 0
+  do {
+    var box: any P & ~Copyable = DeinitOnly()
+    box = DeinitOnly() // destroys the first
+    expectEqual(1, DeinitOnly.deinitCount)
+    consume(box)
+    expectEqual(2, DeinitOnly.deinitCount)
+  }
+  expectEqual(2, DeinitOnly.deinitCount)
+}
+
+// The existential sitting between two other fields: an over-wide leaf range
+// would have overlapped `after`, so check the neighbours survive correctly.
+struct Wrapper: ~Copyable {
+  var before = LifetimeTracked(0)
+  var box: any P & ~Copyable
+  var after = LifetimeTracked(0)
+}
+
+Tests.test("existential nested in an aggregate") {
+  do {
+    let w = Wrapper(box: ThreeFields())
+    borrow(w)
+    // 1 before + 3 payload + 1 after
+    expectEqual(5, LifetimeTracked.instances)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("reassigning the nested existential field") {
+  do {
+    var w = Wrapper(box: ThreeFields())
+    expectEqual(5, LifetimeTracked.instances)
+    w.box = TwoLeaves()
+    // 1 before + 1 payload + 1 after
+    expectEqual(3, LifetimeTracked.instances)
+    consume(w)
+    expectEqual(0, LifetimeTracked.instances)
+  }
+  expectEqual(0, LifetimeTracked.instances)
+}
+
+Tests.test("conditional consume destroys once on both paths") {
+  func run(_ takeIt: Bool) {
+    let box: any P & ~Copyable = ThreeFields()
+    if takeIt {
+      consume(box)
+    } else {
+      borrow(box)
+    }
+  }
+
+  run(true)
+  expectEqual(0, LifetimeTracked.instances)
+  run(false)
+  expectEqual(0, LifetimeTracked.instances)
+}

--- a/test/SILOptimizer/moveonly_noncopyable_existential_local.swift
+++ b/test/SILOptimizer/moveonly_noncopyable_existential_local.swift
@@ -1,0 +1,150 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify -enable-sil-opaque-values %s
+
+// Local bindings of noncopyable existential type used to crash the move-only
+// address checker with "Attempted to set out-of-bounds range!".
+//
+// An existential is an opaque leaf of the type tree: `TypeSubElementCount` of
+// `any P & ~Copyable` is 1. But `SubElementOffset::computeForAddress` looks
+// through `init_existential_addr`/`open_existential_addr` without advancing the
+// offset, while the *width* of the affected leaf range was computed from the
+// projection's own type -- the concrete payload. Any payload with more than one
+// leaf therefore produced a range wider than the whole type tree it sits in.
+
+protocol P: ~Copyable {}
+
+func consume<T: ~Copyable>(_: consuming T) {}
+func borrow<T: ~Copyable>(_: borrowing T) {}
+
+// A payload with two leaves: one stored property plus the deinit bit.
+struct TwoLeaves: ~Copyable, P {
+  var x = 0
+  deinit {}
+}
+
+// A payload with one leaf, which happened not to crash.
+struct OneLeaf: ~Copyable, P {
+  var x = 0
+}
+
+// A payload whose only leaf is the deinit bit.
+struct DeinitOnly: ~Copyable, P {
+  deinit {}
+}
+
+// Several leaves from stored properties alone.
+struct ThreeFields: ~Copyable, P {
+  var x = 0
+  var y = 0
+  var z = 0
+}
+
+// MARK: local `let` bindings
+
+func localLetTwoLeaves() {
+  let box: any P & ~Copyable = TwoLeaves()
+  consume(box)
+}
+
+func localLetOneLeaf() {
+  let box: any P & ~Copyable = OneLeaf()
+  consume(box)
+}
+
+func localLetDeinitOnly() {
+  let box: any P & ~Copyable = DeinitOnly()
+  consume(box)
+}
+
+func localLetThreeFields() {
+  let box: any P & ~Copyable = ThreeFields()
+  consume(box)
+}
+
+func localLetBorrowed() {
+  let box: any P & ~Copyable = TwoLeaves()
+  borrow(box)
+}
+
+// MARK: local `var` bindings
+
+func localVarReassigned() {
+  var box: any P & ~Copyable = TwoLeaves()
+  box = ThreeFields()
+  consume(box)
+}
+
+func localVarBorrowedThenConsumed() {
+  var box: any P & ~Copyable = TwoLeaves()
+  borrow(box)
+  box = DeinitOnly()
+  consume(box)
+}
+
+// MARK: the existential nested inside another noncopyable aggregate
+//
+// Here the existential is not at offset 0, so an over-wide range would claim
+// leaves belonging to the following field rather than just running off the end.
+
+struct Wrapper: ~Copyable {
+  var before: NoncopyableField
+  var box: any P & ~Copyable
+  var after: NoncopyableField
+}
+
+struct NoncopyableField: ~Copyable {
+  var v = 0
+  deinit {}
+}
+
+func nestedExistential(_ w: consuming Wrapper) {
+  borrow(w)
+  consume(w)
+}
+
+func nestedExistentialFieldReassigned(_ w: consuming Wrapper) {
+  var w = consume w
+  w.box = ThreeFields()
+  consume(w)
+}
+
+// MARK: leaf ranges around the nested existential must be precise
+//
+// The existential is exactly one leaf, distinct from its siblings. An over-wide
+// range would make consuming `box` look like it also consumed `after`.
+
+func partialConsumeOfBoxLeavesSiblingsAlone(_ w: consuming Wrapper) {
+  consume(w.box)
+  borrow(w.before)
+  borrow(w.after)
+}
+
+func partialConsumeOfSiblingLeavesBoxAlone(_ w: consuming Wrapper) {
+  consume(w.after)
+  borrow(w.box)
+  borrow(w.before)
+}
+
+// MARK: diagnostics must still be correct, not merely non-crashing
+
+func doubleConsumeOfBoxStillDiagnosed(_ w: consuming Wrapper) { // expected-error {{'w' consumed more than once}}
+  consume(w.box) // expected-note {{consumed here}}
+  consume(w.box) // expected-note {{consumed again here}}
+}
+
+func useOfBoxAfterConsumeStillDiagnosed(_ w: consuming Wrapper) { // expected-error {{'w' used after consume}}
+  consume(w.box) // expected-note {{consumed here}}
+  borrow(w.box) // expected-note {{used here}}
+}
+
+func stillDiagnosedConsumedTwice() {
+  let box: any P & ~Copyable = TwoLeaves() // expected-error {{'box' consumed more than once}}
+  consume(box) // expected-note {{consumed here}}
+  consume(box) // expected-note {{consumed again here}}
+}
+
+func stillDiagnosedUseAfterConsume() {
+  let box: any P & ~Copyable = ThreeFields() // expected-error {{'box' used after consume}}
+  consume(box) // expected-note {{consumed here}}
+  borrow(box) // expected-note {{used here}}
+}


### PR DESCRIPTION
The move checker was crashing on a use of a non-copyable existential stored in a local `let` or `var`.  The problem was a bug in computing the initialization status of the local variable that incorrectly considered the fields of the existential payload.
