### PR TITLE
[RemoteInspection] Limit and NULL check metadata allocation backtrace reading.

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1791,12 +1791,24 @@ public:
       auto BacktraceAddrPtr =
           BacktraceListNext +
           sizeof(MetadataAllocationBacktraceHeader<Runtime>);
-      auto BacktraceBytes = getReader().readBytes(
-          BacktraceAddrPtr, HeaderPtr->Count * sizeof(StoredPointer));
+
+      // Limit how many frames we'll read from one backtrace, to avoid an
+      // enormous read when the count is bad data.
+      uint32_t FrameLimit = 1024;
+
+      uint32_t Count = HeaderPtr->Count;
+      MemoryReader::ReadBytesResult BacktraceBytes;
+      if (Count > 0 && Count <= FrameLimit)
+        BacktraceBytes = getReader().readBytes(BacktraceAddrPtr,
+                                               Count * sizeof(StoredPointer));
       auto BacktracePtr =
           reinterpret_cast<const StoredPointer *>(BacktraceBytes.get());
 
-      Call(HeaderPtr->Allocation, HeaderPtr->Count, BacktracePtr);
+      // Don't hand the callback a count that the pointer doesn't back.
+      if (!BacktracePtr)
+        Count = 0;
+
+      Call(HeaderPtr->Allocation, Count, BacktracePtr);
 
       BacktraceListNext =
           RemoteAddress(HeaderPtr->Next, RemoteAddress::DefaultAddressSpace);

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -988,9 +988,11 @@ const char *swift_reflection_iterateMetadataAllocationBacktraces(
           // systems, while StoredPointer is always the pointer size of the
           // target system.) Convert the array to an array of
           // swift_reflection_ptr_t.
-          std::vector<swift_reflection_ptr_t> ConvertedPtrs{&Ptrs[0],
-                                                            &Ptrs[Count]};
-          Call(AllocationPtr, Count, ConvertedPtrs.data(), ContextPtr);
+          std::vector<swift_reflection_ptr_t> ConvertedPtrs;
+          if (Ptrs)
+            ConvertedPtrs.assign(Ptrs, Ptrs + Count);
+          Call(AllocationPtr, ConvertedPtrs.size(), ConvertedPtrs.data(),
+               ContextPtr);
         });
     return returnableCString(ContextRef, Error);
   });


### PR DESCRIPTION
Report zero frames when a backtrace payload can't be read, and skip the read entirely when the frame count is larger than any real backtrace.

rdar://185697907