### PR TITLE
[WIP][Swiftify] map __single pointer parameters to [Mutable]Ref 

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -328,29 +328,34 @@ public:
   }
 
   void printAvailability() {
-    if (!hasMacroParameter("spanAvailability"))
+    printAvailabilityOfKnownDecl("spanAvailability", "Span");
+    printAvailabilityOfKnownDecl("refAvailability", "Ref");
+  }
+
+protected:
+  void printAvailabilityOfKnownDecl(StringRef ParamName, StringRef DeclName) {
+    if (!hasMacroParameter(ParamName))
       return;
 
-    ValueDecl *D = getKnownSingleDecl(SwiftContext, "Span");
+    ValueDecl *D = getKnownSingleDecl(SwiftContext, DeclName);
     const SemanticAvailableAttributes availabilityAttrs =
         D->getSemanticAvailableAttrs(/*includingInactive=*/true);
     if (availabilityAttrs.empty())
       return; // don't print availability when targeting embedded
 
     printSeparator();
-    out << "spanAvailability: ";
+    out << ParamName << ": ";
     out << "\"";
     llvm::SaveAndRestore<bool> hasAvailbilitySeparatorRestore(firstParam, true);
     for (auto attr : availabilityAttrs) {
       auto introducedOpt = attr.getIntroduced();
       if (!introducedOpt.has_value()) continue;
       printSeparator();
-      out << prettyPlatformString(attr.getPlatform()) << " " << introducedOpt.value();
+      out << platformString(attr.getPlatform()) << " " << introducedOpt.value();
     }
     out << "\"";
   }
 
-protected:
   bool hasMacroParameter(StringRef ParamName) const {
     for (auto *Param : *SwiftifyImportDecl.parameterList)
       if (Param->getArgumentName().str() == ParamName)

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -407,16 +407,38 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
     return true;
   }
 
-  bool printSingle(Type swiftType, ssize_t pointerIndex) {
-    Type pointerType = swiftType->lookThroughSingleOptionalType();
-    if (pointerType->isOpaquePointer() || pointerType->isUnsafeRawPointer() ||
-        pointerType->isUnsafeMutableRawPointer())
-      return false;
+  enum Validity {
+    Ignore,
+    InvalidIfLifetimebound,
+    Valid
+  };
+
+  Validity printSingle(Type swiftType, ssize_t pointerIndex) {
+    Type nonnullType = swiftType->lookThroughSingleOptionalType();
+    PointerTypeKind PTK;
+    Type pointeeTy = nonnullType->getAnyPointerElementType(PTK);
+    if (pointeeTy.isNull())
+      return Ignore;
+    if (PTK != PTK_UnsafePointer && PTK != PTK_UnsafeMutablePointer)
+      return Ignore;
+
     printSeparator();
     out << ".single(pointer: ";
     printParamOrReturn(pointerIndex);
     out << ")";
-    return true;
+
+    // An immutable pointer maps to Ref, and the generated wrapper reaches the
+    // pointee through _swiftifyWithOptionalPointer, which passes the callee a
+    // pointer to a temporary copy rather than to the original storage. That is
+    // fine while the callee only reads through the pointer, but a lifetimebound
+    // parameter may hand back a result that points into it, which would dangle
+    // as soon as the copy dies.
+    //
+    // MutableRef stores the address it was formed from, so the mutable case
+    // does not have this problem.
+    if (PTK == PTK_UnsafePointer)
+      return InvalidIfLifetimebound;
+    return Valid;
   }
 
   void printNonEscaping(int idx) {
@@ -805,16 +827,18 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
         DLOG("Found bounds info '" << clangParamTy << "'\n");
         attachMacro = paramHasBoundsInfo = true;
       }
-      bool paramIsSingle = false;
+      SwiftifyInfoFunctionPrinter::Validity singleStatus =
+          SwiftifyInfoFunctionPrinter::Ignore;
       if (!CAT && clangParamTy->isSinglePointerType() &&
           !clangParamTy->getAs<clang::ValueTerminatedType>() &&
           mappedIndex != SwiftifyInfoPrinter::SELF_PARAM_INDEX) {
-        paramIsSingle = printer.printSingle(swiftParamTy, mappedIndex);
+        singleStatus = printer.printSingle(swiftParamTy, mappedIndex);
       }
       bool paramIsStdSpan =
           printer.registerStdSpanTypeMapping(swiftParamTy, clangParamTy);
       paramHasBoundsInfo |= paramIsStdSpan;
-      paramHasBoundsInfo |= paramIsSingle;
+      paramHasBoundsInfo |=
+          singleStatus != SwiftifyInfoFunctionPrinter::Ignore;
 
       bool paramHasLifetimeInfo = false;
       if (clangParam->template hasAttr<clang::NoEscapeAttr>()) {
@@ -848,6 +872,10 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
           DLOG("lifetimebound not yet supported by stable feature-set - skipping\n");
           return false;
         }
+        if (singleStatus == SwiftifyInfoFunctionPrinter::InvalidIfLifetimebound) {
+          DLOG("can't map lifetimebound pointer to Ref of borrow with no internal pointer\n");
+          return false;
+        }
       }
       if (UnaliasedInstantiationVisitor::checkTemplates(
               clangParamTy, paramHasLifetimeInfo, paramIsStdSpan)) {
@@ -857,7 +885,8 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
         DLOG("Found both std::span and lifetime info\n");
         attachMacro = true;
       }
-      if (paramIsSingle && paramHasLifetimeInfo) {
+      if (singleStatus != SwiftifyInfoFunctionPrinter::Ignore &&
+          paramHasLifetimeInfo) {
         DLOG("Found both __single and lifetime info\n");
         attachMacro = true;
       }

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -407,6 +407,16 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
     return true;
   }
 
+  bool printSingle(Type swiftType, ssize_t pointerIndex) {
+    if (swiftType->lookThroughSingleOptionalType()->isOpaquePointer())
+      return false;
+    printSeparator();
+    out << ".single(pointer: ";
+    printParamOrReturn(pointerIndex);
+    out << ")";
+    return true;
+  }
+
   void printNonEscaping(int idx) {
     printSeparator();
     out << ".nonescaping(pointer: ";
@@ -793,9 +803,16 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
         DLOG("Found bounds info '" << clangParamTy << "'\n");
         attachMacro = paramHasBoundsInfo = true;
       }
+      bool paramIsSingle = false;
+      if (!CAT && clangParamTy->isSinglePointerType() &&
+          !clangParamTy->getAs<clang::ValueTerminatedType>() &&
+          mappedIndex != SwiftifyInfoPrinter::SELF_PARAM_INDEX) {
+        paramIsSingle = printer.printSingle(swiftParamTy, mappedIndex);
+      }
       bool paramIsStdSpan =
           printer.registerStdSpanTypeMapping(swiftParamTy, clangParamTy);
       paramHasBoundsInfo |= paramIsStdSpan;
