### PR TITLE
[CSDiagnostics] Diagnose generic thrown error mismatches

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -924,9 +924,6 @@ void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
 }
 
 bool GenericArgumentsMismatchFailure::diagnoseAsError() {
-  if (getContextualTypePurpose() == CTP_ThrowStmt)
-    return diagnoseThrowsTypeMismatch();
-
   auto anchor = getAnchor();
 
   auto fromType = getFromType();
@@ -1004,6 +1001,9 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
     case ConstraintLocator::ContextualType: {
       auto purpose = getContextualTypePurpose();
       assert(purpose != CTP_Unused);
+
+      if (diagnoseThrowsTypeMismatch())
+        return true;
 
       // If this is call to a closure e.g. `let _: A = { B() }()`
       // let's point diagnostic to its result.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -924,6 +924,9 @@ void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
 }
 
 bool GenericArgumentsMismatchFailure::diagnoseAsError() {
+  if (getContextualTypePurpose() == CTP_ThrowStmt)
+    return diagnoseThrowsTypeMismatch();
+
   auto anchor = getAnchor();
 
   auto fromType = getFromType();

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -142,6 +142,13 @@ func testTryIncompatibleTyped(cond: Bool) throws(HomeworkError) {
   } // expected-error {{thrown expression type 'any Error' cannot be converted to error type 'HomeworkError'}}
 }
 
+func throwsGenericError() throws(GenericError<Int>) {}
+
+func testGenericThrownErrorMismatch() throws(GenericError<String>) {
+  try throwsGenericError() // expected-error{{thrown expression type 'GenericError<Int>' cannot be converted to error type 'GenericError<String>'}}
+  throw GenericError<Int>() // expected-error{{thrown expression type 'GenericError<Int>' cannot be converted to error type 'GenericError<String>'}}
+}
+
 func doSomethingWithoutThrowing() { }
 
 func testDoCatchWithoutThrowing() {


### PR DESCRIPTION
Generic argument mismatches are diagnosed by `GenericArgumentsMismatchFailure`. When a mismatch occurs while converting a typed thrown error, the contextual purpose is `CTP_ThrowStmt`, which the generic mismatch diagnostic did not handle. It therefore returned without emitting a diagnostic and triggered the fallback `failed to produce diagnostic for expression` error.

Route this context through the existing thrown-expression mismatch diagnostic. Add regression coverage for both propagating a generic typed error with `try` and throwing one directly.

Tests:
- `utils/run-test --build-dir ../build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64 --build skip test/stmt/typed_throws.swift`
- Original issue reproducer with the locally built `swift-frontend`

Resolves https://github.com/swiftlang/swift/issues/91612