### PR TITLE
[DebugInfo] Salvage Debug Info in deleteAllDebugUses 

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -45,24 +45,6 @@ namespace swift {
 
 class SILInstruction;
 
-/// Deletes all of the debug instructions that use \p value.
-inline void deleteAllDebugUses(SILValue value) {
-  for (auto ui = value->use_begin(), ue = value->use_end(); ui != ue;) {
-    auto *inst = ui->getUser();
-    ++ui;
-    if (inst->isDebugInstruction()) {
-      inst->eraseFromParent();
-    }
-  }
-}
-
-/// Deletes all of the debug uses of any result of \p inst.
-inline void deleteAllDebugUses(SILInstruction *inst) {
-  for (SILValue v : inst->getResults()) {
-    deleteAllDebugUses(v);
-  }
-}
-
 /// Drops all of the debug uses of \p value.
 /// Unlike deleteAllDebugUses, this preserves the debug_value instruction
 /// but replaces its operand with undef and strips non-fragment DIExpr parts.

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1833,7 +1833,20 @@ SILCloner<ImplClass>::visitDebugValueInst(DebugValueInst *Inst) {
         NewInst->getFunction()->createEmptyDebugReconstructionBlock();
     NewInst->setDebugReconstructionBlock(NewDebugBB);
     asImpl().cloneDebugReconstructionBlock(SrcDebugBB, NewDebugBB);
-    
+
+    // Type substitutions may rewrite a generic type into an opened archetype.
+    // The cloned instruction then carries type dependent operands on
+    // instructions outside of the reconstruction block, which is not supported.
+    // Keeping an undef of that type does not work either, as debug_value
+    // doesn't support type dependent operands itself.
+    if (llvm::any_of(*NewDebugBB, [](const SILInstruction &I) {
+          return I.getNumTypeDependentOperands() != 0;
+        })) {
+      // Drop the debug_value.
+      NewInst->eraseFromParent();
+      return;
+    }
+
     // Type substitutions may map an address-only (generic) type to something
     // else, in which case, the op_deref must be converted to a load.
     if (NewInst->hasDeref()) {

--- a/include/swift/SILOptimizer/Utils/DebugOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/DebugOptUtils.h
@@ -24,24 +24,19 @@
 
 namespace swift {
 
-/// Deletes all of the debug instructions that use \p value.
-inline void deleteAllDebugUses(SILValue value, InstModCallbacks &callbacks) {
-  for (auto ui = value->use_begin(), ue = value->use_end(); ui != ue;) {
-    auto *inst = ui->getUser();
-    ++ui;
-    if (inst->isDebugInstruction()) {
-      callbacks.deleteInst(inst);
-    }
-  }
-}
 
-/// Deletes all of the debug uses of any result of \p inst.
-inline void deleteAllDebugUses(SILInstruction *inst,
-                               InstModCallbacks &callbacks) {
-  for (SILValue v : inst->getResults()) {
-    deleteAllDebugUses(v, callbacks);
-  }
-}
+/// Salvages the debug uses of any result of \p inst, then deletes whatever
+/// could not be salvaged.
+///
+/// Pass \p salvage as false when the instruction already has been salvaged.
+void deleteAllDebugUses(SILInstruction *inst, InstModCallbacks &callbacks,
+                        bool salvage = true);
+
+/// Salvages the debug uses of any result of \p inst, then deletes whatever
+/// could not be salvaged. Does not use callbacks.
+///
+/// Pass \p salvage as false when the instruction already has been salvaged.
+void deleteAllDebugUses(SILInstruction *inst, bool salvage = true);
 
 /// Transfer debug info associated with (the result of) \p I to a
 /// new `debug_value` instruction before \p I is deleted.

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -19,6 +19,7 @@
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/ADT/StringSwitch.h"
 

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -238,8 +238,8 @@ bool SILCombiner::trySinkOwnedForwardingInst(SingleValueInstruction *svi) {
 
     LLVM_DEBUG(llvm::dbgs() << "Sink forwarding: " << *svi << '\n');
 
-    // Otherwise, delete all of the debug uses so we don't have to sink them as
-    // well and then return true so we process svi in its new position.
+    // Otherwise, salvage all of the debug uses so we don't have to sink them
+    // as well and then return true so we process svi in its new position.
     deleteAllDebugUses(svi, getInstModCallbacks());
     svi->moveBefore(consumingUser);
     MadeChange = true;
@@ -255,6 +255,9 @@ bool SILCombiner::trySinkOwnedForwardingInst(SingleValueInstruction *svi) {
   if (llvm::any_of(getNonDebugUses(svi),
                    [](Operand *use) { return !use->isLifetimeEnding(); }))
     return false;
+
+  // Salvage svi before sinking it.
+  salvageDebugInfo(svi);
 
   while (!svi->use_empty()) {
     auto *sviUse = *svi->use_begin();

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
@@ -20,7 +20,7 @@
 #include "SemanticARCOptVisitor.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
-#include "swift/SIL/DebugUtils.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 
 using namespace swift;
 using namespace swift::semanticarc;
@@ -97,7 +97,7 @@ bool SemanticARCOptVisitor::processWorklist() {
       if (isInstructionTriviallyDead(defInst)) {
         assert(!ctx.assumingAtFixedPoint &&
                "Assumed was at fixed point and recomputing state?!");
-        deleteAllDebugUses(defInst);
+        deleteAllDebugUses(defInst, getCallbacks());
         eraseInstruction(defInst);
         madeChange = true;
         ctx.verify();

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -17,6 +17,7 @@
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SIL/DebugUtils.h"
 
 using namespace swift;

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -26,6 +26,7 @@
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "llvm/ADT/STLExtras.h"

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -337,7 +337,9 @@ splitAggregateLoad(LoadOperation loadInst, CanonicalizeInstruction &pass) {
          && nextII->isDebugInstruction()) {
     ++nextII;
   }
-  deleteAllDebugUses(*loadInst, pass.getCallbacks());
+  // TODO: this might be useless as salvageLoadDebugInfo shouldn't let any
+  // debug uses behind.
+  deleteAllDebugUses(*loadInst, pass.getCallbacks(), /*salvage=*/ false);
   nextII = killInstAndIncidentalUses(*loadInst, nextII, pass);
   /// A change has been made; and the load instruction is deleted.  The caller
   /// should now process the instruction where the load was before.

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2410,6 +2410,46 @@ void swift::salvageLoadDebugInfo(LoadOperation load) {
   }
 }
 
+static void deleteAllDebugUsesWithoutSalvaging(SILValue value,
+                                               InstModCallbacks &callbacks) {
+  for (auto ui = value->use_begin(), ue = value->use_end(); ui != ue;) {
+    auto *inst = ui->getUser();
+    ++ui;
+    if (inst->isDebugInstruction()) {
+      callbacks.deleteInst(inst);
+    }
+  }
+}
+
+static void deleteAllDebugUsesWithoutSalvaging(SILValue value) {
+  for (auto ui = value->use_begin(), ue = value->use_end(); ui != ue;) {
+    auto *inst = ui->getUser();
+    ++ui;
+    if (inst->isDebugInstruction()) {
+      inst->eraseFromParent();
+    }
+  }
+}
+
+void swift::deleteAllDebugUses(SILInstruction *inst,
+                               InstModCallbacks &callbacks,
+                               bool salvage) {
+  if (salvage)
+    salvageDebugInfo(inst);
+  for (SILValue v : inst->getResults()) {
+    deleteAllDebugUsesWithoutSalvaging(v, callbacks);
+  }
+}
+
+void swift::deleteAllDebugUses(SILInstruction *inst, bool salvage) {
+  if (salvage)
+    salvageDebugInfo(inst);
+  for (SILValue v : inst->getResults()) {
+    deleteAllDebugUsesWithoutSalvaging(v);
+  }
+}
+
+
 IntegerLiteralInst *swift::optimizeBuiltinCanBeObjCClass(BuiltinInst *bi,
                                                          SILBuilder &builder) {
   assert(bi->getBuiltinInfo().ID == BuiltinValueKind::CanBeObjCClass);

--- a/test/DebugInfo/inline_reconstruction_block_archetype.sil
+++ b/test/DebugInfo/inline_reconstruction_block_archetype.sil
@@ -1,0 +1,70 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -inline %s | %FileCheck %s
+
+// A debug reconstruction block may mention a generic parameter. Inlining
+// substitutes it, and if the substituted type contains an opened archetype, the
+// cloned instruction needs type dependent operands on the
+// open_existential_metatype instruction defining it, which lives outside the block.
+// This is not supported, so the debug_value must be dropped.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Base {}
+class Box<T> : Base {}
+class Concrete {}
+
+// The block casts to a type using the generic type T.
+// This salvage is valid.
+//
+// CHECK-LABEL: sil [always_inline] [ossa] @generic_callee :
+// CHECK:         debug_value %0 : $Base, let, name "boxed", transform {
+// CHECK:           %1 = unchecked_ref_cast %0 : $Base to $Box<T>
+// CHECK:         }
+// CHECK-LABEL: } // end sil function 'generic_callee'
+sil [ossa] [always_inline] @generic_callee : $@convention(thin) <T> (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+  debug_value %0 : $Base, let, name "boxed", transform {
+  bb0(%0 : $Base):
+    %1 = unchecked_ref_cast %0 : $Base to $Box<T>
+    return %1 : $Box<T>
+  }
+  %r = tuple ()
+  return %r : $()
+}
+
+// The debug_value here, upon inlining, would be rewritten to use the
+// type-dependent value %2 within the reconstruction block, which would
+// crash the verifier.
+//
+// CHECK-LABEL: sil [ossa] @caller_opened_archetype :
+// CHECK-NOT:     debug_value
+// CHECK-NOT:     transform
+// CHECK-NOT:     @opened
+// CHECK-LABEL: } // end sil function 'caller_opened_archetype'
+sil [ossa] @caller_opened_archetype : $@convention(thin) (@guaranteed Base, @thick Any.Type) -> () {
+bb0(%0 : @guaranteed $Base, %1 : $@thick Any.Type):
+  %2 = open_existential_metatype %1 : $@thick Any.Type to $@thick (@opened(1, Any) Self).Type
+  %f = function_ref @generic_callee : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %c = apply %f<@opened(1, Any) Self>(%0) : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// If there is no existential, the debug_value gets inlined with the correct
+// replacement type.
+//
+// CHECK-LABEL: sil [ossa] @caller_concrete :
+// CHECK:         debug_value %0 : $Base, let, name "boxed", transform {
+// CHECK:           %1 = unchecked_ref_cast %0 : $Base to $Box<Concrete>
+// CHECK:           return %1 : $Box<Concrete>
+// CHECK:         }
+// CHECK-LABEL: } // end sil function 'caller_concrete'
+sil [ossa] @caller_concrete : $@convention(thin) (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+  %f = function_ref @generic_callee : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %c = apply %f<Concrete>(%0) : $@convention(thin) <T> (@guaranteed Base) -> ()
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/DebugInfo/salvage_owned_forwarding_inst.sil
+++ b/test/DebugInfo/salvage_owned_forwarding_inst.sil
@@ -1,0 +1,241 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -sil-combine %s | %FileCheck %s
+
+// SILCombine removes owned forwarding casts along several paths:
+//   - CanonicalizeInstruction's eliminateUnneededForwardingUnarySingleValueInst,
+//     when the only non-debug uses are destroy_values.
+//   - SILCombiner::trySinkOwnedForwardingInst, when the cast is sunk to its
+//     single consuming use in another block.
+//   - SingleBlockOwnedForwardingInstFolder, which folds a chain of casts into
+//     one and deletes the intermediates.
+// The deleted instructions must be salvaged in all cases.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Base {}
+class Mid : Base {}
+class Leaf : Mid {}
+
+class Unrelated {}
+class Other {}
+
+sil @consume_base : $@convention(thin) (@owned Base) -> ()
+sil @consume_unrelated : $@convention(thin) (@owned Unrelated) -> ()
+sil @consume_other : $@convention(thin) (@owned Other) -> ()
+sil @consume_base_fn : $@convention(thin) (@owned @callee_guaranteed () -> @owned Base) -> ()
+
+// The cast's only non-debug use is a destroy_value in the same block.
+//
+// CHECK-LABEL: sil [ossa] @destroy_in_same_block :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "b", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = upcast %0 : $Leaf to $Base
+// CHECK-NEXT:      return %1 : $Base
+// CHECK:         }
+// CHECK-NEXT:    destroy_value %0 : $Leaf
+// CHECK-LABEL: } // end sil function 'destroy_in_same_block'
+sil [ossa] @destroy_in_same_block : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = upcast %0 : $Leaf to $Base
+  debug_value %1 : $Base, let, name "b"
+  destroy_value %1 : $Base
+  %r = tuple ()
+  return %r : $()
+}
+
+// The cast's only non-debug use is a destroy_value in another block.
+//
+// CHECK-LABEL: sil [ossa] @destroy_in_other_block :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "b", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = upcast %0 : $Leaf to $Base
+// CHECK-NEXT:      return %1 : $Base
+// CHECK:         }
+// CHECK-NEXT:    br bb1
+// CHECK-LABEL: } // end sil function 'destroy_in_other_block'
+sil [ossa] @destroy_in_other_block : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = upcast %0 : $Leaf to $Base
+  debug_value %1 : $Base, let, name "b"
+  br bb1
+
+bb1:
+  destroy_value %1 : $Base
+  %r = tuple ()
+  return %r : $()
+}
+
+// The cast has two destroy_value uses, so it is eliminated after both are
+// rewired to the forwarded operand.
+//
+// CHECK-LABEL: sil [ossa] @two_destroys :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "b", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = upcast %0 : $Leaf to $Base
+// CHECK-NEXT:      return %1 : $Base
+// CHECK:         }
+// CHECK-NEXT:    cond_br undef, bb1, bb2
+// CHECK-LABEL: } // end sil function 'two_destroys'
+sil [ossa] @two_destroys : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = upcast %0 : $Leaf to $Base
+  debug_value %1 : $Base, let, name "b"
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1 : $Base
+  br bb3
+
+bb2:
+  destroy_value %1 : $Base
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// The cast is consumed by an apply in another block, so it is sunk.
+// Its debug value stays behind in bb0.
+//
+// CHECK-LABEL: sil [ossa] @sunk_to_apply :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "b", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = upcast %0 : $Leaf to $Base
+// CHECK-NEXT:      return %1 : $Base
+// CHECK:         }
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK:         upcast %0 : $Leaf to $Base
+// CHECK-LABEL: } // end sil function 'sunk_to_apply'
+sil [ossa] @sunk_to_apply : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = upcast %0 : $Leaf to $Base
+  debug_value %1 : $Base, let, name "b"
+  br bb1
+
+bb1:
+  %f = function_ref @consume_base : $@convention(thin) (@owned Base) -> ()
+  %c = apply %f(%1) : $@convention(thin) (@owned Base) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// The SingleBlockOwnedForwardingInstFolder folds a cast of a cast.
+// Debug values on the middle cast must be salvaged.
+
+// upcast(upcast x) -> upcast x
+//
+// CHECK-LABEL: sil [ossa] @fold_upcast_of_upcast :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "m", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = upcast %0 : $Leaf to $Mid
+// CHECK-NEXT:      return %1 : $Mid
+// CHECK:         }
+// CHECK-NEXT:    upcast %0 : $Leaf to $Base
+// CHECK-LABEL: } // end sil function 'fold_upcast_of_upcast'
+sil [ossa] @fold_upcast_of_upcast : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = upcast %0 : $Leaf to $Mid
+  debug_value %1 : $Mid, let, name "m"
+  %2 = upcast %1 : $Mid to $Base
+  %f = function_ref @consume_base : $@convention(thin) (@owned Base) -> ()
+  %c = apply %f(%2) : $@convention(thin) (@owned Base) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// unchecked_ref_cast(unchecked_ref_cast x) -> unchecked_ref_cast x
+//
+// CHECK-LABEL: sil [ossa] @fold_urc_of_urc :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "u", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = unchecked_ref_cast %0 : $Leaf to $Unrelated
+// CHECK-NEXT:      return %1 : $Unrelated
+// CHECK:         }
+// CHECK-NEXT:    unchecked_ref_cast %0 : $Leaf to $Other
+// CHECK-LABEL: } // end sil function 'fold_urc_of_urc'
+sil [ossa] @fold_urc_of_urc : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = unchecked_ref_cast %0 : $Leaf to $Unrelated
+  debug_value %1 : $Unrelated, let, name "u"
+  %2 = unchecked_ref_cast %1 : $Unrelated to $Other
+  %f = function_ref @consume_other : $@convention(thin) (@owned Other) -> ()
+  %c = apply %f(%2) : $@convention(thin) (@owned Other) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// unchecked_ref_cast(upcast x) -> unchecked_ref_cast x
+//
+// CHECK-LABEL: sil [ossa] @fold_urc_of_upcast :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "m", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = upcast %0 : $Leaf to $Mid
+// CHECK-NEXT:      return %1 : $Mid
+// CHECK:         }
+// CHECK-NEXT:    unchecked_ref_cast %0 : $Leaf to $Unrelated
+// CHECK-LABEL: } // end sil function 'fold_urc_of_upcast'
+sil [ossa] @fold_urc_of_upcast : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = upcast %0 : $Leaf to $Mid
+  debug_value %1 : $Mid, let, name "m"
+  %2 = unchecked_ref_cast %1 : $Mid to $Unrelated
+  %f = function_ref @consume_unrelated : $@convention(thin) (@owned Unrelated) -> ()
+  %c = apply %f(%2) : $@convention(thin) (@owned Unrelated) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// bridge_object_to_ref(unchecked_ref_cast x) -> bridge_object_to_ref x
+//
+// CHECK-LABEL: sil [ossa] @fold_bridge_object_to_ref :
+// CHECK:       bb0(%0 : @owned $Leaf):
+// CHECK-NEXT:    debug_value %0 : $Leaf, let, name "b", transform {
+// CHECK:         bb0(%0 : $Leaf):
+// CHECK-NEXT:      %1 = unchecked_ref_cast %0 : $Leaf to $Builtin.BridgeObject
+// CHECK-NEXT:      return %1 : $Builtin.BridgeObject
+// CHECK:         }
+// CHECK-NEXT:    unchecked_ref_cast %0 : $Leaf to $Other
+// CHECK-LABEL: } // end sil function 'fold_bridge_object_to_ref'
+sil [ossa] @fold_bridge_object_to_ref : $@convention(thin) (@owned Leaf) -> () {
+bb0(%0 : @owned $Leaf):
+  %1 = unchecked_ref_cast %0 : $Leaf to $Builtin.BridgeObject
+  debug_value %1 : $Builtin.BridgeObject, let, name "b"
+  %2 = bridge_object_to_ref %1 : $Builtin.BridgeObject to $Other
+  %f = function_ref @consume_other : $@convention(thin) (@owned Other) -> ()
+  %c = apply %f(%2) : $@convention(thin) (@owned Other) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// convert_function(convert_function x) -> convert_function x
+//
+// CHECK-LABEL: sil [ossa] @fold_convert_of_convert :
+// CHECK:       bb0(%0 : @owned $@callee_guaranteed () -> @owned Leaf):
+// CHECK-NEXT:    debug_value %0 : $@callee_guaranteed () -> @owned Leaf, let, name "fn", transform {
+// CHECK:         bb0(%0 : $@callee_guaranteed () -> @owned Leaf):
+// CHECK-NEXT:      %1 = convert_function %0 : $@callee_guaranteed () -> @owned Leaf to $@callee_guaranteed () -> @owned Mid
+// CHECK-NEXT:      return %1 : $@callee_guaranteed () -> @owned Mid
+// CHECK:         }
+// CHECK-NEXT:    convert_function %0 : $@callee_guaranteed () -> @owned Leaf to $@callee_guaranteed () -> @owned Base
+// CHECK-LABEL: } // end sil function 'fold_convert_of_convert'
+sil [ossa] @fold_convert_of_convert : $@convention(thin) (@owned @callee_guaranteed () -> @owned Leaf) -> () {
+bb0(%0 : @owned $@callee_guaranteed () -> @owned Leaf):
+  %1 = convert_function %0 : $@callee_guaranteed () -> @owned Leaf to $@callee_guaranteed () -> @owned Mid
+  debug_value %1 : $@callee_guaranteed () -> @owned Mid, let, name "fn"
+  %2 = convert_function %1 : $@callee_guaranteed () -> @owned Mid to $@callee_guaranteed () -> @owned Base
+  %f = function_ref @consume_base_fn : $@convention(thin) (@owned @callee_guaranteed () -> @owned Base) -> ()
+  %c = apply %f(%2) : $@convention(thin) (@owned @callee_guaranteed () -> @owned Base) -> ()
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -599,10 +599,15 @@ bb0(%0 : @owned $NativeObjectPair):
 }
 
 // Just make sure that we do not crash on this. We should be able to eliminate
-// everything here.
+// everything here. The debug_value gets salvaged.
 //
 // CHECK-LABEL: sil [ossa] @copy_value_with_debug_user : $@convention(thin) (@guaranteed NativeObjectPair) -> () {
-// CHECK: bb0
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $NativeObjectPair):
+// CHECK-NEXT:  debug_value [[ARG]] : $NativeObjectPair, let, name "myField", transform {
+// CHECK:       bb0(%0 : $NativeObjectPair):
+// CHECK-NEXT:    %1 = struct_extract %0 : $NativeObjectPair, #NativeObjectPair.obj1
+// CHECK-NEXT:    return %1 : $Builtin.NativeObject
+// CHECK-NEXT:  }
 // CHECK-NEXT:  tuple
 // CHECK-NEXT:  return
 // CHECK-NEXT: } // end sil function 'copy_value_with_debug_user'

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1,8 +1,8 @@
-// RUN: %target-sil-opt -sil-print-types -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -wmo | %FileCheck %s
-// RUN: %target-sil-opt -sil-print-types -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -generic-specializer | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
+// RUN: %target-sil-opt -sil-print-types -sil-print-transform-blocks=false -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -wmo | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -sil-print-transform-blocks=false -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -generic-specializer | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
 //
 // FIXME: check copy-propagation output instead once it is the default mode
-// RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -enable-copy-propagation -enable-lexical-lifetimes=false | %FileCheck %s --check-prefix=CHECK_COPYPROP
+// RUN: %target-sil-opt -sil-print-types -sil-print-transform-blocks=false -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -enable-copy-propagation -enable-lexical-lifetimes=false | %FileCheck %s --check-prefix=CHECK_COPYPROP
 
 // REQUIRES: objc_codegen
 


### PR DESCRIPTION
Based on #91680 

This function is called throughout the SILOptimizer in places where the debug uses should be salvaged first. There were two overloads of the function in two different files, but the SIL library didn't have access to the salvageDebugInfo function defined in SILOptimizer, so both overloads were moved to SILOptimizer.

This fixes some lost variables in 3 different passes:
- EarlyCodeMotion: Fixes **all** variables lost by the pass in the stdlib
- SILCombine: Loses **6.4%** fewer variables
- SimplifyCFG: Loses **1%** fewer variables

Total: Loses **2.6%** fewer variables at the SIL level.
Increases the amount of variables with location at the DWARF level by **0.16%** and byte coverage by **0.10%**