### PR TITLE
[any ~Copyable] Don't run existential casting tests against an older runtime

### DIFF
--- a/test/Interpreter/noncopyable_existential_casting.swift
+++ b/test/Interpreter/noncopyable_existential_casting.swift
@@ -3,6 +3,14 @@
 // REQUIRES: swift_feature_NoncopyableCasting
 // REQUIRES: executable_test
 
+// Casting a noncopyable payload out of an existential requires the
+// take-instead-of-copy support added to swift_dynamicCast (see
+// tryCastUnwrappingExistentialSource). An older, OS-resident runtime copies
+// the payload instead, which traps in the noncopyable type's copy value
+// witness -- so this cannot run against the OS stdlib or a back-deployed one.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // End-to-end verification that `is`/`as?`/`as!` work correctly on a
 // noncopyable existential value: SILGen and the move-only checker must
 // agree that the cast fully consumes its source (a `checked_cast_addr_br`

--- a/test/Interpreter/noncopyable_extended_existential_casting.swift
+++ b/test/Interpreter/noncopyable_extended_existential_casting.swift
@@ -3,6 +3,14 @@
 // REQUIRES: swift_feature_NoncopyableCasting
 // REQUIRES: executable_test
 
+// Casting a noncopyable payload out of an existential requires the
+// take-instead-of-copy support added to swift_dynamicCast (here specifically
+// tryCastUnwrappingExtendedExistentialSource). An older, OS-resident runtime
+// copies the payload instead, which traps in the noncopyable type's copy value
+// witness -- so this cannot run against the OS stdlib or a back-deployed one.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // End-to-end verification that `is`/`as?`/`as!` work correctly on an
 // *extended* noncopyable existential. A protocol with a primary associated
 // type (like `P<T>` below) uses ExtendedExistentialTypeMetadata at runtime


### PR DESCRIPTION
Casting a noncopyable payload out of an existential relies on the take-instead-of-copy support that was just added to swift_dynamicCast (tryCastUnwrappingExistentialSource and
tryCastUnwrappingExtendedExistentialSource).  An OS-resident or back-deployed runtime copies the payload instead, which traps in the noncopyable type's copy value witness; on an OS old enough to predate extended existential metadata entirely, the extended-existential test doesn't even launch (missing swift_getExtendedExistentialTypeMetadata_unique).

Mark both tests UNSUPPORTED for use_os_stdlib and back_deployment_runtime, which is how the swift-in-OS back-deployment bots are configured.

Resolves: rdar://185417978 and rdar://185418117