### PR TITLE
[RemoteInspection] Fix reflection of Builtin.FixedArray, Builtin.Borrow, and multi-payload enum extra inhabitants.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1278,6 +1278,18 @@ public:
       TypeCache[TypeCacheKey] = BuiltFixedArray;
       return BuiltFixedArray;
     }
+    case MetadataKind::Borrow: {
+      auto borrow = cast<TargetBorrowTypeMetadata<Runtime>>(Meta);
+      auto referentAddress =
+          RemoteAddress(borrow->Referent, MetadataAddress.getAddressSpace());
+      auto Referent =
+          readTypeFromMetadata(referentAddress, false, recursion_limit);
+      if (!Referent) return BuiltType();
+
+      auto BuiltBorrow = Builder.createBuiltinBorrowType(Referent);
+      TypeCache[TypeCacheKey] = BuiltBorrow;
+      return BuiltBorrow;
+    }
     case MetadataKind::HeapLocalVariable:
     case MetadataKind::HeapGenericLocalVariable:
     case MetadataKind::ErrorObject:

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -277,7 +277,7 @@ static unsigned intTypeBitSize(std::string name) {
   llvm::StringRef nameRef(name);
   if (nameRef.starts_with("Bi") && nameRef.ends_with("_")) {
     llvm::StringRef naturalRef = nameRef.drop_front(2).drop_back();
-    uint8_t natural;
+    unsigned natural;
     if (naturalRef.getAsInteger(10, natural)) {
       return 0;
     }

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -884,7 +884,6 @@ public:
                        remote::RemoteAddress address,
                        int *extraInhabitantIndex) const override {
     unsigned long PayloadSize = getPayloadSize();
-    unsigned PayloadCount = getNumPayloadCases();
     unsigned TagSize = getSize() - PayloadSize;
     unsigned tag = 0;
     if (!reader.readInteger(address + PayloadSize,
@@ -892,7 +891,7 @@ public:
                             &tag)) {
       return false;
     }
-    if (tag < PayloadCount + 1) {
+    if (tag < getNumInhabitedTags()) {
       *extraInhabitantIndex = -1; // Valid payload, not an XI
     } else {
       // XIs are coded starting from the highest value that fits
@@ -901,6 +900,21 @@ public:
       *extraInhabitantIndex = maxTag - tag;
     }
     return true;
+  }
+
+  // The number of tag values that hold valid content: one per payload case,
+  // plus however many are needed to number the non-payload cases in the
+  // payload area.
+  unsigned getNumInhabitedTags() const {
+    unsigned NonPayloadCases = getNumCases() - NumEffectivePayloadCases;
+    if (NonPayloadCases == 0)
+      return NumEffectivePayloadCases;
+    unsigned PayloadSize = getPayloadSize();
+    if (PayloadSize >= 4)
+      return NumEffectivePayloadCases + 1;
+    unsigned CasesPerTag = 1U << (PayloadSize * 8U);
+    return NumEffectivePayloadCases
+      + (NonPayloadCases + CasesPerTag - 1) / CasesPerTag;
   }
 
   BitMask getSpareBits(TypeConverter &TC, bool &hasAddrOnly) const override {
@@ -1039,7 +1053,7 @@ public:
     tagBits += extraTagSize * 8;
 
     // Check whether this tag is used for valid content
-    auto payloadCases = getNumPayloadCases();
+    auto payloadCases = NumEffectivePayloadCases;
     auto nonPayloadCases = getNumCases() - payloadCases;
     uint32_t inhabitedTags;
     if (nonPayloadCases == 0) {

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -502,7 +502,10 @@ ArrayTypeInfo::ArrayTypeInfo(intptr_t size, const TypeRef *elementTR,
                /* size */ elementTI->getStride() * size,
                /* alignment */ elementTI->getAlignment(),
                /* stride */ elementTI->getStride() * size,
-               /* numExtraInhabitants */ elementTI->getNumExtraInhabitants(),
+               // An empty array has nowhere to store an extra inhabitant; a
+               // non-empty one takes them from its first element.
+               /* numExtraInhabitants */
+               size == 0 ? 0 : elementTI->getNumExtraInhabitants(),
                /* borrowability */ elementTI->getBorrowability(),
                /* FixedArray is always afd */ true),
       ElementTR(elementTR), ElementTI(elementTI), ElementCount(size) {}
@@ -510,12 +513,27 @@ ArrayTypeInfo::ArrayTypeInfo(intptr_t size, const TypeRef *elementTR,
 bool ArrayTypeInfo::readExtraInhabitantIndex(
     remote::MemoryReader &reader, remote::RemoteAddress address,
     int *extraInhabitantIndex) const {
+  if (ElementCount == 0) {
+    *extraInhabitantIndex = -1;
+    return true;
+  }
   return ElementTI->readExtraInhabitantIndex(reader, address,
                                              extraInhabitantIndex);
 }
 
 BitMask ArrayTypeInfo::getSpareBits(TypeConverter &TC, bool &hasAddrOnly) const {
-  return ElementTI->getSpareBits(TC, hasAddrOnly);
+  if (ElementCount == 0)
+    return BitMask::zeroMask(getSize());
+
+  // Only the first element contributes spare bits, along with any padding out
+  // to its stride. The remaining elements hold values of their own, so an
+  // enclosing enum can't put its tag there.
+  auto mask = BitMask::oneMask(getSize());
+  mask.andMask(ElementTI->getSpareBits(TC, hasAddrOnly), 0);
+  unsigned elementStride = ElementTI->getStride();
+  if (getSize() > elementStride)
+    mask.andNotMask(BitMask::oneMask(getSize() - elementStride), elementStride);
+  return mask;
 }
 
 class UnsupportedEnumTypeInfo: public EnumTypeInfo {
@@ -2823,8 +2841,14 @@ public:
       return nullptr;
     }
 
-    return TC.makeTypeInfo<ArrayTypeInfo>(sizeInt->getValue(),
-                                          BA->getElementType(), elementTI);
+    // A negative count makes the array uninhabited, and IRGen lays both it and
+    // a zero count out as empty.
+    auto count = sizeInt->getValue();
+    if (count < 0)
+      count = 0;
+
+    return TC.makeTypeInfo<ArrayTypeInfo>(count, BA->getElementType(),
+                                          elementTI);
   }
 
   const TypeInfo *visitBuiltinBorrowTypeRef(const BuiltinBorrowTypeRef *BA) {

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -572,7 +572,10 @@ swift_layout_kind_t getTypeInfoKind(const TypeInfo &TI) {
   }
 
   case TypeInfoKind::Borrow: {
-    swift_unreachable("not implemented");
+    // Either a bitwise copy of the referent or a pointer to it. Not
+    // SWIFT_RAW_POINTER even in the latter case: that promises the address of a
+    // heap allocation, and a borrow can point into the interior of one.
+    return SWIFT_BUILTIN;
   }
   }
 

--- a/validation-test/Reflection/reflect_Builtin_FixedArray_empty.swift
+++ b/validation-test/Reflection/reflect_Builtin_FixedArray_empty.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -lswiftSwiftReflectionTest %s -o %t/reflect_Builtin_FixedArray_empty
+// RUN: %target-codesign %t/reflect_Builtin_FixedArray_empty
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Builtin_FixedArray_empty | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+
+// An empty Builtin.FixedArray occupies no storage, so it has nowhere to hold an
+// extra inhabitant no matter how many its element type has. Bool's byte carries
+// 254, which a zero-element array must not inherit.
+class Holder {
+  var empty: InlineArray<0, Bool> = .init(repeating: false)
+  var one: InlineArray<1, Bool> = .init(repeating: false)
+}
+
+reflect(object: Holder())
+
+// CHECK: Reflecting an object.
+// CHECK: Type reference:
+// CHECK: (class reflect_Builtin_FixedArray_empty.Holder)
+
+// CHECK: Type info:
+// CHECK: (field name=empty
+// CHECK: (array size=0 alignment=1 stride=0 num_extra_inhabitants=0 bitwise_takable=1 count=0
+// CHECK: (field name=one
+// CHECK: (array size=1 alignment=1 stride=1 num_extra_inhabitants=254 bitwise_takable=1 count=1
+
+doneReflecting()
+
+// CHECK: Done.

--- a/validation-test/Reflection/reflect_Enum_MultiPayload_empty_payload_xi.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_empty_payload_xi.swift
@@ -1,0 +1,315 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_empty_payload_xi
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_empty_payload_xi
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_empty_payload_xi | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+
+// Inner's `c(Void)` payload is zero-sized, so layout treats it as a non-payload
+// case and it gets no tag value of its own: tags 0 and 1 hold the payload cases,
+// tag 2 numbers the three non-payload cases, and tags 3 through 255 are extra
+// inhabitants. Counting `c` as a payload case makes tag 3 look like valid
+// content, which loses the last extra inhabitant.
+enum Inner {
+case a(Int8)
+case b(Int8)
+case c(Void)
+case d
+case e
+}
+
+// Outer has enough non-payload cases to reach Inner's last extra inhabitant.
+enum Outer {
+case payload(Inner)
+case x0
+case x1
+case x2
+case x3
+case x4
+case x5
+case x6
+case x7
+case x8
+case x9
+case x10
+case x11
+case x12
+case x13
+case x14
+case x15
+case x16
+case x17
+case x18
+case x19
+case x20
+case x21
+case x22
+case x23
+case x24
+case x25
+case x26
+case x27
+case x28
+case x29
+case x30
+case x31
+case x32
+case x33
+case x34
+case x35
+case x36
+case x37
+case x38
+case x39
+case x40
+case x41
+case x42
+case x43
+case x44
+case x45
+case x46
+case x47
+case x48
+case x49
+case x50
+case x51
+case x52
+case x53
+case x54
+case x55
+case x56
+case x57
+case x58
+case x59
+case x60
+case x61
+case x62
+case x63
+case x64
+case x65
+case x66
+case x67
+case x68
+case x69
+case x70
+case x71
+case x72
+case x73
+case x74
+case x75
+case x76
+case x77
+case x78
+case x79
+case x80
+case x81
+case x82
+case x83
+case x84
+case x85
+case x86
+case x87
+case x88
+case x89
+case x90
+case x91
+case x92
+case x93
+case x94
+case x95
+case x96
+case x97
+case x98
+case x99
+case x100
+case x101
+case x102
+case x103
+case x104
+case x105
+case x106
+case x107
+case x108
+case x109
+case x110
+case x111
+case x112
+case x113
+case x114
+case x115
+case x116
+case x117
+case x118
+case x119
+case x120
+case x121
+case x122
+case x123
+case x124
+case x125
+case x126
+case x127
+case x128
+case x129
+case x130
+case x131
+case x132
+case x133
+case x134
+case x135
+case x136
+case x137
+case x138
+case x139
+case x140
+case x141
+case x142
+case x143
+case x144
+case x145
+case x146
+case x147
+case x148
+case x149
+case x150
+case x151
+case x152
+case x153
+case x154
+case x155
+case x156
+case x157
+case x158
+case x159
+case x160
+case x161
+case x162
+case x163
+case x164
+case x165
+case x166
+case x167
+case x168
+case x169
+case x170
+case x171
+case x172
+case x173
+case x174
+case x175
+case x176
+case x177
+case x178
+case x179
+case x180
+case x181
+case x182
+case x183
+case x184
+case x185
+case x186
+case x187
+case x188
+case x189
+case x190
+case x191
+case x192
+case x193
+case x194
+case x195
+case x196
+case x197
+case x198
+case x199
+case x200
+case x201
+case x202
+case x203
+case x204
+case x205
+case x206
+case x207
+case x208
+case x209
+case x210
+case x211
+case x212
+case x213
+case x214
+case x215
+case x216
+case x217
+case x218
+case x219
+case x220
+case x221
+case x222
+case x223
+case x224
+case x225
+case x226
+case x227
+case x228
+case x229
+case x230
+case x231
+case x232
+case x233
+case x234
+case x235
+case x236
+case x237
+case x238
+case x239
+case x240
+case x241
+case x242
+case x243
+case x244
+case x245
+case x246
+case x247
+case x248
+case x249
+case x250
+case x251
+case x252
+}
+
+reflect(enumValue: Outer.x252)
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_empty_payload_xi.Outer)
+// CHECK-NEXT: Value: .x252
+
+reflect(enumValue: Outer.x0)
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_empty_payload_xi.Outer)
+// CHECK-NEXT: Value: .x0
+
+reflect(enumValue: Outer.payload(.c(())))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_empty_payload_xi.Outer)
+// CHECK-NEXT: Value: .payload(.c(_))
+
+reflect(enumValue: Outer.payload(.a(1)))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_empty_payload_xi.Outer)
+// CHECK-NEXT: Value: .payload(.a(_))
+
+doneReflecting()
+
+// CHECK: Done.


