### PR TITLE
[Sema] Fix tautological diagnostic for property wrapper parameter

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8100,6 +8100,9 @@ NOTE(property_wrapper_param_attr_arg,none,
 NOTE(property_wrapper_no_init_projected_value,none,
      "property wrapper type %0 does not support initialization from a "
      "projected value", (Type))
+ERROR(property_wrapper_no_init_wrapped_value,none,
+     "property wrapper type %0 does not support initialization from a "
+     "wrapped value", (Type))
 ERROR(property_wrapper_param_mutating,none,
       "property wrapper applied to parameter must have a nonmutating "
       "'wrappedValue' getter", ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8030,6 +8030,23 @@ bool ArgumentMismatchFailure::diagnosePropertyWrapperMismatch() const {
   auto argType = getFromType();
   auto paramType = getToType();
 
+  // If the types match but the parameter has an external property wrapper that
+  // has no `init(wrappedValue)` then record a diagnostic and exit early.
+  if (argType->isEqual(paramType)) {
+    if (auto *paramDecl =
+            getParameterAt(Info.getCallee(), Info.getParamPosition() - 1)) {
+      if (paramDecl->hasExternalPropertyWrapper()) {
+        auto wrapperInfo = paramDecl->getAttachedPropertyWrapperTypeInfo(0);
+        if (!wrapperInfo.wrappedValueInit) {
+          auto backingType = paramDecl->getPropertyWrapperBackingPropertyType();
+          emitDiagnostic(diag::property_wrapper_no_init_wrapped_value,
+                        backingType);
+          return true;
+        }
+      }
+    }
+  }
+
   // Verify that this is an implicit call to a property wrapper initializer
   // in a form of `init(wrappedValue:)` or deprecated `init(initialValue:)`.
   auto *call = getAsExpr<CallExpr>(getRawAnchor());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4426,9 +4426,31 @@ ConstraintSystem::applyPropertyWrapperToParameter(
   auto wrapperInfo = param->getAttachedPropertyWrapperTypeInfo(0);
   if (!argLabel.hasDollarPrefix() && !wrapperInfo.wrappedValueInit &&
       param->hasExternalPropertyWrapper()) {
+    bool projectionResolves = false;
+
+    Type projectionType = computeProjectedValueType(param, wrapperType);
+    if (projectionType && !paramType->isEqual(wrapperType)) {
+      llvm::SaveAndRestore<ConstraintSystemOptions> options(
+          Options, Options - ConstraintSystemFlags::AllowFixes);
+      projectionResolves = matchTypes(paramType, projectionType, matchKind,
+                                      TypeMatchFlags::TMF_ApplyingFix, locator)
+                    == SolutionKind::Solved;
+    }
+    
+    
+    // If the property wrapper has a projected value and the type of the
+    // argument matches that of the projected value, record a fix to insert "$"
+    // on the argument label. Otherwise, record a fix for argument mismatch.
     auto *loc = getConstraintLocator(locator);
-    auto *fix = UsePropertyWrapper::create(
-        *this, param, /*usingProjection=*/true, paramType, wrapperType, loc);
+    ConstraintFix *fix;
+    if (projectionResolves) {
+      fix = UsePropertyWrapper::create(*this, param, /*usingProjection=*/true,
+                                       paramType, wrapperType, loc);
+    } else {
+      Type wrappedValueType = computeWrappedValueType(param, wrapperType);
+      fix = AllowArgumentMismatch::create(*this, paramType, wrappedValueType,
+                                          loc);
+    }
     return recordPropertyWrapperFix(fix);
   }
 

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -253,3 +253,19 @@ func buildWidget(_ w: ProjectionWrapper<Int>) -> Widget {
 // when matching default arguments with parameters.
 func testCallerSideDefault(@Wrapper x: Int? = nil) {}
 testCallerSideDefault() // expected-error {{nil default argument value cannot be converted to type 'Wrapper<Int?>'}}
+
+// https://github.com/swiftlang/swift/issues/90985
+// Make sure we correctly handle error recording when `init(wrappedValue:) is omitted.
+@propertyWrapper
+struct ProjectedOnlyWrapper {
+  var wrappedValue: Int
+  var projectedValue: Self {}
+  init(projectedValue: Self) {}
+}
+func takeProjectedOnlyWrapper(@ProjectedOnlyWrapper _ x: Int) {}
+func passProjectedOnlyWrapper(_ x: ProjectedOnlyWrapper) {
+  takeProjectedOnlyWrapper(x) // expected-error {{cannot convert value of type 'ProjectedOnlyWrapper' to expected argument type 'Int'}}
+}
+func passLiteralToProjectedOnlyWrapper(_ x: Int) {
+  takeProjectedOnlyWrapper(42) // expected-error {{property wrapper type 'ProjectedOnlyWrapper' does not support initialization from a wrapped value}}
+}


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
# Summary 
When a parameter has an external property wrapper that does not provide `init(wrappedValue:)`,  CSGen records a fix using `(argType, wrapperType)`, resulting in the tautological error message "cannot convert value 'x' of type 'Wrapper' to expected type 'Wrapper', use wrapper instead". 

This fix addresses the issue by modifying `CSGen` such that the `UsePropertyWrapper` fix is only applied when using the projected value would fix the mismatch. Otherwise, the more generic `AllowArgumentMismatch` fix is used. 

This fix also introduces a change to `CSDiagnostics` for `ArgumentMismatchFailure::diagnosePropertyWrapperMismatch`. This change catches the case where the types of the parameter and argument match, but the property wrapper for the parameter does not have an `init(wrappedValue:)`. This change is necessary as a result of the change to `CSGen` described above to prevent yet another tautological error message when the argument type matches the wrapped value type.

Attempts to address the comment from #91185 
Fixes #90985 

# Testing 
Added two new cases to `test/Sema/property_wrapper_parameter.swift` (ProjectedOnlyWrapper tests):
- `passProjectedOnlyWrapper`: Tests that the reproduction from issue #90985 produces the desired error message.
- `passLiteralToProjectedOnlyWrapper`: Tests that passing a value whose type matches the wrapper's wrapped value type produces the new "does not support initialization from a wrapped value" diagnostic instead of a tautological one.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
