### PR TITLE
[Basic] Make `DeriveConformancesViaMacros` available in prod

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -651,7 +651,7 @@ EXPERIMENTAL_FEATURE(StrictAccessControl, true)
 EXPERIMENTAL_FEATURE(AbstractStoredPropertyLayout, false)
 
 /// Allow use of macros to derive various conformances
-EXPERIMENTAL_FEATURE(DeriveConformancesViaMacros, false)
+EXPERIMENTAL_FEATURE(DeriveConformancesViaMacros, true)
 
 /// Allow use of `@called(...)` on function types.
 EXPERIMENTAL_FEATURE(CalledAttribute, false)


### PR DESCRIPTION
Make the experimental feature `DeriveConformancesViaMacros` available in production so that it is easier to demo in the future.