### PR TITLE
[CoroutineAccessors] Permit `yielding mutate` as a protocol requirement

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -268,7 +268,8 @@ ERROR(static_var_decl_global_scope,none,
       "%select{%error|static properties|class properties}0 may only be declared on a type",
       (StaticSpellingKind))
 ERROR(expected_getreadborrowsetmutate_in_protocol,none,
-      "expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property", ())
+      "expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or "
+      "'yielding mutate' in a protocol property", ())
 
 ERROR(unexpected_getset_implementation_in_protocol,none,
       "protocol property %0 cannot have a default implementation specified "

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3660,6 +3660,11 @@ getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) 
     return AccessStrategy::getAccessor(AccessorKind::Init, dispatch);
   if (storage->requiresOpaqueMutateAccessor())
     return AccessStrategy::getAccessor(AccessorKind::Mutate, dispatch);
+  // A 'yielding mutate' requirement with no plain setter of its own (e.g. a
+  // protocol requirement spelled without 'set') has no setter to fall back to.
+  if (storage->requiresOpaqueYieldingMutateCoroutine() &&
+      !storage->requiresOpaqueSetter())
+    return AccessStrategy::getAccessor(AccessorKind::YieldingMutate, dispatch);
   return AccessStrategy::getAccessor(AccessorKind::Set, dispatch);
 }
 
