### PR TITLE
Fix 91645

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -563,6 +563,9 @@ struct AddressLoweringState {
 
   // All function-exiting terminators (return or throw instructions).
   SmallVector<TermInst *, 8> exitingInsts;
+  
+  // All program-terminating instructions (unreachable instruction).
+  SmallVector<TermInst *, 8> terminatingInsts;
 
   // All instructions that yield values to callees.
   TinyPtrVector<YieldInst *> yieldInsts;
@@ -585,6 +588,9 @@ struct AddressLoweringState {
     for (auto &block : *function) {
       if (block.getTerminator()->isFunctionExiting())
         exitingInsts.push_back(block.getTerminator());
+      
+      if (block.getTerminator()->isProgramTerminating())
+        terminatingInsts.push_back(block.getTerminator());
     }
   }
 
@@ -694,6 +700,10 @@ static void convertDirectToIndirectFunctionArgs(AddressLoweringState &pass) {
       } else {
         load = argBuilder.createLoadBorrow(loc, undefAddress);
         for (SILInstruction *termInst : pass.exitingInsts) {
+          pass.getBuilder(termInst->getIterator())
+              .createEndBorrow(pass.genLoc(), load);
+        }
+        for (SILInstruction *termInst : pass.terminatingInsts) {
           pass.getBuilder(termInst->getIterator())
               .createEndBorrow(pass.genLoc(), load);
         }

--- a/test/Interpreter/moveonly_generics.swift
+++ b/test/Interpreter/moveonly_generics.swift
@@ -6,7 +6,6 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Needed due to limitations of autoclosures and noncopyable types.
 func eagerAssert(_ b: Bool, _ line: Int = #line) {

--- a/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
+++ b/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
@@ -14,7 +14,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 

--- a/validation-test/compiler_crashers_fixed/91645-direct-to-indirect-arg-ownership-leak.swift
+++ b/validation-test/compiler_crashers_fixed/91645-direct-to-indirect-arg-ownership-leak.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -c %s -o %t -swift-version 6 -enable-sil-opaque-values -Onone
+
+func test() {
+  let a: [([Int]) -> [Int]] = [
+    { x in
+      x.map {
+        $0 + 1
+      }
+    }
+  ]
+  print(a)
+}


### PR DESCRIPTION
 Make sure that borrows are also ended in basic blocks terminated by `UnreachableInst`
    
Fixes https://github.com/swiftlang/swift/issues/91645