### PR TITLE
[ModuleInterface] Don't print module selectors on synthesized type witnesses

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6652,6 +6652,16 @@ class TypePrinter : public TypeVisitor<TypePrinter, void, NonRecursivePrintOptio
     if (isMemberOfGenericParameter(T))
       return false;
 
+    // A compiler-synthesized member typealias--most importantly, the implicit
+    // typealias that witnesses an associated type--is never printed into a
+    // module interface, so a module selector naming the module that synthesized
+    // it cannot resolve to it. Reading such a name back instead resolves to the
+    // associated type, which belongs to the protocol's module and cannot be
+    // named with a module selector at all, so omit the selector entirely.
+    if (auto *TAD = dyn_cast<TypeAliasDecl>(GTD))
+      if (TAD->isSynthesized() && TAD->getDeclContext()->isTypeContext())
+        return false;
+
     // Module selectors skip over local types, so don't add one.
     return GTD->getLocalContext() == nullptr;
   }

--- a/test/ModuleInterface/Inputs/module_selector/assoc_type_proto.swift
+++ b/test/ModuleInterface/Inputs/module_selector/assoc_type_proto.swift
@@ -1,0 +1,7 @@
+public protocol HasElement {
+  associatedtype Element
+}
+
+public protocol HasIndex {
+  associatedtype Index
+}

--- a/test/ModuleInterface/module_selector_associated_type.swift
+++ b/test/ModuleInterface/module_selector_associated_type.swift
@@ -1,0 +1,50 @@
+// Associated types are declared in the protocol's module, but the typealias
+// that witnesses them is synthesized in the conforming type's module and is
+// never printed into the interface. Neither module can be named with a module
+// selector in that position, so the printer must omit it.
+
+// RUN: %empty-directory(%t)
+
+// Build the module that declares the associated types.
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -enable-library-evolution -parse-as-library -module-name AssocTypeProto -o %t/AssocTypeProto.swiftmodule -emit-module-interface-path %t/AssocTypeProto.swiftinterface %S/Inputs/module_selector/assoc_type_proto.swift
+
+// RUN: %target-swift-emit-module-interface(%t/TestCase.swiftinterface) %s -I %t -target %target-stable-abi-triple -module-name TestCase
+// RUN: %FileCheck --input-file %t/TestCase.swiftinterface %s
+
+// The interface has to be readable by the compiler that produced it.
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestCase.swiftinterface) -I %t -target %target-stable-abi-triple -module-name TestCase
+
+// The same must hold when module selectors are turned off.
+// RUN: %empty-directory(%t/disabled)
+// RUN: %target-swift-emit-module-interface(%t/disabled/TestCase.swiftinterface) %s -I %t -target %target-stable-abi-triple -module-name TestCase -disable-module-selectors-in-module-interface
+// RUN: %target-swift-typecheck-module-from-interface(%t/disabled/TestCase.swiftinterface) -I %t -target %target-stable-abi-triple -module-name TestCase
+
+import AssocTypeProto
+
+// CHECK-LABEL: public struct Bag<Element> :
+// CHECK-SAME: AssocTypeProto::HasElement
+public struct Bag<Element>: HasElement {
+  public init() {}
+
+  // The associated type is witnessed by 'Bag's generic parameter, so no module
+  // selector belongs on 'Element' here.
+  // CHECK: public func firstAssoc() ->
+  // CHECK-SAME: TestCase::Bag<Element>.Element?
+  // CHECK-NOT: .TestCase::Element
+  // CHECK-NOT: .AssocTypeProto::Element
+  public func firstAssoc() -> Self.Element? { nil }
+}
+
+// CHECK-LABEL: public struct Ints :
+// CHECK-SAME: AssocTypeProto::HasIndex
+public struct Ints: HasIndex {
+  public typealias Index = Int
+
+  public init() {}
+
+  // An explicitly written type witness is printed into the interface, so it is
+  // still nameable through the conforming type; the read-back RUN lines above
+  // check that whatever the printer emits here parses.
+  // CHECK: public func firstIndex() ->
+  public func firstIndex() -> Self.Index? { nil }
+}


### PR DESCRIPTION
### Explanation

The module interface printer qualifies an associated type with a module selector naming the *conforming* type's module instead of the module that declares the associated type, producing a `.swiftinterface` the same compiler cannot read back:

```swift
public struct Bag<Element> : Proto::HasElement {
  public func firstAssoc() -> Client::Bag<Element>.Client::Element?
}
```
`Self.Element` sugars to a `TypeAliasType` whose parent is `Bag<Element>` and whose decl is the implicit typealias synthesized by `recordTypeWitness` to witness `HasElement.Element`. That typealias is created in the conformance's decl context, so `shouldPrintModuleSelector` reads its parent module as `Client`. Because the typealias is implicit it is never printed into the interface, so on read-back the name resolves to the `AssociatedTypeDecl` declared in `Proto` and the `Client::` selector rejects it.

The existing carve-outs don't catch this: the alias desugars to the *generic parameter* `Element`, not a dependent member type, and the parent `Bag<Element>` isn't a `SubstitutableType`. So it's the case left over from ef1470ba (rdar://166180424) and 31ef4d00 (rdar://169720990)  where the member's decl is a synthesized type witness on a *concrete* type.

Neither module can be spelled here, and SE-0491 doesn't permit module selectors on associated types, so this omits the selector for compiler-synthesized member typealiases — restoring the pre-6.4 spelling `Client.Bag<Element>.Element?`, which round-trips. The same condition covers the type witnesses synthesized by the Clang importer and by derived conformances (`TangentVector`).

Two source conditions are both required to hit it: the type must be written as a member type path (`Self.Element`), and the associated type must be declared in a different module. `-enable-library-evolution` only turns on `-verify-emitted-module-interface`, which is what catches it  the bad selector is emitted either way, so builds without verification ship an interface consumers cannot compile against.

### Real-world impact

This breaks library-evolution builds against apple/swift-collections. `OrderedSet.remove(at:)` is declared `-> Self.Element` with `Element` coming from `Collection`/`SetAlgebra` in the `Swift` module, so it hits both conditions. Any library built with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES` and `SWIFT_EMIT_MODULE_INTERFACE=YES` depending on swift-collections 1.1.4 fails, with a cascade of overload-resolution errors from the `@inlinable` bodies the verifier re-parses. Deleting only that one qualifier from the emitted interface `.OrderedCollections::Element`  `.Element`, leaving the other 384 selectors in the file including `Swift::Int` on the same line makes it verify clean.

### Test

`test/ModuleInterface/module_selector_associated_type.swift` builds a separate module for the protocol, FileChecks the printed spelling, and runs `-typecheck-module-from-interface` over the emitted interface with selectors both enabled and disabled. The read-back is the real assertion  it fails on `main` and passes with this change.

Opening as a draft  I haven't been able to build the toolchain locally yet, so this is source-reviewed but unverified. Would appreciate a CI run, and I'll move it out of draft once I've confirmed the tests pass locally.

Fixes #91540 