### PR DESCRIPTION
Various small fixes to RemoteInspection's type lowering and metadata reading.

A multi-payload enum's extra inhabitants start above the number of *effective* payload cases, since a case whose payload is non-generic and zero-sized is laid out as a non-payload case and gets no tag value of its own. Both readExtraInhabitantIndex implementations took the boundary from getNumPayloadCases(), which counts every case carrying a type ref, so an enclosing enum lost the extra inhabitants at the bottom of the range and misprojected the cases encoded in them. The tagged variant also approximated the empty cases as a single extra tag value; it now derives the count the way the spare-bits variant already does.

Builtin.FixedArray gets three layout fixes. An empty array occupies no storage, so it reports no extra inhabitants and no spare bits rather than inheriting the element's — a zero-element array of Bool claimed 254 extra inhabitants in zero bytes. A negative element count lays out as empty, matching IRGen, instead of multiplying into an unsigned size and producing a Builtin.FixedArray<-1, Int> just under 4GiB. Spare bits come from the first element and its trailing padding, as getArraySpareBits does, rather than from the element type alone.

MetadataReader handles MetadataKind::Borrow by reading the referent out of TargetBorrowTypeMetadata and calling createBuiltinBorrowType, which TypeDecoder and both builders already supported; borrow metadata previously fell through to the opaque type. getTypeInfoKind reports TypeInfoKind::Borrow as SWIFT_BUILTIN — type lowering already gives BorrowTypeInfo the size and alignment of whichever representation the borrow uses — where it previously reached swift_unreachable and took the client down when inspecting a type with a Builtin.Borrow field.

intTypeBitSize parses a 'Bi' N '_' mangling's width into an unsigned rather than a uint8_t, so Bi256_ and wider no longer overflow into a parse failure that made the caller read the type's extra inhabitants as a heap pointer's. Latent: nothing wider than Builtin.Int128 is reachable today and Builtin.Int256 gets no builtin descriptor to lower from.