### PR TITLE
[cxx-interop][test] Do not re-run cxx-interop tests with different interop modes

### DIFF
--- a/test/Interop/Cxx/class/conforms-to.swift
+++ b/test/Interop/Cxx/class/conforms-to.swift
@@ -2,9 +2,6 @@
 // RUN: %target-swift-frontend %S/Inputs/conforms-to-imported.swift -module-name ImportedModule -emit-module -emit-module-path %t/ImportedModule.swiftmodule
 
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=default
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -disable-availability-checking -I %t -I %S/Inputs -module-name SwiftTest -cxx-interoperability-mode=upcoming-swift
 
 import ConformsTo
 import ImportedModule

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-irgen.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=swift-6 %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
-// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 
 import MoveOnlyCxxValueType
 

--- a/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
+++ b/test/Interop/Cxx/class/move-only/inherited-field-access-silgen.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=swift-6 %s -validate-tbd-against-ir=none | %FileCheck %s
-// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -cxx-interoperability-mode=default %s -validate-tbd-against-ir=none | %FileCheck %s
 
 import MoveOnlyCxxValueType
 

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default -O)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -1,9 +1,7 @@
 // Tests that a C++ class can conform to a Swift protocol.
 
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -enable-experimental-cxx-interop
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -D VIRTUAL_METHODS -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -D VIRTUAL_METHODS -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -D VIRTUAL_METHODS -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=default -D VIRTUAL_METHODS
 
 import ProtocolConformance
 

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -1,8 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-5.9 | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -skip-unsafe-cxx-methods -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 | %FileCheck %s -check-prefix=CHECK-SKIP-UNSAFE
-// RUN: %target-swift-ide-test -print-module -skip-unsafe-cxx-methods -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s -check-prefix=CHECK-SKIP-UNSAFE
+// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -skip-unsafe-cxx-methods -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s -check-prefix=CHECK-SKIP-UNSAFE
 
 // Make sure we don't import objects that we can't copy or destroy.
 // CHECK-NOT: StructWithPrivateDefaultedCopyConstructor

--- a/test/Interop/Cxx/class/type-classification-typechecker.swift
+++ b/test/Interop/Cxx/class/type-classification-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=default
 
 import TypeClassification
 

--- a/test/Interop/Cxx/driver/invalid-interop-compat-mode.swift
+++ b/test/Interop/Cxx/driver/invalid-interop-compat-mode.swift
@@ -2,7 +2,9 @@
 // RUN: split-file %s %t
 // RUN: not %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -cxx-interoperability-mode=swift-5.8 2>&1 | %FileCheck %s
 
+// RUN: %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -cxx-interoperability-mode=default
 // RUN: %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -cxx-interoperability-mode=swift-5.9
+// RUN: %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -cxx-interoperability-mode=swift-6
 // RUN: %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -cxx-interoperability-mode=upcoming-swift
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
+++ b/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
@@ -2,21 +2,18 @@
 // RUN: split-file %s %t
 // RUN: mkdir -p %t/pch
 
-// RUN: %target-swift-frontend %t/SwiftMod.swift -module-name SwiftMod -emit-module -o %t/SwiftMod.swiftmodule -I %t -enable-experimental-cxx-interop -Xcc -DFIRSTPASS
+// RUN: %target-swift-frontend %t/SwiftMod.swift -module-name SwiftMod -emit-module -o %t/SwiftMod.swiftmodule -I %t -cxx-interoperability-mode=default -Xcc -DFIRSTPASS
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop -Xcc -DINCMOD | %FileCheck %s
-
-// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 -Xcc -DINCMOD | %FileCheck --check-prefixes=CHECK,CHECKLATEST %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift -Xcc -DINCMOD | %FileCheck --check-prefixes=CHECK,CHECKLATEST %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftMod -module-to-print=CxxModule -I %t -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default -Xcc -DINCMOD | %FileCheck %s
 
 // Test through the use of the bridging header
-// RUN: %target-swift-frontend -emit-ir -I %t -import-objc-header %t/Inputs/header.h -enable-experimental-cxx-interop -DBRIDGING_HEADER_TEST -disable-availability-checking %t/SwiftMod.swift
+// RUN: %target-swift-frontend -emit-ir -I %t -import-objc-header %t/Inputs/header.h -cxx-interoperability-mode=default -DBRIDGING_HEADER_TEST -disable-availability-checking %t/SwiftMod.swift
 
 // Precompile the bridging header and test the use of that.
-// RUN: %target-swift-frontend -emit-pch -I %t -pch-output-dir %t/pch %t/Inputs/header.h -enable-experimental-cxx-interop
-// RUN: %target-swift-frontend -emit-ir -I %t -pch-output-dir %t/pch -import-objc-header %t/Inputs/header.h -enable-experimental-cxx-interop -DBRIDGING_HEADER_TEST -disable-availability-checking %t/SwiftMod.swift
+// RUN: %target-swift-frontend -emit-pch -I %t -pch-output-dir %t/pch %t/Inputs/header.h -cxx-interoperability-mode=default
+// RUN: %target-swift-frontend -emit-ir -I %t -pch-output-dir %t/pch -import-objc-header %t/Inputs/header.h -cxx-interoperability-mode=default -DBRIDGING_HEADER_TEST -disable-availability-checking %t/SwiftMod.swift
 
 
 //--- SwiftMod.swift
