### PR TITLE
[Embedded] Limit additional specialization of deinits to only those needed for metadata

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -45,9 +45,10 @@ let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-
     // metadata, which doesn't exist in embedded Swift. Seed the worklist with
     // the specializations so that they get optimized like any other function.
     //
-    // This covers the types SILGen saw. Concrete instantiations of generic
-    // types are not among them, so `optimize` additionally specializes the
-    // deinits of the non-copyable types it encounters in each function.
+    // This covers types which are `@export(interface)`, whose metadata is
+    // emitted eagerly. The other things IRGen emits metadata for -- boxes and
+    // existentials -- are handled in `optimize` when their instructions are
+    // visited.
     specializeDeinitsOfEmittedMetadata(moduleContext, &handledDeinitTypes, &worklist)
   } else {
     worklist.addAllMandatoryRequiredFunctions(of: moduleContext)
@@ -68,12 +69,8 @@ private func optimizeFunctionsTopDown(using worklist: inout FunctionWorklist,
   while let f = worklist.pop() {
     moduleContext.transform(function: f) { context in
       if context.loadFunction(function: f, loadCalleesRecursively: true) {
-        optimize(function: f, context, moduleContext, &worklist)
+        optimize(function: f, context, moduleContext, &worklist, &handledDeinitTypes)
       }
-    }
-
-    if moduleContext.options.enableEmbeddedSwift {
-      specializeDeinitsOfTypes(in: f, &handledDeinitTypes, moduleContext, &worklist)
     }
 
     // Generic specialization takes care of removing metatype arguments of generic functions.
@@ -105,34 +102,8 @@ private func specializeDeinitsOfEmittedMetadata(_ moduleContext: ModulePassConte
   }
 }
 
-/// Specializes the deinits of the non-copyable types appearing in `function`.
-///
-/// The types SILGen recorded are only the ones it declared; a concrete
-/// instantiation of a generic type (`Storage<Int>`) is never among them, yet
-/// IRGen emits metadata — and therefore value witnesses that destroy it — for
-/// such types too. Those instantiations only become apparent once generic
-/// specialization has run, so scan for them as each function is optimized.
-private func specializeDeinitsOfTypes(in function: Function,
-                                      _ handled: inout Set<Type>,
-                                      _ moduleContext: ModulePassContext,
-                                      _ worklist: inout FunctionWorklist) {
-  guard function.isDefinition else {
-    return
-  }
-  for instruction in function.instructions {
-    for result in instruction.results {
-      specializeDeinits(ofType: result.type, in: function, &handled, moduleContext, &worklist)
-    }
-    for operand in instruction.operands {
-      specializeDeinits(ofType: operand.value.type, in: function, &handled, moduleContext,
-                        &worklist)
-    }
-  }
-  for argument in function.arguments {
-    specializeDeinits(ofType: argument.type, in: function, &handled, moduleContext, &worklist)
-  }
-}
-
+/// Specializes the deinits of the non-copyable `type`, and of its stored
+/// properties and enum payloads, because IRGen is about to emit metadata for it.
 private func specializeDeinits(ofType type: Type,
                                in function: Function,
                                _ handled: inout Set<Type>,
@@ -164,7 +135,7 @@ fileprivate struct PathFunctionTuple: Hashable {
   var function: Function
 }
 
-private func optimize(function: Function, _ context: FunctionPassContext, _ moduleContext: ModulePassContext, _ worklist: inout FunctionWorklist) {
+private func optimize(function: Function, _ context: FunctionPassContext, _ moduleContext: ModulePassContext, _ worklist: inout FunctionWorklist, _ handledDeinitTypes: inout Set<Type>) {
   var alreadyInlinedFunctions: Set<PathFunctionTuple> = Set()
 
   // ObjectOutliner replaces calls to findStringSwitchCase with _findStringSwitchCaseWithCache, but this happens as a late SIL optimization,
@@ -186,6 +157,21 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
         worklist.pushIfNotVisited($0)
       }
     }
+  }
+
+  // IRGen emits type metadata for a boxed or existential value, and for the
+  // destination of a checked cast. The destroy value witness of that metadata
+  // calls the type's deinit, which in embedded Swift has to be fully
+  // specialized first.
+  func specializeDeinitsOfMetadata(for type: Type) {
+    if context.options.enableEmbeddedSwift {
+      specializeDeinits(ofType: type, in: function, &handledDeinitTypes, moduleContext,
+                        &worklist)
+    }
+  }
+
+  func specializeDeinitsOfMetadata(forFormalType type: CanonicalType) {
+    specializeDeinitsOfMetadata(for: type.loweredType(in: function))
   }
 
   var changed = true
@@ -210,8 +196,18 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
         }
       case let cast as UnconditionalCheckedCastInst:
         specializeVTable(for: cast.type, instruction: cast)
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
       case let cast as UncheckedRefCastInst:
         specializeVTable(for: cast.type, instruction: cast)
+
+      // The destination of a checked cast needs metadata for the runtime check.
+      case let cast as UnconditionalCheckedCastAddrInst:
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
+      case let cast as CheckedCastBranchInst:
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
+      case let cast as CheckedCastAddrBranchInst:
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
+
       case let kpi as KeyPathInst:
         // In Embedded Swift, specialize the functions that are referenced
         // by the key path.
@@ -240,6 +236,7 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
 
       case let initExRef as InitExistentialRefInst:
         if context.options.enableEmbeddedSwift {
+          specializeDeinitsOfMetadata(for: initExRef.instance.type)
           for c in initExRef.conformances where c.isConcrete {
             specializeWitnessTable(for: c, moduleContext)
             worklist.addWitnessMethods(of: c, moduleContext)
@@ -248,9 +245,19 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
 
       case let initExAddr as InitExistentialAddrInst:
         if context.options.enableEmbeddedSwift {
+          specializeDeinitsOfMetadata(for: initExAddr.formalConcreteType.loweredType(in: function))
           for c in initExAddr.conformances where c.isConcrete && !c.protocol.isMarkerProtocol {
             specializeWitnessTable(for: c, moduleContext)
             worklist.addWitnessMethods(of: c, moduleContext)
+          }
+        }
+
+      case let allocBox as AllocBoxInst:
+        // Metadata is emitted for the boxed type, and its destroy value witness
+        // calls that type's deinit.
+        if context.options.enableEmbeddedSwift {
+          for field in allocBox.type.getBoxFields(in: function) {
+            specializeDeinitsOfMetadata(for: field)
           }
         }
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1441,6 +1441,12 @@ void SILGenModule::recordNonCopyableTypeWithEmittedMetadata(
   if (nom->isGenericContext())
     return;
 
+  // Only `@export(interface)` types get their metadata emitted eagerly; the
+  // metadata of any other type is emitted lazily, and only if something
+  // actually needs it.
+  if (nom->getEffectiveCodeGenerationModel() != CodeGenerationModel::Interface)
+    return;
+
   auto type = nom->getDeclaredInterfaceType()->getCanonicalType();
   M.addNonCopyableTypeWithEmittedMetadata(
       SILType::getPrimitiveObjectType(type));

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1584,9 +1584,16 @@ public:
         diagnosed = true;
       // if the type is public and not frozen, then the method must not be
       // inlinable.
+      //
+      // `discard self` has to know the type's stored properties in order
+      // to destroy them individually, so a body emitted
+      // into a client must not bake in a layout the defining library could
+      // change.
       } else if (auto fragileKind = fn->getFragileFunctionKind();
                  !nominalDecl->getAttrs().hasAttribute<FrozenAttr>()
-                 && fragileKind != FragileFunctionKind{FragileFunctionKind::None}) {
+                 && fragileKind != FragileFunctionKind{FragileFunctionKind::None}
+                 && fn->getResilienceExpansion() ==
+                        ResilienceExpansion::Minimal) {
         ctx.Diags.diagnose(DS->getDiscardLoc(),
                            // Code in ABI stable SDKs has already used the `@inlinable`
                            // attribute on functions using `discard self`.

--- a/test/embedded/Inputs/cxx-move-only-counts.cpp
+++ b/test/embedded/Inputs/cxx-move-only-counts.cpp
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+static int made = 0;
+static int dtors = 0;
+static int doubleFrees = 0;
+
+extern "C" void noteMade(void) { made++; }
+extern "C" void noteDtor(void) { dtors++; }
+extern "C" void noteDoubleFree(void) { doubleFrees++; }
+
+/// A correct program destroys exactly as many objects as it made, and never
+/// destroys the same object twice.
+extern "C" void reportCounts(void) {
+  printf("balanced=%s doubleFree=%d\n", made == dtors ? "yes" : "no",
+         doubleFrees);
+}

--- a/test/embedded/Inputs/cxx-move-only.h
+++ b/test/embedded/Inputs/cxx-move-only.h
@@ -1,0 +1,39 @@
+#ifndef CXX_MOVE_ONLY_H
+#define CXX_MOVE_ONLY_H
+
+extern "C" void noteMade(void);
+extern "C" void noteDtor(void);
+extern "C" void noteDoubleFree(void);
+
+/// A C++ move-only type: copy construction and assignment are deleted, and it
+/// has a non-trivial destructor. Swift imports this as `~Copyable`.
+///
+/// Both the default and move constructors count as "made", so a correct program
+/// destroys exactly as many objects as it makes. The destructor poisons the
+/// pointer so that destroying the same object twice is detected rather than
+/// silently double-freeing.
+struct MoveOnly {
+  int *p;
+
+  MoveOnly() : p(new int(7)) { noteMade(); }
+  MoveOnly(const MoveOnly &) = delete;
+  MoveOnly &operator=(const MoveOnly &) = delete;
+  MoveOnly(MoveOnly &&other) : p(other.p) {
+    other.p = nullptr;
+    noteMade();
+  }
+  ~MoveOnly() {
+    noteDtor();
+    if (p == poison())
+      noteDoubleFree();
+    delete p;
+    p = poison();
+  }
+
+  int value() const { return p ? *p : -1; }
+
+private:
+  static int *poison() { return reinterpret_cast<int *>(-1); }
+};
+
+#endif

--- a/test/embedded/Inputs/module.modulemap
+++ b/test/embedded/Inputs/module.modulemap
@@ -6,3 +6,8 @@ module CxxStdVector {
   header "cxx-std-vector.h"
   requires cplusplus
 }
+
+module CxxMoveOnly {
+  header "cxx-move-only.h"
+  requires cplusplus
+}

--- a/test/embedded/cxx-move-only.swift
+++ b/test/embedded/cxx-move-only.swift
@@ -1,0 +1,123 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/cxx-move-only-counts.cpp -o %t/counts.o
+// RUN: %target-swift-frontend -I %S/Inputs %s -enable-experimental-feature Embedded -enable-experimental-feature Extern -enable-experimental-feature MoveOnlyTuples -cxx-interoperability-mode=default -wmo -O -parse-as-library -c -o %t/main.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %t/counts.o -lc++ %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
+// REQUIRES: swift_feature_MoveOnlyTuples
+
+import CxxMoveOnly
+
+@_extern(c) func reportCounts()
+
+struct Box: ~Copyable {
+  var m: MoveOnly
+  init() { m = MoveOnly() }
+}
+
+struct BoxWithDeinit: ~Copyable {
+  var m: MoveOnly
+  init() { m = MoveOnly() }
+  deinit {}
+}
+
+struct Wrapper<T: ~Copyable>: ~Copyable {
+  var v: T
+  init(_ v: consuming T) { self.v = v }
+}
+
+struct WrapperWithDeinit<T: ~Copyable>: ~Copyable {
+  var v: T
+  init(_ v: consuming T) { self.v = v }
+  deinit {}
+}
+
+enum MaybeMoveOnly: ~Copyable {
+  case none
+  case some(MoveOnly)
+}
+
+final class Holder {
+  var m: MoveOnly
+  init() { m = MoveOnly() }
+}
+
+@inline(never)
+func eat<T: ~Copyable>(_ x: consuming T) {}
+
+@main
+struct Main {
+  static func main() {
+    do {
+      let m = MoveOnly()
+      precondition(m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let b = Box()
+      precondition(b.m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let b = BoxWithDeinit()
+      precondition(b.m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let w = Wrapper(MoveOnly())
+      precondition(w.v.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let t = (MoveOnly(), 1)
+      precondition(t.1 == 1)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let w = WrapperWithDeinit(MoveOnly())
+      precondition(w.v.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let e = MaybeMoveOnly.some(MoveOnly())
+      if case .some(let m) = e { precondition(m.value() == 7) }
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let e = MaybeMoveOnly.none
+      if case .none = e {}
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let h = Holder()
+      precondition(h.m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    eat(MoveOnly())
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+  }
+}

--- a/test/embedded/deinit-specialization-cast.swift
+++ b/test/embedded/deinit-specialization-cast.swift
@@ -1,0 +1,51 @@
+// Metadata is emitted for the destination type of a checked cast, so the
+// deinits reachable from that type's value witnesses have to be specialized.
+// Here the existential is always formed from `Other`, so the cast destination is
+// the only reason `Castee<Int>` would need metadata.
+
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature NoncopyableCasting -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature NoncopyableCasting -Osize -emit-sil -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_NoncopyableCasting
+
+// CHECK-DAG: sil_moveonlydeinit $Castee<Int> {
+
+public protocol P: ~Copyable {
+  func f()
+}
+
+public struct Castee<T>: ~Copyable, P {
+  var p: UnsafeMutablePointer<Int>
+  init() { p = .allocate(capacity: 1) }
+  public func f() {}
+  deinit { p.deallocate() }
+}
+
+public struct Other: ~Copyable, P {
+  public init() {}
+  public func f() {}
+}
+
+// Conditional cast: checked_cast_addr_br / checked_cast_br.
+@inline(never)
+func conditionally(_ e: consuming any P & ~Copyable) -> Int {
+  if let c = e as? Castee<Int> {
+    return c.p.pointee
+  }
+  return 0
+}
+
+// Unconditional cast: unconditional_checked_cast_addr.
+@inline(never)
+func unconditionally(_ e: consuming any P & ~Copyable) -> Int {
+  let c = e as! Castee<Int>
+  return c.p.pointee
+}
+
+// Both call sites pass `Other`, never `Castee`, so no existential of
+// `Castee<Int>` is ever formed and the cast destination is the only thing that
+// makes IRGen emit metadata for it.
+public func go() -> Int {
+  return conditionally(Other()) + unconditionally(Other())
+}

--- a/test/embedded/deinit-specialization.swift
+++ b/test/embedded/deinit-specialization.swift
@@ -1,12 +1,3 @@
-// Emitting the metadata of a non-copyable type also emits its value witnesses,
-// and the destroy witness calls the deinits of the type and its members. In
-// Embedded Swift those deinits must be fully specialized, because unspecialized
-// generic functions take type metadata, which doesn't exist there.
-//
-// `@export(interface)` is what makes a type's metadata emitted eagerly, so the
-// types below use it rather than the module-wide `CodeGenerationModel=interface`
-// (which is not a `Features.def` feature and so can't be spelled in a REQUIRES).
-
 // RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-sil -o - | %FileCheck -check-prefix SIL %s
 // RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-ir -o - | %FileCheck -check-prefix IR %s
 
@@ -54,28 +45,39 @@ public struct Unused: ~Copyable {
   var items: Storage<Int>
 }
 
+// Forming an existential is the other thing that makes IRGen emit metadata for
+// a type, so the deinit of the concrete type has to be specialized there too.
 // A concrete instantiation of a generic type is never among the types SILGen
-// records, so it has to be discovered from the SIL. `LocalOnly<Int>` is only
-// ever a local and `GenericBox<Int>`'s container is itself generic, so neither
-// is reachable from a recorded non-generic type — yet both get a specialized
-// deinit.
-// SIL-DAG: sil_moveonlydeinit $LocalOnly<Int> {
-// SIL-DAG: sil_moveonlydeinit $GenericBox<Int> {
+// recorded, so this one is found from the `init_existential` instruction.
+// SIL-DAG: sil_moveonlydeinit $Existentialized<Int> {
+public protocol HasF: ~Copyable {
+  func f()
+}
+
+public struct Existentialized<T>: ~Copyable, HasF {
+  var q: UnsafeMutablePointer<Int>
+  init() { q = .allocate(capacity: 1) }
+  public func f() {}
+  deinit { q.deallocate() }
+}
+
+@inline(never)
+func take(_ e: consuming any HasF & ~Copyable) { e.f() }
+
+public func useExistential() {
+  take(Existentialized<Int>())
+}
+
+// A type that is merely a local, with no metadata emitted for it, needs no
+// specialized deinit: nothing will ever call it through a value witness.
+// SIL-NOT: sil_moveonlydeinit $LocalOnly<Int> {
 public struct LocalOnly<T>: ~Copyable {
   var p: UnsafeMutablePointer<Int>
   init() { p = .allocate(capacity: 1) }
   deinit { p.deallocate() }
 }
 
-public struct GenericBox<T>: ~Copyable {
-  var q: UnsafeMutablePointer<Int>
-  init() { q = .allocate(capacity: 1) }
-  deinit { q.deallocate() }
-}
-
 public func useLocalOnly() {
   let s = LocalOnly<Int>()
   _ = s.p
-  let g = GenericBox<Int>()
-  _ = g.q
 }

--- a/test/embedded/discard-non-frozen.swift
+++ b/test/embedded/discard-non-frozen.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-sil -verify -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+
+public struct S<T>: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+
+  public init() { p = .allocate(capacity: 1) }
+
+  // Take the pointer out before consuming self, then skip the deinit.
+  public consuming func giveUp() -> UnsafeMutablePointer<Int> {
+    let q = p
+    discard self
+    return q
+  }
+
+  deinit { p.deallocate() }
+}
+
+// A non-generic type in the same position.
+public struct T: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+  public init() { p = .allocate(capacity: 1) }
+  public consuming func giveUp() -> UnsafeMutablePointer<Int> {
+    let q = p
+    discard self
+    return q
+  }
+  deinit { p.deallocate() }
+}
+
+// `discard` skips the deinit, so neither call site destroys the value.
+// CHECK-LABEL: sil{{.*}}@$e4main2goyyF
+// CHECK-NOT: fD
+// CHECK: end sil function
+public func go() {
+  let q = S<Int>().giveUp()
+  q.deallocate()
+  let r = T().giveUp()
+  r.deallocate()
+}


### PR DESCRIPTION
My prior change to ensure that deinits of non-copyable types got
specialized was generating far more specializations than were needed.
Replace the far-too-wide-reaching specializeDeinitsOfTypes with code
in the specializer to identify where type metadata is needed, and
trigger the specialization there. The existential-formation
instructions and checked-cast instructions are the primary ones.

Thank you Erik for the suggestion to simplify this