### PR TITLE
Region isolation: keep Span sources in use

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -587,6 +587,8 @@ private:
   /// NOTE: This can differ from the AST in certain cases since we treat certain
   /// builtin values such as Builtin.RawPointer and Builtin.NativeObject as
   /// non-Sendable even though they are considered Sendable by the AST today.
+  /// ~Escapable types are also treated as non-Sendable so that a live Span is
+  /// an ongoing use of its source.
   static bool isNonSendableType(SILType type, SILFunction *fn);
 
   static bool isSendableType(SILType type, SILFunction *fn) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4444,7 +4444,17 @@ TranslationSemantics
 PartitionOpTranslator::visitMarkDependenceInst(MarkDependenceInst *mdi) {
   assert(isStaticallyLookThroughInst(mdi) && "Out of sync");
   translateSILLookThrough(mdi->getResults(), mdi->getValue());
-  translateSILRequire(mdi->getBase());
+
+  // Nonescaping dependence isn't just a use of the base at this
+  // instruction. The dependent value (e.x.: a Span) keeps using the
+  // borrowed storage until it dies, so put them in the same region.
+  if (mdi->isNonEscaping()) {
+    translateSILMerge(SILValue(mdi),
+                      &mdi->getAllOperands()[MarkDependenceInst::Base],
+                      /*requireOperands=*/true, RegionMergeReason::Assign);
+  } else {
+    translateSILRequire(mdi->getBase());
+  }
   return TranslationSemantics::Special;
 }
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1729,6 +1729,12 @@ bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
     return false;
   }
 
+  // ~Escapable types like Span are often Sendable, but they represent an
+  // ongoing borrow of their source. Region isolation has to track them so a
+  // later use is treated as a use of that source.
+  if (fn && !type.isEscapable(*fn))
+    return true;
+
   // First before we do anything, see if we have a Sendable type. In such a
   // case, just return true early.
   //

--- a/test/Concurrency/span_task_exclusivity.swift
+++ b/test/Concurrency/span_task_exclusivity.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -swift-version 6
+
+// REQUIRES: concurrency
+
+// A live Span is a use of the storage it borrows. Sending the source `var`
+// while that Span is still used is a race; region isolation should reject it.
+//
+// https://github.com/swiftlang/swift/issues/89904
+
+func spanUseAfterSend() async {
+  var a = [1.0, 2.0, 3.0]
+  let s = a.span
+  Task { // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
+    a = []
+  }
+  _ = s[0] // expected-note {{access can happen concurrently}}
+}
+
+func spanUseAfterSendAwaited() async {
+  var a = [1.0, 2.0, 3.0]
+  let s = a.span
+  await Task { // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
+    a = []
+  }.value
+  _ = s[0] // expected-note {{access can happen concurrently}}
+}
+
+@MainActor
+func spanUseAfterSendSameIsolation() async {
+  var a = [1.0, 2.0, 3.0]
+  let s = a.span
+  await Task { @MainActor in // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
+    a.append(4.0)
+  }.value
+  _ = s[0] // expected-note {{access can happen concurrently}}
+}
+
+func spanDeadBeforeSend() async {
+  var a = [1.0, 2.0, 3.0]
+  do {
+    let s = a.span
+    _ = s[0]
+  }
+  Task {
+    a = []
+  }
+}

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -478,6 +478,34 @@ sil [ossa] @mark_dependence_test_base_is_a_require : $@convention(thin) @async (
   return %9999 : $()
 }
 
+// Sending the base of a nonescaping mark_dependence must conflict with a later
+// use of the dependent value. Today the dependent value only required the base
+// at the mark_dependence itself.
+sil [ossa] @mark_dependence_nonescaping_use_result_after_sending_base : $@convention(thin) @async () -> () {
+bb0:
+  %0 = alloc_ref $NonSendableKlass
+  %1 = alloc_ref $NonSendableKlass
+
+  %1a = begin_borrow %1 : $NonSendableKlass
+  %2 = mark_dependence [nonescaping] %1a : $NonSendableKlass on %0 : $NonSendableKlass
+
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-warning @-1 {{}}
+  // expected-note @-2 {{}}
+
+  %useNonSendableKlass = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  apply %useNonSendableKlass(%2) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  // expected-note @-1 {{access can happen concurrently}}
+
+  end_borrow %1a : $NonSendableKlass
+  destroy_value %0 : $NonSendableKlass
+  destroy_value %1 : $NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
 // NOTE: Since Error is Sendable, this just validates that we handle the
 // instruction and don't crash.
 sil [ossa] @alloc_existential_box_test : $@convention(thin) @async <T : Error> (@in T) -> @owned any Error {

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -2285,6 +2285,26 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
 }
 
 
+// CHECK-LABEL: begin running test {{.*}} on test_mark_dependence_nonescaping: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: require %%1:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: merge %%0 with %%1:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_mark_dependence_nonescaping: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_mark_dependence_nonescaping : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %2 = copy_value %0
+  %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %3
+  %r = tuple ()
+  return %r : $()
+}
+
+
 // CHECK-LABEL: begin running test {{.*}} on test_builtin: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 // CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %0 = integer_literal $Builtin.Int64, 1


### PR DESCRIPTION
## Summary
- Region isolation treated `mark_dependence` as a one-shot require of the base, so a live `Span` did not count as a later use of the borrowed storage.
- A `sending` closure could therefore capture and mutate the source `var` while the `Span` was still used (`#89904`).
- Nonescaping `mark_dependence` now merges the dependent value into the base region, and `~Escapable` types are tracked even when they are Sendable.

This matches the approach from the forum thread: don't add a concurrent exclusivity runtime; treat the `Span` as an ongoing local use so the existing use-after-send diagnostic fires.

https://github.com/swiftlang/swift/issues/89904
https://forums.swift.org/t/how-does-this-example-using-span-and-swift-concurrency-compiles/87321

## Test plan
- [ ] `test/Concurrency/span_task_exclusivity.swift`
- [ ] `test/Concurrency/transfernonsendable_instruction_matching.sil`
- [ ] `test/Concurrency/transfernonsendable_partitionop_translation.sil`


Made with [Cursor](https://cursor.com)