### PR TITLE
Adjust to "[ADT] Remove unused DenseMapInfo::getEmptyKey (#201998)"

### DIFF
--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -132,8 +132,7 @@ public:
 
 /// The information identifying the llvm intrinsic - its id and types.
 class IntrinsicInfo {
-  mutable llvm::AttributeSet FnAttrs =
-      llvm::DenseMapInfo<llvm::AttributeSet>::getEmptyKey();
+  mutable std::optional<llvm::AttributeSet> FnAttrs;
 
 public:
   llvm::Intrinsic::ID ID;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -596,12 +596,15 @@ private:
 void simple_display(raw_ostream &out, GenericSignature sig);
 
 inline bool CanGenericSignature::isActuallyCanonicalOrNull() const {
-  return getPointer() == nullptr ||
-         getPointer() ==
-             llvm::DenseMapInfo<GenericSignatureImpl *>::getEmptyKey() ||
-         getPointer() ==
-             llvm::DenseMapInfo<GenericSignatureImpl *>::getTombstoneKey() ||
-         getPointer()->isCanonical();
+#if LLVM_VERSION_MAJOR <= 21
+  if (getPointer() ==
+          llvm::DenseMapInfo<GenericSignatureImpl *>::getEmptyKey() ||
+      getPointer() ==
+          llvm::DenseMapInfo<GenericSignatureImpl *>::getTombstoneKey())
+    return true;
+#endif
+
+  return getPointer() == nullptr || getPointer()->isCanonical();
 }
 
 int compareAssociatedTypes(AssociatedTypeDecl *assocType1,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -8675,10 +8675,13 @@ inline CanType CanType::getNominalParent() const {
 }
 
 inline bool CanType::isActuallyCanonicalOrNull() const {
-  return getPointer() == nullptr ||
-         getPointer() == llvm::DenseMapInfo<TypeBase *>::getEmptyKey() ||
-         getPointer() == llvm::DenseMapInfo<TypeBase *>::getTombstoneKey() ||
-         getPointer()->isCanonical();
+#if LLVM_VERSION_MAJOR <= 21
+  if (getPointer() == llvm::DenseMapInfo<TypeBase *>::getEmptyKey() ||
+      getPointer() == llvm::DenseMapInfo<TypeBase *>::getTombstoneKey())
+    return true;
+#endif
+
+  return getPointer() == nullptr || getPointer()->isCanonical();
 }
 
 inline TupleTypeElt TupleTypeElt::getWithName(Identifier name) const {

--- a/include/swift/Basic/Located.h
+++ b/include/swift/Basic/Located.h
@@ -61,6 +61,7 @@ template<typename T>
 struct DenseMapInfo<swift::Located<T>> {
   using SourceLoc = swift::SourceLoc;
 
+#if LLVM_VERSION_MAJOR <= 21
   static inline swift::Located<T> getEmptyKey() {
     return swift::Located<T>(DenseMapInfo<T>::getEmptyKey(),
                              DenseMapInfo<SourceLoc>::getEmptyKey());
@@ -70,6 +71,7 @@ struct DenseMapInfo<swift::Located<T>> {
     return swift::Located<T>(DenseMapInfo<T>::getTombstoneKey(),
                              DenseMapInfo<SourceLoc>::getTombstoneKey());
   }
+#endif
 
   static unsigned getHashValue(const swift::Located<T> &LocatedVal) {
     return detail::combineHashValue(DenseMapInfo<T>::getHashValue(LocatedVal.Item),

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -259,14 +259,14 @@ struct hash<swift::remote::RemoteAddress> {
 namespace llvm {
 template <>
 struct DenseMapInfo<swift::remote::RemoteAddress> {
+  // Do not remove: stdlib/include/llvm/ADT/DenseMap.h still needs this
   static swift::remote::RemoteAddress getEmptyKey() {
-    return swift::remote::RemoteAddress(DenseMapInfo<uint64_t>::getEmptyKey(),
-                                        0);
+    return swift::remote::RemoteAddress(~0ULL, 0);
   }
 
+  // Do not remove: stdlib/include/llvm/ADT/DenseMap.h still needs this.
   static swift::remote::RemoteAddress getTombstoneKey() {
-    return swift::remote::RemoteAddress(
-        DenseMapInfo<uint64_t>::getTombstoneKey(), 0);
+    return swift::remote::RemoteAddress(~0ULL - 1ULL, 0);
   }
 
   static unsigned getHashValue(swift::remote::RemoteAddress address) {

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -400,6 +400,7 @@ struct DenseMapInfo<swift::constraints::inference::PotentialBinding> {
   }
 
   static bool isEqual(const Binding &LHS, const Binding &RHS) {
+#if LLVM_VERSION_MAJOR <= 21
     // If either side is empty or tombstone, let's use pointer equality.
     {
       auto lhsTy = LHS.BindingType.getPointer();
@@ -415,6 +416,7 @@ struct DenseMapInfo<swift::constraints::inference::PotentialBinding> {
       if (rhsTy == emptyTy || rhsTy == tombstoneTy)
         return lhsTy == rhsTy;
     }
+#endif
 
     return LHS == RHS;
   }

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -49,12 +49,11 @@ bool BuiltinInfo::isReadNone() const {
 
 const llvm::AttributeSet &
 IntrinsicInfo::getOrCreateFnAttributes(ASTContext &Ctx) const {
-  using DenseMapInfo = llvm::DenseMapInfo<llvm::AttributeSet>;
-  if (DenseMapInfo::isEqual(FnAttrs, DenseMapInfo::getEmptyKey())) {
+  if (!FnAttrs) {
     FnAttrs =
         llvm::Intrinsic::getFnAttributes(Ctx.getIntrinsicScratchContext(), ID);
   }
-  return FnAttrs;
+  return FnAttrs.value();
 }
 
 Type swift::getBuiltinType(ASTContext &Context, StringRef Name) {

--- a/lib/Basic/Cache.cpp
+++ b/lib/Basic/Cache.cpp
@@ -57,11 +57,13 @@ template<> struct DenseMapInfo<DefaultCacheKey> {
   static bool isEqual(const DefaultCacheKey &LHS, const DefaultCacheKey &RHS) {
     if (LHS.Key == RHS.Key)
       return true;
+#if LLVM_VERSION_MAJOR <= 21
     if (LHS.Key == DenseMapInfo<void*>::getEmptyKey() ||
         LHS.Key == DenseMapInfo<void*>::getTombstoneKey() ||
         RHS.Key == DenseMapInfo<void*>::getEmptyKey() ||
         RHS.Key == DenseMapInfo<void*>::getTombstoneKey())
       return false;
+#endif
     return LHS.CBs->keyIsEqualCB(LHS.Key, RHS.Key, nullptr);
   }
 };

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -41,9 +41,6 @@ public:
 
   Address(llvm::Value *addr, llvm::Type *elementType, Alignment align)
       : Addr(addr), ElementType(elementType), Align(align) {
-    if (addr == llvm::DenseMapInfo<llvm::Value *>::getEmptyKey() ||
-        llvm::DenseMapInfo<llvm::Value *>::getTombstoneKey())
-      return;
     assert(addr != nullptr && "building an invalid address");
   }
 


### PR DESCRIPTION
After the `DenseMap` redesign made it no longer create empty/tombstone buckets, `DenseMapInfo::getEmptyKey` and `DenseMapInfo::getTombstoneKey` were removed.

Stop relying on the removed partial specialisations, but defer the removal of our own specialisations to a post-rebranch date.

See:
- https://github.com/llvm/llvm-project/commit/836bf567e622a2e083a0c850b861b450fc97b915 (https://github.com/llvm/llvm-project/pull/200959).
- https://github.com/llvm/llvm-project/commit/11496fa35dfdf9a84c82d2c6181e54caf7288fce (https://github.com/llvm/llvm-project/pull/201998).