### PR TITLE
[6.4.x] Sema: Ban unavailable computed properties with initial values

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -442,6 +442,16 @@ namespace swift {
     /// until the next major language version.
     InFlightDiagnostic &warnUntilLanguageMode(LanguageMode mode);
 
+    /// Conditionally limit the diagnostic behavior to warning until the
+    /// specified language mode. If \p mode is \c std::nullopt, no limit is
+    /// imposed.
+    InFlightDiagnostic &
+    warnUntilLanguageMode(std::optional<LanguageMode> mode) {
+      if (!mode)
+        return *this;
+      return warnUntilLanguageMode(*mode);
+    }
+
     /// Limit the diagnostic behavior to warning if the context is a
     /// swiftinterface.
     ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7409,13 +7409,21 @@ ERROR(availability_global_script_no_unavailable,
       none, "global variable cannot be marked unavailable "
       "with '@available' in script mode", ())
 
-ERROR(availability_stored_property_no_potential,
-      none, "stored properties cannot be marked potentially unavailable with "
-      "'@available'", ())
+#define NO_AVAILABLE_ON_PROPERTY_SELECT "select{" \
+      "stored properties|" \
+      "computed property with initial value}"
 
-ERROR(availability_stored_property_no_unavailable,
-      none, "stored properties cannot be marked unavailable with '@available'",
-      ())
+ERROR(availability_stored_property_no_potential, none,
+      "%" NO_AVAILABLE_ON_PROPERTY_SELECT "0 "
+      "cannot be marked potentially unavailable with '@available'",
+      (unsigned))
+
+ERROR(availability_stored_property_no_unavailable, none,
+      "%" NO_AVAILABLE_ON_PROPERTY_SELECT "0 "
+      "cannot be marked unavailable with '@available'",
+      (unsigned))
+
+#undef NO_AVAILABLE_ON_PROPERTY_SELECT
 
 ERROR(availability_enum_element_no_potential,
       none, "enum cases with associated values cannot be marked potentially unavailable with "

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2352,6 +2352,45 @@ getSemanticAvailableRangeDeclAndAttr(const Decl *decl,
   return std::nullopt;
 }
 
+// The raw values of this enum must be kept in sync with the select clause
+// in diag::availability_stored_property_no_potential and
+// diag::availability_stored_property_no_unavailable.
+enum NoAvailableAttrDiagnosticPropertyKind : unsigned {
+  StoredProperty,
+  ComputedPropertyWithInitialValue,
+};
+
+static std::optional<NoAvailableAttrDiagnosticPropertyKind>
+getPropertyKindForAvailableAttrDiagnostic(const VarDecl *VD) {
+  if (VD->hasStorageOrWrapsStorage())
+    return StoredProperty;
+
+  if (VD->hasInitialValue())
+    return ComputedPropertyWithInitialValue;
+
+  return std::nullopt;
+}
+
+/// Returns a non-null language mode if diagnostics about the availability of
+/// \p D relative to \p domain should be downgraded to a warning until that
+/// language mode.
+static std::optional<LanguageMode>
+getLanguageModeForPropertyAvailabilityErrors(const Decl *D,
+                                             AvailabilityDomain domain) {
+  auto *VD = dyn_cast<VarDecl>(D);
+  if (!VD)
+    return std::nullopt;
+
+  auto kind = getPropertyKindForAvailableAttrDiagnostic(VD);
+  if (kind != ComputedPropertyWithInitialValue)
+    return std::nullopt;
+
+  if (!domain.isPlatform() && !domain.isUniversal())
+    return std::nullopt;
+
+  return LanguageMode::future;
+}
+
 void AttributeChecker::visitAvailableAttr(AvailableAttr *parsedAttr) {
   if (Ctx.LangOpts.DisableAvailabilityChecking)
     return;
@@ -5676,13 +5715,18 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
   if (!availabilityConstraint)
     return;
 
+  auto *parsedAttr = const_cast<AvailableAttr *>(
+      availabilityConstraint->getAttr().getParsedAttr());
+  auto domain = availabilityConstraint->getAttr().getDomain();
+
   // If the decl is unavailable relative to its parent and it's not a
   // declaration that is allowed to be unavailable, diagnose.
   if (availabilityConstraint->isUnavailable()) {
-    auto attr = availabilityConstraint->getAttr();
-    if (auto diag = TypeChecker::diagnosticIfDeclCannotBeUnavailable(D, attr)) {
-      diagnoseAndRemoveAttr(const_cast<AvailableAttr *>(attr.getParsedAttr()),
-                            *diag);
+    if (auto diag = TypeChecker::diagnosticIfDeclCannotBeUnavailable(
+            D, availabilityConstraint->getAttr())) {
+      diagnoseAndRemoveAttr(parsedAttr, *diag)
+          .warnUntilLanguageMode(
+              getLanguageModeForPropertyAvailabilityErrors(D, domain));
       return;
     }
   }
@@ -5690,10 +5734,11 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
   // If the decl is potentially unavailable relative to its parent and it's
   // not a declaration that is allowed to be potentially unavailable, diagnose.
   if (!availabilityConstraint->isUnavailable()) {
-    auto attr = availabilityConstraint->getAttr();
     if (auto diag =
             TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D))
-      diagnose(attr.getParsedAttr()->getLocation(), diag.value());
+      diagnose(parsedAttr->getLocation(), diag.value())
+          .warnUntilLanguageMode(
+              getLanguageModeForPropertyAvailabilityErrors(D, domain));
   }
 }
 
@@ -6010,7 +6055,8 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
   }
 
   if (auto *VD = dyn_cast<VarDecl>(D)) {
-    if (!VD->hasStorageOrWrapsStorage())
+    auto disallowedKind = ::getPropertyKindForAvailableAttrDiagnostic(VD);
+    if (!disallowedKind)
       return std::nullopt;
 
     // Do not permit potential availability of script-mode global variables;
@@ -6022,7 +6068,8 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
     // Globals and statics are lazily initialized, so they are safe
     // for potential unavailability.
     if (!VD->isStatic() && !DC->isModuleScopeContext())
-      return diag::availability_stored_property_no_potential;
+      return Diagnostic(diag::availability_stored_property_no_potential,
+                        unsigned(*disallowedKind));
 
   } else if (auto *EED = dyn_cast<EnumElementDecl>(D)) {
     // An enum element with an associated value cannot be potentially
@@ -6084,7 +6131,8 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D,
   }
 
   if (auto *VD = dyn_cast<VarDecl>(D)) {
-    if (!VD->hasStorageOrWrapsStorage())
+    auto disallowedKind = ::getPropertyKindForAvailableAttrDiagnostic(VD);
+    if (!disallowedKind)
       return std::nullopt;
 
     if (parentIsUnavailable(D))
@@ -6108,7 +6156,8 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D,
     // Globals and statics are lazily initialized, so they are safe for
     // unavailability.
     if (!VD->isStatic() && !D->getDeclContext()->isModuleScopeContext())
-      return diag::availability_stored_property_no_unavailable;
+      return Diagnostic(diag::availability_stored_property_no_unavailable,
+                        unsigned(*disallowedKind));
   }
 
   return std::nullopt;

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -598,3 +598,46 @@ func testP() { // expected-note 2{{add '@available' attribute to enclosing globa
   acceptP(MyType3.self)  // expected-error{{conformance of 'MyType3' to 'P' is only available in DisabledDomain}}
   // expected-note@-1{{add 'if #available' version check}}
 }
+
+struct HasPropertiesWithAvailabilityRestrictions {
+  @available(DynamicDomain) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  var potentiallyUnavailable: Int = 0
+
+  @available(DynamicDomain, unavailable) // expected-error {{stored properties cannot be marked unavailable with '@available'}}
+  var unavailable: Int = 0
+
+  @available(DynamicDomain) // OK
+  var potentiallyUnavailableComputed: Int {
+    get { 0 }
+    set { _ = newValue }
+  }
+
+  @available(DynamicDomain, unavailable) // OK
+  var unavailableComputed: Int {
+    get { 0 }
+    set { _ = newValue }
+  }
+
+  @available(DynamicDomain) // expected-error {{computed property with initial value cannot be marked potentially unavailable with '@available'}}
+  public var potentiallyUnavailableComputedWithInitialValue: Int? {
+    init { _ = newValue }
+    get { 0 }
+  }
+
+  @available(DynamicDomain, unavailable) // expected-error {{computed property with initial value cannot be marked unavailable with '@available'}}
+  public var unavailableComputedWithInitialValue: Int? {
+    init { _ = newValue }
+    get { 0 }
+  }
+
+  init() { fatalError() } // To suppress memberwise initializer
+}
+
+enum HasAssociatedValueCasesWithAvailabilityRestrictions {
+  @available(DynamicDomain) // expected-error {{enum cases with associated values cannot be marked potentially unavailable with '@available'}}
+  case potentiallyUnavailable(Int)
+
+  // FIXME: [availability] This should be rejected
+  @available(DynamicDomain, unavailable)
+  case unavailable(Int)
+}

--- a/test/Availability/availability_script_mode.swift
+++ b/test/Availability/availability_script_mode.swift
@@ -32,3 +32,21 @@ var unavailableOnMacOSVar: UnavailableOnMacOS = .init() // expected-error {{'Una
 
 @available(*, unavailable) // expected-error {{global variable cannot be marked unavailable with '@available' in script mode}}
 var unconditionallyUnavailableVar: UnavailableUnconditionally = .init() // expected-error {{'UnavailableUnconditionally' is unavailable}}
+
+// Computed globals have no initial value to execute eagerly, so they are safe
+// to mark unavailable in script mode.
+
+@available(macOS, introduced: 51)
+var computedPotentiallyUnavailableVar: Available51 {
+  Available51()
+}
+
+@available(macOS, unavailable)
+var computedUnavailableOnMacOSVar: UnavailableOnMacOS {
+  UnavailableOnMacOS()
+}
+
+@available(*, unavailable)
+var computedUnconditionallyUnavailableVar: UnavailableUnconditionally {
+  UnavailableUnconditionally()
+}

--- a/test/Availability/availability_stored.swift
+++ b/test/Availability/availability_stored.swift
@@ -27,6 +27,22 @@ struct GoodReferenceStruct {
   var x: NewStruct
   @NewPropertyWrapper var y: Int
   lazy var z: Int = 42
+  var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+  var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+  var computedWithInitialValue: NewStruct = .init() {
+    init { _ = newValue }
+    get { x }
+  }
+  var computedWithImplicitInitialValue: NewStruct? {
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 @available(macOS 50, *)
@@ -50,6 +66,32 @@ struct BadReferenceStruct1 {
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   lazy var z: Int = 42
+
+  @available(macOS 50, *)
+  var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+
+  @available(macOS 50, *)
+  var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(macOS 50, *)
+  var computedWithInitialValue: NewStruct = .init() {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(macOS 50, *)
+  var computedWithImplicitInitialValue: NewStruct? {
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 @available(macOS 40, *)
@@ -65,6 +107,32 @@ struct BadReferenceStruct2 {
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   lazy var z: Int = 42
+
+  @available(macOS 50, *)
+  var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+
+  @available(macOS 50, *)
+  var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(macOS 50, *)
+  var computedWithInitialValue: NewStruct = .init() {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(macOS 50, *)
+  var computedWithImplicitInitialValue: NewStruct? {
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 @available(macOS 40, *)
@@ -80,6 +148,32 @@ public struct PublicStruct {
   // expected-error@+1 {{stored properties cannot be marked potentially unavailable with '@available'}}
   @available(macOS 50, *)
   public lazy var z: Int = 42
+
+  @available(macOS 50, *)
+  public var computed: NewStruct {
+    get { x }
+    set { x = newValue }
+  }
+
+  @available(macOS 50, *)
+  public var computedWithInit: NewStruct {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(macOS 50, *)
+  public var computedWithInitialValue: NewStruct = .init() {
+    init { _ = newValue }
+    get { x }
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked potentially unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(macOS 50, *)
+  public var computedWithImplicitInitialValue: NewStruct? {
+    init { _ = newValue }
+    get { x }
+  }
 }
 
 // The same behavior should hold for enum elements with payloads.

--- a/test/Availability/availability_stored_unavailable.swift
+++ b/test/Availability/availability_stored_unavailable.swift
@@ -3,14 +3,14 @@
 // REQUIRES: OS=macosx
 
 @available(macOS, unavailable)
-struct UnavailableMacOSStruct {} // expected-note 2 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
+struct UnavailableMacOSStruct {} // expected-note 4 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
 
 @available(iOS, introduced: 8.0)
 @_spi_available(macOS, introduced: 10.9)
 public struct SPIAvailableMacOSStruct {}
 
 @available(*, unavailable)
-public struct UniversallyUnavailableStruct {} // expected-note {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
+public struct UniversallyUnavailableStruct {} // expected-note 3 {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
 
 // Ok, initialization of globals is lazy and boxed.
 @available(macOS, unavailable)
@@ -22,6 +22,14 @@ var spiAvailableMacOSGlobal: SPIAvailableMacOSStruct = .init()
 
 @available(*, unavailable)
 var universallyUnavailableGlobal: UniversallyUnavailableStruct = .init()
+
+// Computed globals have no initial value to execute eagerly, so they are safe
+// to mark unavailable.
+@available(macOS, unavailable)
+var computedUnavailableMacOSGlobal: UnavailableMacOSStruct { .init() }
+
+@available(*, unavailable)
+var computedUniversallyUnavailableGlobal: UniversallyUnavailableStruct { .init() }
 
 struct GoodAvailableStruct {
   // Ok, computed property.
@@ -37,6 +45,13 @@ struct GoodAvailableStruct {
   // Ok, initialization of static vars is lazy and boxed.
   @available(macOS, unavailable)
   static var staticUnavailableMacOS: UnavailableMacOSStruct = .init()
+
+  // Ok, an init accessor without an initial value has no initialization to run.
+  @available(macOS, unavailable)
+  var unavailableMacOSComputedWithInit: UnavailableMacOSStruct {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
 }
 
 @available(macOS, unavailable)
@@ -47,6 +62,13 @@ struct GoodUnavailableMacOSStruct {
   // Ok, the container is unavailable.
   @available(macOS, unavailable)
   var unavailableMacOSExplicit: UnavailableMacOSStruct = .init()
+
+  // Ok, the container is unavailable.
+  @available(macOS, unavailable)
+  var unavailableMacOSComputedWithInitialValue: UnavailableMacOSStruct = .init() {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
 }
 
 @available(macOS, unavailable)
@@ -82,6 +104,31 @@ struct BadStruct {
   // expected-error@+1 {{stored properties cannot be marked unavailable with '@available'}}
   @available(*, unavailable)
   var universallyUnavailable: UniversallyUnavailableStruct = .init() // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
+
+  // Ok, pure computed property.
+  @available(macOS, unavailable)
+  var computedUnavailableMacOS: UnavailableMacOSStruct { .init() }
+
+  // Ok, init accessor without an initial value.
+  @available(macOS, unavailable)
+  var computedUnavailableMacOSWithInit: UnavailableMacOSStruct {
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() }
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(macOS, unavailable)
+  var computedUnavailableMacOSWithInitialValue: UnavailableMacOSStruct = .init() { // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
+    init { _ = newValue }
+    get { UnavailableMacOSStruct() } // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
+  }
+
+  // expected-warning@+1 {{computed property with initial value cannot be marked unavailable with '@available'; this will be an error in a future Swift language mode}}
+  @available(*, unavailable)
+  var computedUniversallyUnavailableWithInitialValue: UniversallyUnavailableStruct = .init() { // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
+    init { _ = newValue }
+    get { UniversallyUnavailableStruct() } // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
+  }
 }
 
 enum GoodAvailableEnum {


### PR DESCRIPTION
- **Explanation:** A computed property with an init accessor may also have an initial value, which is executed at instance initialization time just like the initial value of a stored property. These properties cannot be allowed to be unavailable or potentially unavailable because the compiler does not know how to safely generate the code to execute the initial value expressions. 
- **Scope:** Affects code containing computed properties with availability restrictions and init accessors.
- **Issue/Radar:** rdar://185898446
- **Original PR:** https://github.com/swiftlang/swift/pull/90651
- **Risk:** Low. The diagnostic is staged in as a warning for properties with platform or universal availability restrictions, so this shouldn't break source compatibility for existing code. Only code using experimental custom availability domains should be rejected.
- **Testing:** New compiler tests.
- **Reviewer:** @nkcsgexi 
