### PR TITLE
Sema: Look through implicit function conversions in `#_hasSymbol` conditions

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -792,6 +792,17 @@ static Expr *getDeclRefProvidingExpressionForHasSymbol(Expr *E) {
   if (auto CE = dyn_cast<CoerceExpr>(E))
     return getDeclRefProvidingExpressionForHasSymbol(CE->getSubExpr());
 
+  // Strip implicit function conversions, which may be inserted to adjust the
+  // type or isolation of the reference:
+  //
+  //   if #_hasSymbol(foo as () throws -> ()) { ... }
+  //
+  if (isa<FunctionConversionExpr>(E) ||
+      isa<CovariantFunctionConversionExpr>(E) ||
+      isa<ActorIsolationErasureExpr>(E))
+    return getDeclRefProvidingExpressionForHasSymbol(
+        cast<ImplicitConversionExpr>(E)->getSubExpr());
+
   // Unwrap curry thunks which are injected into the AST to wrap some forms of
   // unapplied method references, e.g.
   //
@@ -808,6 +819,14 @@ static Expr *getDeclRefProvidingExpressionForHasSymbol(Expr *E) {
   //
   if (auto DSCE = dyn_cast<DotSyntaxCallExpr>(E))
     return getDeclRefProvidingExpressionForHasSymbol(DSCE->getFn());
+
+  // Drill into the right hand side of a DotSyntaxBaseIgnoredExpr, which wraps
+  // an uncurried reference to an instance member, e.g.
+  //
+  //   if #_hasSymbol(SomeStruct.foo) { ... }
+  //
+  if (auto DSBIE = dyn_cast<DotSyntaxBaseIgnoredExpr>(E))
+    return getDeclRefProvidingExpressionForHasSymbol(DSBIE->getRHS());
 
   return E;
 }

--- a/test/Sema/Inputs/has_symbol/has_symbol_helper.swift
+++ b/test/Sema/Inputs/has_symbol/has_symbol_helper.swift
@@ -7,6 +7,9 @@ public func ambiguousFunc() {}
 public func ambiguousFunc() -> Int { return 0 }
 public func genericFunc<T: P>(_ t: T) {}
 
+@MainActor public func mainActorFunc() {}
+@MainActor public func mainActorFunction(with argument: Int) {}
+
 public protocol P {
   func requirement()
   func requirementWithDefaultImpl()
@@ -27,7 +30,7 @@ extension PAT {
 }
 
 public struct S {
-  public static var staticMember: Int = 0
+  public nonisolated(unsafe) static var staticMember: Int = 0
   public static func staticFunc() {}
 
   public var member: Int
@@ -38,6 +41,14 @@ public struct S {
   public func noArgsMethod() {}
   public func method(with argument: Int) {}
   public func genericFunc<T: P>(_ t: T) {}
+  public func ambiguousMethod() {}
+  public func ambiguousMethod() -> Int { return 0 }
+
+  @MainActor public static var mainActorStaticMember: Int = 0
+  @MainActor public static func mainActorStaticFunc() {}
+  @MainActor public var mainActorMember: Int { return 0 }
+  @MainActor public func mainActorMethod() {}
+  @MainActor public subscript(index: Int) -> Int { return 0 }
 }
 
 extension S: P {
@@ -55,7 +66,7 @@ public struct GenericS<T: P> {
 }
 
 public class C {
-  public static var staticMember: Int = 0
+  public nonisolated(unsafe) static var staticMember: Int = 0
   public class func classFunc() {}
 
   public var member: Int
@@ -65,11 +76,17 @@ public class C {
   }
   public func noArgsMethod() {}
   public func method(with argument: Int) {}
+  public func methodReturningSelf() -> Self { return self }
+
+  @MainActor public func mainActorMethod() {}
+  @MainActor public func mainActorMethodReturningSelf() -> Self { return self }
 }
 
 extension C: P {
   public func requirement() {}
 }
+
+public class SubC: C {}
 
 public enum E {
   case basicCase

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol/has_symbol_helper.swift -enable-library-evolution
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -disable-availability-checking -I %t
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol/has_symbol_helper.swift -enable-library-evolution -target %target-swift-5.1-abi-triple
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %t -target %target-swift-5.1-abi-triple -swift-version 5
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %t -target %target-swift-5.1-abi-triple -swift-version 6
 
 // UNSUPPORTED: OS=windows-msvc
 
@@ -8,11 +9,15 @@
 
 func testGlobalFunctions() {
   if #_hasSymbol(noArgFunc) {}
+  if #_hasSymbol(noArgFunc as () throws -> Void) {}
+  if #_hasSymbol(noArgFunc as () async -> Void) {}
   if #_hasSymbol(function(with:)) {}
   if #_hasSymbol(throwingFunc) {}
   if #_hasSymbol(ambiguousFunc) {} // expected-error {{ambiguous use of 'ambiguousFunc()'}}
   if #_hasSymbol(ambiguousFunc as () -> Int) {}
   if #_hasSymbol(genericFunc(_:) as (S) -> Void) {}
+  if #_hasSymbol(mainActorFunc) {}
+  if #_hasSymbol(mainActorFunction(with:)) {}
 }
 
 func testVars() {
@@ -23,12 +28,25 @@ func testVars() {
 func testStruct(_ s: S) {
   if #_hasSymbol(s.member) {}
   if #_hasSymbol(s.noArgsMethod) {}
+  if #_hasSymbol(s.noArgsMethod as () throws -> Void) {}
+  if #_hasSymbol(s.noArgsMethod as () async -> Void) {}
+  if #_hasSymbol(S.noArgsMethod) {}
+  if #_hasSymbol(S.noArgsMethod as (S) -> () throws -> Void) {}
   if #_hasSymbol(s.method(with:)) {}
+  if #_hasSymbol(s.method(with:) as (Int) -> Void) {}
+  if #_hasSymbol(S.method(with:)) {}
+  if #_hasSymbol(s.ambiguousMethod) {} // expected-error {{ambiguous use of 'ambiguousMethod()'}}
+  if #_hasSymbol(s.ambiguousMethod as () -> Int) {}
+  if #_hasSymbol(s.ambiguousMethod as () throws -> Int) {}
+  if #_hasSymbol(S.ambiguousMethod as (S) -> () -> Int) {}
   if #_hasSymbol(s.genericFunc(_:)) {} // expected-error {{generic parameter 'T' could not be inferred}}
   if #_hasSymbol(s.genericFunc(_:) as (S) -> ()) {}
   if #_hasSymbol(s.requirement) {}
+  if #_hasSymbol(S.requirement) {}
   if #_hasSymbol(s.requirementWithDefaultImpl) {}
-
+  if #_hasSymbol(s.mainActorMethod) {}
+  if #_hasSymbol(S.mainActorMethod) {}
+  if #_hasSymbol(S.mainActorStaticFunc) {}
   if #_hasSymbol(S.staticFunc) {}
   if #_hasSymbol(S.staticMember) {}
   if #_hasSymbol(S.init(member:)) {}
@@ -37,19 +55,30 @@ func testStruct(_ s: S) {
 func testGenericStruct(_ s: GenericS<S>) {
   if #_hasSymbol(s.member) {}
   if #_hasSymbol(s.noArgsMethod) {}
+  if #_hasSymbol(GenericS<S>.noArgsMethod) {}
   if #_hasSymbol(s.method(with:)) {}
 }
 
-func testClass(_ c: C) {
+func testClass(_ c: C, _ sub: SubC) {
   if #_hasSymbol(c.member) {}
   if #_hasSymbol(c.noArgsMethod) {}
+  if #_hasSymbol(C.noArgsMethod) {}
   if #_hasSymbol(c.method(with:)) {}
   if #_hasSymbol(c.requirement) {}
   if #_hasSymbol(c.requirementWithDefaultImpl) {}
-
+  if #_hasSymbol(c.mainActorMethod) {}
+  if #_hasSymbol(C.mainActorMethod) {}
   if #_hasSymbol(C.classFunc) {}
   if #_hasSymbol(C.staticMember) {}
   if #_hasSymbol(C.init(member:)) {}
+  if #_hasSymbol(c.methodReturningSelf) {}
+  if #_hasSymbol(C.methodReturningSelf) {}
+
+  if #_hasSymbol(sub.mainActorMethodReturningSelf) {}
+  if #_hasSymbol(sub.methodReturningSelf) {}
+  if #_hasSymbol(sub.methodReturningSelf as () -> SubC) {}
+  if #_hasSymbol(sub.methodReturningSelf as () -> any P) {}
+  if #_hasSymbol(SubC.methodReturningSelf) {}
 }
 
 func testEnum(_ e: E) {
@@ -57,6 +86,27 @@ func testEnum(_ e: E) {
   if #_hasSymbol(E.payloadCase) {}
   if #_hasSymbol(E.payloadCase(_:)) {}
   if #_hasSymbol(e.method) {}
+  if #_hasSymbol(E.method) {}
+}
+
+extension S {
+  func testImplicitSelf() {
+    if #_hasSymbol(noArgsMethod) {}
+    if #_hasSymbol(noArgsMethod as () throws -> Void) {}
+    if #_hasSymbol(noArgsMethod as () async -> Void) {}
+    if #_hasSymbol(method(with:) as (Int) -> Void) {}
+    if #_hasSymbol(ambiguousMethod) {} // expected-error {{ambiguous use of 'ambiguousMethod()'}}
+    if #_hasSymbol(ambiguousMethod as () -> Int) {}
+  }
+}
+
+@MainActor
+func testFromActorIsolatedContext(_ s: S) {
+  if #_hasSymbol(mainActorFunc) {}
+  if #_hasSymbol(s.mainActorMethod) {}
+  if #_hasSymbol(s.mainActorMember) {}
+  if #_hasSymbol(S.mainActorStaticMember) {}
+  if #_hasSymbol(s[0]) {}
 }
 
 func testOpaqueParameter<T: PAT>(_ p: T) {
@@ -69,6 +119,10 @@ func testOpaqueParameter<T: PAT>(_ p: T) {
 func testExistentialParameter(_ p: any P) {
   if #_hasSymbol(p.requirement) {}
   if #_hasSymbol(p.requirementWithDefaultImpl) {}
+
+  // An uncurried reference to a protocol requirement.
+  if #_hasSymbol(P.requirement) {}
+  if #_hasSymbol(P.requirementWithDefaultImpl) {}
 }
 
 func testMetatypes() {
@@ -80,7 +134,7 @@ func testMetatypes() {
   if #_hasSymbol(E.self) {}
 }
 
-var localGlobal: Int = 0
+nonisolated(unsafe) var localGlobal: Int = 0
 
 func localFunc() {}
 
@@ -126,6 +180,7 @@ func testWhile() {
   while #_hasSymbol(localFunc) { break } // expected-warning {{global function 'localFunc()' is not a weakly linked declaration}}
 }
 
+@usableFromInline
 func doIt(_ closure: () -> ()) {
   closure()
 }


### PR DESCRIPTION
Expand the expressions which are accepted in `#_hasSymbol` by looking through more kinds of syntax nodes when attempting to identify the referenced declaration:

- Strip implicit conversions that the solver inserts to adjust a member by widening its type.
- handle `DotSyntaxBaseIgnored` nodes, which appear for uncurried references to instance members.

Resolves rdar://185799595.