@@ -158,4 +155,4 @@ private:
 
 // CHECK: struct UnsafeSendable : @unchecked Sendable {
 
-// CHECKLATEST: struct NonCopyableCopyable
+// CHECK: struct NonCopyableCopyable

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-6
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default
 
 import MemberInheritance
 

--- a/test/Interop/Cxx/foreign-reference/member-inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance.swift
@@ -1,6 +1,3 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
 // RUN: %target-run-simple-swift(-g -I %S/Inputs -cxx-interoperability-mode=default)
 //
 // REQUIRES: executable_test

--- a/test/Interop/Cxx/function/default-arguments-irgen.swift
+++ b/test/Interop/Cxx/function/default-arguments-irgen.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=swift-5.9 %s | %FileCheck %s
-// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=swift-6 %s | %FileCheck %s
-// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s | %FileCheck %s
+// RUN: %target-swift-emit-irgen -I %S/Inputs -cxx-interoperability-mode=default %s | %FileCheck %s
 
 import DefaultArguments
 

--- a/test/Interop/Cxx/function/default-arguments-module-interface.swift
+++ b/test/Interop/Cxx/function/default-arguments-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultArguments -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-5.9 | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultArguments -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultArguments -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultArguments -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
 
 // CHECK: func isZero(_ value: CInt = cxxDefaultArg) -> CBool
 // CHECK: func isNil(_ ptr: UnsafeMutablePointer<CInt>! = cxxDefaultArg) -> CBool

--- a/test/Interop/Cxx/function/default-arguments-typechecker.swift
+++ b/test/Interop/Cxx/function/default-arguments-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default
 
 import DefaultArguments
 

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=default
 
 import MemberInline
 

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -1,6 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++23 -D CPP23)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -Xcc -std=c++23 -D CPP23)
 //
 // REQUIRES: executable_test
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-properties.swift
@@ -1,11 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -D HAS_NONCOPYABLE_GENERICS)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-5.9 -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=swift-6 -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=upcoming-swift -O -D HAS_NONCOPYABLE_GENERICS)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default -D HAS_NONCOPYABLE_GENERICS)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default -O -D HAS_NONCOPYABLE_GENERICS)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
@@ -1,11 +1,8 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=swift-5.9 -DNO_CONSUME
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=swift-6 -DNO_CONSUME
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -DNO_CONSUME
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -DNO_CONSUME
 
 // Note: some errors need full SIL emission right now.
 // FIXME: they should be type checker errors.
-// RUN: not %target-swift-emit-sil %s -I %S/Inputs -cxx-interoperability-mode=swift-6 2>&1 | %FileCheck %s
-// RUN: not %target-swift-emit-sil %s -I %S/Inputs -cxx-interoperability-mode=upcoming-swift 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-sil %s -I %S/Inputs -cxx-interoperability-mode=default 2>&1 | %FileCheck %s
 
 import MoveOnlyCxxOperators
 

--- a/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
+++ b/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend %s -typecheck -verify -enable-experimental-cxx-interop
-// RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=swift-6
-// RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=default
 
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=freebsd
 

--- a/test/Interop/Cxx/stdlib/avoid-redundant-copies.swift
+++ b/test/Interop/Cxx/stdlib/avoid-redundant-copies.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/custom-expressible-by-string-literal.swift
+++ b/test/Interop/Cxx/stdlib/custom-expressible-by-string-literal.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -verify -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -verify -I %S/Inputs -cxx-interoperability-mode=default %s | %FileCheck %s
 
 import CxxStdlib
 import StdString

--- a/test/Interop/Cxx/stdlib/import-cxx-math-ambiguities.swift
+++ b/test/Interop/Cxx/stdlib/import-cxx-math-ambiguities.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend %s -typecheck -enable-experimental-cxx-interop
-// RUN: %target-swift-frontend %s -typecheck -cxx-interoperability-mode=swift-6
-// RUN: %target-swift-frontend %s -typecheck -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-swift-frontend %s -typecheck -cxx-interoperability-mode=default
 
 #if canImport(Foundation)
 // Foundation depends on C++ standard library

--- a/test/Interop/Cxx/stdlib/no-cxx-stdlib.swift
+++ b/test/Interop/Cxx/stdlib/no-cxx-stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -nostdinc++
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -nostdinc++
 
 import NoCXXStdlib
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -1,6 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
 //
 // REQUIRES: executable_test
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -1,6 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-libcxx-linux.swift
+++ b/test/Interop/Cxx/stdlib/use-libcxx-linux.swift
@@ -1,9 +1,7 @@
-// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
-// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-Xcc -stdlib=libc++ -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // REQUIRES: OS=linux-gnu
 // REQUIRES: system_wide_libcxx

--- a/test/Interop/Cxx/stdlib/use-math.swift
+++ b/test/Interop/Cxx/stdlib/use-math.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
 
 // This ensures that Swift can import C/C++ modules that contain `#include <math.h>`.
 

