### PR TITLE
[stdlib, 6.4.x] prevent overflow in `Array.init(unsafeUninitializedCapacity...)`

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1532,41 +1532,6 @@ extension Array {
   }
 #endif
 
-  /// Implementation for:
-  /// Array(unsafeUninitializedCapacity:initializingWith:)
-  /// and ContiguousArray(unsafeUninitializedCapacity:initializingWith:)
-  @_alwaysEmitIntoClient
-  internal init<E: Error>(
-    _unsafeUninitializedCapacity: Int,
-    initializingWithTypedThrowsInitializer initializer: (
-      _ buffer: inout UnsafeMutableBufferPointer<Element>,
-      _ initializedCount: inout Int
-    ) throws(E) -> Void
-  ) throws(E) {
-    var firstElementAddress: UnsafeMutablePointer<Element>
-    unsafe (self, firstElementAddress) =
-      unsafe Array._allocateUninitialized(_unsafeUninitializedCapacity)
-
-    var initializedCount = 0
-    var buffer = unsafe UnsafeMutableBufferPointer<Element>(
-      start: firstElementAddress, count: _unsafeUninitializedCapacity)
-    defer {
-      // Update self.count even if initializer throws an error.
-      _precondition(
-        UInt(truncatingIfNeeded: initializedCount) <=
-        UInt(truncatingIfNeeded: _unsafeUninitializedCapacity),
-        "Initialized count must be in 0 ... _unsafeUninitializedCapacity."
-      )
-      unsafe _precondition(
-        buffer.baseAddress == firstElementAddress,
-        "Can't reassign buffer in Array(unsafeUninitializedCapacity:initializingWith:)"
-      )
-      self._buffer.mutableCount = initializedCount
-      _endMutation()
-    }
-    try unsafe initializer(&buffer, &initializedCount)
-  }
-
   /// Creates an array with the specified capacity, and then calls the given
   /// closure with a buffer covering the array's uninitialized memory.
   ///

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1122,8 +1122,9 @@ extension ContiguousArray {
       start: firstElementAddress, count: unsafeUninitializedCapacity)
     defer {
       _precondition(
-        initializedCount <= unsafeUninitializedCapacity,
-        "Initialized count set to greater than specified capacity."
+        UInt(truncatingIfNeeded: initializedCount) <=
+        UInt(truncatingIfNeeded: unsafeUninitializedCapacity),
+        "Initialized count must be in 0 ... unsafeUninitializedCapacity."
       )
       unsafe _precondition(
         buffer.baseAddress == firstElementAddress,

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -612,6 +612,21 @@ ${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/reassignBuffe
   }
 }
 
+${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/negativeCapacity")
+.require(.crashTesting)
+.code {
+  expectCrashLater()
+  _ = ${ArrayType}<Int>(unsafeUninitializedCapacity: -10) { $1 = 0 }
+}
+
+${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/negativeCount")
+.require(.minimumStdlib(.stdlib_6_4))
+.require(.crashTesting)
+.code {
+  expectCrashLater()
+  _ = ${ArrayType}<Int>(unsafeUninitializedCapacity: 10) { $1 = -1 }
+}
+
 %end
 
 //===---


### PR DESCRIPTION
**Explanation**: 
Re-apply the fix of https://github.com/swiftlang/swift/pull/84917 along with a regression test. The code path we fixed in the previous PR was one of two nearly-identical implementations, and a later refactoring bypassed the fixed version.

**Scope**: 
Correctness fix for `Array(unsafeUninitializedCopacity:...)` and its `ContiguousArray` counterpart.

**Risk**: Low. Turns a deferred crash or UB into a trap.

**Testing**: CI testing, additional test.

**Original PR**: https://github.com/swiftlang/swift/pull/91689

**Reviewed by**: @stephentyrone

**Issues**: Addresses rdar://183390527