### PR TITLE
[Demangler] Fix a potential null pointer deref

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4723,8 +4723,7 @@ NodePointer Demangler::demangleMacroExpansion() {
   } else {
     result = createWithChildren(kind, context, macroName, discriminator);
   }
-  if (privateDiscriminator)
-    result->addChild(privateDiscriminator, *this);
+  addChild(result, privateDiscriminator);
   return result;
 }
 


### PR DESCRIPTION
The input string `"$s3abcLlfMf_"` causes the demangler to dereference a null pointer. This can be prevented by using the`addChild` function, which checks both its arguments for `null`.
