### PR TITLE
[Markup] Declare the remaining doc comment fields in the comment XML schema

### DIFF
--- a/bindings/xml/comment-xml-schema.rng
+++ b/bindings/xml/comment-xml-schema.rng
@@ -533,6 +533,30 @@
     </element>
   </define>
 
+  <define name="Keyword">
+    <element name="Keyword">
+      <zeroOrMore>
+        <ref name="BlockContent"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="Mutatingvariant">
+    <element name="Mutatingvariant">
+      <zeroOrMore>
+        <ref name="BlockContent"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="Nonmutatingvariant">
+    <element name="Nonmutatingvariant">
+      <zeroOrMore>
+        <ref name="BlockContent"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
   <define name="Note">
     <element name="Note">
       <zeroOrMore>
@@ -551,6 +575,22 @@
 
   <define name="Precondition">
     <element name="Precondition">
+      <zeroOrMore>
+        <ref name="BlockContent"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="Recommended">
+    <element name="Recommended">
+      <zeroOrMore>
+        <ref name="BlockContent"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="Recommendedover">
+    <element name="Recommendedover">
       <zeroOrMore>
         <ref name="BlockContent"/>
       </zeroOrMore>
@@ -821,9 +861,14 @@
       <ref name="Experiment"/>
       <ref name="Important"/>
       <ref name="Invariant"/>
+      <ref name="Keyword"/>
+      <ref name="Mutatingvariant"/>
+      <ref name="Nonmutatingvariant"/>
       <ref name="Note"/>
       <ref name="Postcondition"/>
       <ref name="Precondition"/>
+      <ref name="Recommended"/>
+      <ref name="Recommendedover"/>
       <ref name="Remark"/>
       <ref name="Remarks"/>
       <ref name="Requires"/>

--- a/include/swift/Markup/ASTNodes.def
+++ b/include/swift/Markup/ASTNodes.def
@@ -83,7 +83,7 @@ MARKUP_AST_NODE(PrivateExtension, MarkupASTNode)
   MARKUP_AST_NODE(RecommendedField, PrivateExtension)
   MARKUP_AST_NODE(RecommendedoverField, PrivateExtension)
 
-MARKUP_AST_NODE_RANGE(Private, ParamField, WarningField)
+MARKUP_AST_NODE_RANGE(Private, ParamField, RecommendedoverField)
 #undef MARKUP_AST_NODE
 #undef ABSTRACT_MARKUP_AST_NODE
 #undef MARKUP_AST_NODE_RANGE

--- a/test/IDE/Inputs/comment_extensions.swift
+++ b/test/IDE/Inputs/comment_extensions.swift
@@ -30,6 +30,15 @@ struct Invariant {
   let x: Int!
 }
 
+/// - keyword: subscript
+func keyword() {}
+
+/// - mutatingvariant: sort()
+func mutatingvariant() {}
+
+/// - nonmutatingvariant: sorted()
+func nonmutatingvariant() {}
+
 /// - note: This function is very hip and exciting.
 func note() {}
 
@@ -40,6 +49,12 @@ func postcondition(_ x: inout Int) {}
 func precondition(_ x: Int) {
   assert(x < 100)
 }
+
+/// - recommended: sorted()
+func recommended() {}
+
+/// - recommendedover: sort()
+func recommendedover() {}
 
 /// - remark: Always, no, never forget to check your references.
 func remark() {}

