### PR TITLE
[stdlib] Factor out span range checks for `fixed_storage.check_range` semantics

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -217,6 +217,30 @@ extension MutableRawSpan {
     _precondition(byteOffsets.contains(position), "Index out of bounds")
   }
 
+  // SILOptimizer looks for fixed_storage.check_range semantics
+  // for bounds checking optimizations.
+  @_semantics("fixed_storage.check_range")
+  @export(implementation) @inline(__always)
+  internal func _checkRange(lowerBound: Int, upperBound: Int) {
+    _precondition(
+      UInt(bitPattern: lowerBound) <= _assumeNonNegative(_count) &&
+      UInt(bitPattern: upperBound) <= _assumeNonNegative(_count),
+      "Byte offset range out of bounds"
+    )
+  }
+
+  // SILOptimizer looks for fixed_storage.check_range_offset semantics
+  // for bounds checking optimizations.
+  @_semantics("fixed_storage.check_range_offset")
+  @export(implementation) @inline(__always)
+  internal func _checkRange(offset: Int, length: Int) {
+    _precondition(
+      UInt(bitPattern: offset) <= _assumeNonNegative(_count) &&
+      UInt(bitPattern: offset &+ length) <= _assumeNonNegative(_count),
+      "Byte offset range out of bounds"
+    )
+  }
+
   /// Accesses the byte at the specified offset in the span.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
