### PR TITLE
[SILCloner] Drop debug_values using type-dependent operands

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1833,7 +1833,20 @@ SILCloner<ImplClass>::visitDebugValueInst(DebugValueInst *Inst) {
         NewInst->getFunction()->createEmptyDebugReconstructionBlock();
     NewInst->setDebugReconstructionBlock(NewDebugBB);
     asImpl().cloneDebugReconstructionBlock(SrcDebugBB, NewDebugBB);
-    
+
+    // Type substitutions may rewrite a generic type into an opened archetype.
+    // The cloned instruction then carries type dependent operands on
+    // instructions outside of the reconstruction block, which is not supported.
+    // Keeping an undef of that type does not work either, as debug_value
+    // doesn't support type dependent operands itself.
+    if (llvm::any_of(*NewDebugBB, [](const SILInstruction &I) {
+          return I.getNumTypeDependentOperands() != 0;
+        })) {
+      // Drop the debug_value.
+      NewInst->eraseFromParent();
+      return;
+    }
+
     // Type substitutions may map an address-only (generic) type to something
     // else, in which case, the op_deref must be converted to a load.
     if (NewInst->hasDeref()) {

--- a/test/DebugInfo/inline_reconstruction_block_archetype.sil
+++ b/test/DebugInfo/inline_reconstruction_block_archetype.sil
@@ -1,0 +1,70 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -inline %s | %FileCheck %s
+
+// A debug reconstruction block may mention a generic parameter. Inlining
+// substitutes it, and if the substituted type contains an opened archetype, the
+// cloned instruction needs type dependent operands on the
+// open_existential_metatype instruction defining it, which lives outside the block.
+// This is not supported, so the debug_value must be dropped.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Base {}
+class Box<T> : Base {}
+class Concrete {}
+
+// The block casts to a type using the generic type T.
+// This salvage is valid.
+//
+// CHECK-LABEL: sil [always_inline] [ossa] @generic_callee :
+// CHECK:         debug_value %0 : $Base, let, name "boxed", transform {
+// CHECK:           %1 = unchecked_ref_cast %0 : $Base to $Box<T>
+// CHECK:         }
+// CHECK-LABEL: } // end sil function 'generic_callee'
+sil [ossa] [always_inline] @generic_callee : $@convention(thin) <T> (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+  debug_value %0 : $Base, let, name "boxed", transform {
+  bb0(%0 : $Base):
+    %1 = unchecked_ref_cast %0 : $Base to $Box<T>
+    return %1 : $Box<T>
+  }
+  %r = tuple ()
+  return %r : $()
+}
+
+// The debug_value here, upon inlining, would be rewritten to use the
+// type-dependent value %2 within the reconstruction block, which would
+// crash the verifier.
+//
+// CHECK-LABEL: sil [ossa] @caller_opened_archetype :
+// CHECK-NOT:     debug_value
+// CHECK-NOT:     transform
+// CHECK-NOT:     @opened
+// CHECK-LABEL: } // end sil function 'caller_opened_archetype'
+sil [ossa] @caller_opened_archetype : $@convention(thin) (@guaranteed Base, @thick Any.Type) -> () {
+bb0(%0 : @guaranteed $Base, %1 : $@thick Any.Type):
+  %2 = open_existential_metatype %1 : $@thick Any.Type to $@thick (@opened(1, Any) Self).Type
+  %f = function_ref @generic_callee : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %c = apply %f<@opened(1, Any) Self>(%0) : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// If there is no existential, the debug_value gets inlined with the correct
+// replacement type.
+//
+// CHECK-LABEL: sil [ossa] @caller_concrete :
+// CHECK:         debug_value %0 : $Base, let, name "boxed", transform {
+// CHECK:           %1 = unchecked_ref_cast %0 : $Base to $Box<Concrete>
+// CHECK:           return %1 : $Box<Concrete>
+// CHECK:         }
+// CHECK-LABEL: } // end sil function 'caller_concrete'
+sil [ossa] @caller_concrete : $@convention(thin) (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+  %f = function_ref @generic_callee : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %c = apply %f<Concrete>(%0) : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
If inlining causes a generic to be replaced with an opened archetype, it would crash the compiler with a verifier failure, as the extra type-dependent operands added by the builder would be defined outside of the debug reconstruction block.

Instead, drop those invalid debug values, as there is no way to safely have a debug_value with an opened archetype undef value.

Doesn't change lost variables statistics as this only fixes a rare crash.