### PR TITLE
[cxx-interop] Enable ImportCxxMembersLazily by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -535,7 +535,7 @@ EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 
 /// Do not import non-field C++ record members until requested from Swift.
-EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
+LANGUAGE_FEATURE(ImportCxxMembersLazily, 0, "import C++ members lazily")
 
 /// Import a C++ foreign reference type's primary FRT base as a Swift
 /// superclass.

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1066,8 +1066,15 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
   } else {
     // Check if begin() returns an iterator.
     auto *iterDecl = iterTy->getAsCXXRecordDecl();
-    if (!iterDecl || !iterDecl->hasDefinition())
+    if (!iterDecl)
       return;
+
+    // NOTE: isCompleteType eagerly instantiates the return type of begin(),
+    // which may lead to spurious template instantiation failures, but is needed
+    // for CxxIteratorInfoRequest and the collection protocol conformances.
+    if (!clangSema.isCompleteType(beginConst->getLocation(), iterTy))
+      return;
+
     auto iterInfo = evaluateOrDefault(
         ctx.evaluator, CxxIteratorInfoRequest({iterDecl, clangSema}), {});
     if (!iterInfo.has_value())

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5634,7 +5634,9 @@ static bool checkConditionalParams(
         nonPackArgs.push_back(arg);
       for (auto nonPackArg : nonPackArgs) {
         if (nonPackArg.getKind() != clang::TemplateArgument::Type) {
-          if (impl)
+          if (impl && impl->DiagnosedConditionalAttrParams
+                          .insert({specDecl, argToCheck.first})
+                          .second)
             impl->diagnose(HeaderLoc(recordDecl->getLocation()),
                            diag::type_template_parameter_expected,
                            argToCheck.second);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -974,7 +974,13 @@ static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl,
     return false;
   }
 
+  if (isa<clang::FunctionTemplateDecl>(decl))
+    return true;
+
   if (auto *fn = dyn_cast<clang::FunctionDecl>(decl)) {
+    if (fn->getDescribedFunctionTemplate())
+      return true;
+
     switch (fn->getDeclName().getNameKind()) {
     case clang::DeclarationName::CXXOperatorName:
     case clang::DeclarationName::CXXConversionFunctionName:
@@ -2652,9 +2658,7 @@ namespace {
         if (nd->getDeclName().isIdentifier())
           allMemberNames.insert(nd->getName());
 
-        if (Impl.SwiftContext.LangOpts.hasFeature(
-                Feature::ImportCxxMembersLazily) &&
-            !shouldEagerlyImportClangRecordMember(nd,
+        if (!shouldEagerlyImportClangRecordMember(nd,
                                                   Impl.SwiftContext.LangOpts))
           continue;
 
@@ -4613,10 +4617,6 @@ namespace {
     /// the renamed spelling is imported a second time as a deprecated migration
     /// stub, which is only '@unsafe'.
     ///
-    /// Instantiation is gated on ImportCxxMembersLazily; without that
-    /// feature ClangImporter eagerly instantiates typedef members, so the
-    /// return type is usually already instantiated by the time we get here.
-    ///
     /// This is done post-import so we don't eagerly instantiate templates for
     /// methods we may not import.
     void renameToUnsafeIfNeeded(
@@ -4629,23 +4629,19 @@ namespace {
         // Does not apply to operators, ctors, dtors, conversions
         return;
 
-      if (Impl.SwiftContext.LangOpts.hasFeature(
-              Feature::ImportCxxMembersLazily)) {
-        using ClassTmplSpec = clang::ClassTemplateSpecializationDecl;
+      using ClassTmplSpec = clang::ClassTemplateSpecializationDecl;
 
-        auto retTy = desugarIfElaborated(clangDecl->getReturnType());
-        auto *retTemplate =
-            dyn_cast_or_null<ClassTmplSpec>(retTy->getAsTagDecl());
+      auto retTy = desugarIfElaborated(clangDecl->getReturnType());
+      auto *retTemplate =
+          dyn_cast_or_null<ClassTmplSpec>(retTy->getAsTagDecl());
 
-        if (retTemplate && !retTemplate->hasDefinition()) {
-          // N.B. InstantiateClassTemplateSpecialization() returns true if it
-          // encountered an error while instantiating the returned template.
-          (void)Impl.getClangSema().InstantiateClassTemplateSpecialization(
-              clangDecl->getLocation(),
-              const_cast<ClassTmplSpec *>(retTemplate),
-              clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
-              /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
-        }
+      if (retTemplate && !retTemplate->hasDefinition()) {
+        // N.B. InstantiateClassTemplateSpecialization() returns true if it
+        // encountered an error while instantiating the returned template.
+        (void)Impl.getClangSema().InstantiateClassTemplateSpecialization(
+            clangDecl->getLocation(), const_cast<ClassTmplSpec *>(retTemplate),
+            clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
+            /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
       }
 
       auto importedName = Impl.importFullName(clangDecl, Impl.CurrentVersion);
@@ -11066,10 +11062,20 @@ void ClangRecordMemberLoader::load(const clang::RecordDecl *clangRecord,
         member->getClangDecl()->getFriendObjectKind() != clang::Decl::FOK_None)
       continue;
 
-    // FIXME: constructors are added eagerly, but shouldn't be
-    // FIXME: subscripts are added eagerly, but shouldn't be
-    if (isa<AccessorDecl, SubscriptDecl, ConstructorDecl>(member))
+    // AccessorDecls should not be directly added as members, so skip them here
+    // if they appear for whatever reason
+    if (isa<AccessorDecl>(member))
       continue;
+
+    // FIXME: subscripts and constructors are imported and added eagerly
+    //        (though they shouldn't be and won't be in the near future).
+    // Skip adding these here to avoid double-adding the same member.
+    if (isa<SubscriptDecl, ConstructorDecl>(member)) {
+      const auto &LangOpts = Impl.SwiftContext.LangOpts;
+      if (auto *nd = dyn_cast_or_null<clang::NamedDecl>(member->getClangDecl());
+          nd && shouldEagerlyImportClangRecordMember(nd, LangOpts))
+        continue;
+    }
 
     swiftDecl->addMember(member);
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -495,6 +495,12 @@ public:
   llvm::DenseSet<std::pair<const clang::FunctionDecl *, DiagID>>
       DiagnosedTemplateDiagnostics;
 
+  // Tracks already-emitted diagnostics associated with template arguments
+  // (e.g., from a malformed SWIFT_ESCAPABLE_IF) to avoid duplicate diagnostics.
+  llvm::DenseSet<
+      std::pair<const clang::ClassTemplateSpecializationDecl *, unsigned>>
+      DiagnosedConditionalAttrParams;
+
   const bool ImportForwardDeclarations;
   const bool DisableSwiftBridgeAttr;
   const bool BridgingHeaderExplicitlyRequested;

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
@@ -62,7 +62,6 @@ struct GoodStruct {
 // CHECK:      struct GoodStruct {
 // CHECK-NEXT:   init()
 //
-// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func badReturn() -> Never
 //
 // NOTE-MISSING: func badArg(_: Never)

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -7,12 +7,10 @@
 //
 // Compare usability of function.h in Swift with swift-frontend
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
 // RUN:   -typo-correction-limit 0 \
 // RUN:   %t%{fs-sep}ok.swift -verify-additional-prefix ok-swift-
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
 // RUN:   -typo-correction-limit 0 \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
@@ -24,10 +22,7 @@
 // Check module interface of function.h
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -module-to-print=Function | %FileCheck %s
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module Function {

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -91,8 +91,10 @@ struct GoodStruct {
   // FIXME: operators are imported eagerly, so having this member would make GoodStruct unusable
   // int operator+(Bro<Ken>) const;
 
-  Bro<Ken> begin() const;
-  Bro<Ken> end() const;
+  // FIXME: begin()/end() are imported eagerly to derive the CxxSequence
+  // conformance, so having these members would make GoodStruct unusable
+  // Bro<Ken> begin() const;
+  // Bro<Ken> end() const;
 
   // Return type templates are instantiated only if the function member is
   // actually imported, e.g., not if the function member is deleted.
@@ -118,9 +120,6 @@ struct GoodStruct {
 //
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: CInt, _: CInt)
 // NOTE-MISSING: func overloadsDiffNumArgs(_: Never)
-//
-// CHECK-NEXT:   func __beginUnsafe() -> Never
-// CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 
 
@@ -132,8 +131,6 @@ struct DerivedGoodStruct : GoodStruct {};
 // NOTE-MISSING: func badVirtual(_: Never) -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: CInt)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: CInt, _: CInt)
-// CHECK-NEXT:   func __beginUnsafe() -> Never
-// CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 
 struct UsingGoodStruct : GoodStruct {
@@ -149,8 +146,6 @@ struct UsingGoodStruct : GoodStruct {
 // CHECK-NEXT:   func getBad() -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: CInt)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: CInt, _: CInt)
-// CHECK-NEXT:   func __beginUnsafe() -> Never
-// CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 
 

--- a/test/Interop/Cxx/class/invalid-members/rdar156949141.swift
+++ b/test/Interop/Cxx/class/invalid-members/rdar156949141.swift
@@ -2,11 +2,8 @@
 // RUN: split-file %s %t
 //
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}header.h \
 // RUN:   %t%{fs-sep}test.swift
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module TheHeader {

--- a/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+++ b/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
@@ -13,22 +13,17 @@
 //
 // Compare usability of std-contain-incomplete.h in Swift with swift-frontend
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}std-contain-incomplete.h \
 // RUN:   %t%{fs-sep}ok.swift
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
 // RUN:   -verify-ignore-unrelated \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}std-contain-incomplete.h \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
 //
 // Check module interface of std-contain-incomplete.h
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -module-to-print=StdContain | %FileCheck %s
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module StdContain {

--- a/test/Interop/Cxx/class/invalid-members/type-alias-members-of-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/type-alias-members-of-invalid-types.swift
@@ -7,21 +7,16 @@
 //
 // Compare usability of type.h in Swift with swift-frontend
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h \
 // RUN:   %t%{fs-sep}ok.swift
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
 //
 // Check module interface of type.h
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -module-to-print=Type | %FileCheck %s
-
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module Type {

--- a/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
+++ b/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
@@ -5,15 +5,11 @@ struct B {
   // expected-to-note @+1 {{while importing 'renamedFrom0'}}
   void renamedFrom0(A &a) const
     __attribute__((swift_name("A.renamedFrom0(self:)")));
-  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
-  // expected-from-note @-3 {{while importing 'renamedFrom0'}}
 
   // expected-to-warning@+2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
   // expected-to-note @+1 {{while importing 'renamedFrom1'}}
   void renamedFrom1(A &a, int i) const
     __attribute__((swift_name("A.renamedFrom1(self:j:)")));
-  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
-  // expected-from-note @-3 {{while importing 'renamedFrom1'}}
 
   void other() const;
 };

--- a/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
+++ b/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
@@ -1,7 +1,19 @@
 struct A {};
 
 struct B {
-  void b(A &a, int e) const // expected-warning {{swift_name cannot be used to import a non-static C++ method as a member of a different type}} expected-note {{while importing 'b'}}
-    __attribute__((swift_name("A.c(self:d:)")));
+  // expected-to-warning@+2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-to-note @+1 {{while importing 'renamedFrom0'}}
+  void renamedFrom0(A &a) const
+    __attribute__((swift_name("A.renamedFrom0(self:)")));
+  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-from-note @-3 {{while importing 'renamedFrom0'}}
+
+  // expected-to-warning@+2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-to-note @+1 {{while importing 'renamedFrom1'}}
+  void renamedFrom1(A &a, int i) const
+    __attribute__((swift_name("A.renamedFrom1(self:j:)")));
+  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-from-note @-3 {{while importing 'renamedFrom1'}}
+
   void other() const;
 };

--- a/test/Interop/Cxx/class/method/swift-name-different-type.swift
+++ b/test/Interop/Cxx/class/method/swift-name-different-type.swift
@@ -1,7 +1,26 @@
-// RUN: %target-typecheck-verify-swift -I %S%{fs-sep}Inputs -cxx-interoperability-mode=default -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}swift-name-different-type.h
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default \
+// RUN:   -DUSE_RENAMED_FROM -verify-additional-prefix from- \
+// RUN:   -I %S%{fs-sep}Inputs \
+// RUN:   -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}swift-name-different-type.h
+
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default \
+// RUN:   -DUSE_RENAMED_TO -verify-additional-prefix to- \
+// RUN:   -I %S%{fs-sep}Inputs \
+// RUN:   -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}swift-name-different-type.h
 
 import SwiftNameDifferentType
 
-func testB(_ b: B) {
+func test(_ a: A, _ b: B) {
+
+#if USE_RENAMED_FROM
+  a.renamedFrom0()   // expected-from-error {{has no member}}
+  a.renamedFrom1(42) // expected-from-error {{has no member}}
+#endif
+
+#if USE_RENAMED_TO
+  b.renamedTo0()    // expected-to-error {{has no member}}
+  b.renamedTo1(42)  // expected-to-error {{has no member}}
+#endif
+
   b.other()
 }

--- a/test/Interop/Cxx/stdlib/derived-conformance-uninstantiated-member-type.swift
+++ b/test/Interop/Cxx/stdlib/derived-conformance-uninstantiated-member-type.swift
@@ -4,10 +4,7 @@
 // RUN:   -module-to-print=DerivedConformanceUninstantiatedMemberType \
 // RUN:   -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %S/Inputs | %FileCheck %s
-
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 // CHECK: struct vector<CInt> : CxxVector {
 // CHECK:   typealias const_iterator = __gnu_cxx.__normal_iterator<UnsafePointer<CInt>, std.vector<CInt>>

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t -enable-experimental-feature ImportCxxMembersLazily > %t/interface.swift
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t > %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-STD < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-SIZE-T < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-TO-STRING < %t/interface.swift
@@ -9,10 +9,9 @@
 
 // This test is specific to libstdc++ and only runs on platforms where libstdc++ is used.
 // REQUIRES: OS=linux-gnu
-//
+
 // The RHS of basic_string's typealias value_type depends on how eagerly/lazily
 // we import type members
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection, CxxIterable {

--- a/test/Interop/Cxx/templates/function-template-parameter-pack-typechecker.swift
+++ b/test/Interop/Cxx/templates/function-template-parameter-pack-typechecker.swift
@@ -1,12 +1,6 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -cxx-interoperability-mode=default \
 // RUN:   -I %S/Inputs
-// RUN: %target-typecheck-verify-swift \
-// RUN:   -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
-// RUN:   -I %S/Inputs
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 import FunctionTemplateParameterPack
 

--- a/test/Interop/Cxx/templates/invalid-return-type.swift
+++ b/test/Interop/Cxx/templates/invalid-return-type.swift
@@ -1,21 +1,16 @@
 // RUN: split-file %s %t
 // RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/cxx.cpp
 // RUN: %target-swift-frontend -typecheck -verify \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
 // RUN:   %t%{fs-sep}ok.swift
 // RUN: %target-swift-frontend -typecheck -verify \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix err-
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
 // RUN:   -module-to-print=CxxModule | %FileCheck %t/Inputs/CxxHeader.h
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
@@ -1,11 +1,5 @@
 // RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
 // RUN: | %FileCheck %s
-//
-// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
-// RUN: | %FileCheck %s
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 import TemplateTypeParameterNotInSignature
 

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
@@ -1,8 +1,4 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 import TemplateTypeParameterNotInSignature
 

--- a/test/Interop/Cxx/templates/using-return-type.swift
+++ b/test/Interop/Cxx/templates/using-return-type.swift
@@ -7,12 +7,9 @@
 
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}main.swift \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
 // RUN:   -suppress-notes \
 // RUN:   -cxx-interoperability-mode=default
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module CxxModule {


### PR DESCRIPTION
This patch set enables ImportCxxMembersLazily by default, which causes C++ type and function members to be looked up and imported lazily (with caveats around constructors and operators).

This patch set also includes a couple of small compiler changes.

- Previously, in ClangRecordMemberLoader, we were not correctly loading non-constructors that are imported as constructors via `SWIFT_NAME(init(...))`, due to logic in ClangRecordMemberLoader that accounts for the eager import behavior of normal constructors. That is fixed.
- Previously, with ImportCxxMembersLazily enabled, we instantiated the return type of `begin()` lazily. It turns out we need to do so eagerly in order to compute derived conformances for the C++ collection protocols.

rdar://185444478