### PR TITLE
[Concurrency] Improve signing of the concurrency hook variables.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1824,6 +1824,10 @@ namespace SpecialPointerAuthDiscriminators {
   /// concurrency runtime.
   const uint16_t IsCurrentGlobalActorFunction = 0xd1b8; // = 53688
 
+  /// Concurrency hook variables. They are address-diversified, so one
+  /// discriminator covers all of them.
+  const uint16_t ConcurrencyHook = 0xc0a1; // = 49313
+
   /// Function pointers stored in the coro allocator struct.
   const uint16_t CoroAllocationFunction = 0x5f95;   // = 24469
   const uint16_t CoroDeallocationFunction = 0x9faf; // = 40879

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -1008,17 +1008,19 @@ void swift_task_enqueueOnDispatchQueue(Job *job, HeapObject *queue);
 #endif
 
 // Declare all the hooks
-#define SWIFT_CONCURRENCY_HOOK(returnType, name, ...)                   \
-  typedef SWIFT_CC(swift) returnType (*name##_original)(__VA_ARGS__);   \
-  typedef SWIFT_CC(swift) returnType                                    \
-    (*name##_hook_t)(__VA_ARGS__, name##_original original);            \
-  SWIFT_EXPORT_FROM(swift_Concurrency) name##_hook_t name##_hook
+#define SWIFT_CONCURRENCY_HOOK(returnType, name, ...)                          \
+  typedef SWIFT_CC(swift) returnType (*name##_original)(__VA_ARGS__);          \
+  typedef SWIFT_CC(swift)                                                      \
+      returnType (*name##_hook_t)(__VA_ARGS__, name##_original original);      \
+  SWIFT_EXPORT_FROM(swift_Concurrency)                                         \
+  name##_hook_t __ptrauth_swift_concurrency_hook name##_hook
 
-#define SWIFT_CONCURRENCY_HOOK0(returnType, name)                       \
-  typedef SWIFT_CC(swift) returnType (*name##_original)();              \
-  typedef SWIFT_CC(swift) returnType                                    \
-    (*name##_hook_t)(name##_original original);                         \
-  SWIFT_EXPORT_FROM(swift_Concurrency) name##_hook_t name##_hook
+#define SWIFT_CONCURRENCY_HOOK0(returnType, name)                              \
+  typedef SWIFT_CC(swift) returnType (*name##_original)();                     \
+  typedef SWIFT_CC(swift)                                                      \
+      returnType (*name##_hook_t)(name##_original original);                   \
+  SWIFT_EXPORT_FROM(swift_Concurrency)                                         \
+  name##_hook_t __ptrauth_swift_concurrency_hook name##_hook
 
 #include "ConcurrencyHooks.def"
 
@@ -1027,7 +1029,8 @@ typedef SWIFT_CC(swift) void (*swift_task_asyncMainDrainQueue_original)();
 typedef SWIFT_CC(swift) void (*swift_task_asyncMainDrainQueue_override)(
     swift_task_asyncMainDrainQueue_original original);
 SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_asyncMainDrainQueue_hook)(
+SWIFT_CC(swift)
+void (*__ptrauth_swift_concurrency_hook swift_task_asyncMainDrainQueue_hook)(
     swift_task_asyncMainDrainQueue_original original,
     swift_task_asyncMainDrainQueue_override compatOverride);
 

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -347,6 +347,9 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_is_global_actor_function                               \
   __ptrauth(ptrauth_key_function_pointer, 1,                                   \
             SpecialPointerAuthDiscriminators::IsCurrentGlobalActorFunction)
+#define __ptrauth_swift_concurrency_hook                                       \
+  __ptrauth(ptrauth_key_function_pointer, 1,                                   \
+            SpecialPointerAuthDiscriminators::ConcurrencyHook)
 
 #if __has_attribute(ptrauth_struct)
 #define swift_ptrauth_struct(key, discriminator)                               \
@@ -391,6 +394,7 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_type_layout_string
 #define __ptrauth_swift_deinit_work_function
 #define __ptrauth_swift_is_global_actor_function
+#define __ptrauth_swift_concurrency_hook
 #define swift_ptrauth_struct(key, discriminator)
 #define swift_ptrauth_struct_derived(from)
 #endif

--- a/stdlib/public/Concurrency/ConcurrencyHooks.cpp
+++ b/stdlib/public/Concurrency/ConcurrencyHooks.cpp
@@ -21,17 +21,20 @@
 #include "ExecutorImpl.h"
 #include "TaskPrivate.h"
 
+using namespace swift;
+
 // Define all the hooks
-#define SWIFT_CONCURRENCY_HOOK(returnType, name, ...)           \
-  swift::name##_hook_t swift::name##_hook = nullptr
-#define SWIFT_CONCURRENCY_HOOK0(returnType, name)               \
-  swift::name##_hook_t swift::name##_hook = nullptr
-#define SWIFT_CONCURRENCY_HOOK_OVERRIDE0(returnType, name)      \
-  swift::name##_hook_t swift::name##_hook = nullptr
+#define SWIFT_CONCURRENCY_HOOK(returnType, name, ...)                          \
+  swift::name##_hook_t __ptrauth_swift_concurrency_hook swift::name##_hook =   \
+      nullptr
+#define SWIFT_CONCURRENCY_HOOK0(returnType, name)                              \
+  swift::name##_hook_t __ptrauth_swift_concurrency_hook swift::name##_hook =   \
+      nullptr
+#define SWIFT_CONCURRENCY_HOOK_OVERRIDE0(returnType, name)                     \
+  swift::name##_hook_t __ptrauth_swift_concurrency_hook swift::name##_hook =   \
+      nullptr
 
 #include "swift/Runtime/ConcurrencyHooks.def"
-
-using namespace swift;
 
 // Define the external entry points; because the Impl functions use the C
 // types from `ExecutorHooks.h`, we need to make an Orig version containing

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -2029,7 +2029,8 @@ extern "C" SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_CC(swift)
 void swift_task_asyncMainDrainQueueImpl();
 
 SWIFT_CC(swift)
-void (*swift::swift_task_asyncMainDrainQueue_hook)(
+void (*__ptrauth_swift_concurrency_hook
+          swift::swift_task_asyncMainDrainQueue_hook)(
     swift_task_asyncMainDrainQueue_original original,
     swift_task_asyncMainDrainQueue_override compatOverride) = nullptr;
 


### PR DESCRIPTION
Give them a custom ptrauth scheme with a non-zero discriminator and address diversification.

rdar://185743365