@@ -384,11 +408,7 @@ extension MutableRawSpan {
   public func unsafeLoad<T>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
-    _precondition(
-      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
-      MemoryLayout<T>.size <= (_count &- offset),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(offset: offset, length: MemoryLayout<T>.size)
     return unsafe unsafeLoad(fromUncheckedByteOffset: offset, as: T.self)
   }
 
@@ -439,11 +459,7 @@ extension MutableRawSpan {
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
-    _precondition(
-      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
-      MemoryLayout<T>.size <= (_count &- offset),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(offset: offset, length: MemoryLayout<T>.size)
     return unsafe unsafeLoadUnaligned(fromUncheckedByteOffset: offset, as: T.self)
   }
 
@@ -540,11 +556,7 @@ extension MutableRawSpan {
   internal mutating func _storeBytes<T: BitwiseCopyable>(
     of value: T, toByteOffset offset: Int, as type: T.Type
   ) {
-    _precondition(
-      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
-      MemoryLayout<T>.size <= (_count &- offset),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(offset: offset, length: MemoryLayout<T>.size)
     unsafe storeBytes(of: value, toUncheckedByteOffset: offset, as: T.self)
   }
 
@@ -721,11 +733,7 @@ extension MutableRawSpan {
   @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(_ bounds: Range<Int>) -> Self {
-    _precondition(
-      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
-      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(lowerBound: bounds.lowerBound, upperBound: bounds.upperBound)
     return unsafe _mutatingExtracting(unchecked: bounds)
   }
 
@@ -763,11 +771,7 @@ extension MutableRawSpan {
   @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Int>) -> Self {
-    _precondition(
-      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
-      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(lowerBound: bounds.lowerBound, upperBound: bounds.upperBound)
     return unsafe _consumingExtracting(unchecked: bounds)
   }
 

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -411,6 +411,19 @@ extension MutableSpan where Element: ~Copyable {
   internal func _checkIndex(_ position: Index) {
     _precondition(indices.contains(position), "index out of bounds")
   }
+
+  // SILOptimizer looks for fixed_storage.check_range semantics for bounds check optimizations.
+  @_semantics("fixed_storage.check_range")
+  @inline(__always)
+  @export(implementation)
+  internal func _checkRange(lowerBound: Index, upperBound: Index) {
+    _precondition(
+      UInt(bitPattern: lowerBound) <= _assumeNonNegative(_count) &&
+      UInt(bitPattern: upperBound) <= _assumeNonNegative(_count),
+      "Index range out of bounds"
+    )
+  }
+
   /// Accesses the element at the specified index in the `MutableSpan`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
@@ -664,11 +677,7 @@ extension MutableSpan where Element: ~Copyable {
   @export(implementation)
   @_lifetime(&self)
   mutating public func _mutatingExtracting(_ bounds: Range<Index>) -> Self {
-    _precondition(
-      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
-      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Index range out of bounds"
-    )
+    _checkRange(lowerBound: bounds.lowerBound, upperBound: bounds.upperBound)
     return unsafe _mutatingExtracting(unchecked: bounds)
   }
 
@@ -706,11 +715,7 @@ extension MutableSpan where Element: ~Copyable {
   @export(implementation)
   @_lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Index>) -> Self {
-    _precondition(
-      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
-      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Index range out of bounds"
-    )
+    _checkRange(lowerBound: bounds.lowerBound, upperBound: bounds.upperBound)
     return unsafe _consumingExtracting(unchecked: bounds)
   }
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -400,6 +400,30 @@ extension RawSpan {
     _precondition(byteOffsets.contains(position), "Index out of bounds")
   }
 
+  // SILOptimizer looks for fixed_storage.check_range semantics
+  // for bounds checking optimizations.
+  @_semantics("fixed_storage.check_range")
+  @export(implementation) @inline(__always)
+  internal func _checkRange(lowerBound: Int, upperBound: Int) {
+    _precondition(
+      UInt(bitPattern: lowerBound) <= _assumeNonNegative(_count) &&
+      UInt(bitPattern: upperBound) <= _assumeNonNegative(_count),
+      "Byte offset range out of bounds"
+    )
+  }
+
+  // SILOptimizer looks for fixed_storage.check_range_offset semantics
+  // for bounds checking optimizations.
+  @_semantics("fixed_storage.check_range_offset")
+  @export(implementation) @inline(__always)
+  internal func _checkRange(offset: Int, length: Int) {
+    _precondition(
+      UInt(bitPattern: offset) <= _assumeNonNegative(_count) &&
+      UInt(bitPattern: offset &+ length) <= _assumeNonNegative(_count),
+      "Byte offset range out of bounds"
+    )
+  }
+
   /// Accesses the byte at the specified offset in the span.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
@@ -443,11 +467,7 @@ extension RawSpan {
   @export(implementation)
   @_lifetime(copy self)
   public func extracting(_ bounds: Range<Int>) -> Self {
-    _precondition(
-      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
-      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(lowerBound: bounds.lowerBound, upperBound: bounds.upperBound)
     return unsafe extracting(unchecked: bounds)
   }
 
@@ -654,11 +674,7 @@ extension RawSpan {
   public func unsafeLoad<T>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
-    _precondition(
-      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
-      MemoryLayout<T>.size <= (_count &- offset),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(offset: offset, length: MemoryLayout<T>.size)
     return unsafe unsafeLoad(fromUncheckedByteOffset: offset, as: T.self)
   }
 
@@ -709,11 +725,7 @@ extension RawSpan {
   public func unsafeLoadUnaligned<T: BitwiseCopyable>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
-    _precondition(
-      UInt(bitPattern: offset) <= UInt(bitPattern: _count) &&
-      MemoryLayout<T>.size <= (_count &- offset),
-      "Byte offset range out of bounds"
-    )
+    _checkRange(offset: offset, length: MemoryLayout<T>.size)
     return unsafe unsafeLoadUnaligned(
       fromUncheckedByteOffset: offset, as: T.self
     )

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -472,6 +472,18 @@ extension Span where Element: ~Copyable {
     _precondition(indices.contains(position), "Index out of bounds")
   }
 
+  // SILOptimizer looks for fixed_storage.check_range semantics for bounds check optimizations.
+  @_semantics("fixed_storage.check_range")
+  @inline(__always)
+  @export(implementation)
+  internal func _checkRange(lowerBound: Index, upperBound: Index) {
+    _precondition(
+      UInt(bitPattern: lowerBound) <= _assumeNonNegative(_count) &&
+      UInt(bitPattern: upperBound) <= _assumeNonNegative(_count),
+      "Index range out of bounds"
+    )
+  }
+
   /// Accesses the element at the specified index in the `Span`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
@@ -612,11 +624,7 @@ extension Span where Element: ~Copyable {
   @export(implementation)
   @_lifetime(copy self)
   public func extracting(_ bounds: Range<Index>) -> Self {
-    _precondition(
-      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
-      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Index range out of bounds"
-    )
+    _checkRange(lowerBound: bounds.lowerBound, upperBound: bounds.upperBound)
     return unsafe extracting(unchecked: bounds)
   }
 


### PR DESCRIPTION
Enables bounds-checking elimination for Span, MutableSpan, RawSpan, and MutableRawSpan `extracting(:Range<Int>)`, `unsafeLoad<T>(:Int:T.Type)` and `unsafeLoadUnaligned<T: BitwiseCopyable>(:Int:T.Type)` methods. 