### PR TITLE
[Runtime] Narrow Apple platform check for _swift_isPrivilegedProcess.

### DIFF
--- a/include/swift/Runtime/Privilege.h
+++ b/include/swift/Runtime/Privilege.h
@@ -24,8 +24,8 @@ namespace swift {
 namespace runtime {
 
 /// True if the process gained credentials at exec that its invoker does not
-/// hold: `AT_SECURE` on Linux, `issetugid()` elsewhere. Windows has no
-/// equivalent and always reports false.
+/// hold: `AT_SECURE` on Linux, `issetugid()` elsewhere. Targets with no
+/// equivalent always return false.
 SWIFT_RUNTIME_STDLIB_INTERNAL
 bool _swift_isPrivilegedProcess();
 

--- a/stdlib/public/runtime/Privilege.cpp
+++ b/stdlib/public/runtime/Privilege.cpp
@@ -47,7 +47,8 @@ extern "C" int csops(int, unsigned int, void *, size_t);
 bool swift::runtime::_swift_isPrivilegedProcess() {
 #if defined(__linux__)
   return getauxval(AT_SECURE);
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif TARGET_OS_OSX || TARGET_OS_IPHONE || defined(__FreeBSD__) ||             \
+    defined(__OpenBSD__)
   return issetugid();
 #else
   return false;


### PR DESCRIPTION
We specifically want macOS, iOS, etc., so use TARGET_OS_OSX || TARGET_OS_IPHONE instead of __APPLE__.