### PR TITLE
build-presets: drop toolchain-benchmarks from mixin_osx_package_base

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1538,9 +1538,6 @@ install-prefix=%(install_toolchain_dir)s/usr
 
 test-installable-package
 
-# Make sure that we can build the benchmarks with swiftpm against the toolchain
-toolchain-benchmarks
-
 # If someone uses this for incremental builds, force reconfiguration.
 reconfigure
 


### PR DESCRIPTION
## Summary
- Removes `toolchain-benchmarks` from `mixin_osx_package_base`, which the nightly macOS package build inherits.
- This flag builds the Swift Benchmark Suite via SwiftPM against the just-built toolchain and runs a single `--num-iters=1` smoke-test iteration of one benchmark. It's separate from `skip-build-benchmarks` (which already disables the in-tree CMake benchmark target and remains untouched here).
- Measured cost on a recent nightly macOS run: ~17 minutes (1,019s) spent in the "Building benchmarks" build-script-helper step, on a job whose "Build Swift" stage already runs ~12 hours.

## Test plan
- [ ] Confirm `oss-swift-package-macos` nightly trigger no longer runs the "Building benchmarks" step and toolchain artifacts still produce/install correctly.
- [ ] Confirm no other consumer of `mixin_osx_package_base` relies on the benchmark smoke test.