### PR TITLE
tests: Fix a 32-64 bit mismatch problem in SILOptimizer/sil_combine_ossa.sil

### DIFF
--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5781,7 +5781,7 @@ bb0:
   %0 = alloc_ref $E
   %1 = upcast %0 to $B
   %2 = integer_literal $Builtin.Int64, 2
-  %3 = struct $UInt (%2)
+  %3 = struct $UInt64 (%2)
   destroy_value [dead_end] %1
   unreachable
 }
@@ -5797,7 +5797,7 @@ bb0:
   %1 = upcast %0 to $B
   %2 = unchecked_ref_cast %1 to $Builtin.NativeObject
   %3 = integer_literal $Builtin.Int64, 2
-  %4 = struct $UInt (%3)
+  %4 = struct $UInt64 (%3)
   destroy_value [dead_end] %2
   unreachable
 }
@@ -5813,7 +5813,7 @@ bb0:
   %0 = alloc_ref $E
   %1 = upcast %0 to $B
   %2 = integer_literal $Builtin.Int64, 2
-  %3 = struct $UInt (%2)
+  %3 = struct $UInt64 (%2)
   destroy_value %1
   %r = tuple ()
   return %r
@@ -5831,7 +5831,7 @@ bb0:
   %0 = alloc_ref $E
   %1 = upcast %0 to $B
   %2 = integer_literal $Builtin.Int64, 2
-  %3 = struct $UInt (%2)
+  %3 = struct $UInt64 (%2)
   destroy_value %1
   unreachable
 }


### PR DESCRIPTION
This test failed on 32 bit platforms

rdar://185849775