@@ -3830,6 +3835,14 @@ bool AbstractStorageDecl::requiresOpaqueSetter() const {
     return false;
   }
   if (getParsedAccessor(AccessorKind::Mutate)) {
+    return false;
+  }
+  if (getParsedAccessor(AccessorKind::YieldingMutate) &&
+      !getParsedAccessor(AccessorKind::Set) &&
+      isa<ProtocolDecl>(getDeclContext())) {
+    // In a protocol, `yielding mutate` by itself suffices
+    // to provide write support and we don't need `set` unless
+    // the protocol explicitly specifies it.
     return false;
   }
   return true;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8220,6 +8220,7 @@ static bool isAllowedWhenParsingLimitedSyntax(AccessorKind kind, bool forSIL) {
   case AccessorKind::YieldingBorrow:
   case AccessorKind::Borrow:
   case AccessorKind::Mutate:
+  case AccessorKind::YieldingMutate:
     return true;
 
   case AccessorKind::Address:
@@ -8228,7 +8229,6 @@ static bool isAllowedWhenParsingLimitedSyntax(AccessorKind kind, bool forSIL) {
   case AccessorKind::DidSet:
   case AccessorKind::Read:
   case AccessorKind::Modify:
-  case AccessorKind::YieldingMutate:
     return false;
 
   case AccessorKind::Init:

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -4337,6 +4337,18 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
       writeImpl = WriteImplKind::Set;
       readWriteImpl = ReadWriteImplKind::MaterializeToTemporary;
     }
+    if (storage->getParsedAccessor(AccessorKind::YieldingMutate)) {
+      // `yielding mutate` implies `yielding borrow`
+      // (unless it's overridden later in this function).
+      readImpl = ReadImplKind::YieldingBorrow;
+      // If there's a written `set`, use `yielding mutate` only
+      // for read/write access and use the `set` for simple write.
+      // If there isn't a written `set`, use `yielding mutate` for
+      // both.
+      if (!storage->getParsedAccessor(AccessorKind::Set))
+        writeImpl = WriteImplKind::YieldingMutate;
+      readWriteImpl = ReadWriteImplKind::YieldingMutate;
+    }
     if (storage->getParsedAccessor(AccessorKind::Get)) {
       readImpl = ReadImplKind::Get;
     }

--- a/test/Parse/coroutine_accessors.swift
+++ b/test/Parse/coroutine_accessors.swift
@@ -388,18 +388,19 @@ var ir_rm_m: Int {
 
 // =============================================================================
 // Protocol Requirements
-// Note that `yielding mutate` is not allowed as a protocol requirement
 // =============================================================================
 
 protocol P {
   var goodP: Int { yielding borrow set } //expected-disabled-error{{accessor_requires_coroutine_accessors}}
 
-  var badP: Int { yielding borrow yielding mutate } //expected-disabled-error{{accessor_requires_coroutine_accessors}}
-                                                    //expected-error@-1{{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  // enabled: ok
+  // disabled: implicit getter.
+  var alsoGoodP: Int { yielding borrow yielding mutate } //expected-disabled-error{{accessor_requires_coroutine_accessors}}
+                                                    //expected-disabled-error@-1{{accessor_requires_coroutine_accessors}}
 
   subscript(goodS goodS: Int) -> Int { yielding borrow set } //expected-disabled-error{{accessor_requires_coroutine_accessors}}
 
-  subscript(badS badS: Int) -> Int { yielding borrow yielding mutate }  //expected-disabled-error{{accessor_requires_coroutine_accessors}}
-                                                    //expected-error@-1{{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  subscript(alsoGoodS alsoGoodS: Int) -> Int { yielding borrow yielding mutate }  //expected-disabled-error{{accessor_requires_coroutine_accessors}}
+                                                    //expected-disabled-error@-1{{accessor_requires_coroutine_accessors}}
 
 }

--- a/test/Parse/effectful_properties.swift
+++ b/test/Parse/effectful_properties.swift
@@ -156,13 +156,13 @@ var bad8 : Double {
 }
 
 protocol BadP {
-  var prop2 : Int { get bogus rethrows set } // expected-error{{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var prop2 : Int { get bogus rethrows set } // expected-error{{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 
   // expected-error@+2 {{only function declarations may be marked 'rethrows'; did you mean 'throws'?}}
-  // expected-error@+1 {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  // expected-error@+1 {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
   var prop3 : Int { get rethrows bogus set }
 
-  // expected-error@+1 {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  // expected-error@+1 {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
   var prop4 : Int { get reasync bogus set }
 
   var prop5 : Int { get throws async } // expected-error {{'async' must precede 'throws'}}

--- a/test/SILGen/coroutine_accessors_yielding_mutate_protocol.swift
+++ b/test/SILGen/coroutine_accessors_yielding_mutate_protocol.swift
@@ -1,0 +1,118 @@
+// A protocol requirement may now be spelled with `yielding mutate` (previously
+// only `yielding borrow` was allowed on the read side, with the write side
+// restricted to `set` or the `mutate` accessor of the `borrow`/`mutate`
+// family).  This exercises `yielding mutate` requirements: witness-table
+// layout, and dispatch through both generic and existential access.
+
+// RUN: %target-swift-emit-silgen %s                          \
+// RUN:     -enable-experimental-feature CoroutineAccessors   \
+// RUN:     -module-name m                                    \
+// RUN:   | %FileCheck %s
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+public protocol P {
+  var x: Int { yielding borrow yielding mutate }
+}
+
+public struct S: P {
+  var _s = 0
+  public var x: Int {
+    yielding borrow { yield _s }
+    yielding mutate { yield &_s }
+  }
+}
+
+@_silgen_name("readGeneric")
+public func readGeneric<T: P>(_ t: T) -> Int {
+// CHECK-LABEL: sil {{.*}}@readGeneric : {{.*}} {
+// CHECK:         witness_method {{.*}}#P.x!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readGeneric'
+  return t.x
+}
+
+@_silgen_name("modifyGeneric")
+public func modifyGeneric<T: P>(_ t: inout T) {
+// CHECK-LABEL: sil {{.*}}@modifyGeneric : {{.*}} {
+// CHECK:         witness_method {{.*}}#P.x!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyGeneric'
+  t.x += 1
+}
+
+@_silgen_name("readExistential")
+public func readExistential(_ t: any P) -> Int {
+// CHECK-LABEL: sil {{.*}}@readExistential : {{.*}} {
+// CHECK:         witness_method {{.*}}#P.x!yielding_borrow
+// CHECK-LABEL: } // end sil function 'readExistential'
+  return t.x
+}
+
+@_silgen_name("modifyExistential")
+public func modifyExistential(_ t: inout any P) {
+// CHECK-LABEL: sil {{.*}}@modifyExistential : {{.*}} {
+// CHECK:         witness_method {{.*}}#P.x!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyExistential'
+  t.x += 1
+}
+
+// The write side may also pair with a plain getter, mirroring how the read
+// side may pair with a plain setter (`yielding borrow set`).
+public protocol Q {
+  var y: Int { get yielding mutate }
+}
+
+public struct T: Q {
+  var _t = 0
+  public var y: Int {
+    get { _t }
+    yielding mutate { yield &_t }
+  }
+}
+
+// An explicitly written `set` is honored alongside the coroutine: the
+// requirement keeps its plain setter slot, so adding `yielding mutate` to an
+// existing `{ get set }` requirement stays additive rather than removing the
+// setter from the witness layout.
+public protocol R {
+  var z: Int { get set yielding mutate }
+}
+
+// A conformer need not write the coroutine; it is synthesized from `set`.
+public struct U: R {
+  public var z: Int = 0
+}
+
+@_silgen_name("assignR")
+public func assignR<V: R>(_ v: inout V) {
+// CHECK-LABEL: sil {{.*}}@assignR : {{.*}} {
+// CHECK:         witness_method {{.*}}#R.z!setter
+// CHECK-LABEL: } // end sil function 'assignR'
+  v.z = 1
+}
+
+@_silgen_name("modifyR")
+public func modifyR<V: R>(_ v: inout V) {
+// CHECK-LABEL: sil {{.*}}@modifyR : {{.*}} {
+// CHECK:         witness_method {{.*}}#R.z!yielding_mutate
+// CHECK-LABEL: } // end sil function 'modifyR'
+  v.z += 1
+}
+
+// Witness tables are emitted after all function bodies.  A pure-coroutine
+// requirement has no plain getter/setter of its own -- S's witness table lists
+// only the coroutine slots, symmetric with a `{ yielding borrow }`-only (or
+// `@_borrowed`) read-only requirement; T's pairs a plain getter with the
+// coroutine write; U's keeps the written setter alongside it.
+// CHECK-LABEL: sil_witness_table [serialized] S: P module m {
+// CHECK-NEXT:    method #P.x!yielding_borrow
+// CHECK-NEXT:    method #P.x!yielding_mutate
+// CHECK-NEXT:  }
+// CHECK-LABEL: sil_witness_table [serialized] T: Q module m {
+// CHECK-NEXT:    method #Q.y!getter
+// CHECK-NEXT:    method #Q.y!yielding_mutate
+// CHECK-NEXT:  }
+// CHECK-LABEL: sil_witness_table [serialized] U: R module m {
+// CHECK-NEXT:    method #R.z!getter
+// CHECK-NEXT:    method #R.z!setter
+// CHECK-NEXT:    method #R.z!yielding_mutate
+// CHECK-NEXT:  }

--- a/test/decl/protocol/invalid_accessors_implementation.swift
+++ b/test/decl/protocol/invalid_accessors_implementation.swift
@@ -6,39 +6,39 @@
 //===---
 
 protocol Protocol1 {
-  var a: Int { get { 0 } } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { get { 0 } } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol2 {
-  var a: Int { set { a = 0 } } // expected-error {{protocol property setter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { set { a = 0 } } // expected-error {{protocol property setter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol3 {
-  var a: Int { get { 0 } set } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { get { 0 } set } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol4 {
-  var a: Int { get { 0 } set { a = 0 } } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { get { 0 } set { a = 0 } } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol5 {
-  var a: Int { get set willSet { print("HI")} } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { get set willSet { print("HI")} } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol6 {
-  var a: Int { get { 0 } set willSet { print("HI")} } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { get { 0 } set willSet { print("HI")} } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol7 {
-  var a: Int { set { print("HI") } willSet { print("HI") } } // expected-error {{protocol property setter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { set { print("HI") } willSet { print("HI") } } // expected-error {{protocol property setter cannot have a default implementation specified here; use extension instead}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol8 {
-  var a: Int { set willSet { print("HI") } } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { set willSet { print("HI") } } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol9 {
-  var a: Int { return 0 } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { return 0 } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 
 protocol Protocol10 {

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -152,16 +152,16 @@ protocol ProtocolGetSet4 {
 }
 
 protocol ProtocolWillSetDidSet1 {
-  subscript(i: Int) -> Int { willSet } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
+  subscript(i: Int) -> Int { willSet } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 protocol ProtocolWillSetDidSet2 {
-  subscript(i: Int) -> Int { didSet } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
+  subscript(i: Int) -> Int { didSet } // expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 protocol ProtocolWillSetDidSet3 {
-  subscript(i: Int) -> Int { willSet didSet } // expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
+  subscript(i: Int) -> Int { willSet didSet } // expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 protocol ProtocolWillSetDidSet4 {
-  subscript(i: Int) -> Int { didSet willSet } // expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
+  subscript(i: Int) -> Int { didSet willSet } // expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 
 class DidSetInSubscript {

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -885,20 +885,20 @@ protocol ProtocolGetSet6 {
 }
 
 protocol ProtocolWillSetDidSet1 {
-  var a: Int { willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-25={ get <#set#> \}}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-25={ get <#set#> \}}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 protocol ProtocolWillSetDidSet2 {
-  var a: Int { didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-24={ get <#set#> \}}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-24={ get <#set#> \}}} expected-error {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 protocol ProtocolWillSetDidSet3 {
-  var a: Int { willSet didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { willSet didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 
 }
 protocol ProtocolWillSetDidSet4 {
-  var a: Int { didSet willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}}
+  var a: Int { didSet willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} {{14-32={ get <#set#> \}}} expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}}
 }
 protocol ProtocolWillSetDidSet5 {
-  let a: Int { didSet willSet }  // expected-error {{protocols cannot require properties to be immutable; declare read-only properties by using 'var' with a '{ get }' specifier}} {{3-6=var}} {{13-13= { get \}}} {{none}} expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set' or 'mutate' in a protocol property}} expected-error {{'let' declarations cannot be computed properties}} {{3-6=var}}
+  let a: Int { didSet willSet }  // expected-error {{protocols cannot require properties to be immutable; declare read-only properties by using 'var' with a '{ get }' specifier}} {{3-6=var}} {{13-13= { get \}}} {{none}} expected-error 2 {{expected 'get', 'yielding borrow', 'borrow', 'set', 'mutate' or 'yielding mutate' in a protocol property}} expected-error {{'let' declarations cannot be computed properties}} {{3-6=var}}
 }
 
 var globalDidsetWillSet: Int {  // expected-error {{non-member observing properties require an initializer}}


### PR DESCRIPTION
The `yielding mutate` is synthesized from other provided accessors when necessary and possible.

A nuance:
To preserve existing ABI contracts, `{ get set }` implies that a coroutine mutator will be generated. In practice, this means that `{ get set }` and `{ get set yielding mutate}` are synonyms. But note that `{ get yielding mutate }` does not imply `set`.