### PR TITLE
build-script: disable benchmark build by default

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -259,7 +259,7 @@ Build the toolchain with optimizations, debuginfo, and assertions, using Ninja:
 
 - macOS:
   ```sh
-  utils/build-script --skip-build-benchmarks \
+  utils/build-script \
     --swift-darwin-supported-archs "$(uname -m)" \
     --release-debuginfo --swift-disable-dead-stripping
   ```

--- a/docs/WebAssembly.md
+++ b/docs/WebAssembly.md
@@ -79,8 +79,7 @@ and the Emscripten stdlib:
   --emscripten-path /opt/homebrew/Cellar/emscripten/<VERSION>/libexec \
   --skip-test-emscripten-stdlib \
   --sccache \
-  --install-swift --install-llvm \
-  --skip-build-benchmarks
+  --install-swift --install-llvm
 ```
 
 Replace `<VERSION>` with your installed Emscripten version (e.g. `5.0.2`).

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -317,7 +317,6 @@ lldb-use-system-debugserver
 release-debuginfo
 test
 no-swift-stdlib-assertions
-skip-build-benchmarks
 skip-test-swift
 skip-test-cmark
 
@@ -325,6 +324,7 @@ skip-test-cmark
 release
 no-assertions
 reconfigure
+build-benchmarks
 
 #===------------------------------------------------------------------------===#
 # Incremental buildbots for Darwin OSes
@@ -455,7 +455,6 @@ test
 skip-test-cmark
 skip-test-swift
 skip-test-foundation
-skip-build-benchmarks
 
 [preset: buildbot_incremental_asan,tools=RDA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms
@@ -681,9 +680,6 @@ stdlib-deployment-targets=macosx-x86_64
 swift-primary-variant-sdk=OSX
 swift-primary-variant-arch=x86_64
 
-# Don't build the benchmarks
-skip-build-benchmarks
-
 # Skip playground tests
 skip-test-playgroundsupport
 
@@ -736,7 +732,6 @@ release
 test
 
 lit-args=-v --time-tests
-skip-build-benchmarks
 no-swift-stdlib-assertions
 lldb-use-system-debugserver
 
@@ -1056,7 +1051,6 @@ install-swift
 install-swiftsyntax
 
 skip-test-linux
-skip-build-benchmarks
 
 reconfigure
 
@@ -1496,9 +1490,6 @@ build-swift-stdlib-unittest-extra
 
 build-embedded-stdlib-cross-compiling
 
-# Don't build the benchmarks
-skip-build-benchmarks
-
 # When building for an Xcode toolchain, don't copy the Swift Resource/ directory
 # into the LLDB.framework. LLDB.framework will be installed alongside a Swift
 # compiler, so LLDB should use its resource directory directly.
@@ -1731,7 +1722,6 @@ mixin-preset=
 #===------------------------------------------------------------------------===#
 
 [preset: LLDB_Nested]
-skip-build-benchmarks
 install-destdir=%(swift_install_destdir)s
 llvm-targets-to-build=X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV
 
@@ -2020,9 +2010,6 @@ llvm-cmake-options=
 # SwiftPM package base
 [preset: mixin_swiftpm_package_macos_platform]
 mixin-preset=mixin_swiftpm_base
-
-# We don't need to build the benchmark if we just want SwiftPM
-skip-build-benchmarks
 
 # We don't need these platforms. Skip them
 skip-ios
@@ -2347,7 +2334,6 @@ darwin-install-extract-symbols=1
 skip-build-cmark
 skip-build-llvm
 skip-build-llbuild
-skip-build-benchmarks
 install-llvm
 install-static-linux-config
 install-swift
@@ -2448,7 +2434,6 @@ reconfigure
 verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra
-skip-build-benchmarks
 
 # This is needed to avoid needless rebuild
 # (in particolar compiler-rt) if we run
@@ -2747,7 +2732,6 @@ build-swift-dynamic-stdlib=0
 build-swift-static-sdk-overlay=0
 build-swift-dynamic-sdk-overlay=0
 build-runtime-with-host-compiler=0
-skip-build-benchmarks
 llvm-include-tests=0
 llvm-enable-modules=0
 build-swift-examples=0
@@ -2775,7 +2759,6 @@ mixin-preset=buildbot_linux
 # small part of llvm and configure both llvm/cmark.
 skip-build-llvm
 skip-build-cmark
-skip-build-benchmarks
 skip-test-cmark
 
 # This triggers the stdlib standalone build: don't build the native tools from
@@ -3123,7 +3106,6 @@ install-swift-testing
 install-swift-testing-macros
 reconfigure
 verbose-build
-skip-build-benchmarks
 
 install-destdir=%(install_destdir)s
 install-prefix=%(install_prefix)s
@@ -3288,7 +3270,6 @@ test
 
 skip-test-cmark
 skip-test-swift
-skip-build-benchmarks
 skip-test-foundation
 
 llvm-cmake-options=
@@ -3315,7 +3296,6 @@ libdispatch
 
 skip-early-swiftsyntax
 skip-early-swift-driver
-skip-build-benchmarks
 build-swift-examples=0
 
 build-runtime-with-host-compiler=0
@@ -3364,7 +3344,6 @@ foundation
 libdispatch
 
 skip-early-swift-driver
-skip-build-benchmarks
 
 enable-experimental-concurrency=1
 
@@ -3403,7 +3382,6 @@ llvm-include-tests=0
 foundation
 libdispatch
 
-skip-build-benchmarks
 skip-test-cmark
 
 build-subdir=%(build_subdir)s
@@ -3438,9 +3416,6 @@ release
 build-ninja
 
 build-embedded-stdlib-cross-compiling
-
-# Don't build the benchmarks
-skip-build-benchmarks
 
 install-llvm
 install-swift

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1399,8 +1399,12 @@ def create_argument_parser():
     option('--skip-build-android', toggle_false('build_android'),
            help='skip building Swift stdlibs for Android')
 
-    option('--skip-build-benchmarks', toggle_false('build_benchmarks'),
-           help='skip building Swift Benchmark Suite')
+    option('--build-benchmarks', toggle_true('build_benchmarks'), default=False,
+           help='build Swift Benchmark Suite')
+
+    option('--skip-build-benchmarks', toggle_true('skip_build_benchmarks'),
+           help='[no-op] building the Swift Benchmark Suite is skipped by '
+                'default; pass --build-benchmarks to opt in')
 
     option('--build-external-benchmarks', toggle_true,
            help='skip building Swift Benchmark Suite')

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -49,7 +49,7 @@ EXPECTED_DEFAULTS = {
     'benchmark_num_onone_iterations': 3,
     'build_android': False,
     'build_args': [],
-    'build_benchmarks': True,
+    'build_benchmarks': False,
     'build_clang_tools_extra': True,
     'build_compiler_rt': True,
     'build_cygwin': True,
@@ -650,6 +650,7 @@ EXPECTED_OPTIONS = [
     SetTrueOption('--reconfigure'),
 
     EnableOption('--android'),
+    EnableOption('--build-benchmarks'),
     EnableOption('--build-external-benchmarks'),
     EnableOption('--build-ninja'),
     EnableOption('--build-lld'),
@@ -759,7 +760,6 @@ EXPECTED_OPTIONS = [
     DisableOption('--skip-build-swift', dest='build_swift'),
 
     DisableOption('--skip-build-android', dest='build_android'),
-    DisableOption('--skip-build-benchmarks', dest='build_benchmarks'),
     DisableOption('--skip-build-cygwin', dest='build_cygwin'),
     DisableOption('--skip-build-freebsd', dest='build_freebsd'),
     DisableOption('--skip-build-ios', dest='build_ios'),
@@ -964,6 +964,7 @@ EXPECTED_OPTIONS = [
     IgnoreOption('--tvos-all'),
     IgnoreOption('--watchos-all'),
     IgnoreOption('--xros-all'),
+    IgnoreOption('--skip-build-benchmarks'),
 
     StrOption('--llvm-install-components'),
     ChoicesOption('--use-linker', dest='use_linker', choices=['gold', 'lld']),


### PR DESCRIPTION
Only the benchmark bots require to build and run those, so make this part opt in to speed up the remaining configurations.

To achieve this, make the current flag a no op (to support configurations we have no control over) and add a new flag to opt in into the build of the benchmarks.

Co-Authored by: Claude

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
