### PR TITLE
[Embedded] Improvements to deinit devirtualization

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -179,15 +179,8 @@ private struct FunctionChecker {
     case let ucc as UnconditionalCheckedCastInst:
       checkCastTargetUniqueness(ucc.targetFormalType, in: instruction)
 
-    case let abi as AllocBoxInst:
-      // It needs a bit of work to support alloc_box of generic non-copyable structs/enums with deinit,
-      // because we need to specialize the deinit functions, though they are not explicitly referenced in SIL.
-      // Until this is supported, give an error in such cases. Otherwise IRGen would crash.
-      if abi.allocsGenericValueTypeWithDeinit {
-        throw Violation(.embedded_capture_of_generic_value_with_deinit, in: abi)
-      }
-      fallthrough
-    case is AllocRefInst,
+    case is AllocBoxInst,
+         is AllocRefInst,
          is AllocRefDynamicInst:
       try diagnoseHeapAllocation(
         Violation(.embedded_swift_allocating_type,
@@ -593,12 +586,6 @@ private struct ReportedProblem: Hashable {
   }
 }
 
-private extension AllocBoxInst {
-  var allocsGenericValueTypeWithDeinit: Bool {
-    type.getBoxFields(in: parentFunction).contains { $0.hasGenericValueDeinit(in: parentFunction) }
-  }
-}
-
 private extension ApplySite {
   var callsEmbeddedRuntimeFunction: Bool {
     if let callee = referencedFunction,
@@ -620,25 +607,3 @@ private extension ApplySite {
   }
 }
 
-private extension Type {
-  func hasGenericValueDeinit(in function: Function) -> Bool {
-    guard isMoveOnly, let nominal = nominal else {
-      return false
-    }
-
-    if nominal.isGenericAtAnyLevel && nominal.valueTypeDestructor != nil {
-      return true
-    }
-
-    if isStruct {
-      if let fields = getNominalFields(in: function) {
-        return fields.contains { $0.hasGenericValueDeinit(in: function) }
-      }
-    } else if isEnum {
-      if let enumCases = getEnumCases(in: function) {
-        return enumCases.contains { $0.payload?.hasGenericValueDeinit(in: function) ?? false }
-      }
-    }
-    return false
-  }
-}

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -45,9 +45,10 @@ let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-
     // metadata, which doesn't exist in embedded Swift. Seed the worklist with
     // the specializations so that they get optimized like any other function.
     //
-    // This covers the types SILGen saw. Concrete instantiations of generic
-    // types are not among them, so `optimize` additionally specializes the
-    // deinits of the non-copyable types it encounters in each function.
+    // This covers types which are `@export(interface)`, whose metadata is
+    // emitted eagerly. The other things IRGen emits metadata for -- boxes and
+    // existentials -- are handled in `optimize` when their instructions are
+    // visited.
     specializeDeinitsOfEmittedMetadata(moduleContext, &handledDeinitTypes, &worklist)
   } else {
     worklist.addAllMandatoryRequiredFunctions(of: moduleContext)
@@ -68,12 +69,8 @@ private func optimizeFunctionsTopDown(using worklist: inout FunctionWorklist,
   while let f = worklist.pop() {
     moduleContext.transform(function: f) { context in
       if context.loadFunction(function: f, loadCalleesRecursively: true) {
-        optimize(function: f, context, moduleContext, &worklist)
+        optimize(function: f, context, moduleContext, &worklist, &handledDeinitTypes)
       }
-    }
-
-    if moduleContext.options.enableEmbeddedSwift {
-      specializeDeinitsOfTypes(in: f, &handledDeinitTypes, moduleContext, &worklist)
     }
 
     // Generic specialization takes care of removing metatype arguments of generic functions.
@@ -105,34 +102,8 @@ private func specializeDeinitsOfEmittedMetadata(_ moduleContext: ModulePassConte
   }
 }
 
-/// Specializes the deinits of the non-copyable types appearing in `function`.
-///
-/// The types SILGen recorded are only the ones it declared; a concrete
-/// instantiation of a generic type (`Storage<Int>`) is never among them, yet
-/// IRGen emits metadata — and therefore value witnesses that destroy it — for
-/// such types too. Those instantiations only become apparent once generic
-/// specialization has run, so scan for them as each function is optimized.
-private func specializeDeinitsOfTypes(in function: Function,
-                                      _ handled: inout Set<Type>,
-                                      _ moduleContext: ModulePassContext,
-                                      _ worklist: inout FunctionWorklist) {
-  guard function.isDefinition else {
-    return
-  }
-  for instruction in function.instructions {
-    for result in instruction.results {
-      specializeDeinits(ofType: result.type, in: function, &handled, moduleContext, &worklist)
-    }
-    for operand in instruction.operands {
-      specializeDeinits(ofType: operand.value.type, in: function, &handled, moduleContext,
-                        &worklist)
-    }
-  }
-  for argument in function.arguments {
-    specializeDeinits(ofType: argument.type, in: function, &handled, moduleContext, &worklist)
-  }
-}
-
+/// Specializes the deinits of the non-copyable `type`, and of its stored
+/// properties and enum payloads, because IRGen is about to emit metadata for it.
 private func specializeDeinits(ofType type: Type,
                                in function: Function,
                                _ handled: inout Set<Type>,
@@ -164,7 +135,7 @@ fileprivate struct PathFunctionTuple: Hashable {
   var function: Function
 }
 
-private func optimize(function: Function, _ context: FunctionPassContext, _ moduleContext: ModulePassContext, _ worklist: inout FunctionWorklist) {
+private func optimize(function: Function, _ context: FunctionPassContext, _ moduleContext: ModulePassContext, _ worklist: inout FunctionWorklist, _ handledDeinitTypes: inout Set<Type>) {
   var alreadyInlinedFunctions: Set<PathFunctionTuple> = Set()
 
   // ObjectOutliner replaces calls to findStringSwitchCase with _findStringSwitchCaseWithCache, but this happens as a late SIL optimization,
@@ -186,6 +157,21 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
         worklist.pushIfNotVisited($0)
       }
     }
+  }
+
+  // IRGen emits type metadata for a boxed or existential value, and for the
+  // destination of a checked cast. The destroy value witness of that metadata
+  // calls the type's deinit, which in embedded Swift has to be fully
+  // specialized first.
+  func specializeDeinitsOfMetadata(for type: Type) {
+    if context.options.enableEmbeddedSwift {
+      specializeDeinits(ofType: type, in: function, &handledDeinitTypes, moduleContext,
+                        &worklist)
+    }
+  }
+
+  func specializeDeinitsOfMetadata(forFormalType type: CanonicalType) {
+    specializeDeinitsOfMetadata(for: type.loweredType(in: function))
   }
 
   var changed = true
@@ -210,8 +196,18 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
         }
       case let cast as UnconditionalCheckedCastInst:
         specializeVTable(for: cast.type, instruction: cast)
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
       case let cast as UncheckedRefCastInst:
         specializeVTable(for: cast.type, instruction: cast)
+
+      // The destination of a checked cast needs metadata for the runtime check.
+      case let cast as UnconditionalCheckedCastAddrInst:
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
+      case let cast as CheckedCastBranchInst:
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
+      case let cast as CheckedCastAddrBranchInst:
+        specializeDeinitsOfMetadata(forFormalType: cast.targetFormalType)
+
       case let kpi as KeyPathInst:
         // In Embedded Swift, specialize the functions that are referenced
         // by the key path.
@@ -240,6 +236,7 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
 
       case let initExRef as InitExistentialRefInst:
         if context.options.enableEmbeddedSwift {
+          specializeDeinitsOfMetadata(for: initExRef.instance.type)
           for c in initExRef.conformances where c.isConcrete {
             specializeWitnessTable(for: c, moduleContext)
             worklist.addWitnessMethods(of: c, moduleContext)
@@ -248,9 +245,19 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
 
       case let initExAddr as InitExistentialAddrInst:
         if context.options.enableEmbeddedSwift {
+          specializeDeinitsOfMetadata(for: initExAddr.formalConcreteType.loweredType(in: function))
           for c in initExAddr.conformances where c.isConcrete && !c.protocol.isMarkerProtocol {
             specializeWitnessTable(for: c, moduleContext)
             worklist.addWitnessMethods(of: c, moduleContext)
+          }
+        }
+
+      case let allocBox as AllocBoxInst:
+        // Metadata is emitted for the boxed type, and its destroy value witness
+        // calls that type's deinit.
+        if context.options.enableEmbeddedSwift {
+          for field in allocBox.type.getBoxFields(in: function) {
+            specializeDeinitsOfMetadata(for: field)
           }
         }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -75,7 +75,7 @@ private func devirtualize(destroy: some DevirtualizableDestroy,
   }
 
   if nominal.valueTypeDestructor != nil && !destroy.shouldDropDeinit {
-    guard let deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
+    guard var deinitFunc = context.lookupDeinit(ofNominal: nominal) else {
       return false
     }
     // In mandatory mode, de-virtualization might create function references to functions with wrong linkage.
@@ -85,6 +85,15 @@ private func devirtualize(destroy: some DevirtualizableDestroy,
       let serialized = destroy.parentFunction.serializedKind
       guard serialized == .notSerialized || deinitFunc.hasValidLinkageForFragileRef(serialized) else {
         return false
+      }
+
+      // In Embedded Swift, go looking for an already-specialized deinit for a generic type.
+      // If there isn't one, we have to bail out.
+      if deinitFunc.isGeneric && context.options.enableEmbeddedSwift {
+        guard let specialized = context.lookupSpecializedDeinit(ofType: type) else {
+          return false
+        }
+        deinitFunc = specialized
       }
     }
 
@@ -297,7 +306,9 @@ extension DestroyAddrInst : DevirtualizableDestroy {
 
   fileprivate func createDeinitCall(to deinitializer: Function, _ context: some MutatingContext) {
     let builder = Builder(before: self, context)
-    let subs = context.getContextSubstitutionMap(for: destroyedAddress.type)
+    let subs = deinitializer.isGeneric
+        ? context.getContextSubstitutionMap(for: destroyedAddress.type)
+        : SubstitutionMap()
     let deinitRef = builder.createFunctionRef(deinitializer)
     if !deinitializer.argumentConventions[deinitializer.selfArgumentIndex!].isIndirect {
       let value = builder.createLoad(fromAddress: destroyedAddress, ownership: .take)

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -410,8 +410,6 @@ GROUPED_WARNING(embedded_swift_cast_to_nonunique_type,EmbeddedRestrictions,none,
       "casting to %0 across a module boundary in embedded Swift may fail at "
       "runtime because its type metadata is not unique; mark %0 with "
       "'@export(interface)' in its defining module", (Type))
-GROUPED_ERROR(embedded_capture_of_generic_value_with_deinit,EmbeddedRestrictions,none,
-      "capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift", ())
 GROUPED_ERROR(embedded_call_generic_function,EmbeddedRestrictions,none,
       "cannot specialize generic function or default protocol method in this context", ())
 GROUPED_ERROR(embedded_call_generic_function_with_dynamic_self,EmbeddedRestrictions,none,

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -617,6 +617,35 @@ void TypeTreeLeafTypeRange::constructFilteredProjections(
   llvm_unreachable("Not understand subtype");
 }
 
+/// If a use of \p projectedValue reaches its root by projecting a payload out
+/// of an existential, returns that existential's type; otherwise returns an
+/// empty type.
+///
+/// An existential is opaque: the leaf subelements of its payload are not tracked
+/// separately, so projecting a payload address out of one does not enter a
+/// larger element space. `SubElementOffset::compute` accordingly treats the
+/// existential projections as offset-preserving pass-throughs, so counting the
+/// payload's subelements would produce a range past the end of the
+/// existential's own elements -- e.g. a payload with a deinit has an extra bit
+/// for `self`.
+static SILType getExistentialTypeForSubElementCount(SILValue projectedValue) {
+  SILValue value = projectedValue;
+  SILType existentialType;
+  while (true) {
+    if (auto *iea = dyn_cast<InitExistentialAddrInst>(value)) {
+      value = iea->getOperand();
+      existentialType = value->getType();
+      continue;
+    }
+    if (auto *oea = dyn_cast<OpenExistentialAddrInst>(value)) {
+      value = oea->getOperand();
+      existentialType = value->getType();
+      continue;
+    }
+    return existentialType;
+  }
+}
+
 void TypeTreeLeafTypeRange::get(
     Operand *op, SILValue rootValue,
     SmallVectorImpl<TypeTreeLeafTypeRange> &ranges) {
@@ -685,16 +714,23 @@ void TypeTreeLeafTypeRange::get(
   // Uses that borrow a value do not involve the deinit bit.
   //
   // FIXME: This shouldn't be limited to applies.
+  auto subElementCount = TypeSubElementCount(projectedValue);
+  SILType deinitBitType = projectedValue->getType();
+  if (SILType existentialType =
+          getExistentialTypeForSubElementCount(projectedValue)) {
+    subElementCount = TypeSubElementCount(existentialType, op->getFunction());
+    deinitBitType = existentialType;
+  }
+
   unsigned deinitBitOffset = 0;
-  if (op->get()->getType().isValueTypeWithDeinit() &&
+  if (deinitBitType.isValueTypeWithDeinit() &&
       op->getOperandOwnership() == OperandOwnership::Borrow &&
       ApplySite::isa(op->getUser())) {
     deinitBitOffset = 1;
   }
 
-  ranges.push_back({*startEltOffset, *startEltOffset +
-                                         TypeSubElementCount(projectedValue) -
-                                         deinitBitOffset});
+  ranges.push_back(
+      {*startEltOffset, *startEltOffset + subElementCount - deinitBitOffset});
 }
 
 void TypeTreeLeafTypeRange::constructProjectionsForNeededElements(

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1584,9 +1584,16 @@ public:
         diagnosed = true;
       // if the type is public and not frozen, then the method must not be
       // inlinable.
+      //
+      // `discard self` has to know the type's stored properties in order
+      // to destroy them individually, so a body emitted
+      // into a client must not bake in a layout the defining library could
+      // change.
       } else if (auto fragileKind = fn->getFragileFunctionKind();
                  !nominalDecl->getAttrs().hasAttribute<FrozenAttr>()
-                 && fragileKind != FragileFunctionKind{FragileFunctionKind::None}) {
+                 && fragileKind != FragileFunctionKind{FragileFunctionKind::None}
+                 && fn->getResilienceExpansion() ==
+                        ResilienceExpansion::Minimal) {
         ctx.Diags.diagnose(DS->getDiscardLoc(),
                            // Code in ABI stable SDKs has already used the `@inlinable`
                            // attribute on functions using `discard self`.

--- a/test/SILOptimizer/moveonly_existential_local.swift
+++ b/test/SILOptimizer/moveonly_existential_local.swift
@@ -1,9 +1,3 @@
-// Binding a non-copyable existential to a local used to crash the move-only
-// address checker. The marked value is the existential, which has a single leaf
-// subelement, but the range for a use of the payload address was computed from
-// the payload's own subelement count -- larger when the payload has a deinit,
-// which adds a bit for `self` -- overrunning the liveness bit vector.
-
 // RUN: %target-swift-frontend %s -module-name main -parse-as-library -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend %s -module-name main -parse-as-library -O -emit-sil -o /dev/null
 

--- a/test/SILOptimizer/moveonly_existential_local.swift
+++ b/test/SILOptimizer/moveonly_existential_local.swift
@@ -1,0 +1,46 @@
+// Binding a non-copyable existential to a local used to crash the move-only
+// address checker. The marked value is the existential, which has a single leaf
+// subelement, but the range for a use of the payload address was computed from
+// the payload's own subelement count -- larger when the payload has a deinit,
+// which adds a bit for `self` -- overrunning the liveness bit vector.
+
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -O -emit-sil -o /dev/null
+
+
+protocol P: ~Copyable {
+  func f()
+}
+
+// A payload with a deinit: its subelement count exceeds the existential's.
+struct WithDeinit<T>: ~Copyable, P {
+  var p: UnsafeMutablePointer<Int>
+  init() { p = .allocate(capacity: 1) }
+  func f() {}
+  deinit { p.deallocate() }
+}
+
+// Several stored properties, so the payload count exceeds 1 for another reason.
+struct MultiField: ~Copyable, P {
+  var a: Int
+  var b: Int
+  init() { a = 0; b = 0 }
+  func f() {}
+  deinit {}
+}
+
+func bindGenericPayload() {
+  let e: any P & ~Copyable = WithDeinit<Int>()
+  e.f()
+}
+
+func bindMultiFieldPayload() {
+  let e: any P & ~Copyable = MultiField()
+  e.f()
+}
+
+func bindAndBorrowRepeatedly() {
+  let e: any P & ~Copyable = WithDeinit<Int>()
+  e.f()
+  e.f()
+}

--- a/test/embedded/Inputs/cxx-move-only-counts.cpp
+++ b/test/embedded/Inputs/cxx-move-only-counts.cpp
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+static int made = 0;
+static int dtors = 0;
+static int doubleFrees = 0;
+
+extern "C" void noteMade(void) { made++; }
+extern "C" void noteDtor(void) { dtors++; }
+extern "C" void noteDoubleFree(void) { doubleFrees++; }
+
+/// A correct program destroys exactly as many objects as it made, and never
+/// destroys the same object twice.
+extern "C" void reportCounts(void) {
+  printf("balanced=%s doubleFree=%d\n", made == dtors ? "yes" : "no",
+         doubleFrees);
+}

--- a/test/embedded/Inputs/cxx-move-only.h
+++ b/test/embedded/Inputs/cxx-move-only.h
@@ -1,0 +1,39 @@
+#ifndef CXX_MOVE_ONLY_H
+#define CXX_MOVE_ONLY_H
+
+extern "C" void noteMade(void);
+extern "C" void noteDtor(void);
+extern "C" void noteDoubleFree(void);
+
+/// A C++ move-only type: copy construction and assignment are deleted, and it
+/// has a non-trivial destructor. Swift imports this as `~Copyable`.
+///
+/// Both the default and move constructors count as "made", so a correct program
+/// destroys exactly as many objects as it makes. The destructor poisons the
+/// pointer so that destroying the same object twice is detected rather than
+/// silently double-freeing.
+struct MoveOnly {
+  int *p;
+
+  MoveOnly() : p(new int(7)) { noteMade(); }
+  MoveOnly(const MoveOnly &) = delete;
+  MoveOnly &operator=(const MoveOnly &) = delete;
+  MoveOnly(MoveOnly &&other) : p(other.p) {
+    other.p = nullptr;
+    noteMade();
+  }
+  ~MoveOnly() {
+    noteDtor();
+    if (p == poison())
+      noteDoubleFree();
+    delete p;
+    p = poison();
+  }
+
+  int value() const { return p ? *p : -1; }
+
+private:
+  static int *poison() { return reinterpret_cast<int *>(-1); }
+};
+
+#endif

--- a/test/embedded/Inputs/module.modulemap
+++ b/test/embedded/Inputs/module.modulemap
@@ -6,3 +6,8 @@ module CxxStdVector {
   header "cxx-std-vector.h"
   requires cplusplus
 }
+
+module CxxMoveOnly {
+  header "cxx-move-only.h"
+  requires cplusplus
+}

--- a/test/embedded/cxx-move-only.swift
+++ b/test/embedded/cxx-move-only.swift
@@ -1,0 +1,123 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -c %S/Inputs/cxx-move-only-counts.cpp -o %t/counts.o
+// RUN: %target-swift-frontend -I %S/Inputs %s -enable-experimental-feature Embedded -enable-experimental-feature Extern -enable-experimental-feature MoveOnlyTuples -cxx-interoperability-mode=default -wmo -O -parse-as-library -c -o %t/main.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %t/counts.o -lc++ %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
+// REQUIRES: swift_feature_MoveOnlyTuples
+
+import CxxMoveOnly
+
+@_extern(c) func reportCounts()
+
+struct Box: ~Copyable {
+  var m: MoveOnly
+  init() { m = MoveOnly() }
+}
+
+struct BoxWithDeinit: ~Copyable {
+  var m: MoveOnly
+  init() { m = MoveOnly() }
+  deinit {}
+}
+
+struct Wrapper<T: ~Copyable>: ~Copyable {
+  var v: T
+  init(_ v: consuming T) { self.v = v }
+}
+
+struct WrapperWithDeinit<T: ~Copyable>: ~Copyable {
+  var v: T
+  init(_ v: consuming T) { self.v = v }
+  deinit {}
+}
+
+enum MaybeMoveOnly: ~Copyable {
+  case none
+  case some(MoveOnly)
+}
+
+final class Holder {
+  var m: MoveOnly
+  init() { m = MoveOnly() }
+}
+
+@inline(never)
+func eat<T: ~Copyable>(_ x: consuming T) {}
+
+@main
+struct Main {
+  static func main() {
+    do {
+      let m = MoveOnly()
+      precondition(m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let b = Box()
+      precondition(b.m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let b = BoxWithDeinit()
+      precondition(b.m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let w = Wrapper(MoveOnly())
+      precondition(w.v.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let t = (MoveOnly(), 1)
+      precondition(t.1 == 1)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let w = WrapperWithDeinit(MoveOnly())
+      precondition(w.v.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let e = MaybeMoveOnly.some(MoveOnly())
+      if case .some(let m) = e { precondition(m.value() == 7) }
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let e = MaybeMoveOnly.none
+      if case .none = e {}
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    do {
+      let h = Holder()
+      precondition(h.m.value() == 7)
+    }
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+
+    eat(MoveOnly())
+    reportCounts()
+    // CHECK: balanced=yes doubleFree=0
+  }
+}

--- a/test/embedded/deinit-existential-local-exec.swift
+++ b/test/embedded/deinit-existential-local-exec.swift
@@ -1,0 +1,40 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -O -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+var deinits = 0
+
+protocol P: ~Copyable {
+  func f()
+}
+
+struct S<T>: ~Copyable, P {
+  var p: UnsafeMutablePointer<Int>
+  init(_ v: Int) { p = .allocate(capacity: 1); p.pointee = v }
+  func f() { precondition(p.pointee == 7) }
+  deinit {
+    deinits += 1
+    p.deallocate()
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    do {
+      let e: any P & ~Copyable = S<Int>(7)
+      e.f()
+    }
+    print("after one: \(deinits)")
+    // CHECK: after one: 1
+
+    do {
+      let e: any P & ~Copyable = S<Int>(7)
+      e.f()
+      e.f()
+    }
+    print("after two: \(deinits)")
+    // CHECK: after two: 2
+  }
+}

--- a/test/embedded/deinit-existential-local-exec.swift
+++ b/test/embedded/deinit-existential-local-exec.swift
@@ -3,6 +3,12 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Embedded
 
+// Specializing the protocol witness thunk for a generic non-copyable type
+// produces invalid ownership SIL under opaque values -- unrelated to deinits,
+// and pre-existing. Several other embedded existential tests XFAIL for the same
+// reason (e.g. dynamic-cast.swift, existential-default-method.swift).
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 var deinits = 0
 
 protocol P: ~Copyable {

--- a/test/embedded/deinit-existential-local.swift
+++ b/test/embedded/deinit-existential-local.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -Osize -c -o /dev/null
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -O -c -o /dev/null
+
+// The destroy stays as a destroy_addr; no call to the unspecialized generic
+// deinit is left behind, and the specialized one exists for IRGen to use.
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -Osize -emit-sil -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+
+// CHECK-DAG: sil_moveonlydeinit $S<Int> {
+// CHECK-NOT: apply {{%[0-9]+}}<Int>({{.*}}) : $@convention(method) <{{.*}}> (@owned S<{{.*}}>) -> ()
+
+protocol P: ~Copyable {
+  func f()
+}
+
+struct S<T>: ~Copyable, P {
+  var p: UnsafeMutablePointer<Int>
+  init() { p = .allocate(capacity: 1) }
+  func f() {}
+  deinit { p.deallocate() }
+}
+
+public func bindToLocal() -> Bool {
+  let e: any P & ~Copyable = S<Int>()
+  e.f()
+  return true
+}

--- a/test/embedded/deinit-specialization-cast.swift
+++ b/test/embedded/deinit-specialization-cast.swift
@@ -1,0 +1,51 @@
+// Metadata is emitted for the destination type of a checked cast, so the
+// deinits reachable from that type's value witnesses have to be specialized.
+// Here the existential is always formed from `Other`, so the cast destination is
+// the only reason `Castee<Int>` would need metadata.
+
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature NoncopyableCasting -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature NoncopyableCasting -Osize -emit-sil -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_NoncopyableCasting
+
+// CHECK-DAG: sil_moveonlydeinit $Castee<Int> {
+
+public protocol P: ~Copyable {
+  func f()
+}
+
+public struct Castee<T>: ~Copyable, P {
+  var p: UnsafeMutablePointer<Int>
+  init() { p = .allocate(capacity: 1) }
+  public func f() {}
+  deinit { p.deallocate() }
+}
+
+public struct Other: ~Copyable, P {
+  public init() {}
+  public func f() {}
+}
+
+// Conditional cast: checked_cast_addr_br / checked_cast_br.
+@inline(never)
+func conditionally(_ e: consuming any P & ~Copyable) -> Int {
+  if let c = e as? Castee<Int> {
+    return c.p.pointee
+  }
+  return 0
+}
+
+// Unconditional cast: unconditional_checked_cast_addr.
+@inline(never)
+func unconditionally(_ e: consuming any P & ~Copyable) -> Int {
+  let c = e as! Castee<Int>
+  return c.p.pointee
+}
+
+// Both call sites pass `Other`, never `Castee`, so no existential of
+// `Castee<Int>` is ever formed and the cast destination is the only thing that
+// makes IRGen emit metadata for it.
+public func go() -> Int {
+  return conditionally(Other()) + unconditionally(Other())
+}

--- a/test/embedded/deinit-specialization.swift
+++ b/test/embedded/deinit-specialization.swift
@@ -1,12 +1,3 @@
-// Emitting the metadata of a non-copyable type also emits its value witnesses,
-// and the destroy witness calls the deinits of the type and its members. In
-// Embedded Swift those deinits must be fully specialized, because unspecialized
-// generic functions take type metadata, which doesn't exist there.
-//
-// `@export(interface)` is what makes a type's metadata emitted eagerly, so the
-// types below use it rather than the module-wide `CodeGenerationModel=interface`
-// (which is not a `Features.def` feature and so can't be spelled in a REQUIRES).
-
 // RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-sil -o - | %FileCheck -check-prefix SIL %s
 // RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-ir -o - | %FileCheck -check-prefix IR %s
 
@@ -54,28 +45,39 @@ public struct Unused: ~Copyable {
   var items: Storage<Int>
 }
 
+// Forming an existential is the other thing that makes IRGen emit metadata for
+// a type, so the deinit of the concrete type has to be specialized there too.
 // A concrete instantiation of a generic type is never among the types SILGen
-// records, so it has to be discovered from the SIL. `LocalOnly<Int>` is only
-// ever a local and `GenericBox<Int>`'s container is itself generic, so neither
-// is reachable from a recorded non-generic type — yet both get a specialized
-// deinit.
-// SIL-DAG: sil_moveonlydeinit $LocalOnly<Int> {
-// SIL-DAG: sil_moveonlydeinit $GenericBox<Int> {
+// recorded, so this one is found from the `init_existential` instruction.
+// SIL-DAG: sil_moveonlydeinit $Existentialized<Int> {
+public protocol HasF: ~Copyable {
+  func f()
+}
+
+public struct Existentialized<T>: ~Copyable, HasF {
+  var q: UnsafeMutablePointer<Int>
+  init() { q = .allocate(capacity: 1) }
+  public func f() {}
+  deinit { q.deallocate() }
+}
+
+@inline(never)
+func take(_ e: consuming any HasF & ~Copyable) { e.f() }
+
+public func useExistential() {
+  take(Existentialized<Int>())
+}
+
+// A type that is merely a local, with no metadata emitted for it, needs no
+// specialized deinit: nothing will ever call it through a value witness.
+// SIL-NOT: sil_moveonlydeinit $LocalOnly<Int> {
 public struct LocalOnly<T>: ~Copyable {
   var p: UnsafeMutablePointer<Int>
   init() { p = .allocate(capacity: 1) }
   deinit { p.deallocate() }
 }
 
-public struct GenericBox<T>: ~Copyable {
-  var q: UnsafeMutablePointer<Int>
-  init() { q = .allocate(capacity: 1) }
-  deinit { q.deallocate() }
-}
-
 public func useLocalOnly() {
   let s = LocalOnly<Int>()
   _ = s.p
-  let g = GenericBox<Int>()
-  _ = g.q
 }

--- a/test/embedded/discard-non-frozen.swift
+++ b/test/embedded/discard-non-frozen.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -emit-sil -verify -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+
+public struct S<T>: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+
+  public init() { p = .allocate(capacity: 1) }
+
+  // Take the pointer out before consuming self, then skip the deinit.
+  public consuming func giveUp() -> UnsafeMutablePointer<Int> {
+    let q = p
+    discard self
+    return q
+  }
+
+  deinit { p.deallocate() }
+}
+
+// A non-generic type in the same position.
+public struct T: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+  public init() { p = .allocate(capacity: 1) }
+  public consuming func giveUp() -> UnsafeMutablePointer<Int> {
+    let q = p
+    discard self
+    return q
+  }
+  deinit { p.deallocate() }
+}
+
+// `discard` skips the deinit, so neither call site destroys the value.
+// CHECK-LABEL: sil{{.*}}@$e4main2goyyF
+// CHECK-NOT: fD
+// CHECK: end sil function
+public func go() {
+  let q = S<Int>().giveUp()
+  q.deallocate()
+  let r = T().giveUp()
+  r.deallocate()
+}

--- a/test/embedded/noncopyable-captures-exec.swift
+++ b/test/embedded/noncopyable-captures-exec.swift
@@ -1,0 +1,63 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -O -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+var deinits = 0
+
+struct S<T>: ~Copyable {
+  var p: UnsafeMutablePointer<Int>
+  init() { p = .allocate(capacity: 1); p.pointee = 7 }
+  mutating func bump() { p.pointee += 1 }
+  deinit {
+    deinits += 1
+    p.deallocate()
+  }
+}
+
+struct Outer: ~Copyable {
+  var inner: S<Int>
+}
+
+enum E: ~Copyable {
+  case a(S<Int>)
+  case b
+  mutating func touch() {}
+}
+
+var escape: (() -> ())?
+
+@main
+struct Main {
+  static func main() {
+    do {
+      var s = S<Int>()
+      s.bump()
+      escape = { s.bump() }
+      escape!()
+      escape = nil
+    }
+    print("after struct: \(deinits)")
+    // CHECK: after struct: 1
+
+    do {
+      var o = Outer(inner: S<Int>())
+      o.inner.bump()
+      escape = { o.inner.bump() }
+      escape!()
+      escape = nil
+    }
+    print("after nested: \(deinits)")
+    // CHECK: after nested: 2
+
+    do {
+      var e = E.a(S<Int>())
+      e.touch()
+      escape = { e.touch() }
+      escape!()
+      escape = nil
+    }
+    print("after enum: \(deinits)")
+    // CHECK: after enum: 3
+  }
+}

--- a/test/embedded/noncopyable-captures.swift
+++ b/test/embedded/noncopyable-captures.swift
@@ -1,24 +1,28 @@
-// RUN: %target-swift-emit-ir %s -DIGNORE_FAILS -enable-experimental-feature Embedded -wmo -o /dev/null
-// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -verify
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -verify -o /dev/null
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -Osize -o /dev/null
 
 // REQUIRES: swift_feature_Embedded
 
 struct MyStruct<Item> : ~Copyable {
-    var member = "42"
+    var p: UnsafeMutablePointer<Int>
 
-    init() {}
-    deinit {}
-    mutating func foo() {}
+    init() { p = .allocate(capacity: 1) }
+    // A non-trivial deinit, so that destroying the box really does reference it.
+    deinit { p.deallocate() }
+    mutating func foo() { p.pointee += 1 }
 }
 
-var escape: (()->())?
+// Escaping into a class property, so that the box survives to IRGen rather than
+// being promoted to the stack.
+public final class Keeper {
+    public var run: (() -> ())?
+    public init() {}
+}
 
-#if !IGNORE_FAILS
-
-public func test() {
-    var s = MyStruct<Int>() // expected-error {{capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift}}
+public func test(_ k: Keeper) {
+    var s = MyStruct<Int>()
     s.foo()
-    escape = {
+    k.run = {
         s.foo()
     }
 }
@@ -29,10 +33,10 @@ struct Outer: ~Copyable {
   var inner: MyStruct<Int>
 }
 
-public func testNested() {
-    var s = Outer(inner: MyStruct<Int>()) // expected-error {{capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift}}
+public func testNested(_ k: Keeper) {
+    var s = Outer(inner: MyStruct<Int>())
     s.inner.foo()
-    escape = {
+    k.run = {
         s.inner.foo()
     }
 }
@@ -46,17 +50,37 @@ enum E: ~Copyable {
   mutating func foo() {}
 }
 
-public func testEnum() {
-    var s = E.A(MyStruct<Int>()) // expected-error {{capturing generic non-copyable type with deinit in escaping closure not supported in embedded Swift}}
+public func testEnum(_ k: Keeper) {
+    var s = E.A(MyStruct<Int>())
     s.foo()
-    escape = {
+    k.run = {
         s.foo()
     }
 }
 
-#endif
+//
+
+// A generic non-copyable type with a deinit that is *only* ever boxed: no
+// non-generic non-copyable type has it as a field or payload, so the `alloc_box`
+// is the only thing that makes IRGen emit metadata for it.
+struct OnlyBoxed<Item>: ~Copyable {
+    var p: UnsafeMutablePointer<Int>
+    init() { p = .allocate(capacity: 1) }
+    deinit { p.deallocate() }
+    mutating func foo() { p.pointee += 1 }
+}
+
+public func testOnlyBoxed(_ k: Keeper) {
+    var s = OnlyBoxed<Int>()
+    s.foo()
+    k.run = {
+        s.foo()
+    }
+}
 
 //
+
+var escape: (()->())?
 
 struct StructWithoutDeinit<Item> {
     var member = "42"


### PR DESCRIPTION
Building on https://github.com/swiftlang/swift/pull/91686, improve handling of deinit devirtualization:
* Handle devirtualization when dealing with move-only existentials
* Lift restriction on generic deinits in captures