### PR TITLE
don't use cdecl name for @objc @implementation diagnostic

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1893,12 +1893,12 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
       attr->setCategoryNameInvalid();
     }
 
-    // FIXME: if (AFD->getCDeclName().empty())
-
     if (!AFD->getImplementedObjCDecl()) {
+      StringRef name = AFD->getCDeclName();
+      if (name.empty())
+        name = AFD->getNameStr();
       diagnose(attr->getLocation(),
-               diag::attr_objc_implementation_func_not_found,
-               AFD->getCDeclName(), AFD);
+               diag::attr_objc_implementation_func_not_found, name, AFD);
     }
   }
 }

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -678,6 +678,15 @@ func CImplFuncAvailable1(_: Int32) { }
 @implementation @_cdecl("CImplFuncAvailable2")
 func CImplFuncAvailable2(_: Int32) { }
 
+// When the '@objc' (not '@_cdecl') spelling is used, there is no C name to
+// mention, so the diagnostic should fall back to the Swift name rather than
+// printing an empty '' name.
+class SwiftSubclassWithImplMethod: ObjCClass {
+  @objc @implementation
+  func unimplementedMethod(_: CInt) {}
+  // expected-error@-2 {{could not find imported function 'unimplementedMethod' matching instance method 'unimplementedMethod'; make sure you import the module or header that declares it}}
+}
+
 //
 // TODO: @_cdecl for global functions imported as computed vars
 //


### PR DESCRIPTION
Swift function decls get a cdecl name when using C ABI. The underlying AST node kind is shared between @c and @objc, but @objc does not give it a cdecl name. Fall back to the Swift decl name.
