### PR TITLE
Fix NSNumber test to support new clang feature

### DIFF
--- a/test/IRGen/objc_globals.swift
+++ b/test/IRGen/objc_globals.swift
@@ -10,10 +10,9 @@ import Foundation
 @inline(never)
 func blackHole<T>(_ t: T) { }
 
-// CHECK-DAG: @"OBJC_CLASS_$_NSNumber" = external global %struct._class_t
 // CHECK-DAG: @"OBJC_CLASS_$_NSString" = external global %struct._class_t
-// CHECK-DAG: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = internal global ptr @"OBJC_CLASS_$_NSNumber", section "__DATA,__objc_classrefs,regular,no_dead_strip"
 // CHECK-DAG: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = internal global ptr @"OBJC_CLASS_$_NSString", section "__DATA,__objc_classrefs,regular,no_dead_strip"
+// CHECK-DAG: @_unnamed_nsconstantintegernumber_ = private constant %struct.__builtin_NSConstantIntegerNumber
 
 public func testLiterals() {
   blackHole(gadget.giveMeASelector())
@@ -34,9 +33,7 @@ public func fooLazy() {
 // CHECK:         ret
 
 // CHECK-LABEL: define internal ptr @giveMeANumber()
-// CHECK:         [[CLASS:%.*]] = load ptr, ptr
-// CHECK-DAG:         [[SELECTOR:%.*]] = load ptr, ptr @OBJC_SELECTOR_REFERENCES_.{{.*}}
-// CHECK:         call {{.*}} @objc_msgSend
+// CHECK:         tail call ptr @llvm.objc.retainAutoreleaseReturnValue(ptr @_unnamed_nsconstantintegernumber_)
 // CHECK:         ret
 
 // CHECK-LABEL: define internal ptr @giveMeAMetaclass()


### PR DESCRIPTION
clang now emits NSNumber literals by constructing a constant of type NSConstantIntegerNumber. Adjust a Swift-side test to match.