### PR TITLE
[SILOptimizer] Keep Span sources in use across sending closures

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -687,6 +687,14 @@ RegionAnalysisValueMap::getIsolationRegion(SILValue value) const {
   return iter->getSecond().getIsolationRegionInfo();
 }
 
+/// ~Escapable values (Span, etc.) can be Sendable, but they are still a
+/// borrow of their source. Region isolation has to track them so a later
+/// use counts as a use of that source.
+static bool isEscapableForRegionIsolation(SILValue value) {
+  SILFunction *fn = value->getFunction();
+  return !fn || value->getType().isEscapable(*fn);
+}
+
 std::pair<TrackableValue, bool>
 RegionAnalysisValueMap::initializeTrackableValue(
     SILValue value, SILIsolationInfo newInfo) const {
@@ -705,8 +713,10 @@ RegionAnalysisValueMap::initializeTrackableValue(
   // If we did not insert, just return the already stored value.
   self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
 
-  // Before we do anything, see if we have a Sendable value.
-  if (!SILIsolationInfo::isNonSendable(value)) {
+  // Before we do anything, see if we have a Sendable value. ~Escapable
+  // Sendable values are still tracked (see isEscapableForRegionIsolation).
+  if (!SILIsolationInfo::isNonSendable(value) &&
+      isEscapableForRegionIsolation(value)) {
     iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
     return {{iter.first->first, iter.first->second}, true};
   }
@@ -748,8 +758,10 @@ TrackableValue RegionAnalysisValueMap::getTrackableValueHelper(
   }
 
   // Then check our oracle to see if the value is actually sendable. If we have
-  // a Sendable value, just return early.
-  if (SILIsolationInfo::isSendable(value)) {
+  // a Sendable value that can escape, just return early. ~Escapable Sendable
+  // values fall through so later uses keep their source in use.
+  if (SILIsolationInfo::isSendable(value) &&
+      isEscapableForRegionIsolation(value)) {
     iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
     return {iter.first->first, iter.first->second};
   }
@@ -4444,7 +4456,17 @@ TranslationSemantics
 PartitionOpTranslator::visitMarkDependenceInst(MarkDependenceInst *mdi) {
   assert(isStaticallyLookThroughInst(mdi) && "Out of sync");
   translateSILLookThrough(mdi->getResults(), mdi->getValue());
-  translateSILRequire(mdi->getBase());
+
+  // Nonescaping dependence isn't just a use of the base at this
+  // instruction. The dependent value (e.x.: a Span) keeps using the
+  // borrowed storage until it dies, so put them in the same region.
+  if (mdi->isNonEscaping()) {
+    translateSILMerge(SILValue(mdi),
+                      &mdi->getAllOperands()[MarkDependenceInst::Base],
+                      /*requireOperands=*/true, RegionMergeReason::Assign);
+  } else {
+    translateSILRequire(mdi->getBase());
+  }
   return TranslationSemantics::Special;
 }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/LifetimeDependence.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/FrozenMultiMap.h"
 #include "swift/Basic/SmallBitVector.h"
@@ -687,14 +688,24 @@ RegionAnalysisValueMap::getIsolationRegion(SILValue value) const {
   return iter->getSecond().getIsolationRegionInfo();
 }
 
-/// A nonescaping mark_dependence result may have a Sendable type, but sending
-/// it must still transfer the region of the value it depends on. Treat that
-/// specific value as non-Sendable inside region isolation without changing the
-/// type's Sendable conformance for the rest of the compiler.
+/// A nonescaping mark_dependence result may have a Sendable type while its
+/// lifetime base is non-Sendable. Treat that specific result as non-Sendable
+/// inside region isolation without changing its type's Sendable conformance.
 static bool isSendableForRegionIsolation(SILValue value) {
   auto *mdi = dyn_cast<MarkDependenceInst>(value);
-  return SILIsolationInfo::isSendable(value) &&
-         !(mdi && mdi->isNonEscaping());
+  bool isSendable = SILIsolationInfo::isSendable(value);
+  if (!isSendable || !mdi || !mdi->isNonEscaping())
+    return isSendable;
+
+  auto base = mdi->getBase();
+  if (SILIsolationInfo::isNonSendable(base))
+    return false;
+
+  if (base->getType().isAddress()) {
+    AddressBaseComputingVisitor visitor;
+    base = visitor.compute(base);
+  }
+  return SILIsolationInfo::isSendable(base);
 }
 
 std::pair<TrackableValue, bool>
@@ -1031,6 +1042,45 @@ namespace {
 /// model. Otherwise, there is an implicit contract in between the frontend and
 /// the optimizer where both are following each other making it easy for the two
 /// to get out of sync.
+static SILValue getSingleInheritedLifetimeSource(ApplyInst *apply) {
+  FullApplySite applySite(apply);
+  auto dependence =
+      applySite.getSubstCalleeType()->getLifetimeDependenceForResult();
+  if (!dependence || !dependence->hasInheritLifetimeParamIndices() ||
+      dependence->hasScopeLifetimeParamIndices() || dependence->hasCaptures())
+    return {};
+
+  auto *indices = dependence->getInheritIndices();
+  if (indices->getNumIndices() != 1)
+    return {};
+
+  unsigned parameterIndex = *indices->begin();
+  auto arguments = applySite.getArgumentsWithoutIndirectResults();
+  if (parameterIndex >= arguments.size())
+    return {};
+  return arguments[parameterIndex];
+}
+
+/// Return true when \p value is forwarded from a nonescaping dependence by
+/// ordinary ownership forwarding or by a single-source inherited lifetime.
+static bool isForwardedFromNonescapingDependence(SILValue value) {
+  while (value) {
+    if (auto *mdi = dyn_cast<MarkDependenceInst>(value))
+      return mdi->isNonEscaping();
+
+    if (auto *apply = dyn_cast<ApplyInst>(value)) {
+      value = getSingleInheritedLifetimeSource(apply);
+      continue;
+    }
+
+    auto *svi = dyn_cast<SingleValueInstruction>(value);
+    if (!svi || !isStaticallyLookThroughInst(svi))
+      return false;
+    value = svi->getOperand(0);
+  }
+  return false;
+}
+
 struct UnderlyingTrackedObjectValueVisitor {
   SILValue value;
 
@@ -1045,6 +1095,18 @@ private:
         mdi && mdi->isNonEscaping()) {
       value = mdi;
       return {};
+    }
+
+    // An inherited lifetime result, such as Span.extracting(...), forwards
+    // the dependence of its source without introducing another
+    // mark_dependence. Follow that result only when it leads back to the
+    // nonescaping dependence tracked here; ordinary Sendable apply results
+    // retain their existing behavior.
+    if (auto *apply = dyn_cast<ApplyInst>(sourceValue)) {
+      auto inheritedSource = getSingleInheritedLifetimeSource(apply);
+      if (inheritedSource &&
+          isForwardedFromNonescapingDependence(inheritedSource))
+        return inheritedSource;
     }
 
     // If our result is ever Sendable, we record that as our value if we do
@@ -1949,6 +2011,22 @@ struct PartitionOpBuilder {
     currentInstPartitionOps->emplace_back(
         PartitionOp::Merge(lookupValueID(rep), lookupValueID(srcOperand->get()),
                            reason, srcOperand));
+  }
+
+  /// Merge a tracked source that is the non-Sendable base of \p srcOperand.
+  /// The operand is retained so diagnostics still point at the SIL use which
+  /// caused the regions to be joined.
+  void addMerge(TrackableValue destValue, TrackableValue srcValue,
+                Operand *srcOperand,
+                RegionMergeReason reason = RegionMergeReason::Unknown) {
+    if (destValue.isSendable() || srcValue.isSendable())
+      return;
+
+    if (destValue.getID() == srcValue.getID())
+      return;
+
+    currentInstPartitionOps->emplace_back(PartitionOp::Merge(
+        destValue.getID(), srcValue.getID(), reason, srcOperand));
   }
 
   /// Mark \p value artifically as being part of an actor-isolated region by
@@ -4470,6 +4548,21 @@ PartitionOpTranslator::visitMarkDependenceInst(MarkDependenceInst *mdi) {
     translateSILMultiAssign(mdi->getResults(), ArrayRef<Operand *>(),
                             makeOperandRefRange(mdi->getAllOperands()),
                             RegionMergeReason::Assign);
+
+    // Multi-assign deliberately ignores Sendable operands. A Sendable address
+    // can still be rooted in the mutable non-Sendable capture box which a
+    // sending closure transfers. Join that base too.
+    auto result = tryToTrackValue(mdi);
+    if (!result)
+      return TranslationSemantics::Special;
+    for (Operand &operand : mdi->getAllOperands()) {
+      auto source = tryToTrackValue(operand.get());
+      if (source && source->value.isSendable() && source->base &&
+          source->base->isNonSendable()) {
+        builder.addMerge(result->value, *source->base, &operand,
+                         RegionMergeReason::Assign);
+      }
+    }
     return TranslationSemantics::Special;
   }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -687,12 +687,14 @@ RegionAnalysisValueMap::getIsolationRegion(SILValue value) const {
   return iter->getSecond().getIsolationRegionInfo();
 }
 
-/// ~Escapable values (Span, etc.) can be Sendable, but they are still a
-/// borrow of their source. Region isolation has to track them so a later
-/// use counts as a use of that source.
-static bool isEscapableForRegionIsolation(SILValue value) {
-  SILFunction *fn = value->getFunction();
-  return !fn || value->getType().isEscapable(*fn);
+/// A nonescaping mark_dependence result may have a Sendable type, but sending
+/// it must still transfer the region of the value it depends on. Treat that
+/// specific value as non-Sendable inside region isolation without changing the
+/// type's Sendable conformance for the rest of the compiler.
+static bool isSendableForRegionIsolation(SILValue value) {
+  auto *mdi = dyn_cast<MarkDependenceInst>(value);
+  return SILIsolationInfo::isSendable(value) &&
+         !(mdi && mdi->isNonEscaping());
 }
 
 std::pair<TrackableValue, bool>
@@ -713,10 +715,9 @@ RegionAnalysisValueMap::initializeTrackableValue(
   // If we did not insert, just return the already stored value.
   self->stateIndexToEquivalenceClass[iter.first->second.getID()] = value;
 
-  // Before we do anything, see if we have a Sendable value. ~Escapable
-  // Sendable values are still tracked (see isEscapableForRegionIsolation).
-  if (!SILIsolationInfo::isNonSendable(value) &&
-      isEscapableForRegionIsolation(value)) {
+  // Before we do anything, see if we have a value that region isolation can
+  // ignore.
+  if (isSendableForRegionIsolation(value)) {
     iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
     return {{iter.first->first, iter.first->second}, true};
   }
@@ -757,11 +758,8 @@ TrackableValue RegionAnalysisValueMap::getTrackableValueHelper(
     return {iter.first->first, iter.first->second};
   }
 
-  // Then check our oracle to see if the value is actually sendable. If we have
-  // a Sendable value that can escape, just return early. ~Escapable Sendable
-  // values fall through so later uses keep their source in use.
-  if (SILIsolationInfo::isSendable(value) &&
-      isEscapableForRegionIsolation(value)) {
+  // Then check our oracle to see if region isolation can ignore the value.
+  if (isSendableForRegionIsolation(value)) {
     iter.first->getSecond().addFlag(TrackableValueFlag::isSendable);
     return {iter.first->first, iter.first->second};
   }
@@ -1040,6 +1038,15 @@ private:
   /// Visit \p sourceValue returning a load base if we find one. The actual
   /// underlying object is value.
   SILValue visit(SILValue sourceValue) {
+    // Copies of a nonescaping mark_dependence result must resolve to the
+    // mark_dependence itself. It is the point where the dependent value is
+    // joined to its base region, even when the result's type is Sendable.
+    if (auto *mdi = dyn_cast<MarkDependenceInst>(sourceValue);
+        mdi && mdi->isNonEscaping()) {
+      value = mdi;
+      return {};
+    }
+
     // If our result is ever Sendable, we record that as our value if we do
     // not have a value yet. We always want to take the first one.
     if (SILIsolationInfo::isSendable(sourceValue)) {
@@ -4455,18 +4462,19 @@ PartitionOpTranslator::visitRefToRawPointerInst(RefToRawPointerInst *r) {
 TranslationSemantics
 PartitionOpTranslator::visitMarkDependenceInst(MarkDependenceInst *mdi) {
   assert(isStaticallyLookThroughInst(mdi) && "Out of sync");
-  translateSILLookThrough(mdi->getResults(), mdi->getValue());
 
   // Nonescaping dependence isn't just a use of the base at this
-  // instruction. The dependent value (e.x.: a Span) keeps using the
-  // borrowed storage until it dies, so put them in the same region.
+  // instruction. The dependent value (e.g. a Span) keeps using the borrowed
+  // storage until it dies, so put the result, value, and base in one region.
   if (mdi->isNonEscaping()) {
-    translateSILMerge(SILValue(mdi),
-                      &mdi->getAllOperands()[MarkDependenceInst::Base],
-                      /*requireOperands=*/true, RegionMergeReason::Assign);
-  } else {
-    translateSILRequire(mdi->getBase());
+    translateSILMultiAssign(mdi->getResults(), ArrayRef<Operand *>(),
+                            makeOperandRefRange(mdi->getAllOperands()),
+                            RegionMergeReason::Assign);
+    return TranslationSemantics::Special;
   }
+
+  translateSILLookThrough(mdi->getResults(), mdi->getValue());
+  translateSILRequire(mdi->getBase());
   return TranslationSemantics::Special;
 }
 

--- a/test/Concurrency/span_task_exclusivity.swift
+++ b/test/Concurrency/span_task_exclusivity.swift
@@ -9,6 +9,15 @@
 func spanUseAfterSend() async {
   var a = [1.0, 2.0, 3.0]
   let s = a.span
+  Task { // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
+    a = []
+  }
+  _ = s[0] // expected-note {{access can happen concurrently}}
+}
+
+func spanUseAfterAwaitedSend() async {
+  var a = [1.0, 2.0, 3.0]
+  let s = a.span
   await Task { // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
     a = []
   }.value
@@ -23,6 +32,16 @@ func spanUseAfterSendSameIsolation() async {
     a.append(4.0)
   }.value
   _ = s[0] // expected-note {{access can happen concurrently}}
+}
+
+func derivedSpanUseAfterSend() async {
+  var a = [1.0, 2.0, 3.0]
+  let s = a.span
+  let tail = s.extracting(droppingFirst: 1)
+  await Task { // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
+    a = []
+  }.value
+  _ = tail[0] // expected-note {{access can happen concurrently}}
 }
 
 func spanDeadBeforeSend() async {

--- a/test/Concurrency/span_task_exclusivity.swift
+++ b/test/Concurrency/span_task_exclusivity.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -swift-version 6
+
+// REQUIRES: concurrency
+
+// A live Span is a use of the storage it borrows. Sending the source var
+// while that Span is still used should be diagnosed.
+// https://github.com/swiftlang/swift/issues/89904
+
+func spanUseAfterSend() async {
+  var a = [1.0, 2.0, 3.0]
+  let s = a.span
+  await Task { // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
+    a = []
+  }.value
+  _ = s[0] // expected-note {{access can happen concurrently}}
+}
+
+@MainActor
+func spanUseAfterSendSameIsolation() async {
+  var a = [1.0, 2.0, 3.0]
+  let s = a.span
+  await Task { @MainActor in // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'a' which is accessed later by code in the current isolation context}}
+    a.append(4.0)
+  }.value
+  _ = s[0] // expected-note {{access can happen concurrently}}
+}
+
+func spanDeadBeforeSend() async {
+  var a = [1.0, 2.0, 3.0]
+  do {
+    let s = a.span
+    _ = s[0]
+  }
+  Task {
+    a = []
+  }
+}

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -478,6 +478,33 @@ sil [ossa] @mark_dependence_test_base_is_a_require : $@convention(thin) @async (
   return %9999 : $()
 }
 
+// Sending the base of a nonescaping mark_dependence must conflict with a
+// later use of the dependent value.
+sil [ossa] @mark_dependence_nonescaping_use_result_after_sending_base : $@convention(thin) @async () -> () {
+bb0:
+  %0 = alloc_ref $NonSendableKlass
+  %1 = alloc_ref $NonSendableKlass
+
+  %1a = begin_borrow %1 : $NonSendableKlass
+  %2 = mark_dependence [nonescaping] %1a : $NonSendableKlass on %0 : $NonSendableKlass
+
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // expected-warning @-1 {{}}
+  // expected-note @-2 {{}}
+
+  %useNonSendableKlass = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  apply %useNonSendableKlass(%2) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  // expected-note @-1 {{access can happen concurrently}}
+
+  end_borrow %1a : $NonSendableKlass
+  destroy_value %0 : $NonSendableKlass
+  destroy_value %1 : $NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
 // NOTE: Since Error is Sendable, this just validates that we handle the
 // instruction and don't crash.
 sil [ossa] @alloc_existential_box_test : $@convention(thin) @async <T : Error> (@in T) -> @owned any Error {

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -29,6 +29,7 @@ final class SendableKlass : Sendable {}
 
 sil @transferSendableKlass : $@convention(thin) @async (@guaranteed SendableKlass) -> ()
 sil @constructSendableKlass : $@convention(thin) () -> @owned SendableKlass
+sil @useInt : $@convention(thin) (Int) -> ()
 
 final class KlassContainingKlasses {
   let nsImmutable : NonSendableKlass
@@ -478,28 +479,25 @@ sil [ossa] @mark_dependence_test_base_is_a_require : $@convention(thin) @async (
   return %9999 : $()
 }
 
-// Sending the base of a nonescaping mark_dependence must conflict with a
-// later use of the dependent value.
+// A nonescaping mark_dependence result remains tied to its base even when the
+// result type is Sendable.
 sil [ossa] @mark_dependence_nonescaping_use_result_after_sending_base : $@convention(thin) @async () -> () {
 bb0:
   %0 = alloc_ref $NonSendableKlass
-  %1 = alloc_ref $NonSendableKlass
-
-  %1a = begin_borrow %1 : $NonSendableKlass
-  %2 = mark_dependence [nonescaping] %1a : $NonSendableKlass on %0 : $NonSendableKlass
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = struct $Int (%1)
+  %3 = mark_dependence [nonescaping] %2 : $Int on %0 : $NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   // expected-warning @-1 {{}}
   // expected-note @-2 {{}}
 
-  %useNonSendableKlass = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  apply %useNonSendableKlass(%2) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  %useInt = function_ref @useInt : $@convention(thin) (Int) -> ()
+  apply %useInt(%3) : $@convention(thin) (Int) -> ()
   // expected-note @-1 {{access can happen concurrently}}
 
-  end_borrow %1a : $NonSendableKlass
   destroy_value %0 : $NonSendableKlass
-  destroy_value %1 : $NonSendableKlass
 
   %9999 = tuple ()
   return %9999 : $()

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -2290,9 +2290,12 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
 // CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
 // CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
 // CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
 // CHECK-NEXT: require %%0:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
 // CHECK-NEXT: require %%1:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
 // CHECK-NEXT: merge %%0 with %%1:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: assign_direct %%2 = %%0:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
 // CHECK-NEXT: end running test {{.*}} on test_mark_dependence_nonescaping: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_mark_dependence_nonescaping : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
 bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -2285,6 +2285,26 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
 }
 
 
+// CHECK-LABEL: begin running test {{.*}} on test_mark_dependence_nonescaping: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %1 = argument of bb0 : $NonSendableKlass
+// CHECK-NEXT: require %%0:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: require %%1:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: merge %%0 with %%1:   %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_mark_dependence_nonescaping: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_mark_dependence_nonescaping : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
+  %2 = copy_value %0
+  %3 = mark_dependence [nonescaping] %2 : $NonSendableKlass on %1 : $NonSendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %3
+  %r = tuple ()
+  return %r : $()
+}
+
+
 // CHECK-LABEL: begin running test {{.*}} on test_builtin: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 // CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %0 = integer_literal $Builtin.Int64, 1

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -2308,6 +2308,48 @@ bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $NonSendableKlass):
 }
 
 
+// A Sendable address can be rooted in a mutable capture box. The box, not the
+// address value, is the source region that a nonescaping dependence must keep
+// in use.
+// CHECK-LABEL: begin running test {{.*}} on test_mark_dependence_nonescaping_sendable_address_base: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK: [[BOX:%%[0-9]+]]: TrackableValue. State: {{.*}}[is_sendable: no]
+// CHECK-NEXT:     Rep Value:   %1 = alloc_box ${ var Int }, var, name "value"
+// CHECK: [[DEPENDENT:%%[0-9]+]]: TrackableValue. State: {{.*}}[is_sendable: no]
+// CHECK-NEXT:     Rep Value:   %4 = mark_dependence [nonescaping] %0 : $Int on %3 : $*Int
+// CHECK: require [mutable_base_of_sendable_val] [[BOX]]:   %4 = mark_dependence [nonescaping] %0 : $Int on %3 : $*Int
+// CHECK-NEXT: assign_fresh [[DEPENDENT]]:   %4 = mark_dependence [nonescaping] %0 : $Int on %3 : $*Int
+// CHECK-NEXT: merge [[DEPENDENT]] with [[BOX]]:   %4 = mark_dependence [nonescaping] %0 : $Int on %3 : $*Int
+// CHECK-NEXT: end running test {{.*}} on test_mark_dependence_nonescaping_sendable_address_base: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_mark_dependence_nonescaping_sendable_address_base : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }, var, name "value"
+  %2 = project_box %1, 0
+  store %0 to [init] %2
+  %3 = begin_access [read] [dynamic] %2
+  %4 = mark_dependence [nonescaping] %0 : $Int on %3 : $*Int
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  end_access %3
+  destroy_value %1
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// A nonescaping dependence with a genuinely Sendable base does not make its
+// Sendable result region-tracked.
+// CHECK-LABEL: begin running test {{.*}} on test_mark_dependence_nonescaping_sendable_base: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK: [[SENDABLE_DEPENDENT:%%[0-9]+]]: TrackableValue. State: {{.*}}[is_sendable: yes]
+// CHECK-NEXT:     Rep Value:   %2 = mark_dependence [nonescaping] %0 : $Int on %1 : $SendableKlass
+// CHECK-NEXT: end running test {{.*}} on test_mark_dependence_nonescaping_sendable_base: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_mark_dependence_nonescaping_sendable_base : $@convention(thin) (Int, @guaranteed SendableKlass) -> () {
+bb0(%0 : $Int, %1 : @guaranteed $SendableKlass):
+  %2 = mark_dependence [nonescaping] %0 : $Int on %1 : $SendableKlass
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  %r = tuple ()
+  return %r : $()
+}
+
+
 // CHECK-LABEL: begin running test {{.*}} on test_builtin: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 // CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   %0 = integer_literal $Builtin.Int64, 1


### PR DESCRIPTION
## Problem

Region isolation does not currently preserve the lifetime relationship between a `Span` and the mutable storage that it borrows.

For example:

```swift
var values = [1.0, 2.0, 3.0]
let span = values.span
await Task { values = [] }.value
print(span[0])
```

The task captures and mutates `values` while `span` is still live. Dynamic exclusivity does not diagnose the mutation because it occurs from another task, and the later `Span` access can read storage that has already been freed.

This is the issue reported in #89904 and discussed on the [Swift Forums](https://forums.swift.org/t/how-does-this-example-using-span-and-swift-concurrency-compiles/87321).

The SIL for this case contains a nonescaping `mark_dependence`, but RBI previously modeled the dependence too narrowly. In the failing case, the lifetime base is a `begin_access` address. That address is Sendable, so RBI's multi-assignment handling deliberately ignored it. However, the address comes from `project_box`, whose root is the mutable `alloc_box` captured by the sending closure.

Ignoring the Sendable intermediate address therefore also lost the relationship to the non-Sendable captured storage that can invalidate the `Span`. This is why the first version of the patch failed the source regression cases in the smoke test.

## Change

This change keeps the exception local to region isolation rather than changing the Sendability of `Span` or introducing a general rule for Sendable values.

RBI resolves copies of dependent values back to a nonescaping `mark_dependence` and preserves the relevant lifetime relationship in the partition model.

Ordinary non-Sendable operands continue to be joined by the existing multi-assignment behavior. The corrective handling is specifically for the case where the lifetime base appears as an otherwise Sendable address, such as `begin_access`, but that address is rooted through `project_box` in a non-Sendable `alloc_box`. In that case, RBI explicitly merges the dependent result with the non-Sendable root of the address.

This matters because the `alloc_box`, rather than the intermediate `begin_access` address, represents the mutable captured storage transferred to the sending closure. Connecting the dependent value to that root makes a later use of the `Span` a use of the same region as the captured source, allowing RBI to diagnose sending or mutating that source while the dependent value remains live.

The handling is intentionally restricted. A nonescaping dependence with a genuinely Sendable base remains Sendable, and unrelated Sendable values keep their existing behavior. Escaping `mark_dependence` instructions are also unchanged.

Derived `Span` values need one additional piece of modeling. Operations such as `extracting(droppingFirst:)` forward a single `@lifetime(copy self)` dependency from one `Span` to another. RBI follows these single-source inherited lifetime chains back to the originating nonescaping `mark_dependence`. This keeps a derived `Span` connected to the same non-Sendable source without introducing general lifetime propagation for unrelated values.

## Tests

The regression coverage added by this series includes:

- sending the source to an unawaited closure while a `Span` is live;
- awaiting the sending closure before subsequently using the `Span`;
- the same pattern on a global actor;
- a derived `Span` whose single inherited lifetime leads back through another `Span`;
- a valid case where the `Span` is dead before the source is sent;
- raw-SIL coverage for a nonescaping `mark_dependence` with a Sendable `Int` result;
- partition-op coverage for the dependence-region joins, including the non-Sendable capture-box root; and
- a negative case verifying that a nonescaping dependence with a genuinely Sendable base remains Sendable.

The earlier smoke test failed the source regression cases and exposed the missing connection from the Sendable `begin_access` address back through `project_box` to its non-Sendable `alloc_box` root. The later correction adds that modeling.

For the current branch:

- `git diff --check` passes.
- The two isolated raw-SIL test cases parse with Apple Swift 6.3.3.
- The modified C++ compiler has not been built locally.
- The full test suite has not been run locally.

I cannot trigger `@swift-ci` from this account, so a collaborator-triggered CI run is still required.

Resolves #89904.
