### PR TITLE
AST: Remove `PlatformKind::none`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -4280,13 +4280,14 @@ public:
   /// Returns the `rename:` field of the attribute, or an empty string.
   StringRef getRename() const { return attr->Rename; }
 
-  /// Returns the platform kind that the attribute applies to, or
-  /// `PlatformKind::none` if the attribute is not platform specific.
+  /// Returns true if the attribute applies to a specific platform.
   bool isPlatformSpecific() const { return getDomain().isPlatform(); }
 
-  /// Returns the platform kind that the attribute applies to, or
-  /// `PlatformKind::none` if the attribute is not platform specific.
-  PlatformKind getPlatform() const { return getDomain().getPlatformKind(); }
+  /// Returns the platform that the attribute applies to, or `nullopt` if the
+  /// attribute is not platform specific.
+  std::optional<PlatformKind> getPlatform() const {
+    return getDomain().getPlatformKind();
+  }
 
   /// Whether this is attribute indicates unavailability in all versions.
   bool isUnconditionallyUnavailable() const {

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -103,6 +103,9 @@ private:
   /// domain can be encapsulated inline in this class.
   class InlineDomain {
     Kind kind;
+    /// The platform of a `Kind::Platform` domain. Every other kind stores a
+    /// placeholder that `getPlatform()` never hands out, since `kind`
+    /// discriminates whether this field is meaningful.
     PlatformKind platform;
 
   public:
@@ -114,8 +117,13 @@ private:
       PlatformShift = KindShift - sizeof(PlatformKind) * CHAR_BIT,
     };
 
-    InlineDomain(Kind kind, PlatformKind platform)
-        : kind(kind), platform(platform) {};
+    InlineDomain(Kind kind, std::optional<PlatformKind> platform)
+        : kind(kind),
+          // A placeholder is needed for the kinds that have no platform. Any
+          // valid enumerator will do, since `getPlatform()` gates on `kind`.
+          platform(platform.value_or(PlatformKind{})) {
+      DEBUG_ASSERT(platform.has_value() == (kind == Kind::Platform));
+    };
     InlineDomain(IntReprType value)
         : kind(static_cast<Kind>(value >> KindShift)),
           platform(static_cast<PlatformKind>(value >> PlatformShift)) {}
@@ -128,7 +136,13 @@ private:
     }
 
     Kind getKind() const { return kind; }
-    PlatformKind getPlatform() { return platform; }
+
+    std::optional<PlatformKind> getPlatform() const {
+      if (kind != Kind::Platform)
+        return std::nullopt;
+
+      return platform;
+    }
   };
 
   using InlineDomainPtr =
@@ -138,7 +152,7 @@ private:
   Storage storage;
 
   AvailabilityDomain(Kind kind)
-      : storage(InlineDomain(kind, PlatformKind::none).asInteger()) {
+      : storage(InlineDomain(kind, std::nullopt).asInteger()) {
     DEBUG_ASSERT(kind != Kind::Platform);
   };
 
@@ -173,8 +187,6 @@ public:
   }
 
   static AvailabilityDomain forPlatform(PlatformKind platformKind) {
-    bool isPlatform = platformKind != PlatformKind::none;
-    ASSERT(isPlatform);
     return AvailabilityDomain(platformKind);
   }
 
@@ -239,12 +251,13 @@ public:
 
   bool isCustom() const { return getKind() == Kind::Custom; }
 
