### PR TITLE
Guard Builtin.(de)allocRawTyped uses

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -294,6 +294,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(TildeSendable, 518, "~Sendable for explicitly mark
 LANGUAGE_FEATURE(SuppressedAssociatedTypesWithDefaults, 503, "Associated types that are ~Copyable and ~Escapable")
 LANGUAGE_FEATURE(SourceWarningControl, 522, "Source-level warning control with @diagnose")
 LANGUAGE_FEATURE(BorrowInout, 519, "Ref and MutableRef")
+LANGUAGE_FEATURE(BuiltinAllocRawTyped, 0, "Builtin.allocRawTyped/deallocRawTyped")
 
 // TEMPORARY: Never use this, because it is only meant to allow us to model
 // suppression of @c in Swift interfaces as a temporary measure.

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -180,6 +180,7 @@ UNINTERESTING_FEATURE(ImportMacroAliases)
 UNINTERESTING_FEATURE(NoExplicitNonIsolated)
 UNINTERESTING_FEATURE(EmbeddedDynamicExclusivity)
 UNINTERESTING_FEATURE(TypedAllocation)
+UNINTERESTING_FEATURE(BuiltinAllocRawTyped)
 UNINTERESTING_FEATURE(MutateAndConsumeInDeinit)
 
 static bool usesFeatureUnderscoreOwned(Decl *D) {

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -279,7 +279,11 @@ extension UnsafePointer where Pointee: ~Copyable {
     // deallocation". Since allocation via `UnsafeMutable[Raw][Buffer]Pointer`
     // always uses the "aligned allocation" path, this ensures that the
     // runtime's allocation and deallocation paths are compatible.
+#if $BuiltinAllocRawTyped
     Builtin.deallocRawTyped(_rawValue, (-1)._builtinWordValue, (0)._builtinWordValue, Pointee.self)
+#else
+    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (0)._builtinWordValue)
+#endif
   }
 
   @export(implementation)
@@ -290,7 +294,11 @@ extension UnsafePointer where Pointee: ~Copyable {
     // deallocation". Since allocation via `UnsafeMutable[Raw][Buffer]Pointer`
     // always uses the "aligned allocation" path, this ensures that the
     // runtime's allocation and deallocation paths are compatible.
+#if $BuiltinAllocRawTyped
     Builtin.deallocRawTyped(_rawValue, size._builtinWordValue, (0)._builtinWordValue, Pointee.self)
+#else
+    Builtin.deallocRaw(_rawValue, size._builtinWordValue, (0)._builtinWordValue)
+#endif
   }
 }
 
@@ -839,7 +847,11 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
     if Int(align) <= _minAllocationAlignment() {
       align = (0)._builtinWordValue
     }
+#if $BuiltinAllocRawTyped
     let rawPtr = Builtin.allocRawTyped(size._builtinWordValue, align, Pointee.self)
+#else
+    let rawPtr = Builtin.allocRaw(size._builtinWordValue, align)
+#endif
     Builtin.bindMemory(rawPtr, count._builtinWordValue, Pointee.self)
     return unsafe UnsafeMutablePointer(rawPtr)
   }
@@ -856,7 +868,11 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
     // deallocation". Since allocation via `UnsafeMutable[Raw][Buffer]Pointer`
     // always uses the "aligned allocation" path, this ensures that the
     // runtime's allocation and deallocation paths are compatible.
+#if $BuiltinAllocRawTyped
     Builtin.deallocRawTyped(_rawValue, (-1)._builtinWordValue, (0)._builtinWordValue, Pointee.self)
+#else
+    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (0)._builtinWordValue)
+#endif
   }
 
   @export(implementation)
@@ -867,7 +883,11 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
     // deallocation". Since allocation via `UnsafeMutable[Raw][Buffer]Pointer`
     // always uses the "aligned allocation" path, this ensures that the
     // runtime's allocation and deallocation paths are compatible.
+#if $BuiltinAllocRawTyped
     Builtin.deallocRawTyped(_rawValue, size._builtinWordValue, (0)._builtinWordValue, Pointee.self)
+#else
+    Builtin.deallocRaw(_rawValue, size._builtinWordValue, (0)._builtinWordValue)
+#endif
   }
 }
 


### PR DESCRIPTION
This fixes a build with an old compiler.

rdar://185824137