--- a/test/Interop/Cxx/stdlib/use-std-any.swift
+++ b/test/Interop/Cxx/stdlib/use-std-any.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-chrono-libcxx.swift
+++ b/test/Interop/Cxx/stdlib/use-std-chrono-libcxx.swift
@@ -1,7 +1,7 @@
 // This test runs another test, use-std-chrono.swift, with libc++ explicitly specified as the C++ stdlib.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/use-std-chrono.swift -I %S/Inputs -o %t/exe -cxx-interoperability-mode=upcoming-swift -Xcc -stdlib=libc++
+// RUN: %target-build-swift %S/use-std-chrono.swift -I %S/Inputs -o %t/exe -cxx-interoperability-mode=default -Xcc -stdlib=libc++
 // RUN: %target-codesign %t/exe
 // RUN: %target-run %t/exe
 

--- a/test/Interop/Cxx/stdlib/use-std-chrono.swift
+++ b/test/Interop/Cxx/stdlib/use-std-chrono.swift
@@ -1,10 +1,8 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++23)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-function-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
 
 import StdFunction
 

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -1,9 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -1,13 +1,9 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
 
 // Also test this with a bridging header instead of the StdMap module.
 // RUN: %empty-directory(%t2)
 // RUN: cp %S/Inputs/std-map.h %t2/std-map-bridging-header.h
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -cxx-interoperability-mode=default)
 
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/stdlib/use-std-numeric-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-numeric-typechecker.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20
 
 import StdNumeric
 

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -1,8 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature AddressableParameters)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature AddressableParameters)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -Xcc -std=c++20)
 //
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -1,9 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -1,16 +1,12 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // Also test this with a bridging header instead of the StdSet module.
 // RUN: %empty-directory(%t2)
 // RUN: cp %S/Inputs/std-set.h %t2/std-set-bridging-header.h
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-set-bridging-header.h -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-set-bridging-header.h -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-set-bridging-header.h -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-set-bridging-header.h -cxx-interoperability-mode=default)
 
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/stdlib/use-std-string-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
 
 import CxxStdlib
 import StdString

--- a/test/Interop/Cxx/stdlib/use-std-string-view-libcxx.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view-libcxx.swift
@@ -1,7 +1,7 @@
 // This test runs another test, use-std-string-view.swift, with libc++ explicitly specified as the C++ stdlib.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/use-std-string-view.swift -I %S/Inputs -o %t/exe -cxx-interoperability-mode=upcoming-swift -Xcc -stdlib=libc++
+// RUN: %target-build-swift %S/use-std-string-view.swift -I %S/Inputs -o %t/exe -cxx-interoperability-mode=default -Xcc -stdlib=libc++
 // RUN: %target-codesign %t/exe
 // RUN: %target-run %t/exe
 

--- a/test/Interop/Cxx/stdlib/use-std-string-view.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-view.swift
@@ -1,7 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -1,10 +1,8 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -D USE_CUSTOM_STRING_API)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -D USE_CUSTOM_STRING_API)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D USE_CUSTOM_STRING_API)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D USE_CUSTOM_STRING_API -Xcc -std=c++14)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D USE_CUSTOM_STRING_API -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D USE_CUSTOM_STRING_API -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -D USE_CUSTOM_STRING_API)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -D USE_CUSTOM_STRING_API -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -D USE_CUSTOM_STRING_API -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -D USE_CUSTOM_STRING_API -Xcc -std=c++20)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/use-std-unique-ptr.swift
@@ -1,9 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++14)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-variant.swift
+++ b/test/Interop/Cxx/stdlib/use-std-variant.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
@@ -1,13 +1,9 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // Also test this with a bridging header instead of the StdVector module.
 // RUN: %empty-directory(%t2)
 // RUN: cp %S/Inputs/std-vector.h %t2/std-vector-bridging-header.h
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
 // std::contiguous_iterator_tag from C++20.

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,13 +1,9 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
 
 // Also test this with a bridging header instead of the StdVector module.
 // RUN: %empty-directory(%t2)
 // RUN: cp %S/Inputs/std-vector.h %t2/std-vector-bridging-header.h
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=default)
 
 // FIXME: also run in C++20 mode when conformance works properly on UBI platform (rdar://109366764):
 // %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=gnu++20)

--- a/test/Interop/Cxx/templates/class-template-variardic-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-variardic-parameter-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateVariadic -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateVariadic -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateVariadic -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateVariadic -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
 
 // CHECK: @available(*, unavailable
 // CHECK: struct Tuple<Ts> {

--- a/test/Interop/Cxx/templates/class-template-with-function-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-function-parameter-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithFunctionParameter -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithFunctionParameter -I %S/Inputs -source-filename=x -cxx-interoperability-mode=swift-6 | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithFunctionParameter -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithFunctionParameter -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
 
 // CHECK: @available(*, unavailable
 // CHECK: struct function_wrapper<Fn> {


### PR DESCRIPTION
Repeating tests for swift-6, upcoming-swift, and other interop modes is redundant and wastes a lot of time in CI.

Run these tests with just one interop mode, `-cxx-interoperability-mode=default`.

rdar://185838587