### PR TITLE
Bugfix for simd floating-point negation.

### DIFF
--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -1316,7 +1316,7 @@ extension SIMD where Scalar: FloatingPoint {
   
   @_transparent
   public static prefix func -(a: Self) -> Self {
-    return 0 - a
+    return -1 * a
   }
   
   @_transparent

--- a/test/stdlib/SIMDGenericFP.swift
+++ b/test/stdlib/SIMDGenericFP.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import Foundation
+import StdlibUnittest
+
+let SIMDGenericFPTests = TestSuite("SIMD Generic FP")
+
+func getNegativeZero<T>(of: T.Type) -> T
+where T: SIMD, T.Scalar: BinaryFloatingPoint {
+  -T()
+}
+
+SIMDGenericFPTests.test("negation") {
+  let negZero = -getNegativeZero(of: SIMD4<Float>)
+  expectEqual(negZero[0].sign, .minus)
+  expectEqual(negZero[1].sign, .minus)
+  expectEqual(negZero[2].sign, .minus)
+  expectEqual(negZero[3].sign, .minus)
+  expectEqual(negZero[0], 0)
+  expectEqual(negZero[1], 0)
+  expectEqual(negZero[2], 0)
+  expectEqual(negZero[3], 0)
+}
+
+runAllTests()

--- a/test/stdlib/SIMDGenericFP.swift
+++ b/test/stdlib/SIMDGenericFP.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
-import Foundation
 import StdlibUnittest
 
 let SIMDGenericFPTests = TestSuite("SIMD Generic FP")
@@ -13,7 +12,7 @@ where T: SIMD, T.Scalar: BinaryFloatingPoint {
 }
 
 SIMDGenericFPTests.test("negation") {
-  let negZero = -getNegativeZero(of: SIMD4<Float>)
+  let negZero = getNegativeZero(of: SIMD4<Float>.self)
   expectEqual(negZero[0].sign, .minus)
   expectEqual(negZero[1].sign, .minus)
   expectEqual(negZero[2].sign, .minus)

--- a/test/stdlib/SIMDGenericFP.swift
+++ b/test/stdlib/SIMDGenericFP.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
 
 import Foundation
 import StdlibUnittest


### PR DESCRIPTION
It appears that the implementation got copied from integer code. But, while `0-a` is a correct implementation of negation for integers, it is not for floating-point. (In particular, if `a` is zero, then `0-a` will be `+0` in the default rounding mode, which means that negating a zero vector gets the wrong sign). Use `-1 * a` instead.

resolves: rdar://185854503