### PR TITLE
[AST] Print raw identifiers, tuple pattern labels and case guard express correctly

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6328,16 +6328,16 @@ void PrintAST::visitCaseStmt(CaseStmt *CS) {
   if (CS->isDefault()) {
     Printer << tok::kw_default;
   } else {
-    auto PrintCaseLabelItem = [&](const CaseLabelItem &CLI) {
+    auto PrintCaseLabelItem = [&](CaseLabelItem &CLI) {
       if (auto *P = CLI.getPattern())
         printPattern(P);
-      if (CLI.getGuardExpr()) {
+      if (auto *guardExpr = CLI.getGuardExpr()) {
         Printer << " " << tok::kw_where << " ";
-        // FIXME: print guard expr
+        visit(guardExpr);
       }
     };
     Printer << tok::kw_case << " ";
-    interleave(CS->getCaseLabelItems(), PrintCaseLabelItem,
+    interleave(CS->getMutableCaseLabelItems(), PrintCaseLabelItem,
                [&] { Printer << ", "; });
   }
   Printer << ":";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1773,6 +1773,10 @@ void PrintAST::printPattern(const Pattern *pattern) {
       if (i != 0)
         Printer << ", ";
 
+      if (!Elt.getLabel().empty()) {
+        Printer.printName(Elt.getLabel(), PrintNameContext::TupleElement);
+        Printer << ": ";
+      }
       printPattern(Elt.getPattern());
     }
     Printer << ")";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1792,7 +1792,10 @@ void PrintAST::printPattern(const Pattern *pattern) {
 
   case PatternKind::EnumElement: {
     auto elt = cast<EnumElementPattern>(pattern);
-    Printer << "." << elt->getElementDecl()->getBaseName();
+    auto *decl = elt->getElementDecl();
+    Printer << ".";
+    Printer.printName(decl->getBaseIdentifier(),
+                      getTypeMemberPrintNameContext(decl));
     if (elt->hasSubPattern())
       printPattern(elt->getSubPattern());
     break;
@@ -5395,7 +5398,7 @@ void PrintAST::visitCallExpr(CallExpr *expr) {
 void PrintAST::printArgument(const Argument &arg) {
   auto label = arg.getLabel();
   if (!label.empty()) {
-    Printer << label.str();
+    Printer.printName(label, PrintNameContext::FunctionParameterExternal);
     Printer << ": ";
   }
   if (arg.isInOut()) {
@@ -5582,8 +5585,25 @@ void PrintAST::visitClosureExpr(ClosureExpr *expr) {
   Printer << "\n}";
 }
 
+/// Print a reference to a value by name, escaping it if needed. 'self' is
+/// never escaped, since it always refers to the implicit base.
+static void printValueRefName(ASTPrinter &Printer, Identifier name,
+                              PrintNameContext context) {
+  if (name.str() == "self")
+    Printer << name;
+  else
+    Printer.printName(name, context);
+}
+
 void PrintAST::visitDeclRefExpr(DeclRefExpr *expr) {
-  Printer << expr->getDecl()->getBaseName();
+  auto *decl = expr->getDecl();
+  auto baseName = decl->getBaseName();
+  if (baseName.isSpecial()) {
+    Printer << baseName;
+    return;
+  }
+  printValueRefName(Printer, baseName.getIdentifier(),
+                    getTypeMemberPrintNameContext(decl));
 }
 
 void PrintAST::visitDotSelfExpr(DotSelfExpr *expr) {
@@ -5702,7 +5722,9 @@ void PrintAST::visitSuperRefExpr(SuperRefExpr *expr) {
 void PrintAST::visitMemberRefExpr(MemberRefExpr *expr) {
   visit(expr->getBase());
   Printer << ".";
-  Printer << expr->getMember().getDecl()->getName();
+  auto *decl = expr->getMember().getDecl();
+  Printer.printName(decl->getName().getBaseIdentifier(),
+                    getTypeMemberPrintNameContext(decl));
 }
 
 void PrintAST::visitSubscriptExpr(SubscriptExpr *expr) {
@@ -5823,7 +5845,8 @@ void PrintAST::visitObjectLiteralExpr(ObjectLiteralExpr *expr) {
 void PrintAST::visitUnresolvedDotExpr(UnresolvedDotExpr *expr) {
   visit(expr->getBase());
   Printer << ".";
-  Printer << expr->getName().getBaseName();
+  Printer.printName(expr->getName().getBaseIdentifier(),
+                    PrintNameContext::Normal);
 }
 
 void PrintAST::visitArrayToPointerExpr(ArrayToPointerExpr *expr) {
@@ -5885,7 +5908,9 @@ void PrintAST::visitDestructureTupleExpr(DestructureTupleExpr *expr) {
 void PrintAST::visitDynamicMemberRefExpr(DynamicMemberRefExpr *expr) {
   visit(expr->getBase());
   Printer << ".";
-  Printer << expr->getMember().getDecl()->getName();
+  auto *decl = expr->getMember().getDecl();
+  Printer.printName(decl->getName().getBaseIdentifier(),
+                    getTypeMemberPrintNameContext(decl));
 }
 
 void PrintAST::visitDynamicSubscriptExpr(DynamicSubscriptExpr *expr) {
@@ -5899,7 +5924,8 @@ void PrintAST::visitPointerToPointerExpr(PointerToPointerExpr *expr) {
 
 void PrintAST::visitUnresolvedMemberExpr(UnresolvedMemberExpr *expr) {
   Printer << ".";
-  Printer << expr->getName();
+  Printer.printName(expr->getName().getBaseIdentifier(),
+                    PrintNameContext::Normal);
 }
 
 void PrintAST::visitDiscardAssignmentExpr(DiscardAssignmentExpr *expr) {
@@ -5926,12 +5952,14 @@ void PrintAST::visitOverloadedDeclRefExpr(OverloadedDeclRefExpr *expr) {
   if (expr->getNameLoc().isCompound()) {
     Printer << expr->getDecls().front()->getName();
   } else {
-    Printer << expr->getDecls().front()->getBaseName();
+    Printer.printName(expr->getDecls().front()->getName().getBaseIdentifier(),
+                      PrintNameContext::Normal);
   }
 }
 
 void PrintAST::visitUnresolvedDeclRefExpr(UnresolvedDeclRefExpr *expr) {
-  Printer << expr->getName();
+  printValueRefName(Printer, expr->getName().getBaseIdentifier(),
+                    PrintNameContext::Normal);
 }
 
 void PrintAST::visitUnresolvedPatternExpr(UnresolvedPatternExpr *expr) {

--- a/test/decl/enum/derived_hashable_equatable_macros.swift
+++ b/test/decl/enum/derived_hashable_equatable_macros.swift
@@ -361,14 +361,14 @@ enum WithArgumentLabels: Hashable {
 enum WithRawIdentifiers: Hashable {
   // CHECK:        @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ lhs: `Self`, _ rhs: `Self`) -> Bool {
   // CHECK-NEXT:     switch (lhs, rhs) {
-  // CHECK-NEXT:     case (.foo bar, .foo bar):
+  // CHECK-NEXT:     case (.`foo bar`, .`foo bar`):
   // CHECK-NEXT:       return true
-  // CHECK-NEXT:     case (.default(let l0), .default(let r0)):
+  // CHECK-NEXT:     case (.`default`(let l0), .`default`(let r0)):
   // CHECK-NEXT:       guard l0 == r0 else {
   // CHECK-NEXT:         return false
   // CHECK-NEXT:       }
   // CHECK-NEXT:       return true
-  // CHECK-NEXT:     case (.a(foo bar: let l0), .a(foo bar: let r0)):
+  // CHECK-NEXT:     case (.a(`foo bar`: let l0), .a(`foo bar`: let r0)):
   // CHECK-NEXT:       guard l0 == r0 else {
   // CHECK-NEXT:         return false
   // CHECK-NEXT:       }
@@ -387,12 +387,12 @@ enum WithRawIdentifiers: Hashable {
 
   // CHECK:        internal func hash(into hasher: inout Hasher) {
   // CHECK-NEXT:     switch self {
-  // CHECK-NEXT:     case .foo bar:
+  // CHECK-NEXT:     case .`foo bar`:
   // CHECK-NEXT:       hasher.combine(0)
-  // CHECK-NEXT:     case .default(let a0):
+  // CHECK-NEXT:     case .`default`(let a0):
   // CHECK-NEXT:       hasher.combine(1)
   // CHECK-NEXT:       hasher.combine(a0)
-  // CHECK-NEXT:     case .a(let a0):
+  // CHECK-NEXT:     case .a(`foo bar`: let a0):
   // CHECK-NEXT:       hasher.combine(2)
   // CHECK-NEXT:       hasher.combine(a0)
   // CHECK-NEXT:     }

--- a/test/expr/print/raw_identifiers.swift
+++ b/test/expr/print/raw_identifiers.swift
@@ -1,0 +1,74 @@
+// RUN: %target-swift-frontend -print-ast %s 2>&1 | %FileCheck %s
+
+// CHECK: enum `an enum` {
+enum `an enum` {
+
+  // CHECK: case `c one`
+  case `c one`
+
+  // CHECK: case `default`(Int)
+  case `default`(Int)
+
+  // CHECK: case labeled(`p lbl`: Int, other: String)
+  case labeled(`p lbl`: Int, other: String)
+}
+
+// CHECK: struct `a struct` {
+struct `a struct` {
+  // CHECK: var `some prop`: Int = 0
+  var `some prop`: Int = 0
+
+  // CHECK-LABEL: func `do thing`(`with arg` x: Int) -> Int {
+  func `do thing`(`with arg` x: Int) -> Int { return x }
+  //CHECK-NEXT:   return x
+  //CHECK-NEXT: }
+
+  // `self` and other keyword-named references must not be escaped.
+  // CHECK-LABEL: internal func selfRef() -> `a struct` {
+  func selfRef() -> `a struct` { return self }
+  // CHECK-NEXT:   return self
+  // CHECK-NEXT: }
+}
+
+// CHECK-LABEL: internal func testPatterns(_ e: `an enum`) -> Int {
+func testPatterns(_ e: `an enum`) -> Int {
+  switch e {
+  case .`c one`:
+    return 0
+  case .`default`(let x) where x > 1:
+    return x
+  case .labeled(`p lbl`: let x, other: let y) where y.isEmpty:
+    return x
+  default:
+    return 2
+  }
+}
+// CHECK-NEXT:   switch e {
+// CHECK-NEXT:   case .`c one`:
+// CHECK-NEXT:     return 0
+// CHECK-NEXT:   case .`default`(let x) where x > 1:
+// CHECK-NEXT:     return x
+// CHECK-NEXT:   case .labeled(`p lbl`: let x, other: let y) where y.isEmpty:
+// CHECK-NEXT:     return x
+// CHECK-NEXT:   default:
+// CHECK-NEXT:     return 2
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// CHECK-LABEL: internal func testIfCase(_ e: `an enum`) -> Bool {
+func testIfCase(_ e: `an enum`) -> Bool {
+  if case .`default`(let x) = e {
+    return x > 0
+  }
+  return false
+}
+// CHECK:        return x > 0
+
+// CHECK-LABEL: internal func testExprs(_ s: `a struct`) -> Int {
+func testExprs(_ s: `a struct`) -> Int {
+  // CHECK: let `local var`: Int = s.`some prop`
+  let `local var` = s.`some prop`
+  
+  // CHECK: return `local var` + s.`do thing`(`with arg`: 1)
+  return `local var` + s.`do thing`(`with arg`: 1)
+}

--- a/test/expr/print/switch.swift
+++ b/test/expr/print/switch.swift
@@ -56,3 +56,24 @@ func foo(_ x: Int?) {
 // CHECK-LABEL:     break
 // CHECK-LABEL:   }
 // CHECK-LABEL: }
+
+func guarded(payload: Payload) -> Int {
+  switch payload {
+  case .int(let int) where int > 0:
+    return int
+  case .keyValue(let key, let value) where key.isEmpty, .keyValue(let key, let value) where value < 0:
+    return value + key.count
+  default:
+    return 0
+  }
+}
+// CHECK-LABEL: internal func guarded(payload: Payload) -> Int {
+// CHECK-NEXT:    switch payload {
+// CHECK-NEXT:    case .int(let int) where int > 0:
+// CHECK-NEXT:      return int
+// CHECK-NEXT:    case .keyValue(let key, let value) where key.isEmpty, .keyValue(let key, let value) where value < 0:
+// CHECK-NEXT:      return value + key.count
+// CHECK-NEXT:    default:
+// CHECK-NEXT:      return 0
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
`ASTPrinter` produced non re-parseable output in some cases:
- Raw identifiers were printed unescaped in expression positions (e.g. `.foo bar`, `f(foo bar:)`), so `-print-ast` of an enum with raw identifier cases was wrong
- Tuple labels were not printed, turning `case .a(value: let x)` into `case .a(let x)`
- case statements guards were not printed, turning `case .foo where someCondition:` into `case .foo where :`

This PR fixes these printing issues and adds a test.