### PR TITLE
OSSA RAUW: don't drop the `[dead_end]` flag when compensating a deleted consume

### DIFF
--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -25,6 +25,7 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/LinearLifetimeChecker.h"
 #include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/ScopedAddressUtils.h"
@@ -288,6 +289,54 @@ void GuaranteedOwnershipExtension::transform(Status status) {
 //                          Utility Helper Functions
 //===----------------------------------------------------------------------===//
 
+/// Whether a destroy_value, which is created to compensate for deleting the
+/// consuming operand \p op, should be marked [dead_end].
+///
+/// If `op`'s user forwards ownership, the new destroy_value takes over the role
+/// of the destroys which ended the forwarded lifetime. Therefore it must only be
+/// a "meaningful" destroy - one which is guaranteed to run the deinitializer -
+/// if one of those destroys was meaningful, too. Otherwise the deinitializer was
+/// never guaranteed to run and earlier optimizations may have left the value
+/// only partially initialized. Running its deinit would then be a miscompile.
+static IsDeadEnd_t isDeadEndCleanup(Operand *op) {
+  ValueWorklist worklist(op->getUser()->getFunction());
+
+  // Pushes all values which take over the forwarded ownership of \p inst,
+  // which also includes the block arguments of forwarding terminators, like
+  // `switch_enum`.
+  // Returns false if \p inst doesn't forward ownership.
+  auto pushForwardedValues = [&](SILInstruction *inst) {
+    ForwardingOperation forwarding(inst);
+    if (!forwarding)
+      return false;
+    return forwarding.visitForwardedValues([&](SILValue value) {
+      worklist.pushIfNotVisited(value);
+      return true;
+    });
+  };
+
+  if (!pushForwardedValues(op->getUser()))
+    return IsntDeadEnd;
+
+  bool foundDeadEndDestroy = false;
+  while (SILValue value = worklist.pop()) {
+    for (Operand *use : value->getUses()) {
+      if (!use->isLifetimeEnding())
+        continue;
+      if (auto *dvi = dyn_cast<DestroyValueInst>(use->getUser())) {
+        if (!dvi->isDeadEnd())
+          return IsntDeadEnd;
+        foundDeadEndDestroy = true;
+        continue;
+      }
+      // Follow forwarded lifetimes.
+      if (!pushForwardedValues(use->getUser()))
+        return IsntDeadEnd;
+    }
+  }
+  return foundDeadEndDestroy ? IsDeadEnd : IsntDeadEnd;
+}
+
 static void cleanupOperandsBeforeDeletion(SILInstruction *oldValue,
                                           InstModCallbacks &callbacks) {
   SILBuilderWithScope builder(oldValue);
@@ -300,7 +349,8 @@ static void cleanupOperandsBeforeDeletion(SILInstruction *oldValue,
     case OwnershipKind::Any:
       llvm_unreachable("Invalid ownership for value");
     case OwnershipKind::Owned: {
-      auto *dvi = builder.createDestroyValue(oldValue->getLoc(), op.get());
+      auto *dvi = builder.createDestroyValue(oldValue->getLoc(), op.get(),
+                                             isDeadEndCleanup(&op));
       callbacks.createdNewInst(dvi);
       continue;
     }

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5766,3 +5766,72 @@ bb0(%2 : @guaranteed $Klass):
   %r = tuple ()
   return %r
 }
+
+// When SILCombine folds away the cast, the destroy_value which it creates to
+// end the lifetime of the cast's operand must keep the [dead_end] flag.
+// Otherwise it turns into a "real" destroy_value which runs the deinitializer,
+// even though earlier optimizations may have left the object only partially
+// initialized (relying on the deinit not being executed).
+//
+// CHECK-LABEL: sil [ossa] @fold_cast_of_dead_end_destroy :
+// CHECK:         destroy_value [dead_end] %0
+// CHECK:       } // end sil function 'fold_cast_of_dead_end_destroy'
+sil [ossa] @fold_cast_of_dead_end_destroy : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $E
+  %1 = upcast %0 to $B
+  %2 = integer_literal $Builtin.Int64, 2
+  %3 = struct $UInt (%2)
+  destroy_value [dead_end] %1
+  unreachable
+}
+
+// Same, but with a chain of forwarding casts.
+//
+// CHECK-LABEL: sil [ossa] @fold_cast_chain_of_dead_end_destroy :
+// CHECK:         destroy_value [dead_end] %0
+// CHECK:       } // end sil function 'fold_cast_chain_of_dead_end_destroy'
+sil [ossa] @fold_cast_chain_of_dead_end_destroy : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $E
+  %1 = upcast %0 to $B
+  %2 = unchecked_ref_cast %1 to $Builtin.NativeObject
+  %3 = integer_literal $Builtin.Int64, 2
+  %4 = struct $UInt (%3)
+  destroy_value [dead_end] %2
+  unreachable
+}
+
+// A meaningful destroy_value must not become a [dead_end] destroy_value.
+//
+// CHECK-LABEL: sil [ossa] @fold_cast_of_real_destroy :
+// CHECK:         destroy_value %0
+// CHECK-NOT:     [dead_end]
+// CHECK:       } // end sil function 'fold_cast_of_real_destroy'
+sil [ossa] @fold_cast_of_real_destroy : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $E
+  %1 = upcast %0 to $B
+  %2 = integer_literal $Builtin.Int64, 2
+  %3 = struct $UInt (%2)
+  destroy_value %1
+  %r = tuple ()
+  return %r
+}
+
+// A meaningful destroy_value in a dead-end block must not become a [dead_end]
+// destroy_value either.
+//
+// CHECK-LABEL: sil [ossa] @fold_cast_of_real_destroy_in_dead_end_block :
+// CHECK:         destroy_value %0
+// CHECK-NOT:     [dead_end]
+// CHECK:       } // end sil function 'fold_cast_of_real_destroy_in_dead_end_block'
+sil [ossa] @fold_cast_of_real_destroy_in_dead_end_block : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $E
+  %1 = upcast %0 to $B
+  %2 = integer_literal $Builtin.Int64, 2
+  %3 = struct $UInt (%2)
+  destroy_value %1
+  unreachable
+}


### PR DESCRIPTION
When OwnershipRAUWHelper erases an ownership forwarding instruction, it creates a `destroy_value` to end the lifetime of the forwarded operand. That `destroy_value` was created without the `[dead_end]` flag, even if the lifetime it takes over only ended in `[dead_end]` destroys.

This is a miscompile: a `[dead_end]` destroy is not guaranteed to run, so other optimizations are free to leave the object partially initialized. Promoting such a destroy to a "real" one then runs the deinitializer on uninitialized fields.

For example, SILCombine folds `destroy_value [dead_end] (upcast %0)` into a destroy of `%0`. For an array buffer object that ended up running `_ContiguousArrayStorage`'s deinit with an uninitialized `countAndCapacity`, which crashed at runtime.

Instead, let the new `destroy_value` inherit the dead-end-ness of the destroys which ended the forwarded lifetime.

rdar://177527604
