### PR TITLE
🍒 Disable ObjC selector stubs in Swift tests

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1235,6 +1235,14 @@ namespace swift {
     /// ones to apply.
     bool LoadVersionIndependentAPINotes = false;
 
+    /// Whether ClangImporter should force \c -fobjc-msgsend-selector-stubs to
+    /// be either on or off. If \c nullopt , the decision will be left to the clang driver.
+    std::optional<bool> ForceObjCMsgSendSelectorStubs = std::nullopt;
+
+    /// Whether ClangImporter should force \c -fobjc-msgsend-class-selector-stubs to
+    /// be either on or off. If \c nullopt , the decision will be left to the clang driver.
+    std::optional<bool> ForceObjCMsgSendClassSelectorStubs = std::nullopt;
+
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Bridging PCH hash.
     llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -230,6 +230,22 @@ def disable_clang_spi :
   Flag<["-"], "disable-clang-spi">,
   HelpText<"Don't import Clang SPIs as Swift SPIs">;
 
+def enable_objc_msgsend_selector_stubs :
+  Flag<["-"], "enable-objc-msgsend-selector-stubs">,
+  HelpText<"Allow use of magic 'objc_msgSend$selector:name:' stubs (default: depends on target and linker version)">;
+
+def disable_objc_msgsend_selector_stubs :
+  Flag<["-"], "disable-objc-msgsend-selector-stubs">,
+  HelpText<"Don't allow use of magic 'objc_msgSend$selector:name:' stubs (default: depends on target and linker version)">;
+
+def enable_objc_msgsend_class_selector_stubs :
+  Flag<["-"], "enable-objc-msgsend-class-selector-stubs">,
+  HelpText<"Allow use of magic 'objc_msgSendClass$selector:name:$classSymbol' stubs (default: depends on target and linker version)">;
+
+def disable_objc_msgsend_class_selector_stubs :
+  Flag<["-"], "disable-objc-msgsend-class-selector-stubs">,
+  HelpText<"Don't allow use of magic 'objc_msgSendClass$selector:name:$classSymbol' stubs (default: depends on target and linker version)">;
+
 def enable_target_os_checking :
   Flag<["-"], "enable-target-os-checking">,
   HelpText<"Enable checking the target OS of serialized modules">;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1045,6 +1045,21 @@ void importer::addCommonInvocationArguments(
     invocationArgStrs.push_back("-fbuild-session-file=" + importerOpts.BuildSessionFilePath);
   }
 
+  if (ctx.LangOpts.EnableObjCInterop) {
+    if (importerOpts.ForceObjCMsgSendSelectorStubs) {
+      if (*importerOpts.ForceObjCMsgSendSelectorStubs)
+        invocationArgStrs.push_back("-fobjc-msgsend-selector-stubs");
+      else
+        invocationArgStrs.push_back("-fno-objc-msgsend-selector-stubs");
+    }
+    if (importerOpts.ForceObjCMsgSendClassSelectorStubs) {
+      if (*importerOpts.ForceObjCMsgSendClassSelectorStubs)
+        invocationArgStrs.push_back("-fobjc-msgsend-class-selector-stubs");
+      else
+        invocationArgStrs.push_back("-fno-objc-msgsend-class-selector-stubs");
+    }
+  }
+
   if (!importerOpts.DirectClangCC1ModuleBuild) {
     for (const auto &extraArg : importerOpts.ExtraArgs) {
       invocationArgStrs.push_back(extraArg);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2370,6 +2370,20 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
     Opts.EnableClangSPI = false;
   }
 
+  if (auto *A = Args.getLastArg(OPT_enable_objc_msgsend_selector_stubs,
+                                OPT_disable_objc_msgsend_selector_stubs))
+    Opts.ForceObjCMsgSendSelectorStubs =
+        A->getOption().matches(OPT_enable_objc_msgsend_selector_stubs);
+  else
+    Opts.ForceObjCMsgSendSelectorStubs = std::nullopt;
+
+  if (auto *A = Args.getLastArg(OPT_enable_objc_msgsend_class_selector_stubs,
+                                OPT_disable_objc_msgsend_class_selector_stubs))
+    Opts.ForceObjCMsgSendClassSelectorStubs =
+        A->getOption().matches(OPT_enable_objc_msgsend_class_selector_stubs);
+  else
+    Opts.ForceObjCMsgSendClassSelectorStubs = std::nullopt;
+
   Opts.DirectClangCC1ModuleBuild |= Args.hasArg(OPT_direct_clang_cc1_module_build);
 
   if (const Arg *A = Args.getLastArg(OPT_pch_output_dir)) {


### PR DESCRIPTION
Cherry-picks most of https://github.com/swiftlang/swift/pull/91623 to reduce conflict surface between main and rebranch.