### PR TITLE
[cxx-interop] Classes with `friend` decls might still be `BitwiseCopyable`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2609,6 +2609,10 @@ namespace {
           if (auto *underlyingDecl = friendDecl->getFriendDecl()) {
             m = underlyingDecl;
             isFriend = true;
+          } else {
+            // A friend declaration that names a type instead of a declaration
+            // has nothing to import.
+            continue;
           }
         }
 

--- a/test/Interop/Cxx/class/Inputs/friend-type.h
+++ b/test/Interop/Cxx/class/Inputs/friend-type.h
@@ -1,0 +1,39 @@
+struct Buddy {};
+
+template <typename T>
+struct BuddyTemplate {};
+
+struct NoFriend {
+  int x;
+};
+
+struct FriendClass {
+  int x;
+  friend struct Buddy;
+};
+
+struct FriendFunction {
+  int x;
+  friend bool areEqual(const FriendFunction &, const FriendFunction &);
+};
+
+struct FriendFunctionDefinition {
+  int x;
+  friend int getX(const FriendFunctionDefinition &self) { return self.x; }
+};
+
+struct FriendTemplateSpecialization {
+  int x;
+  friend struct BuddyTemplate<int>;
+};
+
+struct FriendWholeTemplate {
+  int x;
+
+  template <typename>
+  friend struct BuddyTemplate;
+};
+
+struct HasFriendlyMember {
+  FriendClass member;
+};

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -195,6 +195,12 @@ module FriendFunction {
   export *
 }
 
+module FriendType {
+  header "friend-type.h"
+  requires cplusplus
+  export *
+}
+
 module NoncopyableNonmovableGlobal {
   header "noncopyable-nonmovable-global.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/friend-type-typechecker.swift
+++ b/test/Interop/Cxx/class/friend-type-typechecker.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6 -cxx-interoperability-mode=default -I %S/Inputs %s
+
+import FriendType
+
+func requiresBitwiseCopyable<T: BitwiseCopyable>(_: T.Type) {}
+
+func testBitwiseCopyable() {
+  requiresBitwiseCopyable(NoFriend.self)
+  requiresBitwiseCopyable(FriendClass.self)
+  requiresBitwiseCopyable(FriendFunction.self)
+  requiresBitwiseCopyable(FriendFunctionDefinition.self)
+  requiresBitwiseCopyable(FriendTemplateSpecialization.self)
+  requiresBitwiseCopyable(FriendWholeTemplate.self)
+  requiresBitwiseCopyable(HasFriendlyMember.self)
+}
+
+func testFriendsAreNotMembers(_ value: FriendFunctionDefinition) {
+  _ = getX(value)
+  _ = value.getX() // expected-error {{value of type 'FriendFunctionDefinition' has no member 'getX'}}
+}


### PR DESCRIPTION
When importing a C++ class, ClangImporter checks if any of the members of the class would prevent bitwise copyability.

If a class has a `friend` that does not declare any members, the class should still conform to `BitwiseCopyable` in Swift.

rdar://185869726

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
