### PR TITLE
[Embedded] Treat casting to a class-bound existential as an error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9193,10 +9193,10 @@ GROUPED_WARNING(use_generic_member_of_existential_in_embedded_swift,
                 EmbeddedRestrictions, none,
                 "cannot use generic %kind0 on a value of type %1 in Embedded Swift",
                 (const Decl *, Type))
-GROUPED_WARNING(dynamic_cast_involving_protocol_in_embedded_swift,
-                EmbeddedRestrictions, none,
-                "cannot perform a dynamic cast to a type involving %kind0 in Embedded Swift",
-                (const Decl *))
+GROUPED_ERROR(dynamic_cast_involving_protocol_in_embedded_swift,
+              EmbeddedRestrictions, none,
+              "cannot perform a dynamic cast to a type involving %kind0 in Embedded Swift",
+              (const Decl *))
 
 GROUPED_WARNING(open_existential_in_embedded_swift,
                 EmbeddedRestrictions, none,

--- a/lib/Sema/TypeCheckEmbedded.cpp
+++ b/lib/Sema/TypeCheckEmbedded.cpp
@@ -148,8 +148,12 @@ void swift::diagnoseGenericMemberOfExistentialInEmbedded(
 
 void swift::diagnoseDynamicCastInEmbedded(
     const DeclContext *dc, const CheckedCastExpr *cast) {
-  // If we are not supposed to diagnose Embedded Swift limitations, do nothing.
-  auto behavior = shouldDiagnoseEmbeddedLimitations(dc, cast->getLoc());
+  // A cast to a type involving a protocol needs a runtime conformance lookup,
+  // which the embedded runtime cannot do. This has always been unsupported --
+  // for the address-only forms SILGen produces, the optimizer rejects it
+  // outright -- so it is an error in Embedded Swift rather than a warning.
+  auto behavior = shouldDiagnoseEmbeddedLimitations(dc, cast->getLoc(),
+                                                   /*wasAlwaysEmbeddedError=*/true);
   if (!behavior)
     return;
 

--- a/lib/Sema/TypeCheckEmbedded.cpp
+++ b/lib/Sema/TypeCheckEmbedded.cpp
@@ -37,9 +37,27 @@ defaultEmbeddedLimitationForError(const DeclContext *dc, SourceLoc loc) {
   return DiagnosticBehavior::Warning;
 }
 
+/// Determine whether the code in this declaration context will never be
+/// emitted when compiling for Embedded Swift, in which case there is no point
+/// in diagnosing Embedded Swift limitations within it.
+static bool isNeverEmittedForEmbedded(const DeclContext *dc) {
+  auto decl = dc->getInnermostDeclarationDeclContext();
+  if (!decl)
+    return false;
+
+  // A declaration that is not available during lowering never reaches SILGen,
+  // so its restrictions can never be hit.
+  return !decl->isAvailableDuringLowering();
+}
+
 std::optional<DiagnosticBehavior>
 swift::shouldDiagnoseEmbeddedLimitations(const DeclContext *dc, SourceLoc loc,
                                          bool wasAlwaysEmbeddedError) {
+  // Code that is never emitted for Embedded Swift is free to use constructs
+  // Embedded Swift cannot support.
+  if (isNeverEmittedForEmbedded(dc))
+    return std::nullopt;
+
   // In Embedded Swift, things that were always errors will still be emitted
   // as errors. Use "unspecified" so we don't change anything.
   if (dc->getASTContext().LangOpts.hasFeature(Feature::Embedded) &&

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -155,7 +155,7 @@ extension Executor {
   #endif
   @available(StdlibDeploymentTarget 6.3, *)
   internal var isMainExecutor: Bool {
-    #if os(WASI) || os(Emscripten) || !$Embedded
+    #if !$Embedded
     return self is any MainExecutor
     #else
     return false

--- a/stdlib/public/Concurrency/ExecutorImpl.swift
+++ b/stdlib/public/Concurrency/ExecutorImpl.swift
@@ -43,6 +43,7 @@ internal func donateToGlobalExecutor(
   condition: @convention(c) (_ ctx: UnsafeMutableRawPointer) -> CBool,
   context: UnsafeMutableRawPointer
 ) {
+  #if !$Embedded
   if #available(StdlibDeploymentTarget 6.3, *) {
     if let runnableExecutor = Task.defaultExecutor as? RunLoopExecutor {
       try! runnableExecutor.runUntil { unsafe Bool(condition(context)) }
@@ -52,6 +53,9 @@ internal func donateToGlobalExecutor(
   } else {
     fatalError("this should never happen")
   }
+  #else
+  fatalError("Global executor does not support thread donation")
+  #endif
 }
 
 @available(SwiftStdlib 6.2, *)

--- a/test/embedded/dynamic-cast-class-bound-protocol.swift
+++ b/test/embedded/dynamic-cast-class-bound-protocol.swift
@@ -1,0 +1,48 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Embedded
+
+// REQUIRES: swift_feature_Embedded
+
+public protocol ClassBound: AnyObject { func f() }
+public protocol Other: AnyObject { func g() }
+
+public class C: ClassBound, Other {
+  public init() {}
+  public func f() {}
+  public func g() {}
+}
+
+public class D: C {}
+
+public func castToClassBoundProtocol(_ e: any ClassBound) -> Bool {
+  // expected-error@+1{{cannot perform a dynamic cast to a type involving protocol 'Other' in Embedded Swift}}
+  return e is any Other
+}
+
+public func conditionalCast(_ e: any ClassBound) -> Bool {
+  // expected-error@+1{{cannot perform a dynamic cast to a type involving protocol 'Other' in Embedded Swift}}
+  if let o = e as? any Other { o.g(); return true }
+  return false
+}
+
+public func forcedCast(_ e: any ClassBound) {
+  // expected-error@+1{{cannot perform a dynamic cast to a type involving protocol 'Other' in Embedded Swift}}
+  let o = e as! any Other
+  o.g()
+}
+
+// Casting to a concrete class is still fine: that is a metadata-pointer
+// comparison, which needs no conformance lookup.
+public func downcastToClass(_ e: any ClassBound) -> Bool {
+  if let c = e as? C { c.f(); return true }
+  return false
+}
+
+public func classToSubclass(_ c: C) -> Bool {
+  if let d = c as? D { d.f(); return true }
+  return false
+}
+
+// An upcast is static, not a dynamic cast.
+public func upcast(_ c: C) -> any ClassBound {
+  return c as any ClassBound
+}

--- a/test/embedded/dynamic-cast-class-bound-protocol.swift
+++ b/test/embedded/dynamic-cast-class-bound-protocol.swift
@@ -46,3 +46,29 @@ public func classToSubclass(_ c: C) -> Bool {
 public func upcast(_ c: C) -> any ClassBound {
   return c as any ClassBound
 }
+
+// Code that is stripped during lowering is never emitted for Embedded Swift,
+// so it is free to use casts Embedded Swift cannot support.
+@_unavailableInEmbedded
+public func unavailableInEmbedded(_ e: any ClassBound) -> Bool {
+  return e is any Other
+}
+
+@available(*, unavailable)
+public func universallyUnavailable(_ e: any ClassBound) -> Bool {
+  return e is any Other
+}
+
+@_unavailableInEmbedded
+extension C {
+  public func inUnavailableExtension(_ e: any ClassBound) -> Bool {
+    return e is any Other
+  }
+}
+
+// A nested function inherits its enclosing declaration's unavailability.
+@_unavailableInEmbedded
+public func unavailableWithNestedFunction(_ e: any ClassBound) -> Bool {
+  func nested() -> Bool { return e is any Other }
+  return nested()
+}

--- a/test/embedded/metatypes.swift
+++ b/test/embedded/metatypes.swift
@@ -12,12 +12,13 @@ public func test() -> Int {
 }
 
 func castToExistential<T>(x: T) {
-  if x is any FixedWidthInteger {    // expected-error {{cannot do dynamic casting in embedded Swift}}
-    // expected-warning@-1{{cannot perform a dynamic cast to a type involving protocol 'FixedWidthInteger' in Embedded Swift}}
+  // A cast to a type involving a protocol is rejected during type checking, so
+  // compilation stops before the SIL-level check would run.
+  if x is any FixedWidthInteger {    // expected-error {{cannot perform a dynamic cast to a type involving protocol 'FixedWidthInteger' in Embedded Swift}}
   }
 }
 
 public func callCastToExistential() {
-  castToExistential(x: 42)    // expected-note {{generic specialization called here}}
+  castToExistential(x: 42)
 }
 

--- a/test/embedded/restrictions.swift
+++ b/test/embedded/restrictions.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -Wwarning EmbeddedRestrictions -verify-additional-prefix nonembedded-
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Embedded -verify-additional-prefix embedded-
-// RUN: %target-swift-frontend -typecheck %s -suppress-warnings -enable-experimental-feature Embedded -DSUPPRESS_WEAK
+// RUN: %target-swift-frontend -typecheck %s -suppress-warnings -enable-experimental-feature Embedded -DSUPPRESS_WEAK -DSUPPRESS_CASTS
 // REQUIRES: swift_feature_Embedded
 
 // ---------------------------------------------------------------------------
@@ -117,20 +117,25 @@ class ConformsToQ: Q {
   func okay() { }
 }
 
+#if !SUPPRESS_CASTS
 func dynamicCasting(object: AnyObject, cq: ConformsToQ) {
-  // expected-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  // expected-nonembedded-warning@+2{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  // expected-embedded-error@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
   if let q = object as? any AnyObject & Q {
     _ = q
   }
 
-  // expected-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  // expected-nonembedded-warning@+2{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  // expected-embedded-error@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
   if object is any AnyObject & Q { }
 
-  // expected-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  // expected-nonembedded-warning@+2{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  // expected-embedded-error@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
   _ = object as! AnyObject & Q
 
   _ = cq as AnyObject & Q
 }
+#endif
 
 // ---------------------------------------------------------------------------
 // #if handling to suppress diagnostics for non-Embedded-only code
@@ -138,12 +143,14 @@ func dynamicCasting(object: AnyObject, cq: ConformsToQ) {
 
 #if $Embedded
 
+#if !SUPPRESS_CASTS
 func stillProblematic(object: AnyObject) {
-  // expected-embedded-warning@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
+  // expected-embedded-error@+1{{cannot perform a dynamic cast to a type involving protocol 'Q' in Embedded Swift}}
   if let q = object as? any AnyObject & Q {
     _ = q
   }
 }
+#endif
 
 #else
 


### PR DESCRIPTION
We were allowing dynamic casts to a class-bound existential, emitting only warning, which absolutely doesn't work (and never has). Bump it up to an error.

This uncovered an issue where we weren't suppressing these diagnostics in code that is `@_unavailableInSwift`. Fix that, which is tracked by rdar://160894393