### PR TITLE
[Embedded] Ensure that we specialize deinits for move-only generic types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -31,15 +31,29 @@ let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-
   (moduleContext: ModulePassContext) in
 
   var worklist = FunctionWorklist()
+  // Types whose deinits have already been specialized, shared across the whole
+  // pass so that no aggregate is walked twice.
+  var handledDeinitTypes = Set<Type>()
   // For embedded Swift, optimize all the functions (there cannot be any
   // generics, type metadata, etc.)
   if moduleContext.options.enableEmbeddedSwift {
     worklist.addAllNonGenericFunctionsAndEmbeddedThunks(of: moduleContext)
+
+    // IRGen emits the value witnesses of a type's metadata, and the destroy
+    // witness calls the deinits of the type and its members. Those deinits must
+    // be fully specialized, because unspecialized generic functions take type
+    // metadata, which doesn't exist in embedded Swift. Seed the worklist with
+    // the specializations so that they get optimized like any other function.
+    //
+    // This covers the types SILGen saw. Concrete instantiations of generic
+    // types are not among them, so `optimize` additionally specializes the
+    // deinits of the non-copyable types it encounters in each function.
+    specializeDeinitsOfEmittedMetadata(moduleContext, &handledDeinitTypes, &worklist)
   } else {
     worklist.addAllMandatoryRequiredFunctions(of: moduleContext)
   }
 
-  optimizeFunctionsTopDown(using: &worklist, moduleContext)
+  optimizeFunctionsTopDown(using: &worklist, &handledDeinitTypes, moduleContext)
 
   // It's not required to set the perf_constraint flag on all functions in embedded mode.
   // Embedded mode already implies that flag.
