### PR TITLE
[cxx-interop] Fix parser of conditional attribute params

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -394,6 +394,8 @@ ERROR(unknown_template_parameter,none,
   "template parameter '%0' does not exist", (StringRef))
 ERROR(type_template_parameter_expected,none,
   "template parameter '%0' expected to be a type parameter", (StringRef))
+WARNING(empty_conditional_params, none,
+        "empty %0 annotations are ignored", (StringRef))
 
 NOTE(bridged_type_not_found_in_module,none,
      "could not find type '%0' for bridging; module '%1' may be broken",

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5665,15 +5665,14 @@ static bool checkConditionalParams(
 static ConditionalAttrParams
 getConditionalAttrParams(clang::SwiftAttrAttr *swiftAttr, StringRef attrName) {
   ConditionalAttrParams result;
-  StringRef params = swiftAttr->getAttribute();
-  if (params.consume_front(attrName)) {
-    auto commaPos = params.find(',');
-    StringRef nextParam = params.take_front(commaPos);
-    while (!nextParam.empty() && commaPos != StringRef::npos) {
-      result.insert(nextParam.trim());
-      params = params.drop_front(nextParam.size() + 1);
-      commaPos = params.find(',');
-      nextParam = params.take_front(commaPos);
+  StringRef attribute = swiftAttr->getAttribute();
+  if (attribute.consume_front(attrName)) {
+    SmallVector<StringRef, 2> params;
+    attribute.split(params, ',');
+    for (auto param : params) {
+      param = param.trim();
+      if (!param.empty())
+        result.insert(param);
     }
   }
   return result;
@@ -9315,6 +9314,11 @@ void ClangImporter::Implementation::validateSwiftAttributes(
             }
             auto conditionalParams =
                 getConditionalAttrParams(swiftAttr, attrName);
+
+            if (conditionalParams.empty())
+              diagnose(HeaderLoc{decl->getLocation()},
+                       diag::empty_conditional_params, annotationName);
+
             while (specDecl && !conditionalParams.empty()) {
               auto templateDecl = specDecl->getSpecializedTemplate();
               for (auto [idx, param] :

--- a/test/Interop/Cxx/class/noncopyable-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-typechecker.swift
@@ -210,6 +210,18 @@ struct HasConstSubscript {
     NonCopyable nc;
 };
 
+template<typename T>
+struct SWIFT_COPYABLE_IF() EmptyCopyableIf {};  // expected-warning {{empty SWIFT_COPYABLE_IF annotations are ignored}}
+using EmptyCopyableIfWithInt = EmptyCopyableIf<int>;
+
+#define MY_COPYABLE_IF(...) __attribute__((swift_attr("copyable_if:" __VA_ARGS__)))
+
+template<typename T>
+struct MY_COPYABLE_IF("T") EmptyMyCopyableIf {}; 
+// no warning expected
+// 'T' used to be ignored here
+using EmptyMyCopyableIfWithInt = EmptyMyCopyableIf<int>;
+
 //--- test.swift
 import Test
 import CxxStdlib
@@ -306,4 +318,9 @@ func useConstSubscript() {
   var obj = HasConstSubscript(nc: NonCopyable(5))
   _ = obj[42]
   obj[42] = NonCopyable(7) // expected-error {{cannot assign through subscript: subscript is get-only}}
+}
+
+func useStructWithEmptyCopyableIf() {
+  _ = EmptyCopyableIfWithInt()
+  _ = EmptyMyCopyableIfWithInt()
 }


### PR DESCRIPTION
The parser used to ignore the last parameter if it was not followed by a comma. This was not a problem for the `SWIFT_COPYABLE_IF` and `SWIFT_ESCAPABLE_IF` annotations that come from SwiftBridging, but reproduces when the user defines their own macro for these attributes (such as `MY_COPYABLE_IF` in the test I added).

rdar://185497624

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
