### PR TITLE
[6.4] Cherry pick missing TBD fixes for Distributed properties

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -790,6 +790,7 @@ public:
     LinkEntity::Kind kind;
     switch (declRef.kind) {
     case SILDeclRef::Kind::Func:
+    case SILDeclRef::Kind::DistributedThunk:
       kind = Kind::DispatchThunk;
       break;
     case SILDeclRef::Kind::Initializer:
@@ -823,6 +824,7 @@ public:
     LinkEntity::Kind kind;
     switch (declRef.kind) {
     case SILDeclRef::Kind::Func:
+    case SILDeclRef::Kind::DistributedThunk:
       kind = Kind::MethodDescriptor;
       break;
     case SILDeclRef::Kind::Initializer:

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -169,9 +169,13 @@ struct SILDeclRef {
     /// The asynchronous main entry-point function.
     AsyncEntryPoint,
 
-    /// An init accessor that calls a propery wrapped field's
+    /// An init accessor that calls a property wrapped field's
     /// backing storage initializer
-    PropertyWrappedFieldInitAccessor
+    PropertyWrappedFieldInitAccessor,
+
+    /// A `distributed_thunk` for a distributed func or distributed computed
+    /// property.
+    DistributedThunk
   };
 
   /// Represents the variants of a back deployable function.
@@ -195,8 +199,6 @@ struct SILDeclRef {
   Kind kind : 5;
   /// True if this references a foreign entry point for the referenced decl.
   unsigned isForeign : 1;
-  /// True if this references a distributed function.
-  unsigned distributedThunk : 1;
   /// True if this references a distributed function, but it is known to be local
   unsigned isKnownToBeLocal : 1;
   /// True is this reference to function that could be looked up via a special
@@ -240,7 +242,7 @@ struct SILDeclRef {
 
   /// Produces a null SILDeclRef.
   SILDeclRef()
-      : loc(), kind(Kind::Func), isForeign(0), distributedThunk(0),
+      : loc(), kind(Kind::Func), isForeign(0),
         isKnownToBeLocal(0), isRuntimeAccessible(0),
         backDeploymentKind(BackDeploymentKind::None), defaultArgIndex(0),
         isAsyncLetClosure(0) {}
@@ -249,7 +251,6 @@ struct SILDeclRef {
   explicit SILDeclRef(
       ValueDecl *decl, Kind kind,
       bool isForeign = false,
-      bool isDistributed = false,
       bool isDistributedKnownToBeLocal = false,
       bool isRuntimeAccessible = false,
       BackDeploymentKind backDeploymentKind = BackDeploymentKind::None,
@@ -269,7 +270,6 @@ struct SILDeclRef {
   explicit SILDeclRef(
       Loc loc,
       bool isForeign = false,
-      bool isDistributed = false,
       bool isDistributedLocal = false);
 
   /// See above put produces a prespecialization according to the signature.
@@ -299,7 +299,11 @@ struct SILDeclRef {
   bool hasAutoClosureExpr() const;
   bool hasFuncDecl() const;
 
-  ValueDecl *getDecl() const { return loc.dyn_cast<ValueDecl *>(); }
+  /// The AST node that originated this SILDeclRef, without any decl ref kind
+  /// specific substitutions done by `getDecl()`.
+  ValueDecl *getOriginalDecl() const { return loc.dyn_cast<ValueDecl *>(); }
+
+  ValueDecl *getDecl() const;
   AbstractClosureExpr *getAbstractClosureExpr() const {
     return loc.dyn_cast<AbstractClosureExpr *>();
   }
@@ -436,7 +440,6 @@ struct SILDeclRef {
   bool operator==(SILDeclRef rhs) const {
     return loc.getOpaqueValue() == rhs.loc.getOpaqueValue() &&
            kind == rhs.kind && isForeign == rhs.isForeign &&
-           distributedThunk == rhs.distributedThunk &&
            backDeploymentKind == rhs.backDeploymentKind &&
            defaultArgIndex == rhs.defaultArgIndex && pointer == rhs.pointer &&
            isAsyncLetClosure == rhs.isAsyncLetClosure;
@@ -455,17 +458,18 @@ struct SILDeclRef {
   SILDeclRef asForeign(bool foreign = true) const {
     return SILDeclRef(loc.getOpaqueValue(), kind,
                       /*foreign=*/foreign,
-                      /*distributed=*/false,
                       /*knownToBeLocal=*/false,
                       /*runtimeAccessible=*/false, backDeploymentKind,
                       defaultArgIndex, isAsyncLetClosure,
                       cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
   }
   /// Returns the distributed entry point corresponding to the same decl.
-  SILDeclRef asDistributed(bool distributed = true) const {
-    return SILDeclRef(loc.getOpaqueValue(), kind,
+  SILDeclRef asDistributedThunk(bool distributed = true) const {
+    Kind newKind = distributed ? Kind::DistributedThunk
+                               : (kind == Kind::DistributedThunk ? Kind::Func
+                                                                 : kind);
+    return SILDeclRef(loc.getOpaqueValue(), newKind,
                       /*foreign=*/false,
-                      /*distributed=*/distributed,
                       /*knownToBeLocal=*/false, isRuntimeAccessible,
                       backDeploymentKind, defaultArgIndex, isAsyncLetClosure,
                       cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
@@ -476,7 +480,6 @@ struct SILDeclRef {
   SILDeclRef asDistributedKnownToBeLocal(bool isLocal = true) const {
     return SILDeclRef(loc.getOpaqueValue(), kind,
                       /*foreign=*/false,
-                      /*distributed=*/false,
                       /*distributedKnownToBeLocal=*/isLocal,
                       isRuntimeAccessible, backDeploymentKind, defaultArgIndex,
                       isAsyncLetClosure,
@@ -492,7 +495,7 @@ struct SILDeclRef {
 
   /// Returns a copy of the decl with the given back deployment kind.
   SILDeclRef asBackDeploymentKind(BackDeploymentKind backDeploymentKind) const {
-    return SILDeclRef(loc.getOpaqueValue(), kind, isForeign, distributedThunk,
+    return SILDeclRef(loc.getOpaqueValue(), kind, isForeign,
                       isKnownToBeLocal, isRuntimeAccessible, backDeploymentKind,
                       defaultArgIndex, isAsyncLetClosure,
                       cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
@@ -541,6 +544,7 @@ struct SILDeclRef {
   FuncDecl *getDistributedThunk() const;
 
   /// True if the decl references a 'distributed' function.
+  /// A distributed thunk is NOT 'distributed', it's just a normal nonisolated func.
   bool isDistributed() const;
 
   /// True if the decl ref references a thunk handling a call to a function that
@@ -649,7 +653,6 @@ struct SILDeclRef {
                 : 0),
         llvm::hash_value(ref.isForeign),
         llvm::hash_value(ref.pointer.getOpaqueValue()),
-        llvm::hash_value(ref.distributedThunk),
         llvm::hash_value(unsigned(ref.backDeploymentKind)),
         llvm::hash_value(ref.isKnownToBeLocal),
         llvm::hash_value(ref.isRuntimeAccessible),
@@ -660,13 +663,13 @@ private:
   friend struct llvm::DenseMapInfo<swift::SILDeclRef>;
   /// Produces a SILDeclRef from an opaque value.
   explicit SILDeclRef(void *opaqueLoc, Kind kind, bool isForeign,
-                      bool isDistributedThunk, bool isKnownToBeLocal,
+                      bool isKnownToBeLocal,
                       bool isRuntimeAccessible,
                       BackDeploymentKind backDeploymentKind,
                       unsigned defaultArgIndex, bool isAsyncLetClosure,
                       AutoDiffDerivativeFunctionIdentifier *derivativeId)
       : loc(Loc::getFromOpaqueValue(opaqueLoc)), kind(kind),
-        isForeign(isForeign), distributedThunk(isDistributedThunk),
+        isForeign(isForeign),
         isKnownToBeLocal(isKnownToBeLocal),
         isRuntimeAccessible(isRuntimeAccessible),
         backDeploymentKind(backDeploymentKind),
@@ -694,13 +697,11 @@ template<> struct DenseMapInfo<swift::SILDeclRef> {
 
   static SILDeclRef getEmptyKey() {
     return SILDeclRef(PointerInfo::getEmptyKey(), Kind::Func, false, false,
-                      false, false, BackDeploymentKind::None, 0, false,
-                      nullptr);
+                      false, BackDeploymentKind::None, 0, false, nullptr);
   }
   static SILDeclRef getTombstoneKey() {
     return SILDeclRef(PointerInfo::getTombstoneKey(), Kind::Func, false, false,
-                      false, false, BackDeploymentKind::None, 0, false,
-                      nullptr);
+                      false, BackDeploymentKind::None, 0, false, nullptr);
   }
   static unsigned getHashValue(swift::SILDeclRef Val) {
     return hash_value(Val);

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -299,10 +299,6 @@ struct SILDeclRef {
   bool hasAutoClosureExpr() const;
   bool hasFuncDecl() const;
 
-  /// The AST node that originated this SILDeclRef, without any decl ref kind
-  /// specific substitutions done by `getDecl()`.
-  ValueDecl *getOriginalDecl() const { return loc.dyn_cast<ValueDecl *>(); }
-
   ValueDecl *getDecl() const;
   AbstractClosureExpr *getAbstractClosureExpr() const {
     return loc.dyn_cast<AbstractClosureExpr *>();
@@ -463,17 +459,8 @@ struct SILDeclRef {
                       defaultArgIndex, isAsyncLetClosure,
                       cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
   }
-  /// Returns the distributed entry point corresponding to the same decl.
-  SILDeclRef asDistributedThunk(bool distributed = true) const {
-    Kind newKind = distributed ? Kind::DistributedThunk
-                               : (kind == Kind::DistributedThunk ? Kind::Func
-                                                                 : kind);
-    return SILDeclRef(loc.getOpaqueValue(), newKind,
-                      /*foreign=*/false,
-                      /*knownToBeLocal=*/false, isRuntimeAccessible,
-                      backDeploymentKind, defaultArgIndex, isAsyncLetClosure,
-                      cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
-  }
+  /// Returns a SILDeclRef pointing to the corresponding 'distributed_thunk' of the current loc.
+  SILDeclRef getDistributedThunkDeclRef() const;
 
   /// Returns the distributed known-to-be-local entry point corresponding to
   /// the same decl.
@@ -661,20 +648,12 @@ struct SILDeclRef {
 
 private:
   friend struct llvm::DenseMapInfo<swift::SILDeclRef>;
-  /// Produces a SILDeclRef from an opaque value.
   explicit SILDeclRef(void *opaqueLoc, Kind kind, bool isForeign,
                       bool isKnownToBeLocal,
                       bool isRuntimeAccessible,
                       BackDeploymentKind backDeploymentKind,
                       unsigned defaultArgIndex, bool isAsyncLetClosure,
-                      AutoDiffDerivativeFunctionIdentifier *derivativeId)
-      : loc(Loc::getFromOpaqueValue(opaqueLoc)), kind(kind),
-        isForeign(isForeign),
-        isKnownToBeLocal(isKnownToBeLocal),
-        isRuntimeAccessible(isRuntimeAccessible),
-        backDeploymentKind(backDeploymentKind),
-        defaultArgIndex(defaultArgIndex), isAsyncLetClosure(isAsyncLetClosure),
-        pointer(derivativeId) {}
+                      AutoDiffDerivativeFunctionIdentifier *derivativeId);
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILDeclRef C) {

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -198,12 +198,10 @@ private:
     if (!AFD)
       return;
 
-    auto thunk = AFD->getDistributedThunk();
-    if (!thunk)
+    if (!AFD->getDistributedThunk())
       return;
 
-    SILDeclRef declRef(thunk, kind);
-    asDerived().addMethod(declRef.asDistributedThunk());
+    asDerived().addMethod(SILDeclRef(AFD, kind).getDistributedThunkDeclRef());
   }
 };
 

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -203,7 +203,7 @@ private:
       return;
 
     SILDeclRef declRef(thunk, kind);
-    asDerived().addMethod(declRef.asDistributed());
+    asDerived().addMethod(declRef.asDistributedThunk());
   }
 };
 

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -155,7 +155,7 @@ public:
       auto *requirement = cast<AbstractFunctionDecl *>(target);
       Type = IGF.IGM.getSILTypes().getConstantFunctionType(
           IGF.IGM.getMaximalTypeExpansionContext(),
-          SILDeclRef(requirement).asDistributedThunk());
+          SILDeclRef(requirement).getDistributedThunkDeclRef());
     }
   }
 
@@ -875,7 +875,7 @@ FunctionPointer AccessorTarget::getPointerToTarget(llvm::Value *actorSelf) {
 
   auto *requirementDecl = cast<AbstractFunctionDecl *>(Target);
   auto *protocol = requirementDecl->getDeclContext()->getSelfProtocolDecl();
-  SILDeclRef requirementRef = SILDeclRef(requirementDecl).asDistributedThunk();
+  SILDeclRef requirementRef = SILDeclRef(requirementDecl).getDistributedThunkDeclRef();
 
   if (!IGM.isResilient(protocol, ResilienceExpansion::Maximal)) {
     auto *witness = getWitnessMetadata(actorSelf);

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -155,7 +155,7 @@ public:
       auto *requirement = cast<AbstractFunctionDecl *>(target);
       Type = IGF.IGM.getSILTypes().getConstantFunctionType(
           IGF.IGM.getMaximalTypeExpansionContext(),
-          SILDeclRef(requirement).asDistributed());
+          SILDeclRef(requirement).asDistributedThunk());
     }
   }
 
@@ -875,7 +875,7 @@ FunctionPointer AccessorTarget::getPointerToTarget(llvm::Value *actorSelf) {
 
   auto *requirementDecl = cast<AbstractFunctionDecl *>(Target);
   auto *protocol = requirementDecl->getDeclContext()->getSelfProtocolDecl();
-  SILDeclRef requirementRef = SILDeclRef(requirementDecl).asDistributed();
+  SILDeclRef requirementRef = SILDeclRef(requirementDecl).asDistributedThunk();
 
   if (!IGM.isResilient(protocol, ResilienceExpansion::Maximal)) {
     auto *witness = getWitnessMetadata(actorSelf);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1033,7 +1033,7 @@ namespace {
               entry.getFunction().getAutoDiffDerivativeFunctionIdentifier());
         if (entry.getFunction().isDistributedThunk()) {
           flags = flags.withIsAsync(true);
-          declRef = declRef.asDistributedThunk();
+          declRef = declRef.getDistributedThunkDeclRef();
         }
         addDiscriminator(flags, schema, declRef);
       }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1033,7 +1033,7 @@ namespace {
               entry.getFunction().getAutoDiffDerivativeFunctionIdentifier());
         if (entry.getFunction().isDistributedThunk()) {
           flags = flags.withIsAsync(true);
-          declRef = declRef.asDistributed();
+          declRef = declRef.asDistributedThunk();
         }
         addDiscriminator(flags, schema, declRef);
       }

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -672,8 +672,9 @@ namespace {
       case SILDeclRef::Kind::Deallocator:
         Text = "dealloc";
         break;
-          
+
       case SILDeclRef::Kind::Func:
+      case SILDeclRef::Kind::DistributedThunk:
         Text = cast<FuncDecl>(ref.getDecl())->getObjCSelector()
                  .getString(Buffer);
         break;

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -950,7 +950,8 @@ namespace {
       // ProtocolDescriptorBuilder::getRequirementInfo.
       assert((isa<ConstructorDecl>(func.getDecl())
                   ? (func.kind == SILDeclRef::Kind::Allocator)
-                  : (func.kind == SILDeclRef::Kind::Func)) &&
+                  : (func.kind == SILDeclRef::Kind::Func ||
+                     func.kind == SILDeclRef::Kind::DistributedThunk)) &&
              "unexpected kind for protocol witness declaration ref");
       Entries.push_back(WitnessTableEntry::forFunction(func));
     }

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -507,7 +507,8 @@ std::string LinkEntity::mangleAsString(ASTContext &Ctx) const {
   }
   case Kind::DistributedThunkAsyncFunctionPointer: {
     std::string Result = getSILDeclRef().mangle();
-    Result.append("TE");
+    assert(StringRef(Result).ends_with("TE") &&
+           "expected distributed thunk mangling ending with 'TE'");
     Result.append("Tu");
     return Result;
   }
@@ -626,7 +627,7 @@ SILDeclRef::Kind LinkEntity::getSILDeclRefKind() const {
 SILDeclRef LinkEntity::getSILDeclRef() const {
   auto ref = SILDeclRef(const_cast<ValueDecl *>(getDecl()), getSILDeclRefKind());
   if (getKind() == Kind::DistributedAccessor)
-    return ref.asDistributed();
+    return ref.asDistributedThunk();
   return ref;
 }
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -627,7 +627,7 @@ SILDeclRef::Kind LinkEntity::getSILDeclRefKind() const {
 SILDeclRef LinkEntity::getSILDeclRef() const {
   auto ref = SILDeclRef(const_cast<ValueDecl *>(getDecl()), getSILDeclRefKind());
   if (getKind() == Kind::DistributedAccessor)
-    return ref.asDistributedThunk();
+    return ref.getDistributedThunkDeclRef();
   return ref;
 }
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -133,20 +133,19 @@ bool swift::requiresForeignEntryPoint(ValueDecl *vd) {
 }
 
 SILDeclRef::SILDeclRef(ValueDecl *vd, SILDeclRef::Kind kind, bool isForeign,
-                       bool isDistributedThunk, bool isKnownToBeLocal,
+                       bool isKnownToBeLocal,
                        bool isRuntimeAccessible,
                        SILDeclRef::BackDeploymentKind backDeploymentKind,
                        AutoDiffDerivativeFunctionIdentifier *derivativeId)
     : loc(vd), kind(kind),
       isForeign(isForeign),
-      distributedThunk(isDistributedThunk),
       isKnownToBeLocal(isKnownToBeLocal),
       isRuntimeAccessible(isRuntimeAccessible),
       backDeploymentKind(backDeploymentKind), defaultArgIndex(0),
       isAsyncLetClosure(0), pointer(derivativeId) {}
 
 SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc, bool asForeign,
-                       bool asDistributed, bool asDistributedKnownToBeLocal)
+                       bool asDistributedKnownToBeLocal)
     : isRuntimeAccessible(false),
       backDeploymentKind(SILDeclRef::BackDeploymentKind::None),
       defaultArgIndex(0), isAsyncLetClosure(0),
@@ -197,14 +196,21 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc, bool asForeign,
   }
 
   isForeign = asForeign;
-  distributedThunk = asDistributed;
   isKnownToBeLocal = asDistributedKnownToBeLocal;
 }
 
 SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
                        GenericSignature prespecializedSig)
-    : SILDeclRef(baseLoc, false, false) {
+    : SILDeclRef(baseLoc, /*asForeign=*/false) {
   pointer = prespecializedSig.getPointer();
+}
+
+ValueDecl *SILDeclRef::getDecl() const {
+  if (kind == Kind::DistributedThunk) {
+    if (auto *thunk = getDistributedThunk())
+      return thunk;
+  }
+  return getOriginalDecl();
 }
 
 std::optional<AnyFunctionRef> SILDeclRef::getAnyFunctionRef() const {
@@ -402,6 +408,7 @@ bool SILDeclRef::hasUserWrittenCode() const {
   case Kind::PropertyWrapperInitFromProjectedValue:
   case Kind::EntryPoint:
   case Kind::AsyncEntryPoint:
+  case Kind::DistributedThunk:
     // Implicit decls for these don't splice in user-written code.
     return false;
   }
@@ -501,6 +508,7 @@ static LinkageLimit getLinkageLimit(SILDeclRef constant) {
 
   switch (constant.kind) {
   case Kind::Func:
+  case Kind::DistributedThunk:
   case Kind::Allocator:
   case Kind::Initializer:
   case Kind::Deallocator:
@@ -1317,22 +1325,29 @@ bool SILDeclRef::isNativeToForeignThunk() const {
 }
 
 bool SILDeclRef::isDistributedThunk() const {
-  if (!distributedThunk)
-    return false;
-  return kind == Kind::Func;
+  return kind == Kind::DistributedThunk;
 }
 
 FuncDecl *SILDeclRef::getDistributedThunk() const {
   if (!isDistributedThunk())
     return nullptr;
-  if (auto *afd = getAbstractFunctionDecl())
-    return afd->getDistributedThunk();
-  return nullptr;
+  auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(getOriginalDecl());
+  if (!afd)
+    return nullptr;
+  return afd->getDistributedThunk();
 }
 
 bool SILDeclRef::isDistributed() const {
   if (!hasFuncDecl())
     return false;
+
+  // For a distributed thunk ref, look at the *original* decl -- the
+  // synthesized thunk itself is not marked `distributed`.
+  if (auto *afd =
+          dyn_cast_or_null<AbstractFunctionDecl>(getOriginalDecl())) {
+    if (afd->isDistributed())
+      return true;
+  }
 
   if (auto decl = getFuncDecl()) {
     return decl->isDistributed();
@@ -1464,15 +1479,15 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
         return NameA->Name.str();
       }
 
-    if (SKind == ASTMangler::SymbolKind::DistributedThunk) {
-      return mangler.mangleDistributedThunk(cast<FuncDecl>(getDecl()));
-    }
-
     // Otherwise, fall through into the 'other decl' case.
     LLVM_FALLTHROUGH;
 
   case SILDeclRef::Kind::EnumElement:
     return mangler.mangleEntity(getDecl(), SKind);
+
+  case SILDeclRef::Kind::DistributedThunk:
+    assert(SKind == ASTMangler::SymbolKind::DistributedThunk);
+    return mangler.mangleDistributedThunk(cast<FuncDecl>(getDecl()));
 
   case SILDeclRef::Kind::Deallocator:
     return mangler.mangleDestructorEntity(cast<DestructorDecl>(getDecl()),

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -132,6 +132,22 @@ bool swift::requiresForeignEntryPoint(ValueDecl *vd) {
   return false;
 }
 
+/// Best effort assert that a `Kind::DistributedThunk` SILDeclRef is
+/// being constructed with `vd` pointing at a distributed_thunk, not the
+/// original 'distributed' decl.
+static void assertDistributedThunkLoc(ValueDecl *vd, SILDeclRef::Kind kind) {
+#ifndef NDEBUG
+  if (kind != SILDeclRef::Kind::DistributedThunk)
+    return;
+  auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(vd);
+  if (!afd)
+    return;
+  auto *thunk = afd->getDistributedThunk();
+  assert((!thunk || thunk == afd) &&
+         "SILDeclRef with DistributedThunk kind must be a distributed_thunk");
+#endif
+}
+
 SILDeclRef::SILDeclRef(ValueDecl *vd, SILDeclRef::Kind kind, bool isForeign,
                        bool isKnownToBeLocal,
                        bool isRuntimeAccessible,
@@ -142,7 +158,25 @@ SILDeclRef::SILDeclRef(ValueDecl *vd, SILDeclRef::Kind kind, bool isForeign,
       isKnownToBeLocal(isKnownToBeLocal),
       isRuntimeAccessible(isRuntimeAccessible),
       backDeploymentKind(backDeploymentKind), defaultArgIndex(0),
-      isAsyncLetClosure(0), pointer(derivativeId) {}
+      isAsyncLetClosure(0), pointer(derivativeId) {
+  assertDistributedThunkLoc(vd, kind);
+}
+
+SILDeclRef::SILDeclRef(void *opaqueLoc, Kind kind, bool isForeign,
+                       bool isKnownToBeLocal,
+                       bool isRuntimeAccessible,
+                       BackDeploymentKind backDeploymentKind,
+                       unsigned defaultArgIndex, bool isAsyncLetClosure,
+                       AutoDiffDerivativeFunctionIdentifier *derivativeId)
+    : loc(Loc::getFromOpaqueValue(opaqueLoc)), kind(kind),
+      isForeign(isForeign),
+      isKnownToBeLocal(isKnownToBeLocal),
+      isRuntimeAccessible(isRuntimeAccessible),
+      backDeploymentKind(backDeploymentKind),
+      defaultArgIndex(defaultArgIndex), isAsyncLetClosure(isAsyncLetClosure),
+      pointer(derivativeId) {
+  assertDistributedThunkLoc(loc.dyn_cast<ValueDecl *>(), kind);
+}
 
 SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc, bool asForeign,
                        bool asDistributedKnownToBeLocal)
@@ -205,12 +239,29 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
   pointer = prespecializedSig.getPointer();
 }
 
-ValueDecl *SILDeclRef::getDecl() const {
-  if (kind == Kind::DistributedThunk) {
-    if (auto *thunk = getDistributedThunk())
-      return thunk;
+SILDeclRef SILDeclRef::getDistributedThunkDeclRef() const {
+  auto opaqueLoc = loc.getOpaqueValue();
+
+  // Make sure the new 'loc' is a distributed thunk.
+  // If we're in a decl that as a distributed thunk, get it and store it as the new loc.
+  // If it already is the right decl, this still just works.
+  if (auto *afd =
+          dyn_cast_or_null<AbstractFunctionDecl>(loc.dyn_cast<ValueDecl *>())) {
+    auto *thunk = afd->getDistributedThunk();
+    assert(thunk && "decl has no synthesized distributed thunk to point at, "
+                    "this is a mistake in the compiler in how asDistributed() is used");
+    opaqueLoc = Loc(thunk).getOpaqueValue();
   }
-  return getOriginalDecl();
+
+  return SILDeclRef(opaqueLoc, Kind::DistributedThunk,
+                    /*foreign=*/false,
+                    /*knownToBeLocal=*/false, isRuntimeAccessible,
+                    backDeploymentKind, defaultArgIndex, isAsyncLetClosure,
+                    cast<AutoDiffDerivativeFunctionIdentifier *>(pointer));
+}
+
+ValueDecl *SILDeclRef::getDecl() const {
+  return loc.dyn_cast<ValueDecl *>();
 }
 
 std::optional<AnyFunctionRef> SILDeclRef::getAnyFunctionRef() const {
@@ -1331,28 +1382,14 @@ bool SILDeclRef::isDistributedThunk() const {
 FuncDecl *SILDeclRef::getDistributedThunk() const {
   if (!isDistributedThunk())
     return nullptr;
-  auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(getOriginalDecl());
-  if (!afd)
-    return nullptr;
-  return afd->getDistributedThunk();
+  // With `kind == Kind::DistributedThunk`, `loc` is the synthesized thunk
+  // itself (normalized at construction time).
+  return dyn_cast_or_null<FuncDecl>(loc.dyn_cast<ValueDecl *>());
 }
 
 bool SILDeclRef::isDistributed() const {
-  if (!hasFuncDecl())
-    return false;
-
-  // For a distributed thunk ref, look at the *original* decl -- the
-  // synthesized thunk itself is not marked `distributed`.
-  if (auto *afd =
-          dyn_cast_or_null<AbstractFunctionDecl>(getOriginalDecl())) {
-    if (afd->isDistributed())
-      return true;
-  }
-
-  if (auto decl = getFuncDecl()) {
+  if (auto decl = getFuncDecl())
     return decl->isDistributed();
-  }
-
   return false;
 }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3536,7 +3536,8 @@ static CanSILFunctionType getNativeSILFunctionType(
       return getSILFunctionTypeForConventions(DefaultInitializerConventions());
     case SILDeclRef::Kind::Allocator:
       return getSILFunctionTypeForConventions(DefaultAllocatorConventions());
-    case SILDeclRef::Kind::Func: {
+    case SILDeclRef::Kind::Func:
+    case SILDeclRef::Kind::DistributedThunk: {
       // If we have a setter, use the special setter convention. This ensures
       // that we take normal parameters at +1.
       if (constant) {
@@ -4441,6 +4442,7 @@ static ObjCSelectorFamily getObjCSelectorFamily(SILDeclRef c) {
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
   case SILDeclRef::Kind::EntryPoint:
   case SILDeclRef::Kind::AsyncEntryPoint:
+  case SILDeclRef::Kind::DistributedThunk:
     llvm_unreachable("Unexpected Kind of foreign SILDeclRef");
   }
 
@@ -4780,6 +4782,7 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
       return SILFunctionTypeRepresentation::Thin;
 
     case SILDeclRef::Kind::Func:
+    case SILDeclRef::Kind::DistributedThunk:
       if (c.getDecl()->getDeclContext()->isTypeContext())
         return SILFunctionTypeRepresentation::Method;
       return SILFunctionTypeRepresentation::Thin;
@@ -5165,6 +5168,7 @@ CanAnyFunctionType TypeConverter::getBridgedFunctionType(
 static AbstractFunctionDecl *getBridgedFunction(SILDeclRef declRef) {
   switch (declRef.kind) {
   case SILDeclRef::Kind::Func:
+  case SILDeclRef::Kind::DistributedThunk:
   case SILDeclRef::Kind::Allocator:
   case SILDeclRef::Kind::Initializer:
     return (declRef.hasDecl()

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -346,7 +346,7 @@ void SILDeclRef::print(raw_ostream &OS) const {
     OS << "<file>";
     break;
   case LocKind::Decl: {
-    if (kind != Kind::Func) {
+    if (kind != Kind::Func && kind != Kind::DistributedThunk) {
       printValueDecl(getDecl(), OS);
       break;
     }
@@ -356,11 +356,9 @@ void SILDeclRef::print(raw_ostream &OS) const {
       printValueDecl(getDecl(), OS);
       if (isDistributed()) {
         OS << "!distributed";
-        OS << "(" << getDecl() << ")";
       }
       if (isDistributedThunk()) {
         OS << "!distributed_thunk";
-        OS << "(" << getDecl() << ")";
       }
       isDot = false;
       break;
@@ -369,11 +367,9 @@ void SILDeclRef::print(raw_ostream &OS) const {
     printValueDecl(accessor->getStorage(), OS);
     if (isDistributed()) {
       OS << "!distributed";
-      OS << "(" << getDecl() << ")";
     }
     if (isDistributedThunk()) {
       OS << "!distributed_thunk";
-      OS << "(" << getDecl() << ")";
     }
     switch (accessor->getAccessorKind()) {
     case AccessorKind::WillSet:
@@ -469,6 +465,9 @@ void SILDeclRef::print(raw_ostream &OS) const {
     break;
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
     OS << "!projectedvalueinit";
+    break;
+  case SILDeclRef::Kind::DistributedThunk:
+    // Already handled in the LocKind::Decl branch above.
     break;
   }
 

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -507,8 +507,8 @@ public:
       }
     }
 
-    if (auto distributedThunk = AFD->getDistributedThunk()) {
-      auto thunk = SILDeclRef(distributedThunk).asDistributedThunk();
+    if (AFD->getDistributedThunk()) {
+      auto thunk = SILDeclRef(AFD).getDistributedThunkDeclRef();
       addFunction(thunk);
       addAsyncFunctionPointer(thunk);
     }

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -508,7 +508,7 @@ public:
     }
 
     if (auto distributedThunk = AFD->getDistributedThunk()) {
-      auto thunk = SILDeclRef(distributedThunk).asDistributed();
+      auto thunk = SILDeclRef(distributedThunk).asDistributedThunk();
       addFunction(thunk);
       addAsyncFunctionPointer(thunk);
     }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4360,15 +4360,11 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
     return cast<AnyFunctionType>(derivativeFnTy->getCanonicalType());
   }
 
-  auto *vd = c.loc.dyn_cast<ValueDecl *>();
-
-  // If the value is a distributed thunk, its isolation must be computed
-  // off the 'distributed_thunk', not the original decl.
-  if (auto *thunk = c.getDistributedThunk())
-    vd = thunk;
+  auto *vd = c.getDecl();
 
   switch (c.kind) {
-  case SILDeclRef::Kind::Func: {
+  case SILDeclRef::Kind::Func:
+  case SILDeclRef::Kind::DistributedThunk: {
     CanAnyFunctionType funcTy;
     if (auto *ACE = c.loc.dyn_cast<AbstractClosureExpr *>()) {
       funcTy = cast<AnyFunctionType>(ACE->getType()->getCanonicalType());
@@ -4456,6 +4452,7 @@ TypeConverter::getGenericSignatureWithCapturedEnvironments(SILDeclRef c) {
   /// Get the function generic params, including outer params.
   switch (c.kind) {
   case SILDeclRef::Kind::Func:
+  case SILDeclRef::Kind::DistributedThunk:
   case SILDeclRef::Kind::Allocator:
   case SILDeclRef::Kind::Initializer:
   case SILDeclRef::Kind::Destroyer:

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1366,6 +1366,25 @@ static std::optional<AccessorKind> getAccessorKind(StringRef ident) {
       .Default(std::nullopt);
 }
 
+/// Consume an optional `(0x<addr>)` pointer payload.
+/// Only skips the payload if it looks exactly like a hex literal wrapped in parens,
+/// otherwise leaves produces a syntax error.
+static void consumeOptionalDeclPointerPayload(Parser &P) {
+  if (!P.Tok.is(tok::l_paren))
+    return;
+
+  Parser::CancellableBacktrackingScope backtrack(P);
+  P.consumeToken(tok::l_paren);
+  if (!P.Tok.is(tok::integer_literal) ||
+      !P.Tok.getText().starts_with("0x"))
+    return;
+  P.consumeToken(tok::integer_literal);
+  if (!P.Tok.is(tok::r_paren))
+    return;
+  P.consumeToken(tok::r_paren);
+  backtrack.cancelBacktrack();
+}
+
 ///  sil-decl-ref ::= '#' sil-identifier ('.' sil-identifier)* sil-decl-subref?
 ///  sil-decl-subref ::= '!' sil-decl-subref-part ('.' sil-decl-lang)?
 ///                      ('.' sil-decl-autodiff)?
@@ -1397,7 +1416,7 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
   if (!P.consumeIf(tok::sil_exclamation)) {
     // Construct SILDeclRef.
     Result = SILDeclRef(VD, Kind, IsObjC,
-                        /*distributed=*/false, /*knownToBeLocal=*/false,
+                        /*knownToBeLocal=*/false,
                         /*runtimeAccessible=*/false,
                         SILDeclRef::BackDeploymentKind::None, DerivativeId);
     return false;
@@ -1486,6 +1505,17 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
       } else if (Id.str() == "foreign") {
         IsObjC = true;
         break;
+      } else if (Id.str() == "distributed") {
+        // No need to store isDistributed=true, this is computed off the decl.
+        assert(Result.isDistributed() && "Parsed SILDeclRef has '!distributed' but referred to decl is not distributed!");
+        consumeOptionalDeclPointerPayload(P); // ignore payload of legacy `!distributed(0x...)`
+        ParseState = 1;
+        break;
+      } else if (Id.str() == "distributed_thunk") {
+        Kind = SILDeclRef::Kind::DistributedThunk;
+        consumeOptionalDeclPointerPayload(P); // ignore payload of legacy `!distributed_thunk(0x...)`
+        ParseState = 1;
+        break;
       } else if (Id.str() == "jvp" || Id.str() == "vjp") {
         IndexSubset *parameterIndices = nullptr;
         GenericSignature derivativeGenSig;
@@ -1525,7 +1555,7 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
 
   // Construct SILDeclRef.
   Result = SILDeclRef(VD, Kind, IsObjC,
-                      /*distributed=*/false, /*knownToBeLocal=*/false,
+                      /*knownToBeLocal=*/false,
                       /*runtimeAccessible=*/false,
                       SILDeclRef::BackDeploymentKind::None, DerivativeId);
   return false;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1513,6 +1513,10 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
         break;
       } else if (Id.str() == "distributed_thunk") {
         Kind = SILDeclRef::Kind::DistributedThunk;
+        if (auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(VD)) {
+          if (auto *thunk = afd->getDistributedThunk())
+            VD = thunk;
+        }
         consumeOptionalDeclPointerPayload(P); // ignore payload of legacy `!distributed_thunk(0x...)`
         ParseState = 1;
         break;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -996,7 +996,8 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
   }
 
   switch (constant.kind) {
-  case SILDeclRef::Kind::Func: {
+  case SILDeclRef::Kind::Func:
+  case SILDeclRef::Kind::DistributedThunk: {
     if (auto *ce = constant.getAbstractClosureExpr()) {
       preEmitFunction(constant, f, ce);
       PrettyStackTraceSILFunction X("silgen closureexpr", f);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -721,7 +721,7 @@ public:
       if (auto func = constant->getFuncDecl()) {
         if (SGF.shouldReplaceConstantForApplyWithDistributedThunk(func)) {
           auto thunk = func->getDistributedThunk();
-          constant = SILDeclRef(thunk).asDistributed();
+          constant = SILDeclRef(thunk).asDistributedThunk();
         }
       }
 
@@ -792,7 +792,7 @@ public:
           // If we're calling cross-actor, we must always use a distributed thunk
           if (!isSameActorIsolated(func, SGF.FunctionDC)) {
             /// We must adjust the constant to use a distributed thunk.
-            constant = constant->asDistributed();
+            constant = constant->asDistributedThunk();
           }
         }
       }
@@ -810,7 +810,7 @@ public:
     case Kind::WitnessMethod: {
       if (auto func = constant->getFuncDecl()) {
         if (SGF.shouldReplaceConstantForApplyWithDistributedThunk(func)) {
-          constant = constant->asDistributed();
+          constant = constant->asDistributedThunk();
         }
       }
 
@@ -1173,7 +1173,7 @@ public:
 
     SILDeclRef constant = SILDeclRef(afd);
     if (auto distributedThunk = afd->getDistributedThunk()) {
-      constant = SILDeclRef(distributedThunk).asDistributed();
+      constant = SILDeclRef(distributedThunk).asDistributedThunk();
     } else {
       constant = constant.asForeign(requiresForeignEntryPoint(afd));
     }
@@ -1202,7 +1202,7 @@ public:
     // A call to a `distributed` function may need to go through a thunk.
     if (callSite && callSite->shouldApplyDistributedThunk()) {
       if (auto distributedThunk = afd->getDistributedThunk())
-        return SILDeclRef(distributedThunk).asDistributed();
+        return SILDeclRef(distributedThunk).asDistributedThunk();
     }
 
     // A call to `@backDeployed` function may need to go through a thunk.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -720,8 +720,7 @@ public:
     case Kind::WitnessMethod: {
       if (auto func = constant->getFuncDecl()) {
         if (SGF.shouldReplaceConstantForApplyWithDistributedThunk(func)) {
-          auto thunk = func->getDistributedThunk();
-          constant = SILDeclRef(thunk).asDistributedThunk();
+          constant = constant->getDistributedThunkDeclRef();
         }
       }
 
@@ -791,8 +790,7 @@ public:
         if (func->getStorage()->isDistributed()) {
           // If we're calling cross-actor, we must always use a distributed thunk
           if (!isSameActorIsolated(func, SGF.FunctionDC)) {
-            /// We must adjust the constant to use a distributed thunk.
-            constant = constant->asDistributedThunk();
+            constant = constant->getDistributedThunkDeclRef();
           }
         }
       }
@@ -810,7 +808,7 @@ public:
     case Kind::WitnessMethod: {
       if (auto func = constant->getFuncDecl()) {
         if (SGF.shouldReplaceConstantForApplyWithDistributedThunk(func)) {
-          constant = constant->asDistributedThunk();
+          constant = constant->getDistributedThunkDeclRef();
         }
       }
 
@@ -1172,8 +1170,8 @@ public:
     }
 
     SILDeclRef constant = SILDeclRef(afd);
-    if (auto distributedThunk = afd->getDistributedThunk()) {
-      constant = SILDeclRef(distributedThunk).asDistributedThunk();
+    if (afd->getDistributedThunk()) {
+      constant = SILDeclRef(afd).getDistributedThunkDeclRef();
     } else {
       constant = constant.asForeign(requiresForeignEntryPoint(afd));
     }
@@ -1201,8 +1199,8 @@ public:
 
     // A call to a `distributed` function may need to go through a thunk.
     if (callSite && callSite->shouldApplyDistributedThunk()) {
-      if (auto distributedThunk = afd->getDistributedThunk())
-        return SILDeclRef(distributedThunk).asDistributedThunk();
+      if (afd->getDistributedThunk())
+        return SILDeclRef(afd).getDistributedThunkDeclRef();
     }
 
     // A call to `@backDeployed` function may need to go through a thunk.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4620,9 +4620,7 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
   }
 
   case AccessStrategy::DispatchToDistributedThunk: {
-    auto thunkRef = SILDeclRef(cast<VarDecl>(storage)->getDistributedThunk(),
-                               SILDeclRef::Kind::DistributedThunk,
-                               /*isForeign=*/false);
+    auto thunkRef = SILDeclRef(storage->getAccessor(AccessorKind::Get)).getDistributedThunkDeclRef();
     return SGM.getFunction(thunkRef, NotForDefinition);
   }
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4621,9 +4621,8 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
 
   case AccessStrategy::DispatchToDistributedThunk: {
     auto thunkRef = SILDeclRef(cast<VarDecl>(storage)->getDistributedThunk(),
-                               SILDeclRef::Kind::Func,
-                               /*isForeign=*/false,
-                               /*isDistributed=*/true);
+                               SILDeclRef::Kind::DistributedThunk,
+                               /*isForeign=*/false);
     return SGM.getFunction(thunkRef, NotForDefinition);
   }
   }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -183,6 +183,7 @@ DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
 DeclName SILGenModule::getMagicFunctionName(SILDeclRef ref) {
   switch (ref.kind) {
   case SILDeclRef::Kind::Func:
+  case SILDeclRef::Kind::DistributedThunk:
     if (auto closure = ref.getAbstractClosureExpr())
       return getMagicFunctionName(closure);
     return getMagicFunctionName(cast<FuncDecl>(ref.getDecl()));

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1577,7 +1577,8 @@ namespace {
         ActorIso(copied.ActorIso) {}
 
     AccessorDecl *getAccessorDecl() const {
-      return cast<AccessorDecl>(Accessor.getFuncDecl());
+      // Always use the original accessor, even if this is a distributed thunk.
+      return cast<AccessorDecl>(Accessor.getOriginalDecl());
     }
 
     ManagedValue emitValueForAssignOrInit(SILGenFunction &SGF, SILLocation loc,
@@ -4500,8 +4501,8 @@ void LValue::addMemberVarComponent(
     void emitUsingDistributedThunk() {
       auto *var = cast<VarDecl>(Storage);
       SILDeclRef accessor(var->getAccessor(AccessorKind::Get),
-                          SILDeclRef::Kind::Func,
-                          /*isForeign=*/false, /*isDistributed=*/true);
+                          SILDeclRef::Kind::DistributedThunk,
+                          /*isForeign=*/false);
 
       auto typeData = getLogicalStorageTypeData(
           SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1577,8 +1577,12 @@ namespace {
         ActorIso(copied.ActorIso) {}
 
     AccessorDecl *getAccessorDecl() const {
-      // Always use the original accessor, even if this is a distributed thunk.
-      return cast<AccessorDecl>(Accessor.getOriginalDecl());
+      auto *fd = cast<AccessorDecl>(Accessor.getFuncDecl());
+      // For a distributed thunk, `fd` is the synthesized `DistributedGet`
+      // accessor; the LValue path needs the original getter (Get / Set / ...).
+      if (fd->getAccessorKind() == AccessorKind::DistributedGet)
+        fd = fd->getStorage()->getAccessor(AccessorKind::Get);
+      return fd;
     }
 
     ManagedValue emitValueForAssignOrInit(SILGenFunction &SGF, SILLocation loc,
@@ -4500,7 +4504,7 @@ void LValue::addMemberVarComponent(
 
     void emitUsingDistributedThunk() {
       auto *var = cast<VarDecl>(Storage);
-      SILDeclRef accessor(var->getAccessor(AccessorKind::Get),
+      SILDeclRef accessor(var->getDistributedThunk(),
                           SILDeclRef::Kind::DistributedThunk,
                           /*isForeign=*/false);
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -120,8 +120,8 @@ void SILGenModule::emitDistributedThunkForDecl(
   if (!thunkDecl || !thunkDecl->hasBody() || thunkDecl->isBodySkipped())
     return;
 
-  auto thunk = SILDeclRef(thunkDecl).asDistributedThunk();
-  emitFunctionDefinition(SILDeclRef(thunkDecl).asDistributedThunk(),
+  auto thunk = SILDeclRef(thunkDecl).getDistributedThunkDeclRef();
+  emitFunctionDefinition(thunk,
                          getFunction(thunk, ForDefinition));
 }
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -120,8 +120,8 @@ void SILGenModule::emitDistributedThunkForDecl(
   if (!thunkDecl || !thunkDecl->hasBody() || thunkDecl->isBodySkipped())
     return;
 
-  auto thunk = SILDeclRef(thunkDecl).asDistributed();
-  emitFunctionDefinition(SILDeclRef(thunkDecl).asDistributed(),
+  auto thunk = SILDeclRef(thunkDecl).asDistributedThunk();
+  emitFunctionDefinition(SILDeclRef(thunkDecl).asDistributedThunk(),
                          getFunction(thunk, ForDefinition));
 }
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -758,10 +758,8 @@ SILFunction *SILGenModule::emitProtocolWitness(
        witnessRef.getFuncDecl()->isDistributed());
   if (shouldUseDistributedThunkWitness) {
     // we may not have a thunk if we're in a protocol?
-    if (auto thunk = witnessRef.getFuncDecl()->getDistributedThunk()) {
-      auto thunkDeclRef = SILDeclRef(thunk, SILDeclRef::Kind::Func);
-      witnessRef = thunkDeclRef.asDistributedThunk();
-    }
+    if (witnessRef.getFuncDecl()->getDistributedThunk())
+      witnessRef = witnessRef.getDistributedThunkDeclRef();
   }
 
   // Work out the lowered function type of the SIL witness thunk.

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -760,7 +760,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
     // we may not have a thunk if we're in a protocol?
     if (auto thunk = witnessRef.getFuncDecl()->getDistributedThunk()) {
       auto thunkDeclRef = SILDeclRef(thunk, SILDeclRef::Kind::Func);
-      witnessRef = thunkDeclRef.asDistributed();
+      witnessRef = thunkDeclRef.asDistributedThunk();
     }
   }
 

--- a/test/Distributed/distributed_thunk_sync_decl_cross_module.swift
+++ b/test/Distributed/distributed_thunk_sync_decl_cross_module.swift
@@ -9,7 +9,6 @@
 
 // Reproduces a SILFunction type mismatch uncovered by DistributedCluster.
 // This happens only for a synchronous distributed var decl, across modules.
-// rdar://180980491
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/distributed_var_tbd.swift
+++ b/test/Distributed/distributed_var_tbd.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+
+// The async function pointer of the distributed thunk synthesized for a
+// 'distributed var' must be mangled off the thunk ('...SiyYaKFTETu') and not
+// off the getter ('...SivgTETu'), otherwise TBDGen and IRGen disagree.
+// '-enable-testing' is required to make the internal declarations visible to
+// TBDGen, which is what SwiftPM does for debug builds.
+// RUN: %target-swift-frontend -c -o /dev/null %s -module-name Library -swift-version 5 -target %target-swift-5.7-abi-triple -I %t -parse-as-library -enable-testing -validate-tbd-against-ir=all
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+public distributed actor Pool {
+  internal distributed var internalSize: Int { 0 }
+
+  public distributed var publicSize: Int { 0 }
+
+  public distributed func size() -> Int { 0 }
+}

--- a/test/SIL/Parser/distributed_thunk.sil
+++ b/test/SIL/Parser/distributed_thunk.sil
@@ -1,0 +1,56 @@
+// RUN: %target-sil-opt --sil-disable-input-verify %s -module-name=test | %target-sil-opt --sil-disable-input-verify -module-name=test | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import _Concurrency
+
+// Two distinct protocols so we can hand-author two witness tables in the
+// same module without redeclaring the same conformance.
+
+protocol Greeter {
+  func greet() async throws -> String
+}
+
+protocol LegacyGreeter {
+  func greet() async throws -> String
+}
+
+class Impl : Greeter, LegacyGreeter {
+  init()
+  func greet() async throws -> String
+}
+
+sil @$greet_witness_A : $@convention(witness_method: Greeter) @async <T where T : Greeter> (@in_guaranteed T) -> (@owned String, @error any Error)
+sil @$greet_thunk_A : $@convention(witness_method: Greeter) @async <T where T : Greeter> (@in_guaranteed T) -> (@owned String, @error any Error)
+
+sil @$greet_witness_B : $@convention(witness_method: LegacyGreeter) @async <T where T : LegacyGreeter> (@in_guaranteed T) -> (@owned String, @error any Error)
+sil @$greet_thunk_B : $@convention(witness_method: LegacyGreeter) @async <T where T : LegacyGreeter> (@in_guaranteed T) -> (@owned String, @error any Error)
+
+// Properly parse `!distributed` and `!distributed_thunk`:
+//
+// CHECK-LABEL: sil_witness_table hidden Impl: Greeter module test
+// CHECK: method #Greeter.greet: {{.*}} : @$greet_witness_A
+// CHECK: method #Greeter.greet!distributed_thunk: {{.*}} : @$greet_thunk_A
+sil_witness_table hidden Impl: Greeter module test {
+  method #Greeter.greet: @$greet_witness_A
+  method #Greeter.greet!distributed_thunk: @$greet_thunk_A
+}
+
+// Legacy mode:
+// We used to emit the decl for debugging purposes but this isn't necessary so we removed it again.
+// To not cause disruption in parsing interfaces which may have the `(0x...)` we still  are able to parse these,
+// and just drop the debugging part.
+//
+// CHECK-LABEL: sil_witness_table hidden Impl: LegacyGreeter module test
+// CHECK: method #LegacyGreeter.greet: {{.*}} : @$greet_witness_B
+// CHECK: method #LegacyGreeter.greet!distributed_thunk: {{.*}} : @$greet_thunk_B
+// CHECK-NOT: method #LegacyGreeter.greet!distributed_thunk(0x
+sil_witness_table hidden Impl: LegacyGreeter module test {
+  method #LegacyGreeter.greet: @$greet_witness_B
+  method #LegacyGreeter.greet!distributed_thunk(0xdeadbeef): @$greet_thunk_B
+}

--- a/test/SILOptimizer/dead_function_elimination_distributed.swift
+++ b/test/SILOptimizer/dead_function_elimination_distributed.swift
@@ -36,9 +36,9 @@ distributed actor MyServiceImpl: MyService {
 // The witness table must still contain entries for the distributed func and thunk:
 // CHECK-LABEL: sil_witness_table hidden MyServiceImpl: MyService module dead_function_elimination_distributed {
 // protocol witness (TW):
-// CHECK:   method #MyService.distributedMethod!distributed({{.*}}): <Self where Self : MyService> (isolated Self) -> () async throws -> String : @$s37dead_function_elimination_distributed13MyServiceImplCAA0eF0A2aDP0D6MethodSSyYaKFTW
+// CHECK:   method #MyService.distributedMethod!distributed: <Self where Self : MyService> (isolated Self) -> () async throws -> String : @$s37dead_function_elimination_distributed13MyServiceImplCAA0eF0A2aDP0D6MethodSSyYaKFTW
 // protocol thunk witness (TWTE):
-// CHECK:   method #MyService.distributedMethod!distributed_thunk({{.*}}): <Self where Self : MyService> (Self) -> () async throws -> String : @$s37dead_function_elimination_distributed13MyServiceImplCAA0eF0A2aDP0D6MethodSSyYaKFTWTE
+// CHECK:   method #MyService.distributedMethod!distributed_thunk: <Self where Self : MyService> (Self) -> () async throws -> String : @$s37dead_function_elimination_distributed13MyServiceImplCAA0eF0A2aDP0D6MethodSSyYaKFTWTE
 
 // The not used not-distributed method witness was dead eliminated:
 // CHECK:   method #MyService.nonDistributedMethod: <Self where Self : MyService> (isolated Self) -> () -> () : nil


### PR DESCRIPTION
**Explanation**: 

TBDGen and IRGen mangled async function pointers for distributed thunk property accessors (`distributed var`) differently.  This manifests as compile crash when TBD validation is enabled; this also means that the source compatibility suite for cluster and similar projects is broken on 6.4 for this reason (since those builds validate TBD), making us lose important signal from the compat suite.

This was partially addressed in #90287 which was picked to 6.4, however a few commits from follow ups didn't make it to 6.4 - this cherry pick fixes that.

**Scope**: 
- Any type declaring a `distributed var` that is compiled with TBD validation

**Risk**: 
- Low
  - the change is only about TBD mangling 
  - both commits have been on main since early July with no fallout

**Testing**: 
- CI testing
- new tests added

**Original PR**:
- https://github.com/swiftlang/swift/pull/90287 which we picked the first commit over here https://github.com/swiftlang/swift/pull/90354 but we should have picked all three commits

**Reviewed by**:
- @xedin 

**Issues**: 
  - Resolves rdar://184492620
  - Resolves https://github.com/swiftlang/swift/issues/85557