### PR TITLE
[SIL][ClangImporter] add Decl::hasObjCImplementation

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1446,6 +1446,17 @@ public:
   /// \seeAlso ExtensionDecl::isObjCInterface()
   Decl *getObjCImplementationDecl() const;
 
+  /// Whether this Clang-imported declaration is known to have its definition
+  /// provided by a Swift `@implementation`.
+  ///
+  /// Unlike \c getObjCImplementationDecl(), this only consults the already
+  /// computed interface-to-implementation cache; it never triggers the
+  /// \c ObjCInterfaceAndImplementationRequest (and thus never performs a
+  /// reverse name lookup). It is therefore only meaningful once the relevant
+  /// `@implementation` has been type-checked, which is guaranteed for the
+  /// SIL/IRGen clients that use it.
+  bool hasObjCImplementation() const;
+
   bool getCachedLacksObjCInterfaceOrImplementation() const {
     return Bits.Decl.LacksObjCInterfaceOrImplementation;
   }

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -328,6 +328,15 @@ public:
   /// \param name The name we're searching for.
   void lookupValue(DeclName name, VisibleDeclConsumer &consumer) override;
 
+  /// Whether \p interfaceDecl is a Clang-imported declaration whose definition
+  /// is provided by a Swift `@implementation`.
+  ///
+  /// This only consults the already-populated interface-to-implementation
+  /// cache; it never triggers \c ObjCInterfaceAndImplementationRequest, so it
+  /// performs no reverse name lookup. It is therefore only meaningful once the
+  /// relevant `@implementation` has been type-checked.
+  bool hasObjCImplementation(const Decl *interfaceDecl) const;
+
   /// Look up a type declaration by its Clang name.
   ///
   /// Note that this method does no filtering. If it finds the type in a loaded

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7014,6 +7014,32 @@ Decl *Decl::getObjCImplementationDecl() const {
   return result.implementationDecl;
 }
 
+bool Decl::hasObjCImplementation() const {
+  if (!hasClangNode())
+    // This *is* the implementation, if it has one.
+    return false;
+
+  // ABI-only attributes don't have an `@implementation`, so query the API
+  // counterpart.
+  auto abiRole = ABIRoleInfo(this);
+  if (!abiRole.providesAPI() && abiRole.getCounterpart())
+    return abiRole.getCounterpart()->hasObjCImplementation();
+
+  // Only consult the already-populated interface-to-implementation cache.
+  // Unlike `getObjCImplementationDecl()`, we deliberately avoid evaluating
+  // `ObjCInterfaceAndImplementationRequest` here so that no reverse name
+  // lookup is performed. The cache is populated when the matching
+  // `@implementation` is type-checked, which precedes any SIL/IRGen query.
+  auto *loader = getASTContext().getClangModuleLoader();
+  if (!loader)
+    return false;
+  return static_cast<ClangImporter *>(loader)->hasObjCImplementation(this);
+}
+
+bool ClangImporter::hasObjCImplementation(const Decl *interfaceDecl) const {
+  return Impl.ImplementationsByInterface.count(const_cast<Decl *>(interfaceDecl));
+}
+
 llvm::TinyPtrVector<Decl *>
 ClangCategoryLookupRequest::evaluate(Evaluator &evaluator,
                                      ClangCategoryLookupDescriptor desc) const {

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -39,7 +39,7 @@ FormalLinkage swift::getDeclLinkage(const ValueDecl *D) {
   // Clang declarations are public and can't be assured of having a
   // unique defining location.
   if (isa<ClangModuleUnit>(fileContext) &&
-          !D->getObjCImplementationDecl())
+          !D->hasObjCImplementation())
     return FormalLinkage::PublicNonUnique;
 
   if (SILDeclRef::declHasNonUniqueDefinition(D))

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -384,7 +384,7 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
     auto decl = constant.getDecl();
 
     if (constant.isForeign && decl->hasClangNode() &&
-        !decl->getObjCImplementationDecl())
+        !decl->hasObjCImplementation())
       F->setClangNodeOwner(decl);
 
     if (auto availability = constant.getAvailabilityForLinkage())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1893,12 +1893,12 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
       attr->setCategoryNameInvalid();
     }
 
-    // FIXME: if (AFD->getCDeclName().empty())
-
     if (!AFD->getImplementedObjCDecl()) {
+      StringRef name = AFD->getCDeclName();
+      if (name.empty())
+        name = AFD->getNameStr();
       diagnose(attr->getLocation(),
-               diag::attr_objc_implementation_func_not_found,
-               AFD->getCDeclName(), AFD);
+               diag::attr_objc_implementation_func_not_found, name, AFD);
     }
   }
 }

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -678,6 +678,15 @@ func CImplFuncAvailable1(_: Int32) { }
 @implementation @_cdecl("CImplFuncAvailable2")
 func CImplFuncAvailable2(_: Int32) { }
 
+// When the '@objc' (not '@_cdecl') spelling is used, there is no C name to
+// mention, so the diagnostic should fall back to the Swift name rather than
+// printing an empty '' name.
+class SwiftSubclassWithImplMethod: ObjCClass {
+  @objc @implementation
+  func unimplementedMethod(_: CInt) {}
+  // expected-error@-2 {{could not find imported function 'unimplementedMethod' matching instance method 'unimplementedMethod'; make sure you import the module or header that declares it}}
+}
+
 //
 // TODO: @_cdecl for global functions imported as computed vars
 //


### PR DESCRIPTION
Processing for @c, @objc and @_cdecl attributes currently happens in two
directions when combined with @implementation. First
`getImplementedObjCDecl` is invoked on the implementation decl,
checking that it matches the interface and linking the two. Later on,
during SIL processing, `getObjCImplementationDecl` is invoked on the
interface from the C header. This is only done to check whether the
function has a Swift implementation or not. To support being invoked
with either decl, the function fetches both implementation and interface
via namelookup, despite already having one half of the equation.

This removes the calls from SIL where the interface is passed (the
"reverse" direction), by instead looking up the result in a cache that's
already populated by the "forward" direction call. This is cheaper, and
will also allow a follow-up to simplify the logic by only doing name
lookup for the interface imported from clang.