### PR TITLE
[DebugInfo] Fix concurrency-anchored-types.swift

### DIFF
--- a/test/DebugInfo/concurrency-anchored-types.swift
+++ b/test/DebugInfo/concurrency-anchored-types.swift
@@ -9,6 +9,7 @@ REQUIRES: OS=macosx
 REQUIRES: embedded_stdlib
 REQUIRES: swift_feature_Embedded
 REQUIRES: concurrency
+REQUIRES: optimized_stdlib
 
 A name and a size are not enough: a debugger reads the stored task pointer and
 the raw priority back out of a value it built itself, by member name.


### PR DESCRIPTION
The test was missing a REQUIRES: optimized_stdlib

rdar://184944422
