### PR TITLE
[SendNonSendable] Improve `sending` capture diagnostics

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -3539,7 +3539,7 @@ bool SentNeverSendableDiagnosticEmitter::initForIsolatedPartialApply(
   auto *diagnosticOp = diagnosticPair->first;
 
   ApplyIsolationCrossing crossing(
-      op->getFunction()->getActorIsolation(),
+      actualCallerIsolation.value_or(op->getFunction()->getActorIsolation()),
       diagnosticOp->getFunction()->getActorIsolation());
 
   // We do not need to worry about failing to infer a name here since we are
@@ -3718,6 +3718,26 @@ bool SentNeverSendableDiagnosticEmitter::emit() {
     if (ace->getActorIsolation().isActorIsolated()) {
       if (initForIsolatedPartialApply(op, ace)) {
         return true;
+      }
+    }
+
+    // A `sending` capture of an non-isolated `@called(once)` closure is
+    // translated by `translateSILCalledOncePartialApply` as a send of
+    // that specific operand -- so reaching this operand here means the
+    // capture itself crossed isolation, independent of whether the closure
+    // as a whole is isolated. Let's use the captured value's tracked
+    // isolation (when it is actor-isolated) as the caller isolation.
+    if (auto *pai = dyn_cast<PartialApplyInst>(op->getUser());
+        pai && pai->isCalledOnce()) {
+      ApplySite apply(pai);
+      if (apply.getParamInfoForOperand(*op).hasOption(
+              SILParameterInfo::Sending)) {
+        std::optional<ActorIsolation> callerIsolation;
+        if (diagnosticEmitter.getIsolationRegionInfo()->hasActorIsolation())
+          callerIsolation =
+              diagnosticEmitter.getIsolationRegionInfo()->getActorIsolation();
+        if (initForIsolatedPartialApply(op, ace, callerIsolation))
+          return true;
       }
     }
   }

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -845,10 +845,17 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
         // variable of a concrete class type is wrapped in `any Protocol` before
         // being stored into an indirect return slot, init_existential_ref sits
         // between the concrete copy_value and the enum wrapping. Without
-        // looking through it the inferrer gives up and the diagnostic falls back
-        // to the generic "unknown pattern" catch-all.
+        // looking through it the inferrer gives up and the diagnostic falls
+        // back to the generic "unknown pattern" catch-all.
         isa<InitExistentialRefInst>(searchValue) ||
-        isa<InitExistentialAddrInst>(searchValue)) {
+        isa<InitExistentialAddrInst>(searchValue) ||
+        // A `move_value [var_decl]` with no attached debug_value means the
+        // debug info for this var decl was never emitted (e.g. a capture-list
+        // entry synthesized directly from a member-access initializer, as in
+        // `[sending ns]` capturing `self.ns`). Fall through to the value's
+        // initializer instead of giving up, so e.g. a getter call underneath
+        // can still be named via the call-result path below.
+        isa<MoveValueInst>(searchValue)) {
       searchValue = cast<SingleValueInstruction>(searchValue)->getOperand(0);
       continue;
     }

--- a/test/SIL/called_once_sending_captures.swift
+++ b/test/SIL/called_once_sending_captures.swift
@@ -61,17 +61,19 @@ func testNestedRejectedThroughNonCalledOnceIntermediate(ns1: sending NS) {
   let _: @called(once) () -> Void = {
     manyTimes {
       calledOnce { [sending ns1] in
-        // expected-error@-1 {{task or actor-isolated value cannot be sent}}
         sendAgain(ns1)
+        // expected-error@-1 {{sending 'ns1' risks causing data races}}
+        // expected-note@-2 {{'ns1' is captured by a nonisolated closure. nonisolated uses in closure may race against code in the current isolation context}}
       }
     }
   }
-  
+
   let _: @called(once) () -> Void = { [sending ns1] in
     manyTimes {
       calledOnce { [sending ns1] in
-        // expected-error@-1 {{task or actor-isolated value cannot be sent}}
         sendAgain(ns1)
+        // expected-error@-1 {{sending 'ns1' risks causing data races}}
+        // expected-note@-2 {{'ns1' is captured by a nonisolated closure. nonisolated uses in closure may race against code in the current isolation context}}
       }
     }
   }
@@ -88,8 +90,9 @@ func testNestedAcceptedWithExplicitChain(ns1: sending NS) {
 func testOuterCalledOnceAloneIsNotEnough(ns1: sending NS) {
   let _: @called(once) () -> Void = {
     calledOnce { [sending ns1] in
-      // expected-error@-1 {{task or actor-isolated value cannot be sent}}
       sendAgain(ns1)
+      // expected-error@-1 {{sending 'ns1' risks causing data races}}
+      // expected-note@-2 {{'ns1' is captured by a nonisolated closure. nonisolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -122,12 +125,10 @@ actor CalledOnceActor {
 
 // SentNeverSendable: sending an actor-isolated capture (`ns` here resolves
 // to `self.ns`, captured while already inside the actor-isolated method).
-//
-// TODO: Falls through to the generic path for unknown values.
 extension CalledOnceActor {
   func testSentNeverSendableActorIsolatedCapture() {
-    _ = CalledOnceTask { [sending ns] in // expected-error {{task or actor-isolated value cannot be sent}}
-      sendAgain(ns)
+    _ = CalledOnceTask { [sending ns] in
+      sendAgain(ns) // expected-error {{sending 'self.ns' risks causing data races}} expected-note {{'self'-isolated 'self.ns' is captured by a nonisolated closure. nonisolated uses in closure may race against later actor-isolated uses}}
     }
   }
 }
@@ -167,12 +168,10 @@ func testInOutSendingParametersInSameRegionUnaffected(_ x: inout sending NS, _ y
 // `@called(once)` closure counts as consuming the parameter, and the
 // function must reinitialize it with a disconnected value before returning,
 // exactly as it would for an ordinary direct send.
-//
-// TODO: note should say "capture" instead of "argument".
 func testInOutSendingCaptureNotReinitialized(_ x: inout sending NS) {
   _ = CalledOnceTask { [sending x] in
-    // expected-error@-1 {{sending value of non-Sendable type 'NS' risks causing data races}}
-    // expected-note@-2 {{Passing value of non-Sendable type 'NS' as a 'sending' argument risks causing races in between local and caller code}}
+    // expected-error@-1 {{sending 'x' risks causing data races}}
+    // expected-note@-2 {{'x' used after being passed as a 'sending' parameter; Later uses could race}}
     sendAgain(x)
   }
 } // expected-note {{'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value}}


### PR DESCRIPTION
Fixes a few cases were problem related to `sending` captures caused a fallback or a diagnostic that mentions a type because they couldn't find the variable that is captured.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
