### PR TITLE
Revert "[rebranch] Adjust to "[ObjC] Support emission of selector stubs calls instead of objc_msgSend. (#186293)""

### DIFF
--- a/test/IRGen/UseObjCMethod.swift
+++ b/test/IRGen/UseObjCMethod.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xcc -fno-objc-msgsend-selector-stubs -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
 
 // REQUIRES: objc_interop
 import Foundation
@@ -22,15 +22,6 @@ func testDemo() {
 testDemo()
 
 // Make sure the clang importer puts the selectors and co into the llvm.compiler used variable.
-//
-// This needs Clang to emit the message sends in StaticInline.h as a selector
-// load plus a call to objc_msgSend, so selector-reference globals exist in the
-// first place. Where -fobjc-msgsend-selector-stubs is the default (AArch64
-// targets linked with ld64-811.2 or newer) the sends go through per-selector
-// linker stubs instead and no such globals are emitted, hence the explicit
-// -fno-objc-msgsend-selector-stubs above. The mechanism under test -- merging
-// Clang's llvm.compiler.used into Swift's -- is independent of the ObjC
-// dispatch strategy.
 
 // CHECK: @llvm.compiler.used = appending global [{{.*}} x ptr] [{{.*}} @"OBJC_CLASSLIST_REFERENCES_$_"{{.*}}@OBJC_METH_VAR_NAME_{{.*}}@OBJC_SELECTOR_REFERENCES_{{.*}}@OBJC_METH_VAR_NAME_.{{.*}}@OBJC_SELECTOR_REFERENCES_.{{.*}}]
 

--- a/test/IRGen/objc_globals.swift
+++ b/test/IRGen/objc_globals.swift
@@ -33,18 +33,14 @@ public func fooLazy() {
 // CHECK:         load ptr, ptr @OBJC_SELECTOR_REFERENCES_
 // CHECK:         ret
 
-// The two message sends below are emitted either as a load of the selector
-// followed by a call to objc_msgSend, or, where Clang enables
-// -fobjc-msgsend-selector-stubs by default (AArch64 targets linked with
-// ld64-811.2 or newer), as a call to the per-selector linker stub
-// objc_msgSend$<selector>. Accept both spellings.
-
 // CHECK-LABEL: define internal ptr @giveMeANumber()
 // CHECK:         [[CLASS:%.*]] = load ptr, ptr
-// CHECK:         call {{.*}} @{{"?}}objc_msgSend
+// CHECK-DAG:         [[SELECTOR:%.*]] = load ptr, ptr @OBJC_SELECTOR_REFERENCES_.{{.*}}
+// CHECK:         call {{.*}} @objc_msgSend
 // CHECK:         ret
 
 // CHECK-LABEL: define internal ptr @giveMeAMetaclass()
 // CHECK:         [[CLASS:%.*]] = load ptr, ptr
-// CHECK:         call {{.*}} @{{"?}}objc_msgSend
+// CHECK-DAG:         [[SELECTOR:%.*]] = load ptr, ptr @OBJC_SELECTOR_REFERENCES_
+// CHECK:         call {{.*}} @objc_msgSend
 // CHECK:         ret


### PR DESCRIPTION
This reverts commit ff20ee67d8862759b0400aa3f30effc40fbbbcb1 in favour of https://github.com/swiftlang/swift/pull/91623.