### PR TITLE
[tests] Dynamically detect simulator device names instead of hardcoding

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -78,6 +78,18 @@ def darwin_get_watchos_sim_vers():
     watchos_version_str = re.findall(r'watchOS \d+\.*\d*', sim_output.decode('utf-8'))
     return [float(v.strip('watchOS')) for v in watchos_version_str]
 
+def darwin_get_ios_sim_device():
+    sim_output = subprocess.check_output(['xcrun', 'simctl', 'list', 'devices', 'iPhone'])
+    ios_sim_devices = re.findall(r'(iPhone \d+)\ \([0-9A-F-]*\).*', sim_output.decode('utf-8'))
+    assert len(ios_sim_devices) > 0, "No Simulator iPhone devices found."
+    return ios_sim_devices[0]
+
+def darwin_get_watchos_sim_device():
+    sim_output = subprocess.check_output(['xcrun', 'simctl', 'list', 'devices', 'Apple Watch'])
+    watchos_sim_devices = re.findall(r'(Apple Watch Series \d+ \(\d+mm\))\ \([0-9A-F-]*\).*', sim_output.decode('utf-8'))
+    assert len(watchos_sim_devices) > 0, "No Simulator Apple Watch devices found."
+    return watchos_sim_devices[0]
+
 # Returns the "prefix" command that should be prepended to the command line to
 # run an executable compiled for an iOS, tvOS, or watchOS simulator.
 def get_simulator_command(run_os, run_cpu):
@@ -97,7 +109,7 @@ def get_simulator_command(run_os, run_cpu):
             else:
                 return "simctl spawn --standalone 'iPhone 5'"
         else:
-            return "simctl spawn --standalone 'iPhone 15'"
+            return f"simctl spawn --standalone '{darwin_get_ios_sim_device()}'"
     elif run_os == 'tvos':
         return "simctl spawn --standalone 'Apple TV'"
     elif run_os == 'watchos':
@@ -111,7 +123,7 @@ def get_simulator_command(run_os, run_cpu):
            else:
               return "simctl spawn --standalone 'Apple Watch Series 2 - 42mm'"
         else:
-           return "simctl spawn --standalone 'Apple Watch Series 9 (45mm)'"
+           return f"simctl spawn --standalone '{darwin_get_watchos_sim_device()}'"
     elif run_os == 'xros':
         lit_config.note("xrOS Simulator Is Not Supported Yet - Tests Will Fail")
         return "simctl spawn --standalone 'Apple Vision Pro'"


### PR DESCRIPTION
- **Explanation**:
Hardcoding simulator device names breaks the tests when Xcode version evolves. Dynamically detect them fixes that issue.
- **Scope**:
This is a test-only change.
- **Issues**:
n/a
- **Original PRs**:
https://github.com/swiftlang/swift/pull/89894
- **Risk**:
Low. This is a test-only change.
- **Testing**:
Tested on the new CI nodes being brought up with newer Xcode version.
- **Reviewers**:
@shahmishal 