### PR TITLE
[RemoteInspection] Bound the remaining recursive walks over remote metadata.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -47,6 +47,10 @@ using FunctionParam = swift::Demangle::FunctionParam<BuiltType>;
 template <typename BuilderType>
 using TypeDecoder = swift::Demangle::TypeDecoder<BuilderType>;
 
+/// The depth limit for recursive walks over metadata in the inspected process,
+/// which can be malformed or cyclic.
+constexpr int defaultTypeRecursionLimit = 50;
+
 /// The kind of mangled name to read.
 enum class MangledNameKind {
   Type,
@@ -189,8 +193,6 @@ public:
   using StoredSignedPointer = typename Runtime::StoredSignedPointer;
   using StoredSize = typename Runtime::StoredSize;
   using TargetClassMetadata = TargetClassMetadataType<Runtime>;
-
-  static const int defaultTypeRecursionLimit = 50;
 
 private:
   /// The maximum number of bytes to read when reading metadata. Anything larger
@@ -1649,7 +1651,8 @@ public:
   Demangle::NodePointer
   buildContextMangling(ContextDescriptorRef descriptor,
                        Demangler &dem) {
-    auto demangling = buildContextDescriptorMangling(descriptor, dem, 50);
+    auto demangling = buildContextDescriptorMangling(
+        descriptor, dem, defaultTypeRecursionLimit);
     if (!demangling)
       return nullptr;
 
@@ -1857,7 +1860,8 @@ public:
 
   // This follows getMetadataBounds in ABI/Metadata.h.
   std::optional<ClassMetadataBounds>
-  getClassMetadataBounds(ContextDescriptorRef classRef) {
+  getClassMetadataBounds(ContextDescriptorRef classRef,
+                         int recursion_limit = defaultTypeRecursionLimit) {
     auto classDescriptor = cast<TargetClassDescriptor<Runtime>>(classRef);
 
     if (!classDescriptor->hasResilientSuperclass()) {
@@ -1875,12 +1879,17 @@ public:
       return bounds;
     }
 
-    return computeMetadataBoundsFromSuperclass(classRef);
+    return computeMetadataBoundsFromSuperclass(classRef, recursion_limit);
   }
 
   // This follows computeMetadataBoundsFromSuperclass in Metadata.cpp.
-  std::optional<ClassMetadataBounds>
-  computeMetadataBoundsFromSuperclass(ContextDescriptorRef subclassRef) {
+  std::optional<ClassMetadataBounds> computeMetadataBoundsFromSuperclass(
+      ContextDescriptorRef subclassRef,
+      int recursion_limit = defaultTypeRecursionLimit) {
+    if (recursion_limit <= 0) {
+      return std::nullopt;
+    }
+
     auto subclass = cast<TargetClassDescriptor<Runtime>>(subclassRef);
     std::optional<ClassMetadataBounds> bounds;
 
@@ -1899,7 +1908,7 @@ public:
               -> std::optional<ClassMetadataBounds> {
             if (!isa<TargetClassDescriptor<Runtime>>(superclass))
               return std::nullopt;
-            return getClassMetadataBounds(superclass);
+            return getClassMetadataBounds(superclass, recursion_limit - 1);
           },
           [&](MetadataRef metadata) -> std::optional<ClassMetadataBounds> {
             auto cls = dyn_cast<TargetClassMetadata>(metadata);
@@ -3106,12 +3115,16 @@ private:
       return BuiltTypeDecl();
     std::vector<size_t> paramsPerLevel;
     size_t runningCount = 0;
-    std::function<void(ContextDescriptorRef current, size_t &)> countLevels =
-        [&](ContextDescriptorRef current, size_t &runningCount) {
+    std::function<void(ContextDescriptorRef current, size_t &, int)>
+        countLevels = [&](ContextDescriptorRef current, size_t &runningCount,
+                          int recursion_limit) {
+          if (recursion_limit <= 0)
+            return;
+
           if (auto parentContextRef = readParentContextDescriptor(current))
             if (parentContextRef->isResolved())
               if (auto parentContext = parentContextRef->getResolved())
-                countLevels(parentContext, runningCount);
+                countLevels(parentContext, runningCount, recursion_limit - 1);
 
           auto genericContext = current->getGenericContext();
           // Only consider generic contexts of type class, enum or struct.
@@ -3126,7 +3139,7 @@ private:
             runningCount += paramsPerLevel.back();
           }
         };
-    countLevels(descriptor, runningCount);
+    countLevels(descriptor, runningCount, defaultTypeRecursionLimit);
     BuiltTypeDecl decl = Builder.createTypeDecl(node, paramsPerLevel);
     return decl;
   }

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -2168,7 +2168,13 @@ private:
         remote::RemoteAddress contextDescriptorAddress,
         const ExternalContextDescriptor<ObjCInteropKind, PointerSize>
             *contextDescriptor,
-        std::vector<ContextNameInfo> &chain) {
+        std::vector<ContextNameInfo> &chain,
+        int recursion_limit = remote::defaultTypeRecursionLimit) {
+      if (recursion_limit <= 0) {
+        Error = "Parent context chain is too deep.";
+        return;
+      }
+
       const auto parentDescriptorAddress = getParentDescriptorAddress(
           contextDescriptorAddress, contextDescriptor);
 
@@ -2193,7 +2199,7 @@ private:
         chain.push_back(parentNameInfo.value());
         if (!isModuleDescriptor(parentDescriptor)) {
           getParentContextChain(parentContextDescriptorAddress,
-                                parentDescriptor, chain);
+                                parentDescriptor, chain, recursion_limit - 1);
         }
       };
 

--- a/unittests/MetadataReader/MetadataReaderTest.cpp
+++ b/unittests/MetadataReader/MetadataReaderTest.cpp
@@ -232,3 +232,57 @@ TEST(MetadataReader, WordsArraySavedAcrossNestedDemangle) {
   ASSERT_EQ(argIdent->getKind(), Node::Kind::Identifier);
   EXPECT_EQ(argIdent->getText(), "OtherType");
 }
+
+// A class descriptor in the inspected process can name itself as its own
+// resilient superclass. Walking that chain must stop rather than recurse until
+// the stack runs out.
+TEST(MetadataReader, ResilientSuperclassCycleTerminates) {
+  // The bytes below are laid out by hand, so make sure the descriptor is still
+  // the shape they assume.
+  static_assert(sizeof(TargetClassDescriptor<Runtime>) == 44,
+                "class descriptor layout changed");
+
+  struct ClassDescriptorBytes {
+    uint32_t Flags;
+    int32_t Parent;
+    int32_t Name;
+    int32_t AccessFunctionPtr;
+    int32_t Fields;
+    int32_t SuperclassType;
+    uint32_t ResilientMetadataBounds;
+    uint32_t ExtraClassFlags;
+    uint32_t NumImmediateMembers;
+    uint32_t NumFields;
+    uint32_t FieldOffsetVectorOffset;
+    int32_t ResilientSuperclass;
+  };
+  static_assert(offsetof(ClassDescriptorBytes, ResilientSuperclass) ==
+                    sizeof(TargetClassDescriptor<Runtime>),
+                "resilient superclass is not the first trailing object");
+
+  TypeContextDescriptorFlags typeFlags;
+  typeFlags.class_setHasResilientSuperclass(true);
+  typeFlags.class_setResilientSuperclassReferenceKind(
+      TypeReferenceKind::DirectTypeDescriptor);
+  ContextDescriptorFlags flags(ContextDescriptorKind::Class,
+                               /*isGeneric*/ false, /*isUnique*/ true,
+                               /*hasInvertibleProtocols*/ false,
+                               typeFlags.getOpaqueValue());
+
+  ClassDescriptorBytes descriptor = {};
+  descriptor.Flags = flags.getIntValue();
+  // Relative pointer back to the start of the descriptor itself.
+  descriptor.ResilientSuperclass =
+      -int32_t(offsetof(ClassDescriptorBytes, ResilientSuperclass));
+
+  const uint64_t descriptorAddr = 0x1000;
+  auto reader = std::make_shared<MockMemoryReader>();
+  reader->addMemory(descriptorAddr, &descriptor, sizeof(descriptor));
+
+  TestMetadataReader metadataReader(reader);
+  auto descriptorRef =
+      metadataReader.readContextDescriptor(RemoteAddress(descriptorAddr, 0));
+  ASSERT_TRUE(descriptorRef);
+
+  EXPECT_FALSE(metadataReader.getClassMetadataBounds(descriptorRef).has_value());
+}


### PR DESCRIPTION
Give the superclass walk in getClassMetadataBounds/computeMetadataBoundsFromSuperclass, the parent-context walk in buildNominalTypeDecl's countLevels, and the parent-context walk in QualifiedContextNameReader::getParentContextChain the same depth limit that readTypeFromMetadata and buildContextDescriptorMangling already use. A descriptor in the inspected process can name itself as its own resilient superclass or its own parent, and each of these walks recursed on such a chain until the stack ran out.

defaultTypeRecursionLimit moves to namespace scope so TypeRefBuilder.h can use it too, and buildContextMangling now names the constant instead of repeating the literal 50.

rdar://182477881