### PR TITLE
[6.4][Concurrency] Fix edgecase task local macro expansion

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/TaskLocalMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/TaskLocalMacro.swift
@@ -111,7 +111,8 @@ extension TaskLocalMacro: PeerMacro {
 
     return [
       """
-      \(attributes)\(access)\(nonisolatedKw)\(staticKw)let \(raw: dollarName)\(explicitTypeAnnotation) = TaskLocal(wrappedValue: \(initialValue))
+      \(attributes)
+      \(access)\(nonisolatedKw)\(staticKw)let \(raw: dollarName)\(explicitTypeAnnotation) = TaskLocal(wrappedValue: \(initialValue))
       """
     ]
   }

--- a/test/Concurrency/Macros/task_local_macro_expansion.swift
+++ b/test/Concurrency/Macros/task_local_macro_expansion.swift
@@ -76,3 +76,13 @@ struct SPIAvailableExample {
 
 // CHECK: @_spi_available(macOS 10.15, *)
 // CHECK: public nonisolated static let $spiAvailableVar: TaskLocal<Int?>
+
+@available(SwiftStdlib 5.1, *)
+public struct UsableFromInlineImplicitAccess {
+  @TaskLocal
+  @usableFromInline
+  static var implicitVar: Int?
+}
+
+// CHECK: @usableFromInline
+// CHECK-NEXT: {{ *}}nonisolated static let $implicitVar: TaskLocal<Int?>


### PR DESCRIPTION
**Explanation**: 
This is a regression in 6.4 which would wrongly produce a `usableFromInlinenonisolated` missing a whitespace between the attr and keyword. We fixed this in https://github.com/swiftlang/swift/pull/90791 however we didn't pick this to 6.4, might be worth picking over still if possible.



**Scope**: 
Declarations where `@TaskLocal` is immediately followed by another `@attribute`.

**Risk**: 
- Low, simple correction in macro expansion.

**Testing**: 
- CI testing

**Original PR**:
-  https://github.com/swiftlang/swift/pull/90791

**Reviewed by**:
- @simonjbeaumont 

**Issues**: 
- resolves rdar://182498282
- resolves rdar://185671084