### PR TITLE
Sema: Downgrade Swift availability mismatch diags for @objc @implementation

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -3558,6 +3558,26 @@ private:
     diag.fixItInsert(insertionLoc, attrText);
   }
 
+  /// Returns true if an availability mismatch in \p domain between an
+  /// `@objc @implementation` declaration and the Objective-C declaration it
+  /// implements should be a warning until a future language mode.
+  ///
+  /// \p implIsLessAvailable indicates which of the two declarations the
+  /// restriction applies to.
+  static bool
+  shouldDowngradeAvailabilityMismatchDiag(AvailabilityDomain domain,
+                                          bool implIsLessAvailable) {
+    // Platform availability mismatches were not diagnosed before this check
+    // was introduced, so existing code depends on them being allowed.
+    if (domain.isPlatform())
+      return true;
+
+    // A restriction in the Swift language mode domain only prevents references
+    // from Swift source, so an implementation that is restricted this way is
+    // still reachable through the declaration in the header.
+    return implIsLessAvailable && domain.isSwiftLanguageMode();
+  }
+
   /// If \p ext is less available than the Objective-C declarations in
   /// \p interfaceDecls that it implements, diagnoses the availability
   /// restriction that makes it so.
@@ -3595,7 +3615,9 @@ private:
           domain, domain.isVersioned(), domainAndRange.getRange());
     };
 
-    emit().warnUntilLanguageModeIf(domain.isPlatform(), LanguageMode::future);
+    emit().warnUntilLanguageModeIf(shouldDowngradeAvailabilityMismatchDiag(
+                                       domain, /*implIsLessAvailable=*/true),
+                                   LanguageMode::future);
 
     restriction->emitNoteForDecl(ext);
   }
@@ -4369,7 +4391,10 @@ private:
 
     {
       auto diag = emit();
-      diag.warnUntilLanguageModeIf(domain.isPlatform(), LanguageMode::future);
+      diag.warnUntilLanguageModeIf(
+          shouldDowngradeAvailabilityMismatchDiag(
+              domain, mismatch.candidateIsLessAvailable),
+          LanguageMode::future);
 
       if (mustBe)
         addAvailabilityFixIt(diag, cand, restriction);

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -254,6 +254,21 @@ __attribute__((deprecated("use SomethingElse instead")))
 
 @end
 
+@interface SwiftAvailabilityMembersClass : NSObject
+
+- (void)swiftObsoletedMethod1;
+- (void)swiftObsoletedMethod2;
+- (void)swift99Method1;
+
+@end
+
+@interface SwiftObsoletedExtensionClass : NSObject
+@end
+
+@interface SwiftObsoletedExtensionClass (Category)
+- (void)swiftObsoletedCategoryMethod1;
+@end
+
 #endif
 
 void CImplFunc1(int param);

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -505,6 +505,31 @@ protocol EmptySwiftProto {}
   func notDeprecatedMethod1() { }
 }
 
+// A restriction in the Swift language mode domain only prevents references from
+// Swift source, so an implementation that is restricted this way is still
+// reachable through the declaration in the header.
+@objc @implementation extension SwiftAvailabilityMembersClass {
+  @available(swift, obsoleted: 1.0, renamed: "renamedMethod()")
+  func swiftObsoletedMethod1() { }
+  // expected-warning@-1 {{instance method 'swiftObsoletedMethod1()' does not match the declaration in the header because it is unavailable}} {{none}}
+  // expected-note@-3 {{'swiftObsoletedMethod1()' was obsoleted in Swift 1.0}} {{none}}
+
+  @available(swift, obsoleted: 99.0)
+  func swiftObsoletedMethod2() { }
+
+  @available(swift 99.0)
+  func swift99Method1() { }
+  // expected-warning@-1 {{instance method 'swift99Method1()' does not match the declaration in the header because it is unavailable in Swift}} {{none}}
+  // expected-note@-3 {{'swift99Method1()' was introduced in Swift 99.0}} {{none}}
+}
+
+@available(swift, obsoleted: 1.0)
+@objc(Category) @implementation extension SwiftObsoletedExtensionClass {
+  // expected-warning@-1 {{'@objc @implementation' extension cannot implement class 'SwiftObsoletedExtensionClass' because it is unavailable}} {{none}}
+  // expected-note@-3 {{extension of 'SwiftObsoletedExtensionClass' was obsoleted in Swift 1.0}} {{none}}
+  func swiftObsoletedCategoryMethod1() { }
+}
+
 // Intentionally using `@_objcImplementation` for this test; do not upgrade!
 @_objcImplementation(EmptyCategory) extension ObjCClass {
   // expected-warning@-1 {{'@_objcImplementation' is deprecated; use '@implementation' instead}} {{1-36=@implementation}} {{1-1=@objc(EmptyCategory) }}


### PR DESCRIPTION
For now, only warn when an `@objc @implementation` is less available in the `Swift` domain than the declaration from the header.

Resolves rdar://185642669.
