### PR TITLE
[CoroutineAccessors] Fix missed test expectations for arm64e

### DIFF
--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -23,20 +23,6 @@
 // CHECK-SAME:    i32 0
 // CHECK-SAME:  }>
 
-// CHECK-arm64e-LABEL: _swift_coro_free.ptrauth = private constant {
-// CHECK-arm64e-SAME:    ptr @_swift_coro_free,
-// CHECK-arm64e-SAME:    i32 0,
-// CHECK-arm64e-SAME:    i64 ptrtoint (
-// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
-// CHECK-arm64e-SAME:        ptr @_swift_coro_typed_malloc_allocator,
-// CHECK-arm64e-SAME:        i32 0,
-// CHECK-arm64e-SAME:        i32 2
-// CHECK-arm64e-SAME:      )
-// CHECK-arm64e-SAME:    )
-// CHECK-arm64e-SAME:    i64 40879 },
-// CHECK-arm64e-SAME:  section "llvm.ptrauth",
-// CHECK-arm64e-SAME:  align 8
-
 // CHECK-arm64e-LABEL: _swift_coro_malloc.ptrauth = private constant {
 // CHECK-arm64e-SAME:    ptr @_swift_coro_malloc,
 // CHECK-arm64e-SAME:    i32 0,
@@ -49,6 +35,20 @@
 // CHECK-arm64e-SAME:    )
 // CHECK-arm64e-SAME:    i64 24469 }
 // CHECK-arm64e-SAME:  section "llvm.ptrauth"
+// CHECK-arm64e-SAME:  align 8
+
+// CHECK-arm64e-LABEL: _swift_coro_free.ptrauth = private constant {
+// CHECK-arm64e-SAME:    ptr @_swift_coro_free,
+// CHECK-arm64e-SAME:    i32 0,
+// CHECK-arm64e-SAME:    i64 ptrtoint (
+// CHECK-arm64e-SAME:      ptr getelementptr inbounds (
+// CHECK-arm64e-SAME:        ptr @_swift_coro_malloc_allocator,
+// CHECK-arm64e-SAME:        i32 0,
+// CHECK-arm64e-SAME:        i32 2
+// CHECK-arm64e-SAME:      )
+// CHECK-arm64e-SAME:    )
+// CHECK-arm64e-SAME:    i64 40879 },
+// CHECK-arm64e-SAME:  section "llvm.ptrauth",
 // CHECK-arm64e-SAME:  align 8
 
 // CHECK-arm64e-LABEL: _swift_coro_malloc.ptrauth.{{.*}} = private constant {


### PR DESCRIPTION
Follow-up to #90745

I didn't run arm64e tests on #90745, so missed a change there.  This just rearranges two functions whose order is different now, and adjusts `_swift_coro_malloc.ptrauth` to expect the regular allocator instead of the typed one.  The equivalent change for regular arm64 was done in #90745; this just applies the same fix to the arm64e expectations.

Resolves: rdar://184860588