--- a/test/IDE/comment_extensions.swift
+++ b/test/IDE/comment_extensions.swift
@@ -24,6 +24,12 @@
 
 // CHECK: {{.*}}DocCommentAsXML=none
 
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>keyword()</Name><USR>s:14swift_ide_test7keywordyyF</USR><Declaration>func keyword()</Declaration><CommentParts><Discussion><Keyword><Para>subscript</Para></Keyword></Discussion></CommentParts></Function>]
+
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>mutatingvariant()</Name><USR>s:14swift_ide_test15mutatingvariantyyF</USR><Declaration>func mutatingvariant()</Declaration><CommentParts><Discussion><Mutatingvariant><Para>sort()</Para></Mutatingvariant></Discussion></CommentParts></Function>]
+
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>nonmutatingvariant()</Name><USR>s:14swift_ide_test18nonmutatingvariantyyF</USR><Declaration>func nonmutatingvariant()</Declaration><CommentParts><Discussion><Nonmutatingvariant><Para>sorted()</Para></Nonmutatingvariant></Discussion></CommentParts></Function>]
+
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>note()</Name><USR>s:14swift_ide_test4noteyyF</USR><Declaration>func note()</Declaration><CommentParts><Discussion><Note><Para>This function is very hip and exciting.</Para></Note></Discussion></CommentParts></Function>]
 
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>postcondition(_:)</Name><USR>s:14swift_ide_test13postconditionyySizF</USR><Declaration>func postcondition(_ x: inout Int)</Declaration><CommentParts><Discussion><Postcondition><Para>x is unchanged</Para></Postcondition></Discussion></CommentParts></Function>]
@@ -32,6 +38,10 @@
 
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>precondition(_:)</Name><USR>s:14swift_ide_test12preconditionyySiF</USR><Declaration>func precondition(_ x: Int)</Declaration><CommentParts><Discussion><Precondition><Para><codeVoice>x &lt; 100</codeVoice></Para></Precondition></Discussion></CommentParts></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
+
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>recommended()</Name><USR>s:14swift_ide_test11recommendedyyF</USR><Declaration>func recommended()</Declaration><CommentParts><Discussion><Recommended><Para>sorted()</Para></Recommended></Discussion></CommentParts></Function>]
+
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>recommendedover()</Name><USR>s:14swift_ide_test15recommendedoveryyF</USR><Declaration>func recommendedover()</Declaration><CommentParts><Discussion><Recommendedover><Para>sort()</Para></Recommendedover></Discussion></CommentParts></Function>]
 
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>remark()</Name><USR>s:14swift_ide_test6remarkyyF</USR><Declaration>func remark()</Declaration><CommentParts><Discussion><Remark><Para>Always, no, never forget to check your references.</Para></Remark></Discussion></CommentParts></Function>]
 


### PR DESCRIPTION
Fixes #91560.

Doc comments can carry the `Keyword`, `MutatingVariant`, `NonmutatingVariant`, `Recommended` and `RecommendedOver` fields — they are listed in `SimpleFields.def`, so they parse, and `DocCommentAsXML` prints each of them as an element of the same name. The comment XML schema in `bindings/xml/comment-xml-schema.rng` was never taught about those five elements, so a comment that uses one of them emits XML that does not validate:

```swift
/// - Keyword: subscript
func keyword() {}
```

```
$ swift-ide-test -print-comments -source-filename t.swift \
    -comments-xml-schema bindings/xml/comment-xml-schema.rng
element Keyword: Relax-NG validity error : Did not expect element Keyword there
… CommentXMLInvalid=[not valid XML: Did not expect element Keyword there]
```

This declares the five elements next to the other simple fields and covers them in `test/IDE/comment_extensions.swift`, which validates its output against the schema. Before the change five declarations in that test were reported as `CommentXMLInvalid`; after it none are, and `comment_measurement.swift` / `comment_to_xml.swift`, the other two tests that validate against the schema, are unaffected.

The element names are kept exactly as the converter prints them (`Mutatingvariant`, `Recommendedover`), since consumers already receive them in that spelling.

While here, the second half of #91560: `MARKUP_AST_NODE_RANGE(Private, ParamField, WarningField)` now ends at the last private extension node. `KeywordField`, `RecommendedField` and `RecommendedoverField` were appended after `WarningField` without moving the end of the range, so `PrivateExtension::classof()` did not accept them. Nothing casts to `PrivateExtension` today, so that part is not observable — the schema is what makes these fields fall over in practice — but the range is wrong as written and would misclassify those three nodes as soon as something does cast.

Verification: the three tests above were run against a local `swift-ide-test` (Ninja-ReleaseAssert). None of `lib/Markup`, `include/swift/Markup`, `lib/IDE/CommentConversion.cpp`, `lib/AST/DocComment.cpp` or `bindings/xml` has changed between that build and this branch's base, and the range change was checked to compile with a stand-alone expansion of `ASTNodes.def` asserting that all three fields now fall inside `First_Private…Last_Private`.