@@ -49,6 +63,7 @@ let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-
 }
 
 private func optimizeFunctionsTopDown(using worklist: inout FunctionWorklist,
+                                      _ handledDeinitTypes: inout Set<Type>,
                                       _ moduleContext: ModulePassContext) {
   while let f = worklist.pop() {
     moduleContext.transform(function: f) { context in
@@ -57,12 +72,79 @@ private func optimizeFunctionsTopDown(using worklist: inout FunctionWorklist,
       }
     }
 
+    if moduleContext.options.enableEmbeddedSwift {
+      specializeDeinitsOfTypes(in: f, &handledDeinitTypes, moduleContext, &worklist)
+    }
+
     // Generic specialization takes care of removing metatype arguments of generic functions.
     // But sometimes non-generic functions have metatype arguments which must be removed.
     // We need handle this case with a function signature optimization.
     removeMetatypeArgumentsInCallees(of: f, moduleContext)
 
     worklist.addCallees(of: f, moduleContext)
+  }
+}
+
+/// Creates specialized deinits for the non-copyable types whose metadata IRGen
+/// may emit, so that the destroy value witness can call a concrete deinit.
+private func specializeDeinitsOfEmittedMetadata(_ moduleContext: ModulePassContext,
+                                                _ handled: inout Set<Type>,
+                                                _ worklist: inout FunctionWorklist) {
+  // Any function works to answer type-lowering queries about these types; the
+  // types are fully concrete, so the answers don't depend on the context.
+  // Prefer a definition, but a declaration is enough to lower a concrete type.
+  guard let anyFunction = moduleContext.functions.first(where: { $0.isDefinition })
+                          ?? moduleContext.functions.first(where: { _ in true }) else {
+    return
+  }
+  for type in moduleContext.typesWithEmittedMetadata {
+    Optimizer.specializeDeinits(forType: type, in: anyFunction, handled: &handled,
+                                moduleContext) {
+      worklist.pushIfNotVisited($0)
+    }
+  }
+}
+
+/// Specializes the deinits of the non-copyable types appearing in `function`.
+///
+/// The types SILGen recorded are only the ones it declared; a concrete
+/// instantiation of a generic type (`Storage<Int>`) is never among them, yet
+/// IRGen emits metadata — and therefore value witnesses that destroy it — for
+/// such types too. Those instantiations only become apparent once generic
+/// specialization has run, so scan for them as each function is optimized.
+private func specializeDeinitsOfTypes(in function: Function,
+                                      _ handled: inout Set<Type>,
+                                      _ moduleContext: ModulePassContext,
+                                      _ worklist: inout FunctionWorklist) {
+  guard function.isDefinition else {
+    return
+  }
+  for instruction in function.instructions {
+    for result in instruction.results {
+      specializeDeinits(ofType: result.type, in: function, &handled, moduleContext, &worklist)
+    }
+    for operand in instruction.operands {
+      specializeDeinits(ofType: operand.value.type, in: function, &handled, moduleContext,
+                        &worklist)
+    }
+  }
+  for argument in function.arguments {
+    specializeDeinits(ofType: argument.type, in: function, &handled, moduleContext, &worklist)
+  }
+}
+
+private func specializeDeinits(ofType type: Type,
+                               in function: Function,
+                               _ handled: inout Set<Type>,
+                               _ moduleContext: ModulePassContext,
+                               _ worklist: inout FunctionWorklist) {
+  let objectType = type.objectType
+  guard objectType.isMoveOnly, !handled.contains(objectType) else {
+    return
+  }
+  Optimizer.specializeDeinits(forType: objectType, in: function, handled: &handled,
+                              moduleContext) {
+    worklist.pushIfNotVisited($0)
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
@@ -182,6 +182,18 @@ struct ModulePassContext : Context, CustomStringConvertible {
     notifyFunctionTablesChanged()
   }
 
+  /// The types of all non-copyable nominal types declared in this module for
+  /// which IRGen may emit type metadata.
+  var typesWithEmittedMetadata: [Type] {
+    var types: [Type] = []
+    withUnsafeMutablePointer(to: &types) { typesPtr in
+      bridgedPassContext.visitTypesWithEmittedMetadata(typesPtr) { (typesPtr, bridgedType) in
+        typesPtr.assumingMemoryBound(to: [Type].self).pointee.append(bridgedType.type)
+      }
+    }
+    return types
+  }
+
   func createEmptyFunction(
     name: String,
     parameters: [ParameterInfo],

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -57,6 +57,12 @@ private func devirtualize(destroy: some DevirtualizableDestroy,
     return devirtualizeFixedSizeArray(destroy: destroy, isMandatory: isMandatory, context)
   }
 
+  // A tuple has no deinit of its own, but its elements may. Tuples aren't
+  // nominal, so this has to be handled before the `nominal` check below.
+  if type.isTuple {
+    return destroy.devirtualizeTupleElements(isMandatory: isMandatory, context)
+  }
+
   guard let nominal = type.nominal else {
     // E.g. a non-copyable generic function parameter
     return true
@@ -134,6 +140,7 @@ private protocol DevirtualizableDestroy : UnaryInstruction {
   var shouldDropDeinit: Bool { get }
   func createDeinitCall(to deinitializer: Function, _ context: some MutatingContext)
   func devirtualizeStructFields(isMandatory: Bool, _ context: some MutatingContext) -> Bool
+  func devirtualizeTupleElements(isMandatory: Bool, _ context: some MutatingContext) -> Bool
   func devirtualizeEnumPayload(enumCase: EnumCase,
                                in block: BasicBlock,
                                isMandatory: Bool,
@@ -238,6 +245,30 @@ extension DestroyValueInst : DevirtualizableDestroy {
     return true
   }
 
+  fileprivate func devirtualizeTupleElements(isMandatory: Bool, _ context: some MutatingContext) -> Bool {
+    let elements = type.tupleElements
+
+    defer {
+      context.erase(instruction: self)
+    }
+
+    let builder = Builder(before: self, context)
+    if elements.allSatisfy({ $0.isTrivial(in: parentFunction) }) {
+      builder.createEndLifetime(of: operand.value)
+      return true
+    }
+    let destructure = builder.createDestructureTuple(tuple: destroyedValue)
+    var result = true
+
+    for elementValue in destructure.results where !elementValue.type.isTrivial(in: parentFunction) {
+      let destroyElement = builder.createDestroyValue(operand: elementValue)
+      if !devirtualizeDeinits(of: destroyElement, isMandatory: isMandatory, context) {
+        result = false
+      }
+    }
+    return result
+  }
+
   fileprivate func createSwitchEnum(
     atEndOf block: BasicBlock,
     cases: [(Int, BasicBlock)],
@@ -317,6 +348,31 @@ extension DestroyAddrInst : DevirtualizableDestroy {
       return devirtualizeDeinits(of: destroyPayload, isMandatory: isMandatory, context)
     }
     return true
+  }
+
+  fileprivate func devirtualizeTupleElements(isMandatory: Bool, _ context: some MutatingContext) -> Bool {
+    let builder = Builder(before: self, context)
+    let elements = type.tupleElements
+
+    defer {
+      context.erase(instruction: self)
+    }
+    if elements.allSatisfy({ $0.isTrivial(in: parentFunction) }) {
+      builder.createEndLifetime(of: operand.value)
+      return true
+    }
+    var result = true
+    for (elementIdx, elementTy) in elements.enumerated()
+      where !elementTy.isTrivial(in: parentFunction)
+    {
+      let elementAddr = builder.createTupleElementAddr(tupleAddress: destroyedAddress,
+                                                       elementIndex: elementIdx)
+      let destroyElement = builder.createDestroyAddr(address: elementAddr)
+      if !devirtualizeDeinits(of: destroyElement, isMandatory: isMandatory, context) {
+        result = false
+      }
+    }
+    return result
   }
 
   fileprivate func createSwitchEnum(

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -121,6 +121,88 @@ private struct VTableSpecializer {
   }
 }
 
+/// Specializes the deinit of a non-copyable generic type for the concrete `type`.
+///
+/// This is required in Embedded Swift: IRGen emits a call to the deinit from the
+/// destroy value witness of `type`'s metadata, and an unspecialized deinit takes
+/// type metadata for its generic parameters, which doesn't exist in Embedded Swift.
+///
+/// Recurses into stored properties and enum payloads, because emitting a type's
+/// value witnesses also destroys those.
+///
+/// `handled` carries the types already dealt with, so that a caller can share it
+/// across many calls and avoid re-walking the same aggregates.
+func specializeDeinits(forType type: Type,
+                       in function: Function,
+                       handled: inout Set<Type>,
+                       _ context: ModulePassContext,
+                       notifyNewFunction: (Function) -> ())
+{
+  guard type.isMoveOnly, handled.insert(type).inserted else {
+    return
+  }
+
+  if let nominal = type.nominal, nominal.valueTypeDestructor != nil {
+    specializeDeinit(forType: type, nominal: nominal, context, notifyNewFunction)
+  }
+
+  // The value witnesses of an aggregate destroy its members, so their deinits
+  // need to be specialized, too.
+  if type.isStruct {
+    if let fields = type.getNominalFields(in: function) {
+      for field in fields {
+        specializeDeinits(forType: field, in: function, handled: &handled, context,
+                          notifyNewFunction: notifyNewFunction)
+      }
+    }
+  } else if type.isEnum {
+    if let cases = type.getEnumCases(in: function) {
+      for enumCase in cases {
+        if let payload = enumCase.payload {
+          specializeDeinits(forType: payload, in: function, handled: &handled, context,
+                            notifyNewFunction: notifyNewFunction)
+        }
+      }
+    }
+  }
+}
+
+private func specializeDeinit(forType type: Type,
+                              nominal: NominalTypeDecl,
+                              _ context: ModulePassContext,
+                              _ notifyNewFunction: (Function) -> ())
+{
+  guard let origDeinit = context.lookupDeinit(ofNominal: nominal),
+        // A non-generic deinit needs no specialization.
+        origDeinit.isGeneric,
+        // Don't specialize twice.
+        context.lookupSpecializedDeinit(ofType: type) == nil
+  else {
+    return
+  }
+
+  let deinitSubs = type.canonicalType.contextSubstitutionMap.getMethodSubstitutions(for: origDeinit)
+
+  guard !deinitSubs.conformances.contains(where: { !$0.isValid }),
+        context.loadFunction(function: origDeinit, loadCalleesRecursively: true),
+        let specializedDeinit = context.specialize(function: origDeinit, for: deinitSubs,
+                                                   convertIndirectToDirect: false, isMandatory: true)
+  else {
+    return
+  }
+  notifyNewFunction(specializedDeinit)
+
+  context.deserializeAllCallees(of: specializedDeinit, mode: .allFunctions)
+  // Use `shared` rather than `public` linkage: the specialization is only ever
+  // referenced from the value witnesses of types in this module, and importing
+  // modules create their own. Shared linkage lets the linker merge duplicates
+  // and dead-strip the deinit when the metadata that referenced it is stripped.
+  specializedDeinit.set(linkage: .shared, context)
+  specializedDeinit.set(isSerialized: false, context)
+
+  context.addSpecializedDeinit(ofType: type, specializedDeinit)
+}
+
 /// Specializes a witness table of `conformance` for the concrete type of the conformance.
 func specializeWitnessTable(for conformance: Conformance, _ context: ModulePassContext) {
   if let existingSpecialization = context.lookupWitnessTable(for: conformance),

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -48,6 +48,16 @@ extension Context {
     _bridged.lookUpNominalDeinitFunction(ofNominal.bridged).function
   }
 
+  /// Looks up the specialized deinit for a concrete type, if one was created.
+  public func lookupSpecializedDeinit(ofType type: Type) -> Function? {
+    _bridged.lookUpSpecializedDeinitFunction(type.bridged).function
+  }
+
+  /// Registers `deinitFunc` as the specialized deinit of the concrete `type`.
+  public func addSpecializedDeinit(ofType type: Type, _ deinitFunc: Function) {
+    _bridged.addSpecializedDeinit(type.bridged, deinitFunc.bridged)
+  }
+
   public func getBuiltinIntegerType(bitWidth: Int) -> Type { _bridged.getBuiltinIntegerType(bitWidth).type }
 
   public func getBuiltinWordType() -> Type { _bridged.getBuiltinWordType().type }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1616,6 +1616,8 @@ struct BridgedContext {
                                                                           bool loadCalleesRecursively) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedFunction lookupStdlibFunction(BridgedStringRef name) const;
   SWIFT_IMPORT_UNSAFE OptionalBridgedFunction lookUpNominalDeinitFunction(BridgedDeclObj nominal) const;
+  SWIFT_IMPORT_UNSAFE OptionalBridgedFunction lookUpSpecializedDeinitFunction(BridgedType nominalType) const;
+  void addSpecializedDeinit(BridgedType nominalType, BridgedFunction deinitFunc) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap(BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBuiltinIntegerType(SwiftInt bitWidth) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBuiltinWordType() const;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -299,8 +299,19 @@ private:
   llvm::DenseMap<const NominalTypeDecl *, SILMoveOnlyDeinit *>
       MoveOnlyDeinitMap;
 
+  /// Lookup table for specialized move only deinits from types.
+  /// Currently only used in embedded mode.
+  llvm::DenseMap<SILType, SILMoveOnlyDeinit *> SpecializedMoveOnlyDeinitMap;
+
   /// The list of move only deinits in the module.
   std::vector<SILMoveOnlyDeinit *> moveOnlyDeinits;
+
+  /// Non-copyable types declared in this module for which IRGen may emit type
+  /// metadata, recorded by SILGen as it visits them. Only used in embedded
+  /// mode: emitting a type's metadata also emits its value witnesses, whose
+  /// destroy witness calls the deinits of the type and its members, so those
+  /// deinits must be specialized before IRGen runs.
+  std::vector<SILType> noncopyableTypesWithEmittedMetadata;
 
   /// Declarations which are externally visible.
   ///
@@ -683,6 +694,17 @@ public:
   ArrayRef<SILMoveOnlyDeinit *> getMoveOnlyDeinits() const {
     return ArrayRef<SILMoveOnlyDeinit *>(moveOnlyDeinits);
   }
+
+  /// Non-copyable types declared in this module for which IRGen may emit type
+  /// metadata. Recorded by SILGen; only populated in embedded mode.
+  ArrayRef<SILType> getNonCopyableTypesWithEmittedMetadata() const {
+    return noncopyableTypesWithEmittedMetadata;
+  }
+
+  void addNonCopyableTypeWithEmittedMetadata(SILType type) {
+    noncopyableTypesWithEmittedMetadata.push_back(type);
+  }
+
   using moveonlydeinit_iterator = SILMoveOnlyDeinitListType::iterator;
   using moveonlydeinit_const_iterator =
       SILMoveOnlyDeinitListType::const_iterator;
@@ -931,6 +953,16 @@ public:
   /// Returns null on failure.
   SILMoveOnlyDeinit *lookUpMoveOnlyDeinit(const NominalTypeDecl *nomDecl,
                                           bool deserializeLazily = true);
+
+  /// Look up a specialized move only deinit for the given type.
+  /// Returns null on failure.
+  SILMoveOnlyDeinit *lookUpSpecializedMoveOnlyDeinit(SILType nominalType);
+
+  /// Look up the deinit to use when destroying a value of the given type,
+  /// preferring a specialized deinit if one is available.
+  /// Returns null on failure.
+  SILMoveOnlyDeinit *lookUpMoveOnlyDeinitForType(SILType nominalType,
+                                                 bool deserializeLazily = true);
 
   /// Look up the function mapped to the given move only nominal type decl.
   /// Returns null on failure.

--- a/include/swift/SIL/SILMoveOnlyDeinit.h
+++ b/include/swift/SIL/SILMoveOnlyDeinit.h
@@ -26,6 +26,7 @@
 #include "swift/SIL/SILAllocated.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILType.h"
 
 namespace swift {
 
@@ -39,6 +40,13 @@ class SILMoveOnlyDeinit final : public SILAllocated<SILMoveOnlyDeinit> {
   /// The nominal decl that is mapped to this move only deinit table.
   NominalTypeDecl *nominalDecl;
 
+  /// The nominal type if this is a specialized deinit, otherwise null.
+  ///
+  /// Specialized deinits are used in Embedded Swift, where the deinit of a
+  /// generic type must be fully specialized for the concrete type before it
+  /// can be referenced (e.g. from the destroy value witness).
+  SILType nominalType;
+
   /// The SILFunction that implements this deinit.
   SILFunction *funcImpl;
 
@@ -50,16 +58,27 @@ class SILMoveOnlyDeinit final : public SILAllocated<SILMoveOnlyDeinit> {
   SILMoveOnlyDeinit()
       : nominalDecl(nullptr), funcImpl(nullptr), serialized(unsigned(IsNotSerialized)) {}
 
-  SILMoveOnlyDeinit(NominalTypeDecl *nominaldecl, SILFunction *implementation,
-                    unsigned serialized);
+  SILMoveOnlyDeinit(NominalTypeDecl *nominaldecl, SILType nominalType,
+                    SILFunction *implementation, unsigned serialized);
   ~SILMoveOnlyDeinit();
 
 public:
   static SILMoveOnlyDeinit *create(SILModule &mod, NominalTypeDecl *nominalDecl,
+                                   SILType nominalType,
                                    SerializedKind_t serialized,
                                    SILFunction *funcImpl);
 
+  static SILMoveOnlyDeinit *create(SILModule &mod, NominalTypeDecl *nominalDecl,
+                                   SerializedKind_t serialized,
+                                   SILFunction *funcImpl) {
+    return create(mod, nominalDecl, SILType(), serialized, funcImpl);
+  }
+
   NominalTypeDecl *getNominalDecl() const { return nominalDecl; }
+
+  bool isSpecialized() const { return !nominalType.isNull(); }
+
+  SILType getNominalType() const { return nominalType; }
 
   SILFunction *getImplementation() const {
     assert(funcImpl);

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -199,6 +199,14 @@ struct BridgedPassContext {
 
   bool tryOptimizeApplyOfPartialApply(BridgedInstruction closure) const;
   bool tryDeleteDeadClosure(BridgedInstruction closure, bool needKeepArgsAlive) const;
+
+  /// Visits the type of every non-copyable nominal type declared in this
+  /// module for which IRGen may emit type metadata (and therefore value
+  /// witnesses, which destroy the type).
+  void visitTypesWithEmittedMetadata(
+      void *_Nonnull context,
+      void (*_Nonnull callback)(void *_Nonnull context, BridgedType type)) const;
+
   SWIFT_IMPORT_UNSAFE DevirtResult tryDevirtualizeApply(BridgedInstruction apply, bool isMandatory) const;
   bool tryOptimizeKeypath(BridgedInstruction apply) const;
   SWIFT_IMPORT_UNSAFE OptionalBridgedValue constantFoldBuiltin(BridgedInstruction builtin) const;

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2804,6 +2804,17 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
           wt->getDeclContext()->getParentModule() != getSwiftModule())
         return;
     }
+
+    // A conformance can have both an unspecialized witness table and a
+    // specialized one, e.g. when a default implementation in a protocol
+    // extension had to be specialized for the conforming type. Both mangle to
+    // the same symbol, and lookups use the specialized one (see
+    // SILModule::lookUpWitnessTable), so only that one may be emitted. This
+    // matters when witness tables are emitted eagerly rather than on demand.
+    if (!wt->isSpecialized() &&
+        getSILModule().lookUpWitnessTable(wt->getConformance(),
+                                          /*isSpecialized=*/true))
+      return;
   }
 
   // Ensure that relatively-referenced symbols for witness thunks are collocated

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -3238,8 +3238,8 @@ static bool tryEmitDeinitCall(IRGenFunction &IGF,
     return false;
   }
 
-  auto deinitTable = IGF.getSILModule().lookUpMoveOnlyDeinit(
-      nominal, false /*deserialize lazily*/);
+  auto deinitTable = IGF.getSILModule().lookUpMoveOnlyDeinitForType(
+      T, false /*deserialize lazily*/);
 
   // If we do not have a deinit table already deserialized, call the value
   // witness instead.
@@ -3261,7 +3261,11 @@ static bool tryEmitDeinitCall(IRGenFunction &IGF,
          && !deinitTy->hasError()
          && "deinit should have only one parameter");
 
-  auto substitutions = ty->getContextSubstitutionMap();
+  // A specialized deinit is non-generic: it already has the concrete type
+  // baked in, so it needs no substitutions (and takes no metadata arguments).
+  auto substitutions = deinitTable->isSpecialized()
+                           ? SubstitutionMap()
+                           : ty->getContextSubstitutionMap();
                                                      
   CalleeInfo info(deinitTy,
                   deinitTy->substGenericArgs(IGF.getSILModule(),
@@ -3376,8 +3380,8 @@ IsABIAccessible_t irgen::isTypeABIAccessibleIfFixedSize(IRGenModule &IGM,
     return IsABIAccessible;
 
   if (IGM.getSILModule().isTypeMetadataAccessible(ty) ||
-      IGM.getSILModule().lookUpMoveOnlyDeinit(nom,
-                                              false /*deserialize lazily*/))
+      IGM.getSILModule().lookUpMoveOnlyDeinitForType(
+          SILType::getPrimitiveObjectType(ty), false /*deserialize lazily*/))
     return IsABIAccessible;
 
   return IsNotABIAccessible;

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -611,6 +611,30 @@ SILMoveOnlyDeinit *SILModule::lookUpMoveOnlyDeinit(const NominalTypeDecl *C,
   return tbl;
 }
 
+SILMoveOnlyDeinit *
+SILModule::lookUpSpecializedMoveOnlyDeinit(SILType nominalType) {
+  // Specialized deinits are keyed by the object type, so that a lookup for the
+  // corresponding address type finds them too.
+  auto iter = SpecializedMoveOnlyDeinitMap.find(nominalType.getObjectType());
+  if (iter != SpecializedMoveOnlyDeinitMap.end())
+    return iter->second;
+
+  return nullptr;
+}
+
+SILMoveOnlyDeinit *
+SILModule::lookUpMoveOnlyDeinitForType(SILType nominalType,
+                                       bool deserializeLazily) {
+  // Prefer a specialized deinit, which is what must be used in Embedded Swift
+  // when the type is generic: the unspecialized deinit takes type metadata,
+  // which isn't available there.
+  if (auto *specialized = lookUpSpecializedMoveOnlyDeinit(nominalType))
+    return specialized;
+
+  return lookUpMoveOnlyDeinit(nominalType.getNominalOrBoundGenericNominal(),
+                              deserializeLazily);
+}
+
 SILVTable *SILModule::lookUpSpecializedVTable(SILType classTy) {
   // First try to look up R from the lookup table.
   auto R = SpecializedVTableMap.find(classTy);

--- a/lib/SIL/IR/SILMoveOnlyDeinit.cpp
+++ b/lib/SIL/IR/SILMoveOnlyDeinit.cpp
@@ -19,22 +19,27 @@ using namespace swift;
 
 SILMoveOnlyDeinit *SILMoveOnlyDeinit::create(SILModule &mod,
                                              NominalTypeDecl *nominalDecl,
+                                             SILType nominalType,
                                              SerializedKind_t serialized,
                                              SILFunction *funcImpl) {
   auto buf =
       mod.allocate(sizeof(SILMoveOnlyDeinit), alignof(SILMoveOnlyDeinit));
-  auto *table =
-      ::new (buf) SILMoveOnlyDeinit(nominalDecl, funcImpl, unsigned(serialized));
+  auto *table = ::new (buf) SILMoveOnlyDeinit(nominalDecl, nominalType, funcImpl,
+                                              unsigned(serialized));
   mod.moveOnlyDeinits.push_back(table);
-  mod.MoveOnlyDeinitMap[nominalDecl] = table;
+  if (table->isSpecialized())
+    mod.SpecializedMoveOnlyDeinitMap[nominalType.getObjectType()] = table;
+  else
+    mod.MoveOnlyDeinitMap[nominalDecl] = table;
   return table;
 }
 
 SILMoveOnlyDeinit::SILMoveOnlyDeinit(NominalTypeDecl *nominalDecl,
+                                     SILType nominalType,
                                      SILFunction *implementation,
                                      unsigned serialized)
-    : nominalDecl(nominalDecl), funcImpl(implementation),
-      serialized(serialized) {
+    : nominalDecl(nominalDecl), nominalType(nominalType),
+      funcImpl(implementation), serialized(serialized) {
   assert(funcImpl);
   funcImpl->incrementRefCount();
 }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4193,7 +4193,12 @@ static void printSILMoveOnlyDeinits(
       [](const SILMoveOnlyDeinit *v1, const SILMoveOnlyDeinit *v2) -> bool {
         StringRef name1 = v1->getNominalDecl()->getName().str();
         StringRef name2 = v2->getNominalDecl()->getName().str();
-        return name1.compare(name2) == -1;
+        if (int cmp = name1.compare(name2))
+          return cmp == -1;
+        // A nominal decl can have several specialized deinits, so fall back to
+        // the implementation name to get a deterministic order.
+        return v1->getImplementation()->getName() <
+               v2->getImplementation()->getName();
       });
   for (const auto *tbl : sortedTables)
     tbl->print(printCtx.OS(), printCtx.printVerbose());
@@ -4617,7 +4622,12 @@ void SILVTable::dump() const { print(llvm::errs()); }
 void SILMoveOnlyDeinit::print(llvm::raw_ostream &OS, bool verbose) const {
   OS << "sil_moveonlydeinit ";
   printSerializedKind(OS, getSerializedKind());
-  OS << getNominalDecl()->getName() << " {\n";
+  if (SILType nominalTy = getNominalType()) {
+    OS << nominalTy;
+  } else {
+    OS << getNominalDecl()->getName();
+  }
+  OS << " {\n";
   OS << "  @" << getImplementation()->getName();
   OS << "\t// " << demangleSymbol(getImplementation()->getName());
   OS << "\n";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -8233,27 +8233,37 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
                            nullptr, moveOnlyDeinitTableState, M))
     return true;
 
-  // Parse the class name.
-  Identifier name;
-  SourceLoc loc;
-  if (moveOnlyDeinitTableState.parseSILIdentifier(
-          name, loc, diag::expected_sil_value_name))
-    return true;
+  // Parse the nominal type name, or the type of a specialized deinit.
+  NominalTypeDecl *theNominalDecl = nullptr;
+  SILType specializedNominalTy;
+  if (parser.Tok.is(tok::sil_dollar)) {
+    if (SILParser(parser).parseSILType(specializedNominalTy))
+      return true;
+    theNominalDecl = specializedNominalTy.getNominalOrBoundGenericNominal();
+    if (!theNominalDecl)
+      return true;
+  } else {
+    Identifier name;
+    SourceLoc loc;
+    if (moveOnlyDeinitTableState.parseSILIdentifier(
+            name, loc, diag::expected_sil_value_name))
+      return true;
 
-  // Find the nominal decl.
-  llvm::PointerUnion<ValueDecl *, ModuleDecl *> res =
-      lookupTopDecl(parser, name, /*typeLookup=*/true);
-  assert(isa<ValueDecl *>(res) && "Class Nominal-up should return a Decl");
-  ValueDecl *varDecl = cast<ValueDecl *>(res);
-  if (!varDecl) {
-    parser.diagnose(loc, diag::sil_moveonlydeinit_nominal_not_found, name);
-    return true;
-  }
+    // Find the nominal decl.
+    llvm::PointerUnion<ValueDecl *, ModuleDecl *> res =
+        lookupTopDecl(parser, name, /*typeLookup=*/true);
+    assert(isa<ValueDecl *>(res) && "Class Nominal-up should return a Decl");
+    ValueDecl *varDecl = cast<ValueDecl *>(res);
+    if (!varDecl) {
+      parser.diagnose(loc, diag::sil_moveonlydeinit_nominal_not_found, name);
+      return true;
+    }
 
-  auto *theNominalDecl = dyn_cast<NominalTypeDecl>(varDecl);
-  if (!theNominalDecl) {
-    parser.diagnose(loc, diag::sil_moveonlydeinit_nominal_not_found, name);
-    return true;
+    theNominalDecl = dyn_cast<NominalTypeDecl>(varDecl);
+    if (!theNominalDecl) {
+      parser.diagnose(loc, diag::sil_moveonlydeinit_nominal_not_found, name);
+      return true;
+    }
   }
 
   SourceLoc lBraceLoc = parser.Tok.getLoc();
@@ -8286,7 +8296,8 @@ bool SILParserState::parseSILMoveOnlyDeinit(Parser &parser) {
   parser.parseMatchingToken(tok::r_brace, RBraceLoc, diag::expected_sil_rbrace,
                             lBraceLoc);
 
-  SILMoveOnlyDeinit::create(M, theNominalDecl, Serialized, func);
+  SILMoveOnlyDeinit::create(M, theNominalDecl, specializedNominalTy, Serialized,
+                            func);
   return false;
 }
 

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -28,6 +28,7 @@
 #include "swift/SIL/ParseTestSpecification.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILGlobalVariable.h"
+#include "swift/SIL/SILMoveOnlyDeinit.h"
 #include "swift/SIL/SILNode.h"
 #include "swift/SIL/Test.h"
 #include <string>
@@ -896,6 +897,22 @@ BridgedOwnedString BridgedContext::getModuleDescription() const {
 
 OptionalBridgedFunction BridgedContext::lookUpNominalDeinitFunction(BridgedDeclObj nominal)  const {
   return {context->getModule()->lookUpMoveOnlyDeinitFunction(nominal.getAs<swift::NominalTypeDecl>())};
+}
+
+OptionalBridgedFunction BridgedContext::
+lookUpSpecializedDeinitFunction(BridgedType nominalType) const {
+  auto *deinit =
+      context->getModule()->lookUpSpecializedMoveOnlyDeinit(nominalType.unbridged());
+  return {deinit ? deinit->getImplementation() : nullptr};
+}
+
+void BridgedContext::addSpecializedDeinit(BridgedType nominalType,
+                                          BridgedFunction deinitFunc) const {
+  swift::SILType nominalTy = nominalType.unbridged();
+  swift::SILMoveOnlyDeinit::create(*context->getModule(),
+                                   nominalTy.getNominalOrBoundGenericNominal(),
+                                   nominalTy, swift::IsNotSerialized,
+                                   deinitFunc.getFunction());
 }
 
 BridgedFunction BridgedContext::

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -471,6 +471,11 @@ public:
   /// Emit a deinit table for a noncopyable type.
   void emitNonCopyableTypeDeinitTable(NominalTypeDecl *decl);
 
+  /// In Embedded Swift, record a noncopyable type for which IRGen may emit
+  /// type metadata, so that the deinits reachable from its value witnesses can
+  /// be specialized before IRGen runs.
+  void recordNonCopyableTypeWithEmittedMetadata(NominalTypeDecl *decl);
+
   /// Known functions for bridging.
   SILDeclRef getStringToNSStringFn();
   SILDeclRef getNSStringToStringFn();

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1429,6 +1429,23 @@ void SILGenModule::emitNonCopyableTypeDeinitTable(NominalTypeDecl *nom) {
   SILMoveOnlyDeinit::create(f->getModule(), nom, serialized, f);
 }
 
+void SILGenModule::recordNonCopyableTypeWithEmittedMetadata(
+    NominalTypeDecl *nom) {
+  // Only in Embedded Swift, where the deinits reachable from a type's value
+  // witnesses have to be specialized before IRGen runs.
+  if (!getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    return;
+
+  // A generic type's metadata is emitted per-specialization, so there is
+  // nothing to record for the generic declaration itself.
+  if (nom->isGenericContext())
+    return;
+
+  auto type = nom->getDeclaredInterfaceType()->getCanonicalType();
+  M.addNonCopyableTypeWithEmittedMetadata(
+      SILType::getPrimitiveObjectType(type));
+}
+
 namespace {
 
 /// An ASTVisitor for generating SIL from method declarations
@@ -1468,6 +1485,7 @@ public:
     if (auto *nom = dyn_cast<NominalTypeDecl>(theType)) {
       if (!nom->canBeCopyable()) {
         SGM.emitNonCopyableTypeDeinitTable(nom);
+        SGM.recordNonCopyableTypeWithEmittedMetadata(nom);
       }
     }
 

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -195,6 +195,14 @@ bool BridgedPassContext::fitsInOpaqueExistentialPayload(BridgedType type) const 
   return false;
 }
 
+void BridgedPassContext::visitTypesWithEmittedMetadata(
+    void *context,
+    void (*callback)(void *context, BridgedType type)) const {
+  swift::SILModule *mod = invocation->getPassManager()->getModule();
+  for (SILType type : mod->getNonCopyableTypesWithEmittedMetadata())
+    callback(context, {type});
+}
+
 OptionalBridgedFunction BridgedPassContext::specializeFunction(BridgedFunction function,
                                                                BridgedSubstitutionMap substitutions,
                                                                bool convertIndirectToDirect,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3478,6 +3478,9 @@ void SILSerializer::writeSILMoveOnlyDeinit(const SILMoveOnlyDeinit &deinit) {
       !impl->hasValidLinkageForFragileRef(IsSerialized))
     return;
 
+  if (deinit.isSpecialized())
+    return;
+
   // Use the mangled name of the class as a key to distinguish between classes
   // which have the same name (but are in different contexts).
   Mangle::ASTMangler mangler(deinit.getNominalDecl()->getASTContext());

--- a/test/embedded/deinit-specialization-exec.swift
+++ b/test/embedded/deinit-specialization-exec.swift
@@ -1,0 +1,64 @@
+// Check that a specialized deinit created for the destroy value witness of a
+// non-copyable type still runs the right deinits at runtime.
+
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -O -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+var storageDeinits = 0
+
+struct Storage<T>: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+  init(_ value: Int) {
+    p = .allocate(capacity: 1)
+    p.pointee = value
+  }
+  deinit {
+    storageDeinits += 1
+    p.deallocate()
+  }
+}
+
+@export(interface)
+struct Box: ~Copyable {
+  var items: Storage<Int>
+  init(_ value: Int) { items = Storage<Int>(value) }
+}
+
+@export(interface)
+enum MaybeBox: ~Copyable {
+  case none
+  case some(Storage<Int>)
+}
+
+@main
+struct Main {
+  static func main() {
+    do {
+      let b = Box(42)
+      print("value: \(b.items.p.pointee)")
+      // CHECK: value: 42
+    }
+    print("after box: \(storageDeinits)")
+    // CHECK: after box: 1
+
+    do {
+      let e = MaybeBox.some(Storage<Int>(17))
+      if case .some(let s) = e {
+        print("payload: \(s.p.pointee)")
+        // CHECK: payload: 17
+      }
+    }
+    print("after enum: \(storageDeinits)")
+    // CHECK: after enum: 2
+
+    do {
+      let e = MaybeBox.none
+      if case .none = e { print("empty case") }
+      // CHECK: empty case
+    }
+    print("after empty: \(storageDeinits)")
+    // CHECK: after empty: 2
+  }
+}

--- a/test/embedded/deinit-specialization-tuple.swift
+++ b/test/embedded/deinit-specialization-tuple.swift
@@ -1,0 +1,43 @@
+// A tuple has no deinit of its own, so destroying one has to be decomposed into
+// destroys of its elements. Without that, IRGen sees a destroy of a tuple whose
+// element is a generic non-copyable type and reaches for the unspecialized
+// generic deinit, which is illegal in Embedded Swift.
+
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature MoveOnlyTuples -O -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_MoveOnlyTuples
+
+var deinits = 0
+
+struct Storage<T>: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+  init(_ value: Int) {
+    p = .allocate(capacity: 1)
+    p.pointee = value
+  }
+  deinit {
+    deinits += 1
+    p.deallocate()
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    do {
+      let t = (Storage<Int>(7), 1)
+      _ = t.1
+    }
+    print("after one element: \(deinits)")
+    // CHECK: after one element: 1
+
+    do {
+      let t = (Storage<Int>(1), Storage<Int>(2))
+      _ = t
+    }
+    print("after two elements: \(deinits)")
+    // CHECK: after two elements: 3
+  }
+}

--- a/test/embedded/deinit-specialization.swift
+++ b/test/embedded/deinit-specialization.swift
@@ -1,0 +1,81 @@
+// Emitting the metadata of a non-copyable type also emits its value witnesses,
+// and the destroy witness calls the deinits of the type and its members. In
+// Embedded Swift those deinits must be fully specialized, because unspecialized
+// generic functions take type metadata, which doesn't exist there.
+//
+// `@export(interface)` is what makes a type's metadata emitted eagerly, so the
+// types below use it rather than the module-wide `CodeGenerationModel=interface`
+// (which is not a `Features.def` feature and so can't be spelled in a REQUIRES).
+
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-sil -o - | %FileCheck -check-prefix SIL %s
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-ir -o - | %FileCheck -check-prefix IR %s
+
+// REQUIRES: swift_feature_Embedded
+
+public struct Storage<T>: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+  init() { p = .allocate(capacity: 1) }
+  deinit { p.deallocate() }
+}
+
+// A specialized deinit is created for the concrete Storage<Int> ...
+// SIL-DAG: sil{{.*}} @$e4main7StorageVfDSi_Tg5 : $@convention(method) (@owned Storage<Int>) -> ()
+
+// ... and registered as the deinit to use for that type.
+// SIL-DAG: sil_moveonlydeinit $Storage<Int> {
+// SIL-DAG:   @$e4main7StorageVfDSi_Tg5
+
+// The destroy value witness of a container calls the specialized deinit
+// directly, with no metadata argument.
+// IR-LABEL: define {{.*}} @"$e4main3BoxVwxx"
+// IR: call{{.*}} @"$e4main7StorageVfDSi_Tg5"(ptr
+// IR: ret void
+@export(interface)
+public struct Box: ~Copyable {
+  var items: Storage<Int>
+  init() { items = Storage<Int>() }
+}
+
+// Enum payloads are destroyed by the enum's value witnesses too.
+// IR-LABEL: define {{.*}} @"$e4main9MaybeUsedOwxx"
+// IR: call{{.*}} @"$e4main7StorageVfDSi_Tg5"(ptr
+@export(interface)
+public enum MaybeUsed: ~Copyable {
+  case none
+  case some(Storage<Int>)
+}
+
+// A type is not required to be referenced anywhere for its metadata to be
+// emitted, so an unused container must work as well.
+// IR-LABEL: define {{.*}} @"$e4main6UnusedVwxx"
+// IR: call{{.*}} @"$e4main7StorageVfDSi_Tg5"(ptr
+@export(interface)
+public struct Unused: ~Copyable {
+  var items: Storage<Int>
+}
+
+// A concrete instantiation of a generic type is never among the types SILGen
+// records, so it has to be discovered from the SIL. `LocalOnly<Int>` is only
+// ever a local and `GenericBox<Int>`'s container is itself generic, so neither
+// is reachable from a recorded non-generic type — yet both get a specialized
+// deinit.
+// SIL-DAG: sil_moveonlydeinit $LocalOnly<Int> {
+// SIL-DAG: sil_moveonlydeinit $GenericBox<Int> {
+public struct LocalOnly<T>: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+  init() { p = .allocate(capacity: 1) }
+  deinit { p.deallocate() }
+}
+
+public struct GenericBox<T>: ~Copyable {
+  var q: UnsafeMutablePointer<Int>
+  init() { q = .allocate(capacity: 1) }
+  deinit { q.deallocate() }
+}
+
+public func useLocalOnly() {
+  let s = LocalOnly<Int>()
+  _ = s.p
+  let g = GenericBox<Int>()
+  _ = g.q
+}

--- a/test/embedded/export-interface-specialized-witness-table.swift
+++ b/test/embedded/export-interface-specialized-witness-table.swift
@@ -1,0 +1,52 @@
+// A conformance can end up with two SIL witness tables: the original one, and a
+// `[specialized]` one created when a generic default implementation in a
+// protocol extension had to be specialized for the conforming type. Both mangle
+// to the same symbol, so only the specialized one may be emitted. This is only
+// observable when witness tables are emitted eagerly rather than lazily, which
+// is what `@export(interface)` on the conformance does.
+
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -Osize -emit-sil -o - | %FileCheck -check-prefix SIL %s
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -Osize -emit-ir -o - | %FileCheck -check-prefix IR %s
+
+// REQUIRES: swift_feature_Embedded
+
+public protocol P: AnyObject {
+  func required()
+  func predicate() -> Bool
+}
+
+extension P {
+  // Specializing this generic default method for the conforming type is what
+  // produces the second witness table.
+  public func isSame(_ rhs: some P) -> Bool {
+    if let rhs = rhs as? Self { return rhs.predicate() }
+    return false
+  }
+  public func predicate() -> Bool { true }
+}
+
+public class C {}
+
+@export(interface)
+extension C: P {
+  public func required() {}
+}
+
+// Both witness tables exist in SIL ...
+// SIL-DAG: sil_witness_table C: P module main {
+// SIL-DAG: sil_witness_table shared [specialized] C: P module main {
+
+// ... but exactly one is emitted, and it is the specialized one: the witness for
+// `predicate()` carries a specialization suffix rather than being the generic
+// default implementation's thunk.
+// IR: @"$e4main1CCAA1PAAWP" = constant [{{[0-9]+}} x ptr] [{{.*}}@"$e4main1CCAA1PA2aDP9predicateSbyFTWAC_Tg{{[a-z]*}}5"{{.*}}]
+// IR-NOT: @"$e4main1CCAA1PAAWP" =
+
+var g: any P = C()
+
+@inline(never)
+public func check(_ p: any P) -> Bool {
+  return p.predicate()
+}
+
+public func go() -> Bool { return check(C()) }

--- a/test/embedded/export-interface-specialized-witness-table.swift
+++ b/test/embedded/export-interface-specialized-witness-table.swift
@@ -39,7 +39,7 @@ extension C: P {
 // ... but exactly one is emitted, and it is the specialized one: the witness for
 // `predicate()` carries a specialization suffix rather than being the generic
 // default implementation's thunk.
-// IR: @"$e4main1CCAA1PAAWP" = constant [{{[0-9]+}} x ptr] [{{.*}}@"$e4main1CCAA1PA2aDP9predicateSbyFTWAC_Tg{{[a-z]*}}5"{{.*}}]
+// IR: @"$e4main1CCAA1PAAWP" ={{.*}} constant [{{[0-9]+}} x ptr] [{{.*}}@"$e4main1CCAA1PA2aDP9predicateSbyFTWAC_Tg{{[a-z]*}}5"{{.*}}]
 // IR-NOT: @"$e4main1CCAA1PAAWP" =
 
 var g: any P = C()


### PR DESCRIPTION
We were failing to specialize deinits for move-only generic types,
leading to crashes across modules. Start tracking all of the generic
types that need their deinits specialized, and do so as part of the
generic specializer for embedded swift.

While here, make sure we specialize for move-only tuples as well.
Fixes rdar://185239643.