### PR TITLE
CrossModuleOptimization: fix a crash with `checked_cast_br` on local archetypes

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -158,11 +158,33 @@ private:
   VisitMode mode;
   bool isInstSerializable = true;
 
+  /// Temporary blocks created by `remapBasicBlock`, which are deleted again in
+  /// `postProcess`.
+  llvm::SmallVector<SILBasicBlock *, 2> tempBlocks;
+
+  void eraseTempBlocks() {
+    if (tempBlocks.empty())
+      return;
+
+    SILFunction *f = &getBuilder().getFunction();
+    // Deleting a block sets the `needBreakInfiniteLoops` flag. But the temporary
+    // blocks are empty and not reachable, so they cannot create infinite loops.
+    bool origFlag = f->needBreakInfiniteLoops();
+    for (SILBasicBlock *tempBlock : tempBlocks)
+      tempBlock->eraseFromParent();
+    tempBlocks.clear();
+    f->setNeedBreakInfiniteLoops(origFlag);
+  }
+
 public:
   InstructionVisitor(SILFunction &F, CrossModuleOptimization &CMS, VisitMode visitMode) :
     SILCloner(F), CMS(CMS), mode(visitMode) {}
 
   ~InstructionVisitor() {
+    // In case a visited instruction was not recorded as cloned instruction,
+    // `postProcess` didn't run and the temporary blocks are still around.
+    eraseTempBlocks();
+
     // We use the cloner for type visiting which may clone `unreachable` instructions.
     // However, this does not introduce any incomplete lifetimes.
     Builder.getFunction().setNeedCompleteLifetimes(false);
@@ -255,6 +277,10 @@ public:
   void postProcess(SILInstruction *Orig, SILInstruction *Cloned) {
     SILCloner<InstructionVisitor>::postProcess(Orig, Cloned);
     Cloned->eraseFromParent();
+
+    // The cloned instruction was the only user of the temporary blocks which
+    // `remapBasicBlock` created for it.
+    eraseTempBlocks();
   }
 
   // This method retrieves the operand passed as \p Value as mapped
@@ -296,7 +322,30 @@ public:
     return Value;
   }
 
-  SILBasicBlock *remapBasicBlock(SILBasicBlock *BB) { return BB; }
+  SILBasicBlock *remapBasicBlock(SILBasicBlock *BB) {
+    // The successor blocks of a cloned terminator are not cloned - we return
+    // the original blocks here. Therefore their arguments still refer to the
+    // original local archetypes, whereas the terminator's operands are
+    // re-mapped (see `getMappedValue`). That would create terminators whose
+    // successor argument types don't match the types of its operands, which
+    // some SILBuilder APIs check, e.g. `createCheckedCastBranch`.
+    // Therefore use a temporary block with re-mapped argument types in this
+    // case. It's deleted again in `postProcess`, together with the cloned
+    // terminator.
+    if (llvm::none_of(BB->getArguments(), [&](SILArgument *arg) {
+          return substLocalArchetypes(arg->getType()) != arg->getType();
+        })) {
+      return BB;
+    }
+
+    SILBasicBlock *tempBlock = getBuilder().getFunction().createBasicBlock();
+    for (SILArgument *arg : BB->getArguments()) {
+      tempBlock->createPhiArgument(substLocalArchetypes(arg->getType()),
+                                   arg->getOwnershipKind());
+    }
+    tempBlocks.push_back(tempBlock);
+    return tempBlock;
+  }
 
   bool canSerializeTypesInInst(SILInstruction *inst) {
     return isInstSerializable;

--- a/test/SILOptimizer/cmo_and_local_archetypes.swift
+++ b/test/SILOptimizer/cmo_and_local_archetypes.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -o /dev/null %s -O -cross-module-optimization -sil-verify-all
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -O -enable-cmo-everything -sil-verify-all
 
 // Check that the cross-module-optimization pass can handle instructions which
 // operate on local archetypes, like `value_metatype` on an opened existential
@@ -33,4 +34,18 @@ func nameOfValue<T: P>(_ value: T) -> String {
 // existential archetype.
 public func nameOfExistential(_ value: any P) -> String {
   return nameOfValue(value)
+}
+
+public protocol Q: AnyObject {}
+public class C: Q {}
+
+@inline(__always)
+func castToC<T: Q>(_ value: T) -> C? {
+  return value as? C
+}
+
+// After inlining `castToC`, the `checked_cast_br` operates on an opened
+// existential archetype - and so does the argument of its failure block.
+public func castExistentialToClass(_ value: any Q) -> C? {
+  return castToC(value)
 }


### PR DESCRIPTION
The pass' InstructionVisitor uses the SILCloner just to visit the types of instructions - the created instructions are deleted immediately. Operands are therefore re-mapped to undef values with substituted local archetypes (see `getMappedValue`), but `remapBasicBlock` returned the original successor blocks, whose arguments still refer to the original local archetypes.

This resulted in terminators whose operand type didn't match the type of the successor's block argument, which triggered an assert in `SILBuilder::createCheckedCastBranch` for a `checked_cast_br` on an opened existential.

Fixed by returning a temporary block with re-mapped argument types for such successors.

Follow-up to https://github.com/swiftlang/swift/pull/91562.

rdar://185642812