+      paramHasBoundsInfo |= paramIsSingle;
 
       bool paramHasLifetimeInfo = false;
       if (clangParam->template hasAttr<clang::NoEscapeAttr>()) {
@@ -836,6 +853,10 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       }
       if (paramIsStdSpan && paramHasLifetimeInfo) {
         DLOG("Found both std::span and lifetime info\n");
+        attachMacro = true;
+      }
+      if (paramIsSingle && paramHasLifetimeInfo) {
+        DLOG("Found both __single and lifetime info\n");
         attachMacro = true;
       }
     }

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -408,7 +408,9 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
   }
 
   bool printSingle(Type swiftType, ssize_t pointerIndex) {
-    if (swiftType->lookThroughSingleOptionalType()->isOpaquePointer())
+    Type pointerType = swiftType->lookThroughSingleOptionalType();
+    if (pointerType->isOpaquePointer() || pointerType->isUnsafeRawPointer() ||
+        pointerType->isUnsafeMutableRawPointer())
       return false;
     printSeparator();
     out << ".single(pointer: ";

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -192,7 +192,7 @@ struct Single: ParamInfo {
     switch pointerIndex {
     case .param(let i):
       return SinglePointerThunkBuilder(
-        base: base, index: i - 1, funcDecl: funcDecl, nonescaping: nonescaping)
+        base: base, index: i - 1, funcDecl: funcDecl)
     case .return:
       return base
     case .self:
@@ -338,17 +338,28 @@ func getUnqualifiedStdName(_ type: String) -> String? {
   return nil
 }
 
-func getSafePointerName(mut: Mutability, generateSpan: Bool, isRaw: Bool) -> TokenSyntax {
-  switch (mut, generateSpan, isRaw) {
-  case (.Immutable, true, true): return "RawSpan"
-  case (.Mutable, true, true): return "MutableRawSpan"
-  case (.Immutable, false, true): return "UnsafeRawBufferPointer"
-  case (.Mutable, false, true): return "UnsafeMutableRawBufferPointer"
+enum PointerBoundKind {
+  case countedBy
+  case sizedBy
+  case single
+}
 
-  case (.Immutable, true, false): return "Span"
-  case (.Mutable, true, false): return "MutableSpan"
-  case (.Immutable, false, false): return "UnsafeBufferPointer"
-  case (.Mutable, false, false): return "UnsafeMutableBufferPointer"
+func getSafePointerName(mut: Mutability, lifetimeDependent: Bool, kind: PointerBoundKind) -> TokenSyntax {
+  switch (mut, lifetimeDependent, kind) {
+  case (.Immutable, true, .sizedBy): return "RawSpan"
+  case (.Mutable, true, .sizedBy): return "MutableRawSpan"
+  case (.Immutable, false, .sizedBy): return "UnsafeRawBufferPointer"
+  case (.Mutable, false, .sizedBy): return "UnsafeMutableRawBufferPointer"
+
+  case (.Immutable, true, .countedBy): return "Span"
+  case (.Mutable, true, .countedBy): return "MutableSpan"
+  case (.Immutable, false, .countedBy): return "UnsafeBufferPointer"
+  case (.Mutable, false, .countedBy): return "UnsafeMutableBufferPointer"
+
+  case (.Immutable, true, .single): return "Ref"
+  case (.Mutable, true, .single): return "MutableRef"
+  case (.Immutable, false, .single): fatalError("unexpected __single without lifetime dependence")
+  case (.Mutable, false, .single): fatalError("unexpected __single without lifetime dependence")
   }
 }
 
@@ -372,16 +383,22 @@ func hasOwnershipSpecifier(_ attrType: AttributedTypeSyntax) -> Bool {
 }
 
 func transformType(
-  _ prev: TypeSyntax, _ generateSpan: Bool, _ isSizedBy: Bool, _ setMutableSpanInout: Bool
+  _ prev: TypeSyntax, _ lifetimeDependent: Bool, _ kind: PointerBoundKind, _ setMutableSpanInout: Bool
 ) throws -> TypeSyntax {
   if let optType = prev.as(OptionalTypeSyntax.self) {
     return TypeSyntax(
       optType.with(
         \.wrappedType,
-        try transformType(optType.wrappedType, generateSpan, isSizedBy, setMutableSpanInout)))
+        try transformType(optType.wrappedType, lifetimeDependent, kind, setMutableSpanInout)))
   }
   if let impOptType = prev.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
-    return try transformType(impOptType.wrappedType, generateSpan, isSizedBy, setMutableSpanInout)
+    if kind == .single {
+      return TypeSyntax(
+        OptionalTypeSyntax(
+          wrappedType: try transformType(
+            impOptType.wrappedType, lifetimeDependent, kind, setMutableSpanInout)))
+    }
+    return try transformType(impOptType.wrappedType, lifetimeDependent, kind, setMutableSpanInout)
   }
   if let attrType = prev.as(AttributedTypeSyntax.self) {
     // We insert 'inout' by default for MutableSpan, but it shouldn't override existing ownership
@@ -389,28 +406,31 @@ func transformType(
     return TypeSyntax(
       attrType.with(
         \.baseType,
-        try transformType(attrType.baseType, generateSpan, isSizedBy, setMutableSpanInoutNext)))
+        try transformType(attrType.baseType, lifetimeDependent, kind, setMutableSpanInoutNext)))
   }
   let name = try getTypeName(prev)
   let text = name.text
   let isRaw = isRawPointerType(text: text)
-  if isRaw && !isSizedBy {
+  if isRaw && kind == .countedBy {
     throw DiagnosticError("void pointers not supported for countedBy", node: name)
   }
+  if isRaw && kind == .single {
+    throw DiagnosticError("void pointers not supported for single", node: name)
+  }
 
-  guard let kind: Mutability = getPointerMutability(text: text) else {
+  guard let mut: Mutability = getPointerMutability(text: text) else {
     throw DiagnosticError(
       "expected Unsafe[Mutable][Raw]Pointer type for type \(prev)"
         + " - first type token is '\(text)'", node: name)
   }
-  let token = getSafePointerName(mut: kind, generateSpan: generateSpan, isRaw: isSizedBy)
+  let token = getSafePointerName(mut: mut, lifetimeDependent: lifetimeDependent, kind: kind)
   let mainType =
-    if isSizedBy {
+    if kind == .sizedBy {
       TypeSyntax(IdentifierTypeSyntax(name: token))
     } else {
       try replaceTypeName(prev, token)
     }
-  if setMutableSpanInout && generateSpan && kind == .Mutable {
+  if setMutableSpanInout && lifetimeDependent && mut == .Mutable {
     return TypeSyntax("inout \(mainType)")
   }
   return mainType
@@ -851,6 +871,10 @@ extension PointerBoundsThunkBuilder {
     return (!nullableAsEmptySpan || isOrNull) && oldTypeIsNormalOptional
   }
 
+  var kind: PointerBoundKind {
+    isSizedBy ? .sizedBy : .countedBy
+  }
+
   var oldTypeIsNormalOptional: Bool { return oldType.is(OptionalTypeSyntax.self) }
   var oldTypeIsAnyOptional: Bool { return oldType.is(OptionalTypeSyntax.self) ||
     oldType.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) }
@@ -858,9 +882,9 @@ extension PointerBoundsThunkBuilder {
   var newType: TypeSyntax {
     get throws {
       if !nullable, let optType = oldType.as(OptionalTypeSyntax.self) {
-        return try transformType(optType.wrappedType, generateSpan, isSizedBy, isParameter)
+        return try transformType(optType.wrappedType, generateSpan, kind, isParameter)
       }
-      return try transformType(oldType, generateSpan, isSizedBy, isParameter)
+      return try transformType(oldType, generateSpan, kind, isParameter)
     }
   }
 
@@ -1211,22 +1235,55 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
   }
 }
 
-// FIXME: expose `__single` parameters as Ref
 struct SinglePointerThunkBuilder: ParamBoundsThunkBuilder {
   public let base: BoundsCheckedThunkBuilder
   public let index: Int
   public let funcDecl: FunctionParts
-  public let nonescaping: Bool
 
-  var newType: TypeSyntax { oldType }
+  let nonescaping: Bool = true
+  let isParameter: Bool = true
+
+  var nullable: Bool {
+    return oldType.is(OptionalTypeSyntax.self)
+      || oldType.is(ImplicitlyUnwrappedOptionalTypeSyntax.self)
+  }
+
+  var newType: TypeSyntax {
+    get throws {
+      return try transformType(oldType, nonescaping, .single, isParameter)
+    }
+  }
 
   func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> FunctionSignatureSyntax
   {
-    return try base.buildFunctionSignature(argTypes, returnType)
+    var types = argTypes
+    types[index] = try newType
+    return try base.buildFunctionSignature(types, returnType)
   }
   func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
-    return try base.buildFunctionCall(pointerArgs)
+    var args = pointerArgs
+    assert(args[index] == nil)
+    let questionMark = nullable ? "?" : ""
+    if isMutablePointerType(oldType) {
+      // MutableRef stores the address it was formed from, so `_unsafeAddress`
+      // hands it back directly.
+      args[index] = "\(name)\(raw: questionMark)._unsafeAddress"
+      return try base.buildFunctionCall(args)
+    }
+    // Ref has no address to hand back: for pointee types that fit in 4 words
+    // Builtin.Borrow stores the value inline, so the only address available is
+    // that of a copy. _swiftifyWithOptionalPointer materializes that copy and
+    // scopes the pointer to the call, which is sound because __single implies a
+    // lifetime dependence.
+    let ptrName = TokenSyntax("_\(name.withoutBackticks)Ptr").escapeIfNeeded
+    // The closure always receives an Optional pointer, so a _Nonnull parameter
+    // needs unwrapping.
+    args[index] = nullable ? "\(ptrName)" : "\(ptrName)!"
+    let innerCall = try base.buildFunctionCall(args)
+    return """
+      unsafe _swiftifyWithOptionalPointer(\(name)\(raw: questionMark).value, { \(ptrName) in \(innerCall) })
+      """
   }
   func buildBasicBoundsExtractions() throws -> [CodeBlockItemSyntax.Item] {
     return try base.buildBasicBoundsExtractions()

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1563,14 +1563,14 @@ func parseTypeMappingParam(_ paramAST: LabeledExprSyntax?) throws -> [String: St
   return try parseStringMappingParam(paramAST, paramName: "typeMappings")
 }
 
-func parseSpanAvailabilityParam(_ paramAST: LabeledExprSyntax?) throws -> String? {
+func parseAvailabilityParam(_ paramAST: LabeledExprSyntax?, paramName: String) throws -> String? {
   guard let unwrappedParamAST = paramAST else {
     return nil
   }
   guard let label = unwrappedParamAST.label else {
     return nil
   }
-  if label.trimmed.text != "spanAvailability" {
+  if label.trimmed.text != paramName {
     return nil
   }
   let paramExpr = unwrappedParamAST.expression
@@ -1878,6 +1878,23 @@ func isMutableSpan(_ type: TypeSyntax) -> Bool {
   return name == "MutableSpan" || name == "MutableRawSpan"
 }
 
+func isAnyRef(_ type: TypeSyntax) -> Bool {
+  if let optType = type.as(OptionalTypeSyntax.self) {
+    return isAnyRef(optType.wrappedType)
+  }
+  if let impOptType = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+    return isAnyRef(impOptType.wrappedType)
+  }
+  if let attrType = type.as(AttributedTypeSyntax.self) {
+    return isAnyRef(attrType.baseType)
+  }
+  guard let identifierType = type.as(IdentifierTypeSyntax.self) else {
+    return false
+  }
+  let name = identifierType.name.text
+  return name == "Ref" || name == "MutableRef"
+}
+
 func isAnySpan(_ type: TypeSyntax) -> Bool {
   if let optType = type.as(OptionalTypeSyntax.self) {
     return isAnySpan(optType.wrappedType)
@@ -1895,13 +1912,26 @@ func isAnySpan(_ type: TypeSyntax) -> Bool {
   return name == "Span" || name == "RawSpan" ||  name == "MutableSpan" || name == "MutableRawSpan"
 }
 
-func getAvailability(_ newSignature: FunctionSignatureSyntax, _ spanAvailability: String?)
-  throws -> [AttributeListSyntax.Element] {
+func signatureContainsType(
+  _ newSignature: FunctionSignatureSyntax, _ predicate: (TypeSyntax) -> Bool
+) -> Bool {
+  if let returnClause = newSignature.returnClause, predicate(returnClause.type) {
+    return true
+  }
+  return newSignature.parameterClause.parameters.contains(where: { predicate($0.type) })
+}
+
+func getAvailability(
+  _ newSignature: FunctionSignatureSyntax, _ spanAvailability: String?,
+  _ refAvailability: String?
+) throws -> [AttributeListSyntax.Element] {
+  if let refAvailability, signatureContainsType(newSignature, isAnyRef) {
+    return [.attribute(AttributeSyntax("@available(\(raw: refAvailability), *)"))]
+  }
   guard let spanAvailability else {
     return []
   }
-  let returnIsSpan = newSignature.returnClause != nil && isAnySpan(newSignature.returnClause!.type)
-  if !returnIsSpan && !newSignature.parameterClause.parameters.contains(where: { isAnySpan($0.type) }) {
+  if !signatureContainsType(newSignature, isAnySpan) {
     return []
   }
   return [.attribute(AttributeSyntax("@available(\(raw: spanAvailability), *)"))]
@@ -2098,6 +2128,7 @@ func deconstructFunction(_ declaration: some DeclSyntaxProtocol) throws -> Funct
 
 func constructOverloadFunction(forDecl declaration: some DeclSyntaxProtocol, leadingTrivia: Trivia,
                                args arguments: [ExprSyntax], spanAvailability: String?,
+                               refAvailability: String?,
                                typeMappings: [String: String]?,
                                nullableAsEmptySpan: Bool,
                                parentNode: Syntax?) throws -> DeclSyntax {
@@ -2176,7 +2207,7 @@ func constructOverloadFunction(forDecl declaration: some DeclSyntaxProtocol, lea
   let lifetimes = returnLifetimeAttribute + paramLifetimes(newSignature)
   let newLifetimeAttr = mergeLifetimeAttrs(
     funcComponents.attributes, lifetimes, funcComponents.signature.parameterClause.parameters)
-  let availabilityAttr = try getAvailability(newSignature, spanAvailability)
+  let availabilityAttr = try getAvailability(newSignature, spanAvailability, refAvailability)
   let disfavoredOverload: [AttributeListSyntax.Element] =
     [
       .attribute(
@@ -2268,7 +2299,13 @@ public struct SwiftifyImportMacro: PeerMacro {
       if typeMappings != nil {
         arguments = arguments.dropLast()
       }
-      let spanAvailability = try parseSpanAvailabilityParam(arguments.last)
+      let refAvailability = try parseAvailabilityParam(
+        arguments.last, paramName: "refAvailability")
+      if refAvailability != nil {
+        arguments = arguments.dropLast()
+      }
+      let spanAvailability = try parseAvailabilityParam(
+        arguments.last, paramName: "spanAvailability")
       if spanAvailability != nil {
         arguments = arguments.dropLast()
       }
@@ -2277,6 +2314,7 @@ public struct SwiftifyImportMacro: PeerMacro {
         try constructOverloadFunction(
           forDecl: declaration, leadingTrivia: node.leadingTrivia, args: args,
           spanAvailability: spanAvailability,
+          refAvailability: refAvailability,
           typeMappings: typeMappings,
           nullableAsEmptySpan: nullableAsEmptySpan ?? false,
           parentNode: context.lexicalContext.first)]
@@ -2351,7 +2389,13 @@ public struct SwiftifyImportProtocolMacro: ExtensionMacro {
       if typeMappings != nil {
         arguments = arguments.dropLast()
       }
-      let spanAvailability = try parseSpanAvailabilityParam(arguments.last)
+      let refAvailability = try parseAvailabilityParam(
+        arguments.last, paramName: "refAvailability")
+      if refAvailability != nil {
+        arguments = arguments.dropLast()
+      }
+      let spanAvailability = try parseAvailabilityParam(
+        arguments.last, paramName: "spanAvailability")
       if spanAvailability != nil {
         arguments = arguments.dropLast()
       }
@@ -2377,6 +2421,7 @@ public struct SwiftifyImportProtocolMacro: ExtensionMacro {
         let result = try constructOverloadFunction(
           forDecl: method, leadingTrivia: Trivia(), args: args,
           spanAvailability: spanAvailability,
+          refAvailability: refAvailability,
           typeMappings: typeMappings,
           nullableAsEmptySpan: false,
           parentNode: context.lexicalContext.first)

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -173,6 +173,34 @@ struct CountedBy: ParamInfo {
   }
 }
 
+struct Single: ParamInfo {
+  var pointerIndex: SwiftifyExpr
+  var nonescaping: Bool
+  var dependencies: [LifetimeDependence]
+  var original: SyntaxProtocol
+
+  var description: String {
+    return ".single(pointer: \(pointerIndex))"
+  }
+
+  func getBoundsCheckedThunkBuilder(
+    _ base: BoundsCheckedThunkBuilder, _ funcDecl: FunctionParts
+  ) -> BoundsCheckedThunkBuilder {
+    guard nonescaping else {
+      return base
+    }
+    switch pointerIndex {
+    case .param(let i):
+      return SinglePointerThunkBuilder(
+        base: base, index: i - 1, funcDecl: funcDecl, nonescaping: nonescaping)
+    case .return:
+      return base
+    case .self:
+      return base
+    }
+  }
+}
+
 struct RuntimeError: Error {
   let description: String
 
@@ -1183,6 +1211,43 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
   }
 }
 
+// FIXME: expose `__single` parameters as Ref
+struct SinglePointerThunkBuilder: ParamBoundsThunkBuilder {
+  public let base: BoundsCheckedThunkBuilder
+  public let index: Int
+  public let funcDecl: FunctionParts
+  public let nonescaping: Bool
+
+  var newType: TypeSyntax { oldType }
+
+  func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
+    -> FunctionSignatureSyntax
+  {
+    return try base.buildFunctionSignature(argTypes, returnType)
+  }
+  func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
+    return try base.buildFunctionCall(pointerArgs)
+  }
+  func buildBasicBoundsExtractions() throws -> [CodeBlockItemSyntax.Item] {
+    return try base.buildBasicBoundsExtractions()
+  }
+  func buildBasicBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
+    return try base.buildBasicBoundsChecks()
+  }
+  func buildCompoundBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
+    return try base.buildCompoundBoundsChecks()
+  }
+  func buildSpanUnwraps() throws -> [CodeBlockItemSyntax.Item] {
+    return try base.buildSpanUnwraps()
+  }
+  func buildPreReturnStatements() throws -> [CodeBlockItemSyntax.Item] {
+    return try base.buildPreReturnStatements()
+  }
+  func chainedNullableCount(name: TokenSyntax, isUnsafe: inout Bool) -> ExprSyntax {
+    return base.chainedNullableCount(name: name, isUnsafe: &isUnsafe)
+  }
+}
+
 func getArgumentByName(_ argumentList: LabeledExprListSyntax, _ name: String) throws -> ExprSyntax {
   guard
     let arg = argumentList.first(where: {
@@ -1355,6 +1420,15 @@ func parseEndedByEnum(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> P
   let endPointerExprArg = try getArgumentByName(argumentList, "end")
   let _: SwiftifyExpr = try parseSwiftifyExpr(endPointerExprArg)
   throw RuntimeError("endedBy support not yet implemented")
+}
+
+func parseSingleEnum(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> ParamInfo {
+  let argumentList = enumConstructorExpr.arguments
+  let pointerExprArg = try getArgumentByName(argumentList, "pointer")
+  let pointerExpr: SwiftifyExpr = try parseSwiftifyExpr(pointerExprArg)
+  return Single(
+    pointerIndex: pointerExpr, nonescaping: false, dependencies: [],
+    original: ExprSyntax(enumConstructorExpr))
 }
 
 func parseNonEscaping(_ enumConstructorExpr: FunctionCallExprSyntax) throws -> Int {
@@ -1533,6 +1607,7 @@ func parseMacroParam(
       enumConstructorExpr, rewriter, isOrNull: true,
       nullableAsEmptySpan: nullableAsEmptySpan)
   case "endedBy": return try parseEndedByEnum(enumConstructorExpr)
+  case "single": return try parseSingleEnum(enumConstructorExpr)
   case "nonescaping":
     let index = try parseNonEscaping(enumConstructorExpr)
     nonescapingPointers.insert(index)
@@ -1554,7 +1629,7 @@ func parseMacroParam(
     return nil
   default:
     throw DiagnosticError(
-      "expected 'countedBy', 'countedByOrNull', 'sizedBy', 'sizedByOrNull', 'endedBy', 'nonescaping' or 'lifetimeDependence', got '\(enumName)'",
+      "expected 'countedBy', 'countedByOrNull', 'sizedBy', 'sizedByOrNull', 'endedBy', 'single', 'nonescaping' or 'lifetimeDependence', got '\(enumName)'",
       node: enumConstructorExpr)
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1275,13 +1275,11 @@ struct SinglePointerThunkBuilder: ParamBoundsThunkBuilder {
     // Builtin.Borrow stores the value inline, so the only address available is
     // that of a copy.
     let ptrName = TokenSyntax("_\(name.withoutBackticks)Ptr").escapeIfNeeded
-    // The closure always receives an Optional pointer, so a _Nonnull parameter
-    // needs unwrapping.
     args[index] = "\(ptrName)"
     let innerCall = try base.buildFunctionCall(args)
     let withPointerFunction = nullable ? "_swiftifyWithOptionalPointer(" : "withUnsafePointer(to: "
     return """
-      unsafe \(raw: withPointerFunction)\(name)\(raw: questionMark).value, { \(ptrName) in \(innerCall) })
+      unsafe \(raw: withPointerFunction)\(name)\(raw: questionMark).value) { \(ptrName) in \(innerCall) }
       """
   }
   func buildBasicBoundsExtractions() throws -> [CodeBlockItemSyntax.Item] {

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1273,16 +1273,15 @@ struct SinglePointerThunkBuilder: ParamBoundsThunkBuilder {
     }
     // Ref has no address to hand back: for pointee types that fit in 4 words
     // Builtin.Borrow stores the value inline, so the only address available is
-    // that of a copy. _swiftifyWithOptionalPointer materializes that copy and
-    // scopes the pointer to the call, which is sound because __single implies a
-    // lifetime dependence.
+    // that of a copy.
     let ptrName = TokenSyntax("_\(name.withoutBackticks)Ptr").escapeIfNeeded
     // The closure always receives an Optional pointer, so a _Nonnull parameter
     // needs unwrapping.
-    args[index] = nullable ? "\(ptrName)" : "\(ptrName)!"
+    args[index] = "\(ptrName)"
     let innerCall = try base.buildFunctionCall(args)
+    let withPointerFunction = nullable ? "_swiftifyWithOptionalPointer(" : "withUnsafePointer(to: "
     return """
-      unsafe _swiftifyWithOptionalPointer(\(name)\(raw: questionMark).value, { \(ptrName) in \(innerCall) })
+      unsafe \(raw: withPointerFunction)\(name)\(raw: questionMark).value, { \(ptrName) in \(innerCall) })
       """
   }
   func buildBasicBoundsExtractions() throws -> [CodeBlockItemSyntax.Item] {

--- a/stdlib/public/core/MutableRef.swift
+++ b/stdlib/public/core/MutableRef.swift
@@ -71,4 +71,18 @@ extension MutableRef where Value: ~Copyable {
       unsafe &pointer.pointee
     }
   }
+
+  /// The address of the referenced value.
+  ///
+  /// Unlike `withUnsafeMutablePointer(to:)`, this is not scoped to a closure,
+  /// so the returned pointer's validity is not enforced by the compiler. It is
+  /// only valid for as long as this `MutableRef` is alive. Accessing the value
+  /// through `value` instead lets the compiler check that for you.
+  @available(StdlibDeploymentTarget 6.4, *)
+  @unsafe
+  @export(implementation)
+  @_transparent
+  public var _unsafeAddress: UnsafeMutablePointer<Value> {
+    unsafe pointer
+  }
 }

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -83,6 +83,7 @@ public enum _SwiftifyInfo {
 @attached(peer, names: overloaded)
 public macro _SwiftifyImport(_ paramInfo: _SwiftifyInfo...,
                              spanAvailability: String? = nil,
+                             refAvailability: String? = nil,
                              typeMappings: [String: String] = [:],
                              nullableAsEmptySpan: Bool = false) =
     #externalMacro(module: "SwiftMacros", type: "SwiftifyImportMacro")
@@ -107,6 +108,7 @@ public enum _SwiftifyProtocolMethodInfo {
   public macro _SwiftifyImportProtocol(
     _ methodInfo: _SwiftifyProtocolMethodInfo...,
     spanAvailability: String? = nil,
+    refAvailability: String? = nil,
     typeMappings: [String: String] = [:]
   ) =
     #externalMacro(module: "SwiftMacros", type: "SwiftifyImportProtocolMacro")

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -11,8 +11,9 @@ public enum _DependenceType {
 /// Different ways to annotate pointer parameters using the `@_SwiftifyImport` macro.
 /// All indices into parameter lists start at 1. Indices __must__ be integer literals, and strings
 /// __must__ be string literals, because their contents are parsed by the `@_SwiftifyImport` macro.
-/// Only 1 instance of `countedBy`, `sizedBy` or `endedBy` can refer to each pointer index, however
-/// `nonescaping` is orthogonal to the rest and can (and should) overlap with other annotations.
+/// Only 1 instance of `countedBy`, `sizedBy`, `endedBy` or `single` can refer to each pointer
+/// index, however `nonescaping` is orthogonal to the rest and can (and should) overlap with other
+/// annotations.
 ///
 /// This is not marked @available, because _SwiftifyImport is available for any target. Instances
 /// of _SwiftifyInfo should ONLY be passed as arguments directly to _SwiftifyImport, so they should
@@ -47,6 +48,9 @@ public enum _SwiftifyInfo {
     /// Parameter end: index of pointer in function parameter list, pointing one past the end of
     /// the same buffer as `start`.
     case endedBy(start: _SwiftifyExpr, end: Int)
+    /// Corresponds to the C `__single` attribute.
+    /// Parameter pointer: index of pointer in function parameter list.
+    case single(pointer: _SwiftifyExpr)
     /// Corresponds to the C `noescape` attribute. Allows generated wrapper to use `Span`-types
     /// instead of `UnsafeBuffer`-types, because it is known that the function doesn't capture the
     /// object past the lifetime of the function.

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -151,3 +151,18 @@ public func _swiftifyOverrideLifetime<
   // should be expressed by a builtin that is hidden within the function body.
   dependent
 }
+
+/// Let a generated wrapper turn an Optional value into an optional
+/// pointer argument without branching at the call site, so a function with
+/// several Optional pointer parameters doesn't trigger a combinatorial explosion
+/// of nested if statements.
+@export(implementation)
+@_transparent
+public func _swiftifyWithOptionalPointer<T: ~Copyable, E: ~Copyable>(
+  _ x: borrowing T?, _ f: (UnsafePointer<T>?) -> E
+) -> E {
+  switch x {
+  case .some(let value): return withUnsafePointer(to: value, f)
+  case .none: return f(nil)
+  }
+}

--- a/test/Interop/C/swiftify-import/single.swift
+++ b/test/Interop/C/swiftify-import/single.swift
@@ -77,8 +77,8 @@ void nullUnspecifiedConst(const int * _Null_unspecified __single p __noescape);
 // expected-expansion@+8:50{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nonnullConst(_ p: Ref<CInt>) {|}}
-//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p.value, { _pPtr in|}}
-//   expected-remark@4{{macro content: |            unsafe nonnullConst(_pPtr!)|}}
+//   expected-remark@3{{macro content: |    return unsafe withUnsafePointer(to: p.value, { _pPtr in|}}
+//   expected-remark@4{{macro content: |            unsafe nonnullConst(_pPtr)|}}
 //   expected-remark@5{{macro content: |        })|}}
 //   expected-remark@6{{macro content: |}|}}
 // }}

--- a/test/Interop/C/swiftify-import/single.swift
+++ b/test/Interop/C/swiftify-import/single.swift
@@ -22,80 +22,80 @@ int * __single _Null_unspecified lifetimeless(int * _Null_unspecified __single p
 
 // expected-expansion@+6:56{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutablePointer<CInt>!) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nullUnspecified(p)|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: inout MutableRef<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullUnspecified(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nullUnspecified(int * _Null_unspecified __single p __noescape);
 
 // expected-expansion@+6:39{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: UnsafeMutablePointer<CInt>) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nonnull(p)|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: inout MutableRef<CInt>) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nonnull(p._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nonnull(int * __single _Nonnull p __noescape);
 // expected-expansion@+6:46{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullFlipped(_ p: UnsafeMutablePointer<CInt>) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nonnullFlipped(p)|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullFlipped(_ p: inout MutableRef<CInt>) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nonnullFlipped(p._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nonnullFlipped(int * _Nonnull __single p __noescape);
 
 // expected-expansion@+6:41{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: UnsafeMutablePointer<CInt>?) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nullable(p)|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: inout MutableRef<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullable(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nullable(int * __single _Nullable p __noescape);
 // expected-expansion@+6:48{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableFlipped(_ p: UnsafeMutablePointer<CInt>?) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nullableFlipped(p)|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableFlipped(_ p: inout MutableRef<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullableFlipped(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nullableFlipped(int * _Nullable __single p __noescape);
 
-// expected-expansion@+6:67{{
+// expected-expansion@+8:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecifiedConst(_ p: UnsafePointer<CInt>!) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nullUnspecifiedConst(p)|}}
-//   expected-remark@4{{macro content: |}|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecifiedConst(_ p: Ref<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
+//   expected-remark@4{{macro content: |            unsafe nullUnspecifiedConst(_pPtr)|}}
+//   expected-remark@5{{macro content: |        })|}}
+//   expected-remark@6{{macro content: |}|}}
 // }}
 void nullUnspecifiedConst(const int * _Null_unspecified __single p __noescape);
 
-// expected-expansion@+6:50{{
+// expected-expansion@+8:50{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullConst(_ p: UnsafePointer<CInt>) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nonnullConst(p)|}}
-//   expected-remark@4{{macro content: |}|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullConst(_ p: Ref<CInt>) {|}}
+//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p.value, { _pPtr in|}}
+//   expected-remark@4{{macro content: |            unsafe nonnullConst(_pPtr!)|}}
+//   expected-remark@5{{macro content: |        })|}}
+//   expected-remark@6{{macro content: |}|}}
 // }}
 void nonnullConst(const int * __single _Nonnull p __noescape);
 
-// expected-expansion@+6:52{{
+// expected-expansion@+8:52{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableConst(_ p: UnsafePointer<CInt>?) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nullableConst(p)|}}
-//   expected-remark@4{{macro content: |}|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableConst(_ p: Ref<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
+//   expected-remark@4{{macro content: |            unsafe nullableConst(_pPtr)|}}
+//   expected-remark@5{{macro content: |        })|}}
+//   expected-remark@6{{macro content: |}|}}
 // }}
 void nullableConst(const int * __single _Nullable p __noescape);
 
 // expected-expansion@+6:76{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nested(_ p: UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>!) {|}}
-//   expected-remark@3{{macro content: |    return unsafe nested(p)|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nested(_ p: inout MutableRef<UnsafeMutablePointer<CInt>?>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nested(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nested(int * _Null_unspecified __single * _Null_unspecified __single p __noescape);
 
-// expected-expansion@+6:53{{
-//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func voidpointer(_ p: UnsafeMutableRawPointer!) {|}}
-//   expected-remark@3{{macro content: |    return unsafe voidpointer(p)|}}
-//   expected-remark@4{{macro content: |}|}}
-// }}
 void voidpointer(void * _Null_unspecified __single p __noescape);
 
 struct S;
@@ -105,24 +105,23 @@ struct T{};
 // expected-expansion@+14:12{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.method(self:_:)") @_alwaysEmitIntoClient @_disfavoredOverload|}}
-//   expected-remark@3{{macro content: |public func method(_ p: UnsafeMutablePointer<T>!, _ q: UnsafeMutablePointer<CInt>!) {|}}
-//   expected-remark@4{{macro content: |    return unsafe method(p, q)|}}
+//   expected-remark@3{{macro content: |public func method(_ p: inout MutableRef<T>?, _ q: inout MutableRef<CInt>?) {|}}
+//   expected-remark@4{{macro content: |    return unsafe method(p?._unsafeAddress, q?._unsafeAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+7:99{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
-//   expected-remark@3{{macro content: |public mutating func method(_ q: UnsafeMutablePointer<CInt>!) {|}}
-//   expected-remark@4{{macro content: |    return unsafe method(q)|}}
+//   expected-remark@3{{macro content: |public mutating func method(_ q: inout MutableRef<CInt>?) {|}}
+//   expected-remark@4{{macro content: |    return unsafe method(q?._unsafeAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void method(struct T * _Null_unspecified __single p __noescape, int * _Null_unspecified __single q __noescape) __attribute__((swift_name("T.method(self:_:)")));
 
-// expected-experimental-expansion@+12:89{{
+// expected-experimental-expansion@+11:89{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-error@2{{cannot copy the lifetime of an Escapable type}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func lifetimebound(_ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {|}}
-//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe lifetimebound(p)|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func lifetimebound(_ p: inout MutableRef<CInt>?) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe lifetimebound(p?._unsafeAddress)|}}
 //   expected-experimental-remark@4{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@5{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
 //   expected-experimental-remark@6{{macro content: |      return MutableSpan<CInt>()|}}
@@ -132,12 +131,26 @@ void method(struct T * _Null_unspecified __single p __noescape, int * _Null_unsp
 // }}
 int * __counted_by(2) _Null_unspecified lifetimebound(int * _Null_unspecified __single p __lifetimebound);
 
-// expected-experimental-expansion@+25:60{{
+// expected-experimental-expansion@+13:106{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-error@2{{cannot copy the lifetime of an Escapable type}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func lifetimeboundConst(_ p: Ref<CInt>?) -> Span<CInt> {|}}
+//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafePointer<CInt>? = unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
+//   expected-experimental-remark@4{{macro content: |            unsafe lifetimeboundConst(_pPtr)|}}
+//   expected-experimental-remark@5{{macro content: |        })|}}
+//   expected-experimental-remark@6{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@7{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@8{{macro content: |      return Span<CInt>()|}}
+//   expected-experimental-remark@9{{macro content: |    }|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span<CInt>(_unsafeStart: _resultValue!, count: Int(CInt(2))), copying: ())|}}
+//   expected-experimental-remark@11{{macro content: |}|}}
+// }}
+const int * __counted_by(2) _Null_unspecified lifetimeboundConst(const int * _Null_unspecified __single p __lifetimebound);
+
+// expected-experimental-expansion@+24:60{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.methodLifetimebound(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload|}}
-//   expected-experimental-remark@3{{macro content: |public func methodLifetimebound(_ p: UnsafeMutablePointer<T>!) -> MutableSpan<CInt> {|}}
-//   expected-experimental-remark@4{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe methodLifetimebound(p)|}}
+//   expected-experimental-remark@3{{macro content: |public func methodLifetimebound(_ p: inout MutableRef<T>?) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@4{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe methodLifetimebound(p?._unsafeAddress)|}}
 //   expected-experimental-remark@5{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@6{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
 //   expected-experimental-remark@7{{macro content: |      return MutableSpan<CInt>()|}}
@@ -166,7 +179,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: c5df79bc3b1582d25553af8ea1916d0782f1f979c06c20ecd06883b07969f343
+// GENERATED-HASH: 62994ebc9bab241291c9c7b4be587b8fbea5d9880a47e5505585ae13058e4d98
 import Test
 
 func call_lifetimeless(_ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
@@ -177,89 +190,75 @@ func call_nullUnspecified(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nullUnspecified(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nullUnspecified'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutablePointer<CInt>!) {
-  return unsafe nullUnspecified(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableRef<CInt>?) {
+  return nullUnspecified(&p)
 }
 
 func call_nonnull(_ p: UnsafeMutablePointer<CInt>) {
   return unsafe nonnull(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nonnull'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutablePointer<CInt>) {
-  return unsafe nonnull(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableRef<CInt>) {
+  return nonnull(&p)
 }
 
 func call_nonnullFlipped(_ p: UnsafeMutablePointer<CInt>) {
   return unsafe nonnullFlipped(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nonnullFlipped'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullFlipped(_ p: UnsafeMutablePointer<CInt>) {
-  return unsafe nonnullFlipped(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullFlipped(_ p: inout MutableRef<CInt>) {
+  return nonnullFlipped(&p)
 }
 
 func call_nullable(_ p: UnsafeMutablePointer<CInt>?) {
   return unsafe nullable(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nullable'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe nullable(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableRef<CInt>?) {
+  return nullable(&p)
 }
 
 func call_nullableFlipped(_ p: UnsafeMutablePointer<CInt>?) {
   return unsafe nullableFlipped(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nullableFlipped'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableFlipped(_ p: UnsafeMutablePointer<CInt>?) {
-  return unsafe nullableFlipped(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableFlipped(_ p: inout MutableRef<CInt>?) {
+  return nullableFlipped(&p)
 }
 
 func call_nullUnspecifiedConst(_ p: UnsafePointer<CInt>!) {
   return unsafe nullUnspecifiedConst(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nullUnspecifiedConst'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecifiedConst(_ p: UnsafePointer<CInt>!) {
-  return unsafe nullUnspecifiedConst(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecifiedConst(_ p: Ref<CInt>?) {
+  return nullUnspecifiedConst(p)
 }
 
 func call_nonnullConst(_ p: UnsafePointer<CInt>) {
   return unsafe nonnullConst(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nonnullConst'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullConst(_ p: UnsafePointer<CInt>) {
-  return unsafe nonnullConst(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullConst(_ p: Ref<CInt>) {
+  return nonnullConst(p)
 }
 
 func call_nullableConst(_ p: UnsafePointer<CInt>?) {
   return unsafe nullableConst(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nullableConst'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableConst(_ p: UnsafePointer<CInt>?) {
-  return unsafe nullableConst(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableConst(_ p: Ref<CInt>?) {
+  return nullableConst(p)
 }
 
 func call_nested(_ p: UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>!) {
   return unsafe nested(p)
 }
 
-// expected-error@+1{{invalid redeclaration of 'call_nested'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_nested(_ p: UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>!) {
-  return unsafe nested(p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nested(_ p: inout MutableRef<UnsafeMutablePointer<CInt>?>?) {
+  return unsafe nested(&p)
 }
 
 func call_voidpointer(_ p: UnsafeMutableRawPointer!) {
-  return unsafe voidpointer(p)
-}
-
-// expected-error@+1{{invalid redeclaration of 'call_voidpointer'}}
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_voidpointer(_ p: UnsafeMutableRawPointer!) {
   return unsafe voidpointer(p)
 }
 
@@ -271,9 +270,8 @@ extension T {
   mutating func call_method_T(_ q: UnsafeMutablePointer<CInt>!) {
     return unsafe method(q)
   }
-  // expected-error@+1{{invalid redeclaration of 'call_method_T'}}
-  @_alwaysEmitIntoClient @_disfavoredOverload mutating func call_method_T(_ q: UnsafeMutablePointer<CInt>!) {
-    return unsafe method(q)
+  @_alwaysEmitIntoClient @_disfavoredOverload mutating func call_method_T(_ q: inout MutableRef<CInt>?) {
+    return method(&q)
   }
   mutating func call_methodLifetimebound_T() -> UnsafeMutablePointer<CInt>! {
     return unsafe methodLifetimebound()
@@ -291,9 +289,21 @@ func call_lifetimebound(_ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointe
 }
 
 @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// expected-error@+1{{cannot copy the lifetime of an Escapable type}}
 @_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimebound(_ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimebound(_ p: inout MutableRef<CInt>?) -> MutableSpan<CInt> {
+  // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableRef<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableRef<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
   // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
-  return unsafe lifetimebound(p)
+  return lifetimebound(&p)
+}
+
+func call_lifetimeboundConst(_ p: UnsafePointer<CInt>!) -> UnsafePointer<CInt>! {
+  return unsafe lifetimeboundConst(p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundConst(_ p: Ref<CInt>?) -> Span<CInt> {
+  // expected-stable-error@+2{{cannot convert value of type 'Ref<CInt>?' (aka 'Optional<Ref<Int32>>') to expected argument type 'UnsafePointer<CInt>?' (aka 'Optional<UnsafePointer<Int32>>')}}
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafePointer<CInt>?' (aka 'Optional<UnsafePointer<Int32>>') to return type 'Span<CInt>' (aka 'Span<Int32>')}}
+  return lifetimeboundConst(p)
 }

--- a/test/Interop/C/swiftify-import/single.swift
+++ b/test/Interop/C/swiftify-import/single.swift
@@ -1,0 +1,299 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_Lifetimes
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety \
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking \
+// RUN:   -enable-experimental-feature Lifetimes -verify-additional-prefix stable-
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety \
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking \
+// RUN:   -enable-experimental-feature Lifetimes -enable-experimental-feature SafeInteropWrappers -verify-additional-prefix experimental-
+
+//--- test.h
+#define __single __attribute__((__single__))
+#define __noescape __attribute__((__noescape__))
+#define __lifetimebound __attribute__((__lifetimebound__))
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+int * __single _Null_unspecified lifetimeless(int * _Null_unspecified __single p);
+
+// expected-expansion@+6:56{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutablePointer<CInt>!) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullUnspecified(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nullUnspecified(int * _Null_unspecified __single p __noescape);
+
+// expected-expansion@+6:39{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: UnsafeMutablePointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nonnull(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nonnull(int * __single _Nonnull p __noescape);
+// expected-expansion@+6:46{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullFlipped(_ p: UnsafeMutablePointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nonnullFlipped(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nonnullFlipped(int * _Nonnull __single p __noescape);
+
+// expected-expansion@+6:41{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: UnsafeMutablePointer<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullable(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nullable(int * __single _Nullable p __noescape);
+// expected-expansion@+6:48{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableFlipped(_ p: UnsafeMutablePointer<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullableFlipped(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nullableFlipped(int * _Nullable __single p __noescape);
+
+// expected-expansion@+6:67{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecifiedConst(_ p: UnsafePointer<CInt>!) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullUnspecifiedConst(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nullUnspecifiedConst(const int * _Null_unspecified __single p __noescape);
+
+// expected-expansion@+6:50{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullConst(_ p: UnsafePointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nonnullConst(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nonnullConst(const int * __single _Nonnull p __noescape);
+
+// expected-expansion@+6:52{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableConst(_ p: UnsafePointer<CInt>?) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nullableConst(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nullableConst(const int * __single _Nullable p __noescape);
+
+// expected-expansion@+6:76{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nested(_ p: UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>!) {|}}
+//   expected-remark@3{{macro content: |    return unsafe nested(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void nested(int * _Null_unspecified __single * _Null_unspecified __single p __noescape);
+
+// expected-expansion@+6:53{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func voidpointer(_ p: UnsafeMutableRawPointer!) {|}}
+//   expected-remark@3{{macro content: |    return unsafe voidpointer(p)|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+void voidpointer(void * _Null_unspecified __single p __noescape);
+
+struct S;
+void forwardDeclared(struct S * _Null_unspecified __single p __noescape);
+
+struct T{};
+// expected-expansion@+14:12{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.method(self:_:)") @_alwaysEmitIntoClient @_disfavoredOverload|}}
+//   expected-remark@3{{macro content: |public func method(_ p: UnsafeMutablePointer<T>!, _ q: UnsafeMutablePointer<CInt>!) {|}}
+//   expected-remark@4{{macro content: |    return unsafe method(p, q)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+// expected-expansion@+7:99{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+//   expected-remark@3{{macro content: |public mutating func method(_ q: UnsafeMutablePointer<CInt>!) {|}}
+//   expected-remark@4{{macro content: |    return unsafe method(q)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+void method(struct T * _Null_unspecified __single p __noescape, int * _Null_unspecified __single q __noescape) __attribute__((swift_name("T.method(self:_:)")));
+
+// expected-experimental-expansion@+12:89{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-error@2{{cannot copy the lifetime of an Escapable type}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func lifetimebound(_ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe lifetimebound(p)|}}
+//   expected-experimental-remark@4{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@5{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@6{{macro content: |      return MutableSpan<CInt>()|}}
+//   expected-experimental-remark@7{{macro content: |    }|}}
+//   expected-experimental-remark@8{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(CInt(2))), copying: ())|}}
+//   expected-experimental-remark@9{{macro content: |}|}}
+// }}
+int * __counted_by(2) _Null_unspecified lifetimebound(int * _Null_unspecified __single p __lifetimebound);
+
+// expected-experimental-expansion@+25:60{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-error@2{{cannot copy the lifetime of an Escapable type}}
+//   expected-experimental-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.methodLifetimebound(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload|}}
+//   expected-experimental-remark@3{{macro content: |public func methodLifetimebound(_ p: UnsafeMutablePointer<T>!) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@4{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe methodLifetimebound(p)|}}
+//   expected-experimental-remark@5{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@6{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@7{{macro content: |      return MutableSpan<CInt>()|}}
+//   expected-experimental-remark@8{{macro content: |    }|}}
+//   expected-experimental-remark@9{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(CInt(2))), copying: ())|}}
+//   expected-experimental-remark@10{{macro content: |}|}}
+// }}
+// expected-experimental-expansion@+12:100{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(&self) @_disfavoredOverload|}}
+//   expected-experimental-remark@3{{macro content: |public mutating func methodLifetimebound() -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@4{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe methodLifetimebound()|}}
+//   expected-experimental-remark@5{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@6{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@7{{macro content: |      return MutableSpan<CInt>()|}}
+//   expected-experimental-remark@8{{macro content: |    }|}}
+//   expected-experimental-remark@9{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(CInt(2))), copying: ())|}}
+//   expected-experimental-remark@10{{macro content: |}|}}
+// }}
+int * __counted_by(2) _Null_unspecified methodLifetimebound(struct T * _Null_unspecified __single p __lifetimebound) __attribute__((swift_name("T.methodLifetimebound(self:)")));
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+
+//--- test.swift
+// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
+// GENERATED-HASH: c5df79bc3b1582d25553af8ea1916d0782f1f979c06c20ecd06883b07969f343
+import Test
+
+func call_lifetimeless(_ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe lifetimeless(p)
+}
+
+func call_nullUnspecified(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe nullUnspecified(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nullUnspecified'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: UnsafeMutablePointer<CInt>!) {
+  return unsafe nullUnspecified(p)
+}
+
+func call_nonnull(_ p: UnsafeMutablePointer<CInt>) {
+  return unsafe nonnull(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nonnull'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutablePointer<CInt>) {
+  return unsafe nonnull(p)
+}
+
+func call_nonnullFlipped(_ p: UnsafeMutablePointer<CInt>) {
+  return unsafe nonnullFlipped(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nonnullFlipped'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullFlipped(_ p: UnsafeMutablePointer<CInt>) {
+  return unsafe nonnullFlipped(p)
+}
+
+func call_nullable(_ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe nullable(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nullable'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe nullable(p)
+}
+
+func call_nullableFlipped(_ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe nullableFlipped(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nullableFlipped'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableFlipped(_ p: UnsafeMutablePointer<CInt>?) {
+  return unsafe nullableFlipped(p)
+}
+
+func call_nullUnspecifiedConst(_ p: UnsafePointer<CInt>!) {
+  return unsafe nullUnspecifiedConst(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nullUnspecifiedConst'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecifiedConst(_ p: UnsafePointer<CInt>!) {
+  return unsafe nullUnspecifiedConst(p)
+}
+
+func call_nonnullConst(_ p: UnsafePointer<CInt>) {
+  return unsafe nonnullConst(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nonnullConst'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullConst(_ p: UnsafePointer<CInt>) {
+  return unsafe nonnullConst(p)
+}
+
+func call_nullableConst(_ p: UnsafePointer<CInt>?) {
+  return unsafe nullableConst(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nullableConst'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableConst(_ p: UnsafePointer<CInt>?) {
+  return unsafe nullableConst(p)
+}
+
+func call_nested(_ p: UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>!) {
+  return unsafe nested(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_nested'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nested(_ p: UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>!) {
+  return unsafe nested(p)
+}
+
+func call_voidpointer(_ p: UnsafeMutableRawPointer!) {
+  return unsafe voidpointer(p)
+}
+
+// expected-error@+1{{invalid redeclaration of 'call_voidpointer'}}
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_voidpointer(_ p: UnsafeMutableRawPointer!) {
+  return unsafe voidpointer(p)
+}
+
+func call_forwardDeclared(_ p: OpaquePointer!) {
+  return unsafe forwardDeclared(p)
+}
+
+extension T {
+  mutating func call_method_T(_ q: UnsafeMutablePointer<CInt>!) {
+    return unsafe method(q)
+  }
+  // expected-error@+1{{invalid redeclaration of 'call_method_T'}}
+  @_alwaysEmitIntoClient @_disfavoredOverload mutating func call_method_T(_ q: UnsafeMutablePointer<CInt>!) {
+    return unsafe method(q)
+  }
+  mutating func call_methodLifetimebound_T() -> UnsafeMutablePointer<CInt>! {
+    return unsafe methodLifetimebound()
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(&self)
+    @_alwaysEmitIntoClient @_disfavoredOverload mutating func call_methodLifetimebound_T() -> MutableSpan<CInt> {
+    // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    return methodLifetimebound()
+  }
+}
+
+func call_lifetimebound(_ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
+  return unsafe lifetimebound(p)
+}
+
+@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// expected-error@+1{{cannot copy the lifetime of an Escapable type}}
+@_lifetime(copy p)
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimebound(_ p: UnsafeMutablePointer<CInt>!) -> MutableSpan<CInt> {
+  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+  return unsafe lifetimebound(p)
+}

--- a/test/Interop/C/swiftify-import/single.swift
+++ b/test/Interop/C/swiftify-import/single.swift
@@ -1,6 +1,12 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes
 
+// Ref/MutableRef are annotated with StdlibDeploymentTarget, which CMake clamps
+// to the platform being built, so the availability in the expansions below is
+// specific to a non-strict macOS build.
+// REQUIRES: OS=macosx
+// REQUIRES: !swift_stdlib_strict_availability
+
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
 

--- a/test/Interop/C/swiftify-import/single.swift
+++ b/test/Interop/C/swiftify-import/single.swift
@@ -22,7 +22,7 @@ int * __single _Null_unspecified lifetimeless(int * _Null_unspecified __single p
 
 // expected-expansion@+6:56{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: inout MutableRef<CInt>?) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nullUnspecified(_ p: inout MutableRef<CInt>?) {|}}
 //   expected-remark@3{{macro content: |    return unsafe nullUnspecified(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
@@ -30,14 +30,14 @@ void nullUnspecified(int * _Null_unspecified __single p __noescape);
 
 // expected-expansion@+6:39{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: inout MutableRef<CInt>) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nonnull(_ p: inout MutableRef<CInt>) {|}}
 //   expected-remark@3{{macro content: |    return unsafe nonnull(p._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nonnull(int * __single _Nonnull p __noescape);
 // expected-expansion@+6:46{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullFlipped(_ p: inout MutableRef<CInt>) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nonnullFlipped(_ p: inout MutableRef<CInt>) {|}}
 //   expected-remark@3{{macro content: |    return unsafe nonnullFlipped(p._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
@@ -45,14 +45,14 @@ void nonnullFlipped(int * _Nonnull __single p __noescape);
 
 // expected-expansion@+6:41{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: inout MutableRef<CInt>?) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nullable(_ p: inout MutableRef<CInt>?) {|}}
 //   expected-remark@3{{macro content: |    return unsafe nullable(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
 void nullable(int * __single _Nullable p __noescape);
 // expected-expansion@+6:48{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableFlipped(_ p: inout MutableRef<CInt>?) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nullableFlipped(_ p: inout MutableRef<CInt>?) {|}}
 //   expected-remark@3{{macro content: |    return unsafe nullableFlipped(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
@@ -60,7 +60,7 @@ void nullableFlipped(int * _Nullable __single p __noescape);
 
 // expected-expansion@+8:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecifiedConst(_ p: Ref<CInt>?) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nullUnspecifiedConst(_ p: Ref<CInt>?) {|}}
 //   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
 //   expected-remark@4{{macro content: |            unsafe nullUnspecifiedConst(_pPtr)|}}
 //   expected-remark@5{{macro content: |        })|}}
@@ -70,7 +70,7 @@ void nullUnspecifiedConst(const int * _Null_unspecified __single p __noescape);
 
 // expected-expansion@+8:50{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nonnullConst(_ p: Ref<CInt>) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nonnullConst(_ p: Ref<CInt>) {|}}
 //   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p.value, { _pPtr in|}}
 //   expected-remark@4{{macro content: |            unsafe nonnullConst(_pPtr!)|}}
 //   expected-remark@5{{macro content: |        })|}}
@@ -80,7 +80,7 @@ void nonnullConst(const int * __single _Nonnull p __noescape);
 
 // expected-expansion@+8:52{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullableConst(_ p: Ref<CInt>?) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nullableConst(_ p: Ref<CInt>?) {|}}
 //   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
 //   expected-remark@4{{macro content: |            unsafe nullableConst(_pPtr)|}}
 //   expected-remark@5{{macro content: |        })|}}
@@ -90,7 +90,7 @@ void nullableConst(const int * __single _Nullable p __noescape);
 
 // expected-expansion@+6:76{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nested(_ p: inout MutableRef<UnsafeMutablePointer<CInt>?>?) {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nested(_ p: inout MutableRef<UnsafeMutablePointer<CInt>?>?) {|}}
 //   expected-remark@3{{macro content: |    return unsafe nested(p?._unsafeAddress)|}}
 //   expected-remark@4{{macro content: |}|}}
 // }}
@@ -104,14 +104,14 @@ void forwardDeclared(struct S * _Null_unspecified __single p __noescape);
 struct T{};
 // expected-expansion@+14:12{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.method(self:_:)") @_alwaysEmitIntoClient @_disfavoredOverload|}}
+//   expected-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.method(self:_:)") @_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload|}}
 //   expected-remark@3{{macro content: |public func method(_ p: inout MutableRef<T>?, _ q: inout MutableRef<CInt>?) {|}}
 //   expected-remark@4{{macro content: |    return unsafe method(p?._unsafeAddress, q?._unsafeAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+7:99{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload|}}
 //   expected-remark@3{{macro content: |public mutating func method(_ q: inout MutableRef<CInt>?) {|}}
 //   expected-remark@4{{macro content: |    return unsafe method(q?._unsafeAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
@@ -120,7 +120,7 @@ void method(struct T * _Null_unspecified __single p __noescape, int * _Null_unsp
 
 // expected-experimental-expansion@+11:89{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func lifetimebound(_ p: inout MutableRef<CInt>?) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_lifetime(copy p) @_disfavoredOverload public func lifetimebound(_ p: inout MutableRef<CInt>?) -> MutableSpan<CInt> {|}}
 //   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe lifetimebound(p?._unsafeAddress)|}}
 //   expected-experimental-remark@4{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@5{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
@@ -140,7 +140,7 @@ const int * __counted_by(4) _Null_unspecified lifetimeboundConstBig(const struct
 
 // expected-experimental-expansion@+24:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.methodLifetimebound(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload|}}
+//   expected-experimental-remark@2{{macro content: |@available(swift, obsoleted: 3, renamed: "T.methodLifetimebound(self:)") @_alwaysEmitIntoClient @available(macOS 13.0, *) @_lifetime(copy p) @_disfavoredOverload|}}
 //   expected-experimental-remark@3{{macro content: |public func methodLifetimebound(_ p: inout MutableRef<T>?) -> MutableSpan<CInt> {|}}
 //   expected-experimental-remark@4{{macro content: |    let _resultValue: UnsafeMutablePointer<CInt>? = unsafe methodLifetimebound(p?._unsafeAddress)|}}
 //   expected-experimental-remark@5{{macro content: |    if unsafe _resultValue == nil {|}}
@@ -171,7 +171,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 7be4a677ab495efa3b0f7ac1ca324a02518c3cd8ca97a133119c1d70de86fc2a
+// GENERATED-HASH: fb7b207d35990bf7c2ed5a830f47d60bad41aed4d2d375127544f5c8244c97e0
 import Test
 
 func call_lifetimeless(_ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
@@ -182,6 +182,7 @@ func call_nullUnspecified(_ p: UnsafeMutablePointer<CInt>!) {
   return unsafe nullUnspecified(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecified(_ p: inout MutableRef<CInt>?) {
   return nullUnspecified(&p)
 }
@@ -190,6 +191,7 @@ func call_nonnull(_ p: UnsafeMutablePointer<CInt>) {
   return unsafe nonnull(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: inout MutableRef<CInt>) {
   return nonnull(&p)
 }
@@ -198,6 +200,7 @@ func call_nonnullFlipped(_ p: UnsafeMutablePointer<CInt>) {
   return unsafe nonnullFlipped(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullFlipped(_ p: inout MutableRef<CInt>) {
   return nonnullFlipped(&p)
 }
@@ -206,6 +209,7 @@ func call_nullable(_ p: UnsafeMutablePointer<CInt>?) {
   return unsafe nullable(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullable(_ p: inout MutableRef<CInt>?) {
   return nullable(&p)
 }
@@ -214,6 +218,7 @@ func call_nullableFlipped(_ p: UnsafeMutablePointer<CInt>?) {
   return unsafe nullableFlipped(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableFlipped(_ p: inout MutableRef<CInt>?) {
   return nullableFlipped(&p)
 }
@@ -222,6 +227,7 @@ func call_nullUnspecifiedConst(_ p: UnsafePointer<CInt>!) {
   return unsafe nullUnspecifiedConst(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullUnspecifiedConst(_ p: Ref<CInt>?) {
   return nullUnspecifiedConst(p)
 }
@@ -230,6 +236,7 @@ func call_nonnullConst(_ p: UnsafePointer<CInt>) {
   return unsafe nonnullConst(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnullConst(_ p: Ref<CInt>) {
   return nonnullConst(p)
 }
@@ -238,6 +245,7 @@ func call_nullableConst(_ p: UnsafePointer<CInt>?) {
   return unsafe nullableConst(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nullableConst(_ p: Ref<CInt>?) {
   return nullableConst(p)
 }
@@ -246,6 +254,7 @@ func call_nested(_ p: UnsafeMutablePointer<UnsafeMutablePointer<CInt>?>!) {
   return unsafe nested(p)
 }
 
+@available(macOS 13.0, *)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nested(_ p: inout MutableRef<UnsafeMutablePointer<CInt>?>?) {
   return unsafe nested(&p)
 }
@@ -262,7 +271,8 @@ extension T {
   mutating func call_method_T(_ q: UnsafeMutablePointer<CInt>!) {
     return unsafe method(q)
   }
-  @_alwaysEmitIntoClient @_disfavoredOverload mutating func call_method_T(_ q: inout MutableRef<CInt>?) {
+  @available(macOS 13.0, *)
+    @_alwaysEmitIntoClient @_disfavoredOverload mutating func call_method_T(_ q: inout MutableRef<CInt>?) {
     return method(&q)
   }
   mutating func call_methodLifetimebound_T() -> UnsafeMutablePointer<CInt>! {
@@ -280,7 +290,7 @@ func call_lifetimebound(_ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointe
   return unsafe lifetimebound(p)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@available(macOS 13.0, *)
 @_lifetime(copy p)
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimebound(_ p: inout MutableRef<CInt>?) -> MutableSpan<CInt> {
   // expected-stable-error@+2{{cannot convert value of type 'UnsafeMutablePointer<MutableRef<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableRef<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}

--- a/test/Interop/C/swiftify-import/single.swift
+++ b/test/Interop/C/swiftify-import/single.swift
@@ -67,9 +67,9 @@ void nullableFlipped(int * _Nullable __single p __noescape);
 // expected-expansion@+8:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nullUnspecifiedConst(_ p: Ref<CInt>?) {|}}
-//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
-//   expected-remark@4{{macro content: |            unsafe nullUnspecifiedConst(_pPtr)|}}
-//   expected-remark@5{{macro content: |        })|}}
+//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value) { _pPtr in|}}
+//   expected-remark@4{{macro content: |        unsafe nullUnspecifiedConst(_pPtr)|}}
+//   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |}|}}
 // }}
 void nullUnspecifiedConst(const int * _Null_unspecified __single p __noescape);
@@ -77,9 +77,9 @@ void nullUnspecifiedConst(const int * _Null_unspecified __single p __noescape);
 // expected-expansion@+8:50{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nonnullConst(_ p: Ref<CInt>) {|}}
-//   expected-remark@3{{macro content: |    return unsafe withUnsafePointer(to: p.value, { _pPtr in|}}
-//   expected-remark@4{{macro content: |            unsafe nonnullConst(_pPtr)|}}
-//   expected-remark@5{{macro content: |        })|}}
+//   expected-remark@3{{macro content: |    return unsafe withUnsafePointer(to: p.value) { _pPtr in|}}
+//   expected-remark@4{{macro content: |        unsafe nonnullConst(_pPtr)|}}
+//   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |}|}}
 // }}
 void nonnullConst(const int * __single _Nonnull p __noescape);
@@ -87,9 +87,9 @@ void nonnullConst(const int * __single _Nonnull p __noescape);
 // expected-expansion@+8:52{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(macOS 13.0, *) @_disfavoredOverload public func nullableConst(_ p: Ref<CInt>?) {|}}
-//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
-//   expected-remark@4{{macro content: |            unsafe nullableConst(_pPtr)|}}
-//   expected-remark@5{{macro content: |        })|}}
+//   expected-remark@3{{macro content: |    return unsafe _swiftifyWithOptionalPointer(p?.value) { _pPtr in|}}
+//   expected-remark@4{{macro content: |        unsafe nullableConst(_pPtr)|}}
+//   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |}|}}
 // }}
 void nullableConst(const int * __single _Nullable p __noescape);

--- a/test/Interop/C/swiftify-import/single.swift
+++ b/test/Interop/C/swiftify-import/single.swift
@@ -131,20 +131,12 @@ void method(struct T * _Null_unspecified __single p __noescape, int * _Null_unsp
 // }}
 int * __counted_by(2) _Null_unspecified lifetimebound(int * _Null_unspecified __single p __lifetimebound);
 
-// expected-experimental-expansion@+13:106{{
-//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func lifetimeboundConst(_ p: Ref<CInt>?) -> Span<CInt> {|}}
-//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafePointer<CInt>? = unsafe _swiftifyWithOptionalPointer(p?.value, { _pPtr in|}}
-//   expected-experimental-remark@4{{macro content: |            unsafe lifetimeboundConst(_pPtr)|}}
-//   expected-experimental-remark@5{{macro content: |        })|}}
-//   expected-experimental-remark@6{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@7{{macro content: |      precondition(CInt(2) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
-//   expected-experimental-remark@8{{macro content: |      return Span<CInt>()|}}
-//   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(Span<CInt>(_unsafeStart: _resultValue!, count: Int(CInt(2))), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
-// }}
 const int * __counted_by(2) _Null_unspecified lifetimeboundConst(const int * _Null_unspecified __single p __lifetimebound);
+
+struct Big {
+  int arr[4];
+};
+const int * __counted_by(4) _Null_unspecified lifetimeboundConstBig(const struct Big * _Null_unspecified __single p __lifetimebound);
 
 // expected-experimental-expansion@+24:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
@@ -179,7 +171,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 62994ebc9bab241291c9c7b4be587b8fbea5d9880a47e5505585ae13058e4d98
+// GENERATED-HASH: 7be4a677ab495efa3b0f7ac1ca324a02518c3cd8ca97a133119c1d70de86fc2a
 import Test
 
 func call_lifetimeless(_ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>! {
@@ -300,10 +292,6 @@ func call_lifetimeboundConst(_ p: UnsafePointer<CInt>!) -> UnsafePointer<CInt>! 
   return unsafe lifetimeboundConst(p)
 }
 
-@available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@_lifetime(copy p)
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_lifetimeboundConst(_ p: Ref<CInt>?) -> Span<CInt> {
-  // expected-stable-error@+2{{cannot convert value of type 'Ref<CInt>?' (aka 'Optional<Ref<Int32>>') to expected argument type 'UnsafePointer<CInt>?' (aka 'Optional<UnsafePointer<Int32>>')}}
-  // expected-stable-error@+1{{cannot convert return expression of type 'UnsafePointer<CInt>?' (aka 'Optional<UnsafePointer<Int32>>') to return type 'Span<CInt>' (aka 'Span<Int32>')}}
-  return lifetimeboundConst(p)
+func call_lifetimeboundConstBig(_ p: UnsafePointer<Big>!) -> UnsafePointer<CInt>! {
+  return unsafe lifetimeboundConstBig(p)
 }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -956,6 +956,7 @@ Added: _$ss13_SwiftifyExprOMa
 Added: _$ss13_SwiftifyExprOMn
 Added: _$ss13_SwiftifyExprON
 Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
+Added: _$ss13_SwiftifyInfoO6singleyABs01_A4ExprO_tcABmFWC
 Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
 Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -957,6 +957,7 @@ Added: _$ss13_SwiftifyExprOMa
 Added: _$ss13_SwiftifyExprOMn
 Added: _$ss13_SwiftifyExprON
 Added: _$ss13_SwiftifyInfoO11nonescapingyABs01_A4ExprO_tcABmFWC
+Added: _$ss13_SwiftifyInfoO6singleyABs01_A4ExprO_tcABmFWC
 Added: _$ss13_SwiftifyInfoO7endedByyABs01_A4ExprO_SitcABmFWC
 Added: _$ss13_SwiftifyInfoO7sizedByyABs01_A4ExprO_SStcABmFWC
 Added: _$ss13_SwiftifyInfoO9countedByyABs01_A4ExprO_SStcABmFWC

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -112,6 +112,9 @@ if "@SWIFT_STDLIB_ASSERTIONS@" == "TRUE":
 else:
     config.available_features.add('swift_stdlib_no_asserts')
 
+if "@SWIFT_STDLIB_ENABLE_STRICT_AVAILABILITY@" == "TRUE":
+    config.available_features.add('swift_stdlib_strict_availability')
+
 if "@SWIFT_OPTIMIZED@" == "TRUE":
     config.available_features.add("optimized_stdlib")
 


### PR DESCRIPTION
This takes `[const] T * __single __noescape` parameters and maps them to `[Mutable]Ref<T>`. For non-const pointers they can also be mapped to `MutableRef` if annotated with `__lifetimebound` instead of `__noescape`. `Ref` sometimes carries the value inline, so the pointer passed to the wrapped function is temporary, and would be dangling after the wrapper returned. In the future we _might_ be able to extend this to also generate `Ref` for `__lifetimebound` for pointee types where the `Ref` is known to carry a pointer, which ought to cover most single element pointers you'd want to mark with `__lifetimebound` anyways - but it wouldn't be a very intuitive model for users.

rdar://145605247