-  /// Returns the platform kind for this domain if applicable.
-  PlatformKind getPlatformKind() const {
+  /// Returns the platform for this domain, or `nullopt` if this is not a
+  /// platform domain.
+  std::optional<PlatformKind> getPlatformKind() const {
     if (auto inlineDomain = getInlineDomain())
       return inlineDomain->getPlatform();
 
-    return PlatformKind::none;
+    return std::nullopt;
   }
 
   /// If the domain represents a user-defined domain, returns the metadata for

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -28,7 +28,6 @@ namespace swift {
 
 /// Available platforms for the availability attribute.
 enum class ENUM_EXTENSIBILITY_ATTR(closed) PlatformKind : uint8_t {
-  none,
 #define AVAILABILITY_PLATFORM(X, PrettyName) X,
 #include "swift/AST/PlatformKinds.def"
 };

--- a/include/swift/AST/PlatformKindUtils.h
+++ b/include/swift/AST/PlatformKindUtils.h
@@ -34,6 +34,9 @@ StringRef platformString(PlatformKind platform);
 
 /// Returns the platform kind corresponding to the passed-in short platform name
 /// or None if such a platform kind does not exist.
+///
+/// The wildcard `"*"` is not a platform and yields `nullopt`. Callers that need
+/// to recognize a wildcard must check for it before calling this.
 std::optional<PlatformKind> platformFromString(StringRef Name);
 
 /// Safely converts the given unsigned value to a valid \c PlatformKind value or
@@ -67,22 +70,26 @@ inline bool isApplicationExtensionPlatform(PlatformKind Platform) {
 /// considered active when the target operating system is OS X and app extension
 /// restrictions are enabled, but OSXApplicationExtension is not considered
 /// active when the target platform is OS X and app extension restrictions are
-/// disabled. PlatformKind::none is always considered active.
+/// disabled.
 /// If ForTargetVariant is true then for zippered builds the target-variant
 /// triple will be used rather than the target to determine whether the
 /// platform is active.
 bool isPlatformActive(PlatformKind Platform, const LangOptions &LangOpts,
                       bool ForTargetVariant = false, bool ForRuntimeQuery = false);
 
-/// Returns the target platform for the given language options.
-PlatformKind targetPlatform(const LangOptions &LangOpts);
+/// Returns the target platform for the given language options, or `nullopt` if
+/// the target triple does not correspond to a platform.
+std::optional<PlatformKind> targetPlatform(const LangOptions &LangOpts);
 
-/// Returns the target variant platform for the given language options.
-PlatformKind targetVariantPlatform(const LangOptions &LangOpts);
+/// Returns the target variant platform for the given language options, or
+/// `nullopt` if there is no target variant or it does not correspond to a
+/// platform.
+std::optional<PlatformKind> targetVariantPlatform(const LangOptions &LangOpts);
 
-/// Returns the target platform for the given triple and options.
-PlatformKind platformForTriple(const llvm::Triple &triple,
-                               bool enableAppExtensionRestrictions);
+/// Returns the target platform for the given triple and options, or `nullopt`
+/// if the triple does not correspond to a platform.
+std::optional<PlatformKind>
+platformForTriple(const llvm::Triple &triple, bool enableAppExtensionRestrictions);
 
 /// Returns true when availability attributes from the "parent" platform
 /// should also apply to the "child" platform for declarations without
@@ -95,6 +102,12 @@ tripleOSTypeForPlatform(PlatformKind platform);
 
 llvm::VersionTuple canonicalizePlatformVersion(
     PlatformKind platform, const llvm::VersionTuple &version);
+
+/// Canonicalizes \p version for \p platform. Returns \p version unmodified when
+/// there is no platform, since canonicalization is platform specific.
+llvm::VersionTuple
+canonicalizePlatformVersion(std::optional<PlatformKind> platform,
+                            const llvm::VersionTuple &version);
 
 /// Returns true if \p Platform should be considered to be SPI and therefore not
 /// printed in public `.swiftinterface` files, for example.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -7670,9 +7670,9 @@ ValueOwnership swift::asValueOwnership(ParameterOwnership o) {
 }
 
 static AvailabilityDomain
-targetAvailabilityDomainForPlatform(PlatformKind platform) {
-  if (platform != PlatformKind::none)
-    return AvailabilityDomain::forPlatform(platform);
+targetAvailabilityDomainForPlatform(std::optional<PlatformKind> platform) {
+  if (platform)
+    return AvailabilityDomain::forPlatform(*platform);
 
   // Fall back to the universal domain for triples without a platform.
   return AvailabilityDomain::forUniversal();

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -515,12 +515,18 @@ isShortFormAvailabilityImpliedByOther(SemanticAvailableAttr Attr,
   assert(isShortAvailable(Attr));
 
   auto platform = Attr.getDomain().getPlatformKind();
+  if (!platform)
+    return false;
+
   for (auto other : Others) {
     auto otherPlatform = other.getDomain().getPlatformKind();
     if (platform == otherPlatform)
       continue;
 
-    if (!inheritsAvailabilityFromPlatform(platform, otherPlatform))
+    if (!otherPlatform)
+      continue;
+
+    if (!inheritsAvailabilityFromPlatform(*platform, *otherPlatform))
       continue;
 
     if (Attr.getIntroduced() == other.getIntroduced())

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -184,8 +184,13 @@ void AvailabilityInference::applyInferredAvailableAttrs(
         // declaration.
         if (llvm::any_of(MergedAttrs,
                          [&AvAttr](SemanticAvailableAttr MergedAttr) {
+                           auto platform = AvAttr.getPlatform();
+                           auto mergedPlatform = MergedAttr.getPlatform();
+                           if (!platform || !mergedPlatform)
+                             return false;
+
                            return inheritsAvailabilityFromPlatform(
-                               AvAttr.getPlatform(), MergedAttr.getPlatform());
+                               *platform, *mergedPlatform);
                          }))
           continue;
 
@@ -241,19 +246,24 @@ const Decl *Decl::parentDeclForAvailability() const {
 /// Returns true if the introduced version in \p newAttr should be used instead
 /// of the introduced version in \p prevAttr when both are attached to the same
 /// declaration and refer to the active platform.
+///
+/// Both attributes must be platform specific.
 static bool isBetterThan(const SemanticAvailableAttr &newAttr,
                          const std::optional<SemanticAvailableAttr> &prevAttr) {
   // If there is no prevAttr, newAttr of course wins.
   if (!prevAttr)
     return true;
 
+  DEBUG_ASSERT(newAttr.isPlatformSpecific());
+  DEBUG_ASSERT(prevAttr->isPlatformSpecific());
+
   // If they belong to the same platform, the one that introduces later wins.
   if (prevAttr->getPlatform() == newAttr.getPlatform())
     return prevAttr->getIntroduced().value() < newAttr.getIntroduced().value();
 
   // If the new attribute's platform inherits from the old one, it wins.
-  return inheritsAvailabilityFromPlatform(newAttr.getPlatform(),
-                                          prevAttr->getPlatform());
+  return inheritsAvailabilityFromPlatform(*newAttr.getPlatform(),
+                                          *prevAttr->getPlatform());
 }
 
 static std::optional<SemanticAvailableAttr>
@@ -420,7 +430,7 @@ Decl::getActiveAvailableAttrForCurrentPlatform() const {
     // We have an attribute that is active for the platform, but is it more
     // specific than our current best?
     if (!bestAttr || inheritsAvailabilityFromPlatform(
-                         attr.getPlatform(), bestAttr->getPlatform())) {
+                         *attr.getPlatform(), *bestAttr->getPlatform())) {
       bestAttr.emplace(attr);
     }
   }
@@ -462,8 +472,8 @@ std::optional<SemanticAvailableAttr> Decl::getNoAsyncAttr() const {
       bestAttr.emplace(attr);
     } else if (bestAttr && attr.isPlatformSpecific() &&
                bestAttr->isPlatformSpecific() &&
-               inheritsAvailabilityFromPlatform(attr.getPlatform(),
-                                                bestAttr->getPlatform())) {
+               inheritsAvailabilityFromPlatform(*attr.getPlatform(),
+                                                *bestAttr->getPlatform())) {
       // if they both have a viable platform, use the better one
       bestAttr.emplace(attr);
     } else if (attr.isPlatformSpecific() && !bestAttr->isPlatformSpecific()) {
@@ -512,15 +522,13 @@ getRootTargetDomains(const ASTContext &ctx) {
   if (ctx.LangOpts.hasFeature(Feature::Embedded))
     return domains;
 
-  auto targetPlatform = swift::targetPlatform(ctx.LangOpts);
-  if (targetPlatform != PlatformKind::none)
+  if (auto targetPlatform = swift::targetPlatform(ctx.LangOpts))
     domains.insert(
-        AvailabilityDomain::forPlatform(targetPlatform).getRootDomain());
+        AvailabilityDomain::forPlatform(*targetPlatform).getRootDomain());
 
-  auto targetVariantPlatform = swift::targetVariantPlatform(ctx.LangOpts);
-  if (targetVariantPlatform != PlatformKind::none)
+  if (auto targetVariantPlatform = swift::targetVariantPlatform(ctx.LangOpts))
     domains.insert(
-        AvailabilityDomain::forPlatform(targetVariantPlatform).getRootDomain());
+        AvailabilityDomain::forPlatform(*targetVariantPlatform).getRootDomain());
 
   return domains;
 }

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -467,13 +467,12 @@ createImplicitAvailableAttr(AvailabilityContext::DomainInfo domainInfo,
 void AvailabilityContext::createImplicitAvailableAttrs(
     const AvailabilityContext &other, ASTContext &ctx,
     llvm::SmallVectorImpl<AvailableAttr *> &attrs) const {
-  auto platform = targetPlatform(ctx.LangOpts);
-  if (platform != PlatformKind::none) {
+  if (auto platform = targetPlatform(ctx.LangOpts)) {
     // Only describe the platform range if it is strictly narrower than the
     // range that is already implied by `other`.
     if (other.storage->platformRange.isSupersetOf(storage->platformRange)) {
       if (auto *attr = createImplicitAvailableAttr(
-              DomainInfo(AvailabilityDomain::forPlatform(platform),
+              DomainInfo(AvailabilityDomain::forPlatform(*platform),
                          storage->platformRange),
               ctx))
         attrs.push_back(attr);

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -172,7 +172,7 @@ bool AvailabilityDomain::isVersionValid(
   case Kind::Platform:
     // If the platform kind corresponds to a specific OS, LLVM is the source of
     // truth for version validity.
-    if (auto osType = tripleOSTypeForPlatform(getPlatformKind()))
+    if (auto osType = tripleOSTypeForPlatform(*getPlatformKind()))
       return llvm::Triple::isValidVersionForOS(*osType, version);
 
     // Unified versioning for Apple's operating systems starts at 26.0.
@@ -228,7 +228,7 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx,
     // standalone Swift runtime.
     return ctx.LangOpts.hasFeature(Feature::SwiftRuntimeAvailability);
   case Kind::Platform:
-    return isPlatformActive(getPlatformKind(), ctx.LangOpts, forTargetVariant);
+    return isPlatformActive(*getPlatformKind(), ctx.LangOpts, forTargetVariant);
   case Kind::Custom:
     // For now, custom domains are always active but it's conceivable that in
     // the future someone might want to define a domain but leave it inactive.
@@ -320,7 +320,7 @@ llvm::StringRef AvailabilityDomain::getNameForDiagnostics() const {
   case Kind::Embedded:
     return "Embedded Swift";
   case Kind::Platform:
-    return swift::prettyPlatformString(getPlatformKind());
+    return swift::prettyPlatformString(*getPlatformKind());
   case Kind::Custom:
     return getCustomDomain()->getName().str();
   }
@@ -339,7 +339,7 @@ llvm::StringRef AvailabilityDomain::getNameForAttributePrinting() const {
   case Kind::Embedded:
     return "Embedded";
   case Kind::Platform:
-    return swift::platformString(getPlatformKind());
+    return swift::platformString(*getPlatformKind());
   case Kind::Custom:
     return getCustomDomain()->getName().str();
   }
@@ -370,9 +370,15 @@ static bool domainIsStrictSubsetOf(const AvailabilityDomain &child,
   case AvailabilityDomain::Kind::Embedded:
     // These domains do not have any children in the lattice.
     return false;
-  case AvailabilityDomain::Kind::Platform:
-    return inheritsAvailabilityFromPlatform(child.getPlatformKind(),
-                                            parent.getPlatformKind());
+  case AvailabilityDomain::Kind::Platform: {
+    // A non-platform domain is never a subset of a platform domain.
+    auto childPlatform = child.getPlatformKind();
+    if (!childPlatform)
+      return false;
+
+    return inheritsAvailabilityFromPlatform(*childPlatform,
+                                            *parent.getPlatformKind());
+  }
   case AvailabilityDomain::Kind::Custom:
     // Custom domains do not yet support inheritance relationships.
     return false;
@@ -425,7 +431,7 @@ AvailabilityDomain AvailabilityDomain::getRootDomain() const {
     return iOSDomain;
 
   // App Extension domains are contained by their base platform domain.
-  if (auto basePlatform = basePlatformForExtensionPlatform(getPlatformKind()))
+  if (auto basePlatform = basePlatformForExtensionPlatform(*getPlatformKind()))
     return AvailabilityDomain::forPlatform(*basePlatform);
 
   return *this;
@@ -614,7 +620,7 @@ bool StableAvailabilityDomainComparator::operator()(
   case AvailabilityDomain::Kind::Embedded:
     return false;
   case AvailabilityDomain::Kind::Platform:
-    return lhs.getPlatformKind() < rhs.getPlatformKind();
+    return *lhs.getPlatformKind() < *rhs.getPlatformKind();
   case AvailabilityDomain::Kind::Custom: {
     auto lhsMod = lhs.getModule();
     auto rhsMod = rhs.getModule();

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -57,10 +57,11 @@ AvailabilityRestriction::getFixItDomainAndRange(const ASTContext &ctx) const {
 
 bool AvailabilityRestriction::isActiveForRuntimeQueries(
     const ASTContext &ctx) const {
-  if (getAttr().getPlatform() == PlatformKind::none)
+  auto platform = getAttr().getPlatform();
+  if (!platform)
     return true;
 
-  return swift::isPlatformActive(getAttr().getPlatform(), ctx.LangOpts,
+  return swift::isPlatformActive(*platform, ctx.LangOpts,
                                  /*forTargetVariant=*/false,
                                  /*forRuntimeQuery=*/true);
 }

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -1162,7 +1162,7 @@ private:
         // diagnostic and just use the current scope.
         Context.Diags.diagnose(
             query->getLoc(), diag::availability_query_required_for_platform,
-            platformString(targetPlatform(Context.LangOpts)));
+            Context.getTargetAvailabilityDomain().getNameForAttributePrinting());
         falseFlowBuilder.setUndefined();
         continue;
       }
@@ -1294,13 +1294,13 @@ private:
       // properly. For example, on the OSXApplicationExtension platform
       // we want to chose the OS X spec unless there is an explicit
       // OSXApplicationExtension spec.
-      auto platform = domain.getPlatformKind();
+      auto platform = *domain.getPlatformKind();
       if (isPlatformActive(platform, Context.LangOpts, forTargetVariant,
                            /* ForRuntimeQuery */ true)) {
 
         if (!bestSpec ||
             inheritsAvailabilityFromPlatform(
-                platform, bestSpec->getDomain().getPlatformKind())) {
+                platform, *bestSpec->getDomain().getPlatformKind())) {
           bestSpec = spec;
         }
       }

--- a/lib/AST/PlatformKindUtils.cpp
+++ b/lib/AST/PlatformKindUtils.cpp
@@ -25,8 +25,6 @@ using namespace swift;
 
 StringRef swift::platformString(PlatformKind platform) {
   switch (platform) {
-  case PlatformKind::none:
-    return "*";
 #define AVAILABILITY_PLATFORM(X, PrettyName)                                   \
   case PlatformKind::X:                                                        \
     return #X;
@@ -37,8 +35,6 @@ StringRef swift::platformString(PlatformKind platform) {
 
 StringRef swift::prettyPlatformString(PlatformKind platform) {
   switch (platform) {
-  case PlatformKind::none:
-    return "*";
 #define AVAILABILITY_PLATFORM(X, PrettyName)                                   \
   case PlatformKind::X:                                                        \
     return PrettyName;
@@ -48,8 +44,6 @@ StringRef swift::prettyPlatformString(PlatformKind platform) {
 }
 
 std::optional<PlatformKind> swift::platformFromString(StringRef Name) {
-  if (Name == "*")
-    return PlatformKind::none;
   return llvm::StringSwitch<std::optional<PlatformKind>>(Name)
 #define AVAILABILITY_PLATFORM(X, PrettyName) .Case(#X, PlatformKind::X)
 #include "swift/AST/PlatformKinds.def"
@@ -61,7 +55,6 @@ std::optional<PlatformKind> swift::platformFromString(StringRef Name) {
 std::optional<PlatformKind> swift::platformFromUnsigned(unsigned value) {
   PlatformKind platform = PlatformKind(value);
   switch (platform) {
-  case PlatformKind::none:
 #define AVAILABILITY_PLATFORM(X, PrettyName) case PlatformKind::X:
 #include "swift/AST/PlatformKinds.def"
     return platform;
@@ -122,7 +115,6 @@ swift::basePlatformForExtensionPlatform(PlatformKind Platform) {
   case PlatformKind::OpenBSD:
   case PlatformKind::Windows:
   case PlatformKind::Android:
-  case PlatformKind::none:
     return std::nullopt;
   }
   llvm_unreachable("bad PlatformKind");
@@ -132,9 +124,6 @@ static bool isPlatformActiveForTarget(PlatformKind Platform,
                                       const llvm::Triple &Target,
                                       const LangOptions &LangOpts,
                                       bool ForRuntimeQuery) {
-  if (Platform == PlatformKind::none)
-    return true;
-
   if (!LangOpts.EnableAppExtensionRestrictions &&
       isApplicationExtensionPlatform(Platform))
     return false;
@@ -176,8 +165,6 @@ static bool isPlatformActiveForTarget(PlatformKind Platform,
       return Target.isOSWindows();
     case PlatformKind::Android:
       return Target.isAndroid();
-    case PlatformKind::none:
-      llvm_unreachable("handled above");
   }
   llvm_unreachable("bad PlatformKind");
 }
@@ -194,8 +181,9 @@ bool swift::isPlatformActive(PlatformKind Platform, const LangOptions &LangOpts,
                                    ForRuntimeQuery);
 }
 
-PlatformKind swift::platformForTriple(const llvm::Triple &triple,
-                                      bool enableAppExtensionRestrictions) {
+std::optional<PlatformKind>
+swift::platformForTriple(const llvm::Triple &triple,
+                         bool enableAppExtensionRestrictions) {
   if (triple.isMacOSX()) {
     return (enableAppExtensionRestrictions
                 ? PlatformKind::macOSApplicationExtension
@@ -234,20 +222,21 @@ PlatformKind swift::platformForTriple(const llvm::Triple &triple,
     return PlatformKind::Android;
   }
 
-  return PlatformKind::none;
+  return std::nullopt;
 }
 
-PlatformKind swift::targetPlatform(const LangOptions &LangOpts) {
+std::optional<PlatformKind> swift::targetPlatform(const LangOptions &LangOpts) {
   return platformForTriple(LangOpts.Target,
                            LangOpts.EnableAppExtensionRestrictions);
 }
 
-PlatformKind swift::targetVariantPlatform(const LangOptions &LangOpts) {
-  if (auto variant = LangOpts.TargetVariant)
+std::optional<PlatformKind>
+swift::targetVariantPlatform(const LangOptions &LangOpts) {
+  if (LangOpts.TargetVariant)
     return platformForTriple(*LangOpts.TargetVariant,
                              LangOpts.EnableAppExtensionRestrictions);
 
-  return PlatformKind::none;
+  return std::nullopt;
 }
 
 static bool inheritsAvailabilityFromAnyAppleOS(PlatformKind platform) {
@@ -272,7 +261,6 @@ static bool inheritsAvailabilityFromAnyAppleOS(PlatformKind platform) {
   case PlatformKind::OpenBSD:
   case PlatformKind::Windows:
   case PlatformKind::Android:
-  case PlatformKind::none:
     return false;
   }
 }
@@ -344,8 +332,6 @@ swift::tripleOSTypeForPlatform(PlatformKind platform) {
     return llvm::Triple::Win32;
   case PlatformKind::Android:
     return llvm::Triple::Linux;
-  case PlatformKind::none:
-    return std::nullopt;
   }
   llvm_unreachable("bad PlatformKind");
 }
@@ -360,6 +346,15 @@ swift::canonicalizePlatformVersion(PlatformKind platform,
   }
 
   return version;
+}
+
+llvm::VersionTuple
+swift::canonicalizePlatformVersion(std::optional<PlatformKind> platform,
+                                   const llvm::VersionTuple &version) {
+  if (!platform)
+    return version;
+
+  return canonicalizePlatformVersion(*platform, version);
 }
 
 bool swift::isPlatformSPI(PlatformKind Platform) {
@@ -383,7 +378,6 @@ bool swift::isPlatformSPI(PlatformKind Platform) {
   case PlatformKind::FreeBSD:
   case PlatformKind::Windows:
   case PlatformKind::Android:
-  case PlatformKind::none:
     return false;
   }
   llvm_unreachable("bad PlatformKind");

--- a/lib/ASTGen/Sources/ASTGen/Availability.swift
+++ b/lib/ASTGen/Sources/ASTGen/Availability.swift
@@ -379,6 +379,13 @@ extension ASTGenVisitor {
       let platformName =  platformVersionNode.platform.rawText
       let version = self.generate(versionTuple: platformVersionNode.version)?.bridged ?? BridgedVersionTuple()
 
+      // A wildcard is not a platform, and it carries no version to record. The
+      // legacy parser diagnoses it and skips the entry.
+      // TODO: Diagnostics.
+      if platformName == "*" {
+        continue
+      }
+
       // If the name is a platform name, use it.
       let platform = BridgedOptionalPlatformKind(from: platformName.bridged)
       guard !platform.hasValue else {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2742,7 +2742,11 @@ ClangImporter::getWrapperForModule(const clang::Module *mod,
 
 PlatformAvailability::PlatformAvailability(const LangOptions &langOpts)
     : platformKind(targetPlatform(langOpts)) {
-  switch (platformKind) {
+  // Without a platform there are no platform-specific cutoff messages.
+  if (!platformKind)
+    return;
+
+  switch (*platformKind) {
   case PlatformKind::iOS:
   case PlatformKind::iOSApplicationExtension:
   case PlatformKind::macCatalyst:
@@ -2799,9 +2803,6 @@ PlatformAvailability::PlatformAvailability(const LangOptions &langOpts)
   case PlatformKind::Android:
     deprecatedAsUnavailableMessage = "";
     break;
-
-  case PlatformKind::none:
-    break;
   }
 }
 
@@ -2829,9 +2830,9 @@ PlatformAvailability::platformKindIfRelevant(StringRef platformName) const {
           .Case("android", PlatformKind::Android)
           .Default(std::nullopt);
 
-  if (result) {
-    if (platformKind == *result ||
-        inheritsAvailabilityFromPlatform(platformKind, *result))
+  if (result && platformKind) {
+    if (*platformKind == *result ||
+        inheritsAvailabilityFromPlatform(*platformKind, *result))
       return result;
   }
 
@@ -2845,10 +2846,10 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   unsigned major = version.getMajor();
   std::optional<unsigned> minor = version.getMinor();
 
-  switch (platformKind) {
-  case PlatformKind::none:
+  if (!platformKind)
     llvm_unreachable("version but no platform?");
 
+  switch (*platformKind) {
   case PlatformKind::macOS:
   case PlatformKind::macOSApplicationExtension:
     // Anything deprecated by macOS 10.14 is unavailable for async import

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -634,8 +634,13 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityRange &info,
   if (info.isAlwaysAvailable())
     return;
 
+  // A platform-versioned attribute needs a platform to attach the version to.
+  auto platform = targetPlatform(C.LangOpts);
+  if (!platform)
+    return;
+
   auto AvAttr = AvailableAttr::createPlatformVersioned(
-      C, targetPlatform(C.LangOpts), /*Message=*/"", /*Rename=*/"",
+      C, *platform, /*Message=*/"", /*Rename=*/"",
       info.getRawMinimumVersion(), /*Deprecated=*/{}, /*Obsoleted=*/{});
 
   decl->addAttribute(AvAttr);
@@ -2988,10 +2993,11 @@ namespace {
         importer::checkRetainReleaseFunctions(classDecl, Impl);
 
         auto availability = Impl.SwiftContext.getSwift58Availability();
-        if (!availability.isAlwaysAvailable()) {
+        auto platform = targetPlatform(Impl.SwiftContext.LangOpts);
+        if (!availability.isAlwaysAvailable() && platform) {
           assert(availability.hasMinimumVersion());
           auto AvAttr = AvailableAttr::createPlatformVersioned(
-              Impl.SwiftContext, targetPlatform(Impl.SwiftContext.LangOpts),
+              Impl.SwiftContext, *platform,
               /*Message=*/"", /*Rename=*/"",
               availability.getRawMinimumVersion(), /*Deprecated=*/{},
               /*Obsoleted=*/{});

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -334,7 +334,9 @@ enum class FactoryAsInitKind {
 namespace importer {
 struct PlatformAvailability {
 private:
-  PlatformKind platformKind;
+  /// The platform that compilation is targeting, or `nullopt` if the target
+  /// triple does not correspond to a platform.
+  std::optional<PlatformKind> platformKind;
 
 public:
   /// Returns a non-optional `PlatformKind` corresponding to the platform name

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -343,10 +343,12 @@ public:
     out << "\"";
     llvm::SaveAndRestore<bool> hasAvailbilitySeparatorRestore(firstParam, true);
     for (auto attr : availabilityAttrs) {
+      auto platform = attr.getPlatform();
+      if (!platform) continue;
       auto introducedOpt = attr.getIntroduced();
       if (!introducedOpt.has_value()) continue;
       printSeparator();
-      out << prettyPlatformString(attr.getPlatform()) << " " << introducedOpt.value();
+      out << prettyPlatformString(*platform) << " " << introducedOpt.value();
     }
     out << "\"";
   }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -1261,7 +1261,7 @@ void writeBuilderMember(
           JSON.object([&] {
             JSON.attribute(
                 "platform",
-                platformString(elem.getDomain().getPlatformKind()).str());
+                platformString(*elem.getDomain().getPlatformKind()).str());
             JSON.attribute("minVersion", elem.getVersion().getAsString());
           });
         }

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -243,8 +243,6 @@ getLinkerPlatformId(OriginallyDefinedInAttr::ActiveVersion Ver,
   bool isSimulator = target ? target->isSimulatorEnvironment() : false;
 
   switch(Ver.Platform) {
-  case swift::PlatformKind::none:
-    llvm_unreachable("cannot find platform kind");
   case swift::PlatformKind::DriverKit:
     llvm_unreachable("not used for this platform");
   case swift::PlatformKind::Swift:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1913,16 +1913,12 @@ Parser::parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs) {
   return makeParserSuccess();
 }
 
-static PlatformKind getPlatformFromDomainOrIdentifier(
+static std::optional<PlatformKind> getPlatformFromDomainOrIdentifier(
     const AvailabilityDomainOrIdentifier &domainOrIdentifier) {
   if (auto domain = domainOrIdentifier.getAsDomain())
     return domain->getPlatformKind();
 
-  if (auto platform =
-          platformFromString(domainOrIdentifier.getAsIdentifier()->str()))
-    return *platform;
-
-  return PlatformKind::none;
+  return platformFromString(domainOrIdentifier.getAsIdentifier()->str());
 }
 
 ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
@@ -1943,7 +1939,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
     for (auto *Spec : Specs) {
       auto Platform =
           getPlatformFromDomainOrIdentifier(Spec->getDomainOrIdentifier());
-      if (Platform == PlatformKind::none)
+      if (!Platform)
         continue;
 
       auto Version = Spec->getRawVersion();
@@ -1952,7 +1948,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
                  diag::attr_availability_platform_version_major_minor_only,
                  AttrName);
       }
-      PlatformAndVersions.emplace_back(Platform, Version);
+      PlatformAndVersions.emplace_back(*Platform, Version);
     }
 
     return makeParserSuccess();
@@ -1966,12 +1962,21 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
 
   // Parse the platform name.
   StringRef platformText = Tok.getText();
+  bool IsWildcard = platformText == "*";
   auto MaybePlatform = platformFromString(platformText);
-  WasEmpty = WasEmpty || !MaybePlatform.has_value();
+  WasEmpty = WasEmpty || (!IsWildcard && !MaybePlatform.has_value());
   SourceLoc PlatformLoc = Tok.getLoc();
   consumeToken();
 
-  if (!MaybePlatform.has_value()) {
+  if (IsWildcard) {
+    // Wildcards ('*') aren't supported in this kind of list.
+    diagnose(PlatformLoc, diag::attr_availability_wildcard_ignored,
+             AttrName);
+
+    // If this list entry is just a wildcard, skip it.
+    if (Tok.isAny(tok::comma, tok::r_paren))
+      return makeParserSuccess();
+  } else if (!MaybePlatform.has_value()) {
     if (auto correctedPlatform = closestCorrectedPlatformString(platformText)) {
       diagnose(PlatformLoc, diag::attr_availability_suggest_platform,
                platformText, AttrName, *correctedPlatform)
@@ -1980,14 +1985,6 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
       diagnose(PlatformLoc, diag::attr_availability_unknown_platform,
                platformText, AttrName);
     }
-  } else if (*MaybePlatform == PlatformKind::none) {
-    // Wildcards ('*') aren't supported in this kind of list.
-    diagnose(PlatformLoc, diag::attr_availability_wildcard_ignored,
-             AttrName);
-
-    // If this list entry is just a wildcard, skip it.
-    if (Tok.isAny(tok::comma, tok::r_paren))
-      return makeParserSuccess();
   }
 
   // Parse version number.
@@ -2006,12 +2003,8 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
              AttrName);
   }
 
-  if (MaybePlatform.has_value()) {
-    auto Platform = *MaybePlatform;
-    if (Platform != PlatformKind::none) {
-      PlatformAndVersions.emplace_back(Platform, VerTuple);
-    }
-  }
+  if (MaybePlatform.has_value())
+    PlatformAndVersions.emplace_back(*MaybePlatform, VerTuple);
 
   return makeParserSuccess();
 }

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1873,7 +1873,7 @@ public:
         continue;
       }
 
-      auto platKind = AvAttr.getPlatform();
+      auto platKind = *AvAttr.getPlatform();
       const char *plat;
       switch (platKind) {
       case PlatformKind::macOS:
@@ -1934,8 +1934,6 @@ public:
       case PlatformKind::Android:
         plat = "android";
         break;
-      case PlatformKind::none:
-        llvm_unreachable("handled above");
       }
 
       maybePrintLeadingSpace();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5392,7 +5392,7 @@ void suggestAnyAppleOSAvailability(const Decl *D,
     if (!semAttr || !semAttr->isPlatformSpecific())
       continue;
 
-    auto platform = semAttr->getPlatform();
+    auto platform = *semAttr->getPlatform();
 
     // Don't diagnose any declaration that already has an anyAppleOS attribute.
     if (platform == PlatformKind::anyAppleOS)
@@ -5480,7 +5480,7 @@ void suggestAnyAppleOSAvailability(const Decl *D,
       if (remainingAttrsToReplace.erase(member))
         continue;
       if (auto semAttr = D->getSemanticAvailableAttr(member)) {
-        os << ", " << platformString(semAttr->getPlatform());
+        os << ", " << semAttr->getDomain().getNameForAttributePrinting();
         if (auto v = member->getRawIntroduced())
           os << " " << *v;
       }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -889,7 +889,11 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     // macOS 10.x.y).
     auto RunningVers = ExplicitAvailability->getRawMinimumVersion();
     auto RequiredVers = RequiredAvailability.getRawMinimumVersion();
-    auto Platform = targetPlatform(Context.LangOpts);
+    auto MaybePlatform = targetPlatform(Context.LangOpts);
+    if (!MaybePlatform)
+      return false;
+
+    auto Platform = *MaybePlatform;
     if (RunningVers.getMajor() != RequiredVers.getMajor())
       return false;
     if ((Platform == PlatformKind::macOS ||
@@ -966,9 +970,11 @@ static void fixAvailabilityByAddingVersionCheck(
 
     // Runtime availability checks that specify app extension platforms don't
     // work, so only suggest checks against the base platform.
-    if (auto CanonicalPlatform =
-            basePlatformForExtensionPlatform(QueryDomain.getPlatformKind())) {
-      QueryDomain = AvailabilityDomain::forPlatform(*CanonicalPlatform);
+    if (auto QueryPlatform = QueryDomain.getPlatformKind()) {
+      if (auto CanonicalPlatform =
+              basePlatformForExtensionPlatform(*QueryPlatform)) {
+        QueryDomain = AvailabilityDomain::forPlatform(*CanonicalPlatform);
+      }
     }
 
     Out << "if #available(" << QueryDomain.getNameForAttributePrinting();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7822,12 +7822,13 @@ static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
     bool anyPlatformSpecificAttrs = false;
     for (auto available : enclosing->getSemanticAvailableAttrs()) {
       // FIXME: [availability] Generalize to AvailabilityDomain.
-      if (available.getPlatform() == PlatformKind::none)
+      auto platform = available.getPlatform();
+      if (!platform)
         continue;
 
       auto attr = new (ctx) AvailableAttr(
           SourceLoc(), SourceRange(),
-          AvailabilityDomain::forPlatform(available.getPlatform()), SourceLoc(),
+          AvailabilityDomain::forPlatform(*platform), SourceLoc(),
           AvailableAttr::Kind::Unavailable, available.getMessage(),
           /*Rename=*/"", available.getIntroduced().value_or(noVersion),
           SourceRange(), available.getDeprecated().value_or(noVersion),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5848,7 +5848,7 @@ decodeDomainKind(uint8_t kind) {
 
 static AvailabilityDomain
 decodeNonCustomAvailabilityDomain(AvailabilityDomainKind domainKind,
-                                  PlatformKind platformKind) {
+                                  std::optional<PlatformKind> platformKind) {
   switch (domainKind) {
   case AvailabilityDomainKind::Universal:
     return AvailabilityDomain::forUniversal();
@@ -5861,7 +5861,7 @@ decodeNonCustomAvailabilityDomain(AvailabilityDomainKind domainKind,
   case AvailabilityDomainKind::Embedded:
     return AvailabilityDomain::forEmbedded();
   case AvailabilityDomainKind::Platform:
-    return AvailabilityDomain::forPlatform(platformKind);
+    return AvailabilityDomain::forPlatform(*platformKind);
   case AvailabilityDomainKind::Custom:
     llvm_unreachable("custom domains aren't handled here");
     return AvailabilityDomain::forUniversal();
@@ -5895,12 +5895,17 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   if (!maybeDomainKind)
     return llvm::make_error<InvalidEnumValueError>(rawDomainKind, "AvailabilityDomainKind");
 
-  auto maybePlatform = platformFromUnsigned(rawPlatform);
-  if (!maybePlatform.has_value())
-    return llvm::make_error<InvalidEnumValueError>(rawPlatform, "PlatformKind");
-
   AvailabilityDomainKind domainKind = *maybeDomainKind;
-  PlatformKind platform = *maybePlatform;
+
+  // The platform field is only meaningful for a platform domain; every other
+  // domain kind writes a placeholder.
+  std::optional<PlatformKind> platform;
+  if (domainKind == AvailabilityDomainKind::Platform) {
+    platform = platformFromUnsigned(rawPlatform);
+    if (!platform.has_value())
+      return llvm::make_error<InvalidEnumValueError>(rawPlatform,
+                                                     "PlatformKind");
+  }
   StringRef message = blobData.substr(0, messageSize);
   blobData = blobData.substr(messageSize);
   StringRef rename = blobData.substr(0, renameSize);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1017; // Multi-operand debug_value serialization
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1018; // PlatformKind raw values
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3310,6 +3310,12 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
         }
       }
 
+      // Only a platform domain has a platform. The domain kind tells the
+      // reader whether this field is meaningful.
+      unsigned rawPlatform = 0;
+      if (auto platform = domain.getPlatformKind())
+        rawPlatform = static_cast<unsigned>(*platform);
+
       llvm::SmallString<32> blob;
       blob.append(theAttr->getMessage());
       blob.append(theAttr->getRename());
@@ -3322,7 +3328,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           theAttr->isNoAsync(),
           theAttr->isSPI(),
           static_cast<uint8_t>(domainKind),
-          static_cast<unsigned>(domain.getPlatformKind()),
+          rawPlatform,
           customDomainID,
           LIST_VER_TUPLE_PIECES(Introduced),
           LIST_VER_TUPLE_PIECES(Deprecated),

--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -27,8 +27,14 @@ StringRef Availability::getDomainDescription(AvailabilityDomain Domain) {
   if (Domain.isSwiftLanguageMode())
     return { "Swift" };
 
+  auto Platform = Domain.getPlatformKind();
+
+  // FIXME: [availability] Handle non-universal availabilty domains here.
+  if (!Platform)
+    return "*";
+
   // Platform-specific availability.
-  switch (Domain.getPlatformKind()) {
+  switch (*Platform) {
     case swift::PlatformKind::iOS:
       return { "iOS" };
     case swift::PlatformKind::macCatalyst:
@@ -67,8 +73,6 @@ StringRef Availability::getDomainDescription(AvailabilityDomain Domain) {
       return { "Windows" };
     case swift::PlatformKind::Android:
       return { "Android" };
-    case swift::PlatformKind::none:
-      return { "*" };
   }
   llvm_unreachable("invalid platform kind");
 }

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -695,7 +695,7 @@ isAvailabilityDomainActive(AvailabilityDomain Domain,
   if (!Domain.isPlatform())
     return true;
 
-  auto Platform = Domain.getPlatformKind();
+  auto Platform = *Domain.getPlatformKind();
   return Platform == *ActivePlatform ||
          inheritsAvailabilityFromPlatform(*ActivePlatform, Platform);
 }

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -191,10 +191,9 @@ SymbolGraph *SymbolGraphASTWalker::getModuleSymbolGraph(const Decl *D) {
 }
 
 static bool isUnavailableOrObsoletedOnPlatform(const Decl *D) {
-  if (const auto Avail = D->getUnavailableAttr()) {
-    if (Avail->getPlatform() != PlatformKind::none)
-      return true;
-  }
+  if (const auto Avail = D->getUnavailableAttr())
+    return Avail->getPlatform().has_value();
+
   return false;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -704,10 +704,11 @@ static void reportAvailabilityAttributes(ASTContext &Ctx, const Decl *D,
 
   for (auto Attr : getAvailableAttrs(D, Scratch)) {
     UIdent PlatformUID;
-    switch (Attr.getPlatform()) {
-    case PlatformKind::none:
+    auto Platform = Attr.getPlatform();
+    // FIXME: [availability] Handle non-platform availability domains?
+    if (!Platform) {
       PlatformUID = UIdent();
-      break;
+    } else switch (*Platform) {
     case PlatformKind::iOS:
       PlatformUID = PlatformIOS;
       break;
@@ -768,7 +769,6 @@ static void reportAvailabilityAttributes(ASTContext &Ctx, const Decl *D,
       PlatformUID = PlatformAndroid;
       break;
     }
-    // FIXME: [availability] Handle non-platform availability domains?
 
     AvailableAttrInfo Info;
     Info.AttrKind = AvailableAttrKind;


### PR DESCRIPTION
Having a `none` element in the `PlatformKind` enum has been a common source of bugs. It is much less error-prone to model the absence of a platform with `std::optional<PlatformKind>`, so do that instead.
