### PR TITLE
[CS] Bail from holed keypath dynamic member constraint

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11655,6 +11655,19 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       recordTypeVariablesAsHoles(memberTy);
       return SolutionKind::Solved;
     }
+    // If we have a dynamic member lookup and the member type has already been
+    // bound to a hole, bail without attempting to solve the member constraint.
+    // Keypath dynamic member subscripts expect the applicable function
+    // constraint to be present, which is may not be for a hole since we don't
+    // attempt to solve them when all arguments are bound to holes.
+    if (locator->isSubscriptMemberRef() &&
+        getFixedTypeRecursive(memberTy, /*rvalue*/ true)->isPlaceholder()) {
+      auto hasDynamicMemberLookup = baseObjTy->getMetatypeInstanceType()
+                                        ->eraseDynamicSelfType()
+                                        ->hasDynamicMemberLookupAttribute();
+      if (hasDynamicMemberLookup)
+        return SolutionKind::Solved;
+    }
   }
 
   MemberLookupResult result =

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1572,6 +1572,12 @@ func testNilCoalescingOperatorRemoveFix() {
       ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:9-+0:12=}}
 }
 
+func testInvalidMethodWithInvalidArg(_ x: Int) {
+  x.undefinedMethod(undefined)
+  // expected-error@-1 {{value of type 'Int' has no member 'undefinedMethod'}}
+  // expected-error@-2 {{cannot find 'undefined' in scope}}
+}
+
 // FIXME: https://github.com/swiftlang/swift/issues/89918
 let _ = type(of: Int.foo) // expected-error {{failed to produce diagnostic}}
 

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -715,3 +715,10 @@ func testMultipleArguments() {
     e.implementation("ultimate question", 42)
   }
 }
+
+#if DIAGS
+func testInvalidArgument(_ x: Lens<[Int]>, _ y: SingleLens<[Int]>) {
+  _ = x[undefined] // expected-error {{cannot find 'undefined' in scope}}
+  _ = y[undefined] // expected-error {{cannot find 'undefined' in scope}}
+}
+#endif

--- a/validation-test/compiler_crashers/ConstraintSystem-bindOverloadType-ff4a42.swift
+++ b/validation-test/compiler_crashers/ConstraintSystem-bindOverloadType-ff4a42.swift
@@ -1,0 +1,8 @@
+// {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::bindOverloadType(swift::constraints::SelectedOverload const&, swift::Type, swift::constraints::ConstraintLocator*, swift::DeclContext*)","signatureAssert":"Assertion failed: (constraints.size() == 1), function bindOverloadType","signatureNext":"ConstraintSystem::resolveOverload"}
+// RUN: not --crash %target-swift-frontend -typecheck %s
+@dynamicMemberLookup struct a {
+  subscript(dynamicMember c: KeyPath<Int, Int>) -> Int
+  func d(b: a) {
+    b[e]
+  }
+}

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-bindOverloadType-ff4a42.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-bindOverloadType-ff4a42.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::bindOverloadType(swift::constraints::SelectedOverload const&, swift::Type, swift::constraints::ConstraintLocator*, swift::DeclContext*)","signatureAssert":"Assertion failed: (constraints.size() == 1), function bindOverloadType","signatureNext":"ConstraintSystem::resolveOverload"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @dynamicMemberLookup struct a {
   subscript(dynamicMember c: KeyPath<Int, Int>) -> Int
   func d(b: a) {


### PR DESCRIPTION
If we have a dynamic member lookup and the member type has already been bound to a hole, bail without attempting to solve the member constraint. Keypath dynamic member subscripts expect the applicable function constraint to be present, which is may not be for a hole since we don't attempt to solve them when all arguments are bound to holes.

rdar://185642635