### PR TITLE
Concurrency: extend a workaround for #87548

### DIFF
--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -20,6 +20,8 @@
 #define NOMINMAX
 #include <Windows.h>
 #include <realtimeapiset.h>
+
+#pragma comment(lib, "OneCore.Lib")
 #endif
 
 #if __has_include(<chrono>) && __STDC_HOSTED__

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -41,6 +41,10 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <Windows.h>
+// WORKAROUND #87548
+#if defined(dispatch_STATIC)
+#pragma comment(lib, "dispatch.lib")
+#endif
 #else
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
Windows expects to be able to dynamically link against the dispatch runtime (unless `-static-libdispatch` is passed as a flag, similar to `-static-stdlib`, `-static-libgcc`). Unfortunately, this is not fully wired up properly (see #87548). Add a workaround to pull in libdispatch as a link dependency when built with `-Ddispatch_STATIC`. Normally, we would do a dynamic lookup at runtime via `GetProcAddress` otherwise and not need the import library to link against.

Fixes: #91648