### PR TITLE
[RemoteInspection] Exclude a multi-payload enum's extra discriminator bits from its spare bits.

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1066,7 +1066,17 @@ public:
   BitMask getSpareBits(TypeConverter &TC, bool &hasAddrOnly) const override {
     auto mask = spareBitsMask;
     // Bits we've used for our tag can't be re-used by a containing enum...
-    mask.andNotMask(getMultiPayloadTagBitsMask(), 0);
+    auto payloadTagBitsMask = getMultiPayloadTagBitsMask();
+    mask.andNotMask(payloadTagBitsMask, 0);
+    // ...and neither can the low bits of the extra discriminator, which hold
+    // whatever part of the tag didn't fit in the payload's spare bits.
+    unsigned payloadSize = getPayloadSize();
+    unsigned extraTagSize = getSize() - payloadSize;
+    if (extraTagSize > 0) {
+      unsigned extraTagBits =
+        getNumTagBits() - payloadTagBitsMask.countSetBits();
+      mask.andNotMask(lowBitsMask(extraTagSize, extraTagBits), payloadSize);
+    }
     return mask;
   }
 
@@ -1093,6 +1103,13 @@ public:
     uint64_t payloadTag = 0;
     if (!payloadTagMask.readMaskedInteger(reader, address, &payloadTag)) {
       return false;
+    }
+
+    // Strip any high bits of the extra discriminator that a containing enum
+    // may be using for its own tag.
+    int numExtraTagBits = getNumTagBits() - numPayloadTagBits;
+    if (numExtraTagBits < 32) {
+      extraTag &= (1U << numExtraTagBits) - 1;
     }
 
     // Combine the extra tag and payload tag info:
@@ -1139,8 +1156,8 @@ public:
   // * A separate "discriminator" tag appended to the payload (if necessary)
   // * A "payload tag" that uses (a subset of) the spare bits in the payload
   // * The remainder of the payload bits (for non-payload cases)
-  // This computes the bits used for the payload tag.
-  BitMask getMultiPayloadTagBitsMask() const {
+  // This computes the total number of bits in the first two pieces.
+  int getNumTagBits() const {
     auto payloadTagValues = NumEffectivePayloadCases - 1;
     if (getNumCases() > NumEffectivePayloadCases) {
       // How many payload bits are there?
@@ -1158,15 +1175,33 @@ public:
 	payloadTagValues += (numNonPayloadCases + numNonPayloadCasesPerTag - 1) / numNonPayloadCasesPerTag;
       }
     }
-    int payloadTagBits = 0;
+    int tagBits = 0;
     while (payloadTagValues > 0) {
       payloadTagValues >>= 1;
-      payloadTagBits += 1;
+      tagBits += 1;
     }
+    return tagBits;
+  }
+
+  // The bits of the payload area used for the payload tag.  This is the
+  // most-significant spare bits, up to however many the tag needs; a tag too
+  // wide to fit spills the rest into the extra discriminator.
+  BitMask getMultiPayloadTagBitsMask() const {
     BitMask payloadTagBitsMask = spareBitsMask;
     payloadTagBitsMask.keepOnlyLeastSignificantBytes(getPayloadSize());
-    payloadTagBitsMask.keepOnlyMostSignificantBits(payloadTagBits);
+    payloadTagBitsMask.keepOnlyMostSignificantBits(getNumTagBits());
     return payloadTagBitsMask;
+  }
+
+  // A mask of the `n` least-significant bits, in a field of `sizeInBytes`.
+  static BitMask lowBitsMask(unsigned sizeInBytes, unsigned n) {
+    auto mask = BitMask::oneMask(sizeInBytes);
+    if (n < sizeInBytes * 8) {
+      auto highBits = BitMask::oneMask(sizeInBytes);
+      highBits.keepOnlyMostSignificantBits(sizeInBytes * 8 - n);
+      mask.andNotMask(highBits, 0);
+    }
+    return mask;
   }
 };
 

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_nested_extra_tag.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_nested_extra_tag.swift
@@ -1,0 +1,107 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_nested_extra_tag
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_nested_extra_tag
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_nested_extra_tag | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+
+class C {}
+
+// Inner's three payload cases need two tag bits, and its payload has no spare
+// bits to hold them, so both go in an extra discriminator byte. The remaining
+// six bits of that byte are spare, and Outer takes its own tag from them.
+enum Inner {
+  case a(C, UInt8)
+  case b(C, UInt8)
+  case c(C, UInt8)
+}
+
+enum Outer {
+  case p(Inner)
+  case q(Inner)
+  case r(Inner)
+  case s(Inner)
+  case t(Inner)
+}
+
+let c = C()
+
+reflect(enumValue: Outer.p(.a(c, 1)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.Outer)
+// CHECK-NEXT: Value: .p(.a(_))
+
+reflect(enumValue: Outer.q(.b(c, 2)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.Outer)
+// CHECK-NEXT: Value: .q(.b(_))
+
+reflect(enumValue: Outer.r(.c(c, 3)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.Outer)
+// CHECK-NEXT: Value: .r(.c(_))
+
+reflect(enumValue: Outer.s(.a(c, 4)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.Outer)
+// CHECK-NEXT: Value: .s(.a(_))
+
+reflect(enumValue: Outer.t(.b(c, 5)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.Outer)
+// CHECK-NEXT: Value: .t(.b(_))
+
+// An empty case in the inner enum makes its tag spill into the extra
+// discriminator without the payload contributing spare bits of its own.
+enum InnerWithEmpty {
+  case a(AnyObject)
+  case b(AnyObject)
+  case c
+}
+
+enum OuterOfEmpty {
+  case x(InnerWithEmpty)
+  case y(InnerWithEmpty)
+  case z(InnerWithEmpty)
+}
+
+reflect(enumValue: OuterOfEmpty.x(.a(c)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.OuterOfEmpty)
+// CHECK-NEXT: Value: .x(.a(_))
+
+reflect(enumValue: OuterOfEmpty.y(.b(c)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.OuterOfEmpty)
+// CHECK-NEXT: Value: .y(.b(_))
+
+reflect(enumValue: OuterOfEmpty.z(.c))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_nested_extra_tag.OuterOfEmpty)
+// CHECK-NEXT: Value: .z(.c)
+
+doneReflecting()
+
+// CHECK: Done.


### PR DESCRIPTION
A multi-payload enum whose tag is wider than the payload's spare bits puts the rest of the tag in an extra discriminator byte appended to the payload. MultiPayloadEnumTypeInfo reported that whole byte as spare, so an enclosing enum computed its own tag from bits the inner enum was already using, and projectEnumValue read a tag several values off. Mask those bits out of getSpareBits(), and ignore the discriminator's high bits when projecting, since an enclosing enum may be using them for its own tag.

rdar://185560179