### PR TITLE
Sema: Allow joining bindings involving type variables

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1103,8 +1103,12 @@ namespace swift {
     bool SolverPruneDisjunctions = true;
 
     /// Enable an inefficient form of inference, which will sometimes prevent
-    /// exact binding promotion from taking place.
+    /// exact binding promotion from taking place. This will be off by default
+    /// eventually.
     bool SolverEnableEnumerateSupertypes = true;
+
+    /// Enable type variable joins. This will be on by default eventually.
+    bool SolverEnableTypeVariableJoins = false;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1014,6 +1014,12 @@ def solver_disable_prune_disjunctions : Flag<["-"], "solver-disable-prune-disjun
 def solver_enable_prune_disjunctions : Flag<["-"], "solver-enable-prune-disjunctions">,
   HelpText<"Enable experimental disjunction pruning algorithm for lookahead in the solver">;
 
+def solver_disable_type_var_joins : Flag<["-"], "solver-disable-type-var-joins">,
+  HelpText<"Disable experimental support for joins of types containing type variables">;
+
+def solver_enable_type_var_joins : Flag<["-"], "solver-enable-type-var-joins">,
+  HelpText<"Enable experimental support for joins of types containing type variables">;
+
 def solver_disable_performance_hacks : Flag<["-"], "solver-disable-performance-hacks">,
   HelpText<"Disable various constraint solver performance optimizations that have been "
            "subsumed by subsequent improvements">;

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -152,7 +152,7 @@ struct PotentialBinding {
   /// Determine whether this binding could be a viable candidate
   /// to be "joined" with some other binding. It has to be at least
   /// a non-default r-value supertype binding with no type variables.
-  bool isViableForJoinOrMeet() const;
+  bool isViableForJoinOrMeet(bool allowTypeVariableJoins) const;
 
   static PotentialBinding forHole(TypeVariableType *typeVar,
                                   ConstraintLocator *locator) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2224,6 +2224,11 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
                    OPT_solver_disable_enumerate_supertypes,
                    Opts.SolverEnableEnumerateSupertypes);
 
+  Opts.SolverEnableTypeVariableJoins =
+      Args.hasFlag(OPT_solver_enable_type_var_joins,
+                   OPT_solver_disable_type_var_joins,
+                   Opts.SolverEnableTypeVariableJoins);
+
   if (FrontendOpts.RequestedAction == FrontendOptions::ActionType::Immediate)
     Opts.DeferToRuntime = true;
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -265,15 +265,19 @@ void BindingSet::computeJoinsAndMeets() {
   MergedBinding supertypes;
   MergedBinding subtypes;
 
+  // FIXME: Remove this.
+  bool allowTypeVariableJoins =
+      CS.getASTContext().TypeCheckerOpts.SolverEnableTypeVariableJoins;
+
   for (const auto &binding : Bindings) {
     if (binding.Kind == AllowedBindingKind::Supertypes &&
-        binding.isViableForJoinOrMeet()) {
+        binding.isViableForJoinOrMeet(allowTypeVariableJoins)) {
       if (!isAcceptableJoin(binding.BindingType))
         allowUpperBound = true;
 
       supertypes.add(binding);
     } else if (binding.Kind == AllowedBindingKind::Subtypes &&
-               binding.isViableForJoinOrMeet()) {
+               binding.isViableForJoinOrMeet(allowTypeVariableJoins)) {
       subtypes.add(binding);
     }
   }
@@ -408,7 +412,7 @@ void BindingSet::computeJoinsAndMeets() {
     if (foundCommonSupertype) {
       // Filter out supertype bindings that participated in the join.
       if (binding.Kind == AllowedBindingKind::Supertypes &&
-          binding.isViableForJoinOrMeet()) {
+          binding.isViableForJoinOrMeet(allowTypeVariableJoins)) {
         continue;
       }
     }
@@ -416,7 +420,7 @@ void BindingSet::computeJoinsAndMeets() {
     if (foundCommonSubtype) {
       // Filter out supertype bindings that participated in the join.
       if (binding.Kind == AllowedBindingKind::Subtypes &&
-          binding.isViableForJoinOrMeet()) {
+          binding.isViableForJoinOrMeet(allowTypeVariableJoins)) {
         continue;
       }
     }
@@ -463,12 +467,12 @@ static bool isGenericParameter(TypeVariableType *TypeVar) {
   return locator && locator->isLastElement<LocatorPathElt::GenericParameter>();
 }
 
-bool PotentialBinding::isViableForJoinOrMeet() const {
-  return !BindingType->hasLValueType() &&
-         !BindingType->hasTypeVariable() &&
-         !BindingType->hasPlaceholder() &&
-         !BindingType->hasUnboundGenericType() &&
-         !BindingType->is<PackExpansionType>() &&
+bool PotentialBinding::isViableForJoinOrMeet(bool allowTypeVariableJoins) const {
+  // Temporary staging hack.
+  if (!allowTypeVariableJoins && BindingType->hasTypeVariable())
+    return false;
+
+  return !BindingType->is<PackExpansionType>() &&
          /// FIXME: The old join code didn't understand existentials, so it
          /// did not join 'Any' with 'any Sendable'. The compatibility hack
          /// where 'any Sendable' can bind to 'Any' relies on this behavior.
@@ -1610,13 +1614,17 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // Joins are handled in computeJoinsAndMeets().
 
     // FIXME: Remove this.
-    auto result = isLikelyExactMatch(binding.BindingType, existing.BindingType);
-    if (result.has_value() && *result) {
-      if (binding.BindingType->hasTypeVariable())
-        return SubsumeBindingResult::ExistingIsBetter;
+    bool allowTypeVariableJoins =
+        CS.getASTContext().TypeCheckerOpts.SolverEnableTypeVariableJoins;
+    if (!allowTypeVariableJoins) {
+      auto result = isLikelyExactMatch(binding.BindingType, existing.BindingType);
+      if (result.has_value() && *result) {
+        if (binding.BindingType->hasTypeVariable())
+          return SubsumeBindingResult::ExistingIsBetter;
 
-      ASSERT(existing.BindingType->hasTypeVariable());
-      return SubsumeBindingResult::NewIsBetter;
+        ASSERT(existing.BindingType->hasTypeVariable());
+        return SubsumeBindingResult::NewIsBetter;
+      }
     }
   }
 
@@ -2124,12 +2132,16 @@ void BindingSet::possiblyDropDefaults() {
   if (!Literals.empty())
     return;
 
+  // FIXME: Remove this.
+  bool allowTypeVariableJoins =
+      CS.getASTContext().TypeCheckerOpts.SolverEnableTypeVariableJoins;
+
   bool anySupertypeBindings = false;
   bool anyNonJoinableSupertypeBindings = false;
   for (const auto &binding : Bindings) {
     if (binding.Kind == AllowedBindingKind::Supertypes) {
       anySupertypeBindings = true;
-      if (!binding.isViableForJoinOrMeet())
+      if (!binding.isViableForJoinOrMeet(allowTypeVariableJoins))
         anyNonJoinableSupertypeBindings = true;
     }
   }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -309,6 +309,20 @@ void BindingSet::computeJoinsAndMeets() {
       commonSupertype = subtypeJoin(commonSupertype, ty, &existentialUpperBound);
     }
 
+    if (commonSupertype->is<JoinType>()) {
+      // This indicates we had parameter packs or something else the join
+      // code doesn't understand yet.
+      return;
+    }
+
+    // Don't allow this for now, because it leads to infinite recursion
+    // in constraint simplification. Once optional conversions are no
+    // longer presented as a disjunction, this case be removed.
+    if (auto objectType = commonSupertype->getOptionalObjectType()) {
+      if (objectType->is<JoinType>())
+        return;
+    }
+
     // If the result was 'Any' or 'Any?' but none of the inputs were, don't
     // accept the join unless we have a default of 'Any'.
     if (!allowUpperBound && !isAcceptableJoin(commonSupertype)) {
@@ -343,6 +357,20 @@ void BindingSet::computeJoinsAndMeets() {
       }
 
       commonSubtype = subtypeMeet(commonSubtype, ty, &uninhabited);
+    }
+
+    if (commonSubtype->is<MeetType>()) {
+      // This indicates we had parameter packs or something else the meet
+      // code doesn't understand yet.
+      return;
+    }
+
+    // Don't allow this for now, because it leads to infinite recursion
+    // in constraint simplification. Once optional conversions are no
+    // longer presented as a disjunction, this case be removed.
+    if (auto objectType = commonSubtype->getOptionalObjectType()) {
+      if (objectType->is<MeetType>())
+        return;
     }
 
     auto newKind = uninhabited ? AllowedBindingKind::Exact
@@ -2105,7 +2133,7 @@ void BindingSet::possiblyDropDefaults() {
         anyNonJoinableSupertypeBindings = true;
     }
   }
-  
+
   if (!anySupertypeBindings || anyNonJoinableSupertypeBindings)
     return;
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2761,7 +2761,11 @@ BindingSet ConstraintSystem::getBindingsFor(TypeVariableType *typeVar) {
 /// Check whether this is a dependent member type T.[P]Element where P is some
 /// protocol inheriting from Sequence, or T.[P]ArrayLiteralElement where P is
 /// some protocol inheriting from ExpressibleByArrayLiteral.
-static bool isInterestingElementType(Type type, TypeVariableType *forBase) {
+static bool isInterestingElementType(ConstraintKind forKind, Type type,
+                                     TypeVariableType *forBase) {
+  if (forKind != ConstraintKind::Bind && forKind != ConstraintKind::Equal)
+    return false;
+
   auto *memberTy = type->getAs<DependentMemberType>();
   if (!memberTy)
     return false;
@@ -2922,14 +2926,14 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
     //
     // $T0.Element bind X
     if (firstTypeVar == TypeVar &&
-        isInterestingElementType(first, TypeVar)) {
+        isInterestingElementType(constraint->getKind(), first, TypeVar)) {
       recordElementType(second, constraint);
 
     // And the other direction:
     //
     // X bind $T0.Element
     } else if (secondTypeVar == TypeVar &&
-               isInterestingElementType(second, TypeVar)) {
+               isInterestingElementType(constraint->getKind(), second, TypeVar)) {
       recordElementType(first, constraint);
     }
 

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -531,3 +531,23 @@ do {
     }
   }
 }
+
+// Regression from ElementType bookkeeping that wasn't caught by existing tests
+do {
+  struct C {
+    init(_: [any P]) {}
+    init?(_: [(any P)?]) {}
+
+    init(label: [any P]) {}
+    init?(label: [(any P)?]) {}
+  }
+
+  protocol P {}
+  struct S: P {}
+
+  let x1 = C([S()])
+  let x2 = C(label: [S()])
+
+  let _: C = x1
+  let _: C = x2
+}

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -341,15 +341,9 @@ func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [Strin
 
   // rdar://88334481 – Don't apply the compatibility logic for collection literals.
   typealias Magic<T> = T
-  _ = [i] as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-
-  _ = [i] as Magic as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-
-  _ = ([i]) as Magic as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-
+  _ = [i] as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = [i] as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = ([i]) as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
   _  = [i: i] as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
   _  = ([i: i]) as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
   _  = [i: stringAnyDict] as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}

--- a/test/Constraints/casts_swift6.swift
+++ b/test/Constraints/casts_swift6.swift
@@ -25,11 +25,9 @@ func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [Strin
 
   // Make sure we error on the following in Swift 6 mode.
   _ = id(arr) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[Int]' vs. '[String]')}}
-
   _ = (arr ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[String]' vs. '[Int]')}}
-
-  _ = (arr ?? [] ?? []) as [String] // expected-error 2{{conflicting arguments to generic parameter 'T' ('[String]' vs. '[Int]')}}
-
+  _ = (arr ?? [] ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[String]' vs. '[Int]')}}
+  // expected-error@-1{{conflicting arguments to generic parameter 'T' ('[String]' vs. '[Int]')}}
   _ = (optArr ?? []) as [String] // expected-error {{conflicting arguments to generic parameter 'T' ('[Int]' vs. '[String]'}}
 
   _ = (arr ?? []) as [String]? // expected-error {{'[Int]' is not convertible to '[String]?'}}
@@ -59,25 +57,16 @@ func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [Strin
 
   // Cases from rdar://88334481
   typealias Magic<T> = T
-  _ = [i] as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-
-  _ = [i] as Magic as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-
-  _ = ([i]) as Magic as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-
+  _ = [i] as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = [i] as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = ([i]) as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
   _  = [i: i] as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
   _  = ([i: i]) as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
   _  = [i: stringAnyDict] as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
 
-  _ = [i].self as Magic as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-
-  _ = (try [i]) as Magic as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
-  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
-  // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
+  _ = [i].self as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = (try [i]) as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
 
   // These are wrong, but make sure we don't warn about the value cast always succeeding.
   _  = [i: i] as! [String: Any]

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -475,3 +475,22 @@ func test_unapplied_2(_ x: [Double], y: CGFloat) {
   let _ = x.reduce(0, -) / y
   let _ = x.reduce(0, /) / y
 }
+
+struct Blob {
+  let area: Double
+  let circumference: Double
+}
+
+func test_unapplied_3(_ blobs: [Blob]) {
+  let _: Double = blobs.map(\.area).reduce(0, +)
+  let _: Double = blobs.map(\.area).reduce(0.0, +)
+
+  let _: CGFloat = blobs.map(\.area).reduce(0, +)
+  let _: CGFloat = blobs.map(\.area).reduce(0.0, +)
+
+  let _: Double = blobs.map(\.circumference).reduce(0, +)
+  let _: Double = blobs.map(\.circumference).reduce(0.0, +)
+
+  let _: CGFloat = blobs.map(\.circumference).reduce(0, +)
+  let _: CGFloat = blobs.map(\.circumference).reduce(0.0, +)
+}

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -354,3 +354,17 @@ do {
 
   array2 = [(s, s)]
 }
+
+// In this expression we produce an lvalue supertype binding.
+//
+// FIXME: We need more examples of this so that we can properly exercise type join
+// support for lvalues.
+do {
+  class Chain {
+    var next: Chain?
+  }
+
+  func f(chain: Chain) {
+    _ = (chain.next?.next)?.next?.next
+  }
+}

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -223,7 +223,7 @@ func rdar46459603() {
   // expected-error@-2 {{cannot convert value of type '[E]' to expected argument type 'Dictionary<String, E>.Values'}}
 
   _ = [arr.values] == [[e]]
-  // expected-error@-1 {{generic struct 'Set' requires that 'Dictionary<String, E>.Values' conform to 'Hashable'}}
+  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type '[Dictionary<String, E>.Values]' and '[[E]]'}}
 }
 
 // https://github.com/apple/swift/issues/53233

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -425,9 +425,8 @@ do {
 do {
   struct S {}
 
-  // FIXME: The below diagnostics don't make sense
-  func test(of: [String]) {} // expected-note {{found candidate with type '[S.Type]'}}
-  func test(of: [Int]) {} // expected-note {{found candidate with type '[S.Type]'}}
+  func test(of: [String]) {} // expected-note {{candidate expects value of type '[String]' for parameter #1 (got '[S.Type]')}}
+  func test(of: [Int]) {} // expected-note {{candidate expects value of type '[Int]' for parameter #1 (got '[S.Type]')}}
 
   test(of: [S.self]) // expected-error {{no exact matches in call to local function 'test'}}
 }

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -522,8 +522,7 @@ do {
   func takesFooables(_: [any Fooable]) {}
 
   func test(v: String) {
-    takesFooables([v]) // expected-error {{cannot convert value of type '[String]' to expected argument type '[any Fooable]'}}
-    // expected-note@-1 {{arguments to generic parameter 'Element' ('String' and 'any Fooable') are expected to be equal}}
+    takesFooables([v]) // expected-error {{cannot convert value of type 'String' to expected element type 'any Fooable'}}
   }
 }
 

--- a/validation-test/Sema/type_checker_perf/fast/array_literal_of_optionals.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/array_literal_of_optionals.swift.gyb
@@ -1,0 +1,14 @@
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select NumConstraintScopes %s
+// RUN: %scale-test --invert --begin 1 --end 5 --step 1 --select NumConstraintScopes -Xfrontend=-solver-enable-type-var-joins %s
+// REQUIRES: asserts,no_asan
+
+// FIXME: This becomes slow even with type variable joins, because of issues
+// around Optional conversions and bindings.
+func test() {
+  let _ = [
+    Optional(0),
+  %for i in range(1, N):
+    Optional(0),
+  %end
+  ]
+}

--- a/validation-test/Sema/type_checker_perf/fast/array_literal_of_tuples.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/array_literal_of_tuples.swift.gyb
@@ -1,0 +1,15 @@
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumConstraintScopes -Xfrontend=-solver-enable-type-var-joins %s
+// RUN: %scale-test --invert --begin 1 --end 10 --step 1 --select NumConstraintScopes %s
+
+// This is now fast with type variable joins enabled.
+
+// REQUIRES: asserts,no_asan
+
+func test() {
+  let _ = [
+    (0, "", false, 0.0),
+  %for i in range(1, N):
+    (0, "", false, 0.0),
+  %end
+  ]
+}

--- a/validation-test/Sema/type_checker_perf/fast/array_literal_with_operators_and_double_literals.swift
+++ b/validation-test/Sema/type_checker_perf/fast/array_literal_with_operators_and_double_literals.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -solver-scope-threshold=2000
+// RUN: %target-swift-frontend %s -typecheck -solver-scope-threshold=300 -solver-enable-type-var-joins
+// RUN: %target-swift-frontend %s -typecheck -solver-scope-threshold=2000
 
 // REQUIRES: objc_interop
 
-// FIXME: This should be a scale-test but it doesn't allow passing `%clang-importer-sdk`
+// FIXME: This should be a scale-test but it doesn't allow importing SDK frameworks.
 
 // This import is important because it brings CGFloat and
 // enables Double<->CGFloat implicit conversion that affects

--- a/validation-test/Sema/type_checker_perf/fast/issue-43943.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/issue-43943.swift.gyb
@@ -1,4 +1,5 @@
-// RUN: %scale-test --begin 1 --end 7 --step 1 --select NumLeafScopes %s
+// RUN: %scale-test --begin 1 --end 7 --step 1 --select NumConstraintScopes %s
+// RUN: %scale-test --begin 1 --end 7 --step 1 --select NumConstraintScopes -Xfrontend=-solver-enable-type-var-joins %s
 // REQUIRES: asserts,no_asan
 
 extension String {

--- a/validation-test/Sema/type_checker_perf/fast/rdar118993030-literal.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar118993030-literal.swift.gyb
@@ -1,5 +1,8 @@
 // RUN: %scale-test --begin 1 --end 7 --step 1 --select NumConstraintScopes %s
+// RUN: %scale-test --invert --begin 1 --end 5 --step 1 --select NumConstraintScopes %s -Xfrontend=-solver-enable-type-var-joins
 // REQUIRES: asserts,no_asan
+
+// FIXME: Fix this regression before enabling the flag.
 
 struct Root {
   enum E: Int, Comparable {

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-setTargetFor-9f75fc.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-setTargetFor-9f75fc.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::setTargetFor(swift::constraints::SyntacticElementTargetKey, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (inserted), function setTargetFor","signatureNext":"ConstraintSystem::resolveClosure"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {$0=[{} }(
 [a:


### PR DESCRIPTION
This is behind a staging flag for now, `-solver-enable-type-var-joins`.