### PR TITLE
[Distributed] Harden swift_distributed_actor_is_remote against non-actors

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include "../CompatibilityOverride/CompatibilityOverride.h"
+#include "../runtime/Private.h"
 #include "Debug.h"
 #include "ExecutorBridge.h"
 #include "TaskPrivate.h"
@@ -2370,23 +2371,46 @@ void swift::swift_defaultActor_deallocate(DefaultActor *_actor) {
 }
 
 #if !SWIFT_CONCURRENCY_EMBEDDED
+enum class ActorClassKind {
+  /// A default actor, i.e. it uses the default actor executor
+  DefaultActor,
+  /// An actor which uses a custom executor
+  NonDefaultActor,
+};
+
+/// Returns what kind of actor (if any) the passed metadata represents.
+static std::optional<ActorClassKind>
+classifyActorClass(const Metadata *metadata) {
+  auto *classMetadata = dyn_cast_or_null<ClassMetadata>(metadata);
+
+  if (!classMetadata || !classMetadata->isTypeMetadata())
+    return std::nullopt;
+
+  bool isActor = false;
+  while (true) {
+    if (!classMetadata->isArtificialSubclass()) {
+      const auto *description = classMetadata->getDescription();
+
+      // Trust the class descriptor if it says it's a default actor
+      if (description->isDefaultActor())
+        return ActorClassKind::DefaultActor;
+
+      isActor |= description->isActor();
+    }
+
+    // Go to the superclass
+    classMetadata = classMetadata->Superclass;
+
+    // If we run out of Swift classes, it's not a default actor
+    if (!classMetadata || !classMetadata->isTypeMetadata())
+      return isActor ? std::optional(ActorClassKind::NonDefaultActor)
+                     : std::nullopt;
+  }
+}
+
 static bool isDefaultActorClass(const ClassMetadata *metadata) {
   assert(metadata->isTypeMetadata());
-  while (true) {
-    // Trust the class descriptor if it says it's a default actor.
-    if (!metadata->isArtificialSubclass() &&
-        metadata->getDescription()->isDefaultActor()) {
-      return true;
-    }
-
-    // Go to the superclass.
-    metadata = metadata->Superclass;
-
-    // If we run out of Swift classes, it's not a default actor.
-    if (!metadata || !metadata->isTypeMetadata()) {
-      return false;
-    }
-  }
+  return classifyActorClass(metadata) == ActorClassKind::DefaultActor;
 }
 #endif
 
@@ -2979,10 +3003,17 @@ swift::swift_distributedActor_remote_initialize(const Metadata *actorType) {
 
 bool swift::swift_distributed_actor_is_remote(HeapObject *_actor) {
 #if !SWIFT_CONCURRENCY_EMBEDDED
-  const ClassMetadata *metadata = cast<ClassMetadata>(_actor->metadata);
-  if (isDefaultActorClass(metadata)) {
+  if (!_actor || isObjCTaggedPointer(_actor))
+    return false;
+
+  auto actorKind = classifyActorClass(swift_getObjectType(_actor));
+  if (!actorKind)
+    return false;
+
+  switch (*actorKind) {
+  case ActorClassKind::DefaultActor:
     return asImpl(reinterpret_cast<DefaultActor *>(_actor))->isDistributedRemote();
-  } else {
+  case ActorClassKind::NonDefaultActor:
     return asImpl(reinterpret_cast<NonDefaultDistributedActor *>(_actor))->isDistributedRemote();
   }
 #else

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -434,15 +434,15 @@ extension DistributedActor {
 
 // ==== isRemote / isLocal -----------------------------------------------------
 
-/// Verifies if the passed ``DistributedActor`` conforming type is a remote reference.
-/// Passing a type not conforming to ``DistributedActor`` may result in undefined behavior.
+/// Checks if the passed ``DistributedActor`` instance is a remote reference.
+/// Passing an object that is not a distributed actor will always return `false`.
 ///
 /// Official API to perform this task is `whenLocal`.
 @_silgen_name("swift_distributed_actor_is_remote")
 public func __isRemoteActor(_ actor: AnyObject) -> Bool
 
-/// Verifies if the passed ``DistributedActor`` conforming type is a local reference.
-/// Passing a type not conforming to ``DistributedActor`` may result in undefined behavior.
+/// Checks if the passed ``DistributedActor`` conforming type is a local instance.
+/// Passing an object that is not a distributed actor will always return `false`.
 ///
 /// Official API to perform this task is `whenLocal`.
 public func __isLocalActor(_ actor: AnyObject) -> Bool {

--- a/test/Distributed/Runtime/distributed_actor_isRemote_non_actor.swift
+++ b/test/Distributed/Runtime/distributed_actor_isRemote_non_actor.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -module-name main -target %target-swift-5.7-abi-triple -j2 -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+import Foundation
+
+final class ZeroFirstByte {
+  var first: UInt8 = 0
+}
+
+final class NonZeroFirstByte {
+  var first: UInt8 = 0xFF
+}
+
+/// No storage at all, so there is nothing to read at object+16
+final class Empty {}
+
+/// A plain actor is never a *distributed* actor, so it is never remote
+actor PlainActor {
+  var field: Int = 0xFF
+}
+
+@main
+struct Main {
+  static func main() {
+    // The answer must not depend on the contents of the first stored property
+    print("isRemote(ZeroFirstByte) = \(__isRemoteActor(ZeroFirstByte()))")
+    // CHECK: isRemote(ZeroFirstByte) = false
+    print("isRemote(NonZeroFirstByte) = \(__isRemoteActor(NonZeroFirstByte()))")
+    // CHECK: isRemote(NonZeroFirstByte) = false
+
+    print("isRemote(Empty) = \(__isRemoteActor(Empty()))")
+    // CHECK: isRemote(Empty) = false
+
+    print("isRemote(PlainActor) = \(__isRemoteActor(PlainActor()))")
+    // CHECK: isRemote(PlainActor) = false
+
+    // A pure ObjC object's isa also reports 'MetadataKind::Class', but it has
+    // no class descriptor to read
+    print("isRemote(NSObject) = \(__isRemoteActor(NSObject()))")
+    // CHECK: isRemote(NSObject) = false
+    print("isRemote(NSMutableArray) = \(__isRemoteActor(NSMutableArray()))")
+    // CHECK: isRemote(NSMutableArray) = false
+
+    // A tagged pointer has no metadata field at all, so it must be rejected
+    // before the metadata is even loaded
+    print("isRemote(NSString) = \(__isRemoteActor(NSString(string: "hi")))")
+    // CHECK: isRemote(NSString) = false
+
+    print("isLocal(NSObject) = \(__isLocalActor(NSObject()))")
+    // CHECK: isLocal(NSObject) = true
+
+    print("done")
+    // CHECK: done
+  }
+}


### PR DESCRIPTION
`__isRemoteActor` is internal API but it is used from generated sources in user modules as well so it is actually public, just underscored.

It was not very resilient against passing in nonsense values, and the argument type was just AnyObject.

This hardens the impl to not crash and just property return false when nonsense values are passed to this function.

Resolves rdar://182990695