### PR TITLE
[cxx-interop] Check @cxx function signatures for C++ representability

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6000,7 +6000,7 @@ ERROR(main_function_must_be_mainActor,none,
       "main() must be '@MainActor'", ())
 
 // Keep aligned with enum ForeignLanguage
-#define FOREIGN_LANG_SELECT "select{C|Objective-C}"
+#define FOREIGN_LANG_SELECT "select{C|C++|Objective-C}"
 
 ERROR(not_objc_function_async,none,
       "'async' %kindonly0 cannot be represented in Objective-C",
@@ -7112,7 +7112,7 @@ ERROR(objc_cannot_infer_name_raw_identifier,none,
       (const ValueDecl *))
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked '@c'|marked '@_cdecl'|marked dynamic|marked '@objc'|marked '@objcMembers'|marked '@IBOutlet'|marked '@IBAction'|marked '@IBSegueAction'|marked '@NSManaged'|a member of an '@objc' protocol|implicitly '@objc'|an '@objc' override|an implementation of an '@objc' requirement|marked '@IBInspectable'|marked '@GKInspectable'|in an '@objc' extension of a class (without '@nonobjc')|in an '@objc @implementation' extension of a class (without final or '@nonobjc')|marked '@objc' by an access note}"
+#define OBJC_ATTR_SELECT "select{marked '@c'|marked '@cxx'|marked '@_cdecl'|marked dynamic|marked '@objc'|marked '@objcMembers'|marked '@IBOutlet'|marked '@IBAction'|marked '@IBSegueAction'|marked '@NSManaged'|a member of an '@objc' protocol|implicitly '@objc'|an '@objc' override|an implementation of an '@objc' requirement|marked '@IBInspectable'|marked '@GKInspectable'|in an '@objc' extension of a class (without '@nonobjc')|in an '@objc @implementation' extension of a class (without final or '@nonobjc')|marked '@objc' by an access note}"
 
 ERROR(objc_invalid_on_var,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "
@@ -7164,7 +7164,7 @@ NOTE(not_objc_swift_struct,none,
       "Swift structs cannot be represented in %" FOREIGN_LANG_SELECT "0",
      (ForeignLanguage))
 NOTE(not_cdecl_or_objc_swift_enum,none,
-     "Swift enums not marked '@c'%select{| or '@objc'}0 cannot be "
+     "Swift enums not marked '@c'%select{|| or '@objc'}0 cannot be "
      "represented in %" FOREIGN_LANG_SELECT "0",
      (ForeignLanguage))
 NOTE(not_objc_generic_type_param,none,

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -154,6 +154,7 @@ inline SubstOptions operator|(SubstFlags lhs, SubstFlags rhs) {
 /// bridged.
 enum class ForeignLanguage : uint8_t {
   C,
+  Cxx,
   ObjectiveC,
 };
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5154,11 +5154,12 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Check @c functions for compatibility with the foreign language.
-class TypeCheckCDeclFunctionRequest
-    : public SimpleRequest<TypeCheckCDeclFunctionRequest,
+/// Check a function that is exported to a foreign language for compatibility
+/// with that language. This covers @c, @_cdecl, and @cxx.
+class TypeCheckForeignFunctionRequest
+    : public SimpleRequest<TypeCheckForeignFunctionRequest,
                            evaluator::SideEffect(FuncDecl *FD,
-                                                 CDeclAttr *attr),
+                                                 DeclAttribute *attr),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -5167,7 +5168,7 @@ private:
   friend SimpleRequest;
 
   evaluator::SideEffect
-  evaluate(Evaluator &evaluator, FuncDecl *FD, CDeclAttr *attr) const;
+  evaluate(Evaluator &evaluator, FuncDecl *FD, DeclAttribute *attr) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -588,8 +588,8 @@ SWIFT_REQUEST(TypeChecker, IsNonUserModuleRequest,
 SWIFT_REQUEST(TypeChecker, TypeCheckObjCImplementationRequest,
               unsigned(ExtensionDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, TypeCheckCDeclFunctionRequest,
-              evaluator::SideEffect(FunctionDecl *, CDeclAttr *),
+SWIFT_REQUEST(TypeChecker, TypeCheckForeignFunctionRequest,
+              evaluator::SideEffect(FunctionDecl *, DeclAttribute *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckCDeclEnumRequest,
               evaluator::SideEffect(EnumDecl *, CDeclAttr *),

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6916,13 +6916,14 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
   // Language-specific filtering.
   switch (language) {
   case ForeignLanguage::C:
-    // Ignore _ObjectiveCBridgeable conformances in C.
+  case ForeignLanguage::Cxx:
+    // Ignore _ObjectiveCBridgeable conformances in C and C++.
     if (conformance &&
         conformance->getProtocol()->isSpecificProtocol(
           KnownProtocolKind::ObjectiveCBridgeable))
       return ForeignRepresentationInfo::forNone();
 
-    // Ignore error bridging in C.
+    // Ignore error bridging in C and C++.
     if (entry.getKind() == ForeignRepresentableKind::BridgedError)
       return ForeignRepresentationInfo::forNone();
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11373,6 +11373,9 @@ bool AbstractFunctionDecl::isObjCInstanceMethod() const {
 }
 
 std::optional<ForeignLanguage> AbstractFunctionDecl::getCDeclKind() const {
+  if (getAttrs().hasAttribute<CxxDeclAttr>())
+    return ForeignLanguage::Cxx;
+
   auto attr = getAttrs().getAttribute<CDeclAttr>();
   if (!attr)
     return std::nullopt;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3446,14 +3446,16 @@ getForeignRepresentable(Type type, ForeignLanguage language,
   if (nominal->hasClangNode() || nominal->isObjC()) {
     switch (language) {
     case ForeignLanguage::C:
+    case ForeignLanguage::Cxx:
       if (auto *classDecl = dyn_cast<ClassDecl>(nominal)) {
         switch (classDecl->getForeignClassKind()) {
         case ClassDecl::ForeignKind::Normal:
         case ClassDecl::ForeignKind::RuntimeOnly:
-          // Imported classes cannot be represented in C.
+          // Imported classes cannot be represented in C or C++.
           return failure();
         case ClassDecl::ForeignKind::CFType:
-          // Imported CF types can be represented as trivial pointer types in C.
+          // Imported CF types can be represented as trivial pointer types in C
+          // or C++.
           break;
         }
       }
@@ -3462,8 +3464,8 @@ getForeignRepresentable(Type type, ForeignLanguage language,
       if (isa<ProtocolDecl>(nominal))
         return failure();
 
-      // @objc enums are not representable in C, @c ones and imported ones
-      // are ok.
+      // @objc enums are not representable in C or C++; @c ones and types
+      // imported from Clang are ok.
       if (!nominal->hasClangNode())
         return failure();
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -3162,6 +3162,12 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
   std::optional<ForeignLanguage> cdeclKind = std::nullopt;
   if (auto *FD = dyn_cast<AbstractFunctionDecl>(VD))
     cdeclKind = FD->getCDeclKind();
+
+  // A @cxx function implements a C++ declaration that already exists in an
+  // imported C++ header; never redeclare it in a generated header.
+  if (cdeclKind == ForeignLanguage::Cxx)
+    return false;
+
   if (cdeclKind &&
       (*cdeclKind == ForeignLanguage::C) !=
        (outputLang == OutputLanguageMode::C))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1897,6 +1897,20 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
     }
 
     if (!AFD->getImplementedObjCDecl()) {
+      // A @cxx function whose signature is not representable in C++ cannot
+      // match anything; the representability diagnostics explain the failure
+      // better than "not found" would, so check them first and stand down if
+      // they fire.
+      if (auto *cxxAttr = AFD->getAttrs().getAttribute<CxxDeclAttr>(
+              /*AllowInvalid=*/true)) {
+        auto *FD = dyn_cast<FuncDecl>(AFD);
+        if (FD && !cxxAttr->isInvalid())
+          evaluateOrDefault(Ctx.evaluator,
+                            TypeCheckForeignFunctionRequest{FD, cxxAttr}, {});
+        if (cxxAttr->isInvalid())
+          return;
+      }
+
       StringRef name = AFD->getCDeclName();
       if (name.empty())
         name = AFD->getNameStr();

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -52,6 +52,7 @@ swift::behaviorLimitForObjCReason(ObjCReason reason, ASTContext &ctx) {
     LLVM_FALLTHROUGH;
 
   case ObjCReason::ExplicitlyCDecl:
+  case ObjCReason::ExplicitlyCxxDecl:
   case ObjCReason::ExplicitlyUnderscoreCDecl:
   case ObjCReason::ExplicitlyDynamic:
   case ObjCReason::ExplicitlyObjC:
@@ -86,6 +87,7 @@ swift::behaviorLimitForObjCReason(ObjCReason reason, ASTContext &ctx) {
 unsigned swift::getObjCDiagnosticAttrKind(ObjCReason reason) {
   switch (reason) {
   case ObjCReason::ExplicitlyCDecl:
+  case ObjCReason::ExplicitlyCxxDecl:
   case ObjCReason::ExplicitlyUnderscoreCDecl:
   case ObjCReason::ExplicitlyDynamic:
   case ObjCReason::ExplicitlyObjC:
@@ -138,6 +140,7 @@ void ObjCReason::describe(const Decl *D) const {
 
   case ObjCReason::ExplicitlyObjCByAccessNote:
   case ObjCReason::ExplicitlyCDecl:
+  case ObjCReason::ExplicitlyCxxDecl:
   case ObjCReason::ExplicitlyUnderscoreCDecl:
   case ObjCReason::ExplicitlyDynamic:
   case ObjCReason::ExplicitlyObjC:
@@ -3377,6 +3380,13 @@ class ObjCImplementationChecker {
                             .getAttribute<ObjCAttr>(/*AllowInvalid=*/true))
       return objc->isInvalid();
 
+    // A failed C++ representability check marks the candidate's CxxDeclAttr
+    // invalid.
+    if (auto cxx =
+            cand->getAttrs().getAttribute<CxxDeclAttr>(/*AllowInvalid=*/true))
+      if (cxx->isInvalid())
+        return true;
+
     return getAttr()->hasInvalidImplicitLangAttrs() || getAttr()->isInvalid();
   }
 
@@ -4674,16 +4684,20 @@ evaluate(Evaluator &evaluator, Decl *D) const {
 }
 
 evaluator::SideEffect
-TypeCheckCDeclFunctionRequest::evaluate(Evaluator &evaluator,
+TypeCheckForeignFunctionRequest::evaluate(Evaluator &evaluator,
                                         FuncDecl *FD,
-                                        CDeclAttr *attr) const {
+                                        DeclAttribute *attr) const {
   auto &ctx = FD->getASTContext();
 
   auto lang = FD->getCDeclKind();
-  assert(lang && "missing @c?");
-  auto kind = lang == ForeignLanguage::ObjectiveC
-                      ? ObjCReason::ExplicitlyUnderscoreCDecl
-                      : ObjCReason::ExplicitlyCDecl;
+  assert(lang && "missing @c/@cxx?");
+  ObjCReason::Kind kind;
+  if (*lang == ForeignLanguage::ObjectiveC)
+    kind = ObjCReason::ExplicitlyUnderscoreCDecl;
+  else if (*lang == ForeignLanguage::Cxx)
+    kind = ObjCReason::ExplicitlyCxxDecl;
+  else
+    kind = ObjCReason::ExplicitlyCDecl;
   ObjCReason reason(kind, attr);
 
   std::optional<ForeignAsyncConvention> asyncConvention;
@@ -4698,6 +4712,11 @@ TypeCheckCDeclFunctionRequest::evaluate(Evaluator &evaluator,
       ctx.Diags.diagnose(attr->getLocation(), diag::cdecl_throws,
                          attr);
     }
+
+    // For @cxx, async/throws are hard errors that also invalidate the
+    // attribute so downstream matching diagnostics do not pile on.
+    if (*lang == ForeignLanguage::Cxx && (FD->hasAsync() || FD->hasThrows()))
+      reason.setAttrInvalid();
   } else {
     reason.setAttrInvalid();
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3795,10 +3795,15 @@ public:
       }
     }
 
-    // If the function is exported to C, it must be representable in (Obj-)C.
-    if (auto CDeclAttr = FD->getAttrs().getAttribute<swift::CDeclAttr>()) {
+    // If the function is exported to a foreign language, its signature must be
+    // representable in that language.
+    DeclAttribute *foreignLangAttr =
+        FD->getAttrs().getAttribute<swift::CDeclAttr>();
+    if (!foreignLangAttr)
+      foreignLangAttr = FD->getAttrs().getAttribute<swift::CxxDeclAttr>();
+    if (foreignLangAttr) {
       evaluateOrDefault(Ctx.evaluator,
-                        TypeCheckCDeclFunctionRequest{FD, CDeclAttr},
+                        TypeCheckForeignFunctionRequest{FD, foreignLangAttr},
                         {});
     }
 

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -43,6 +43,8 @@ public:
   enum Kind {
     /// Has the '@c' attribute.
     ExplicitlyCDecl,
+    /// Has the '@cxx' attribute.
+    ExplicitlyCxxDecl,
     /// Has the '@_cdecl' attribute.
     ExplicitlyUnderscoreCDecl,
     /// Has the 'dynamic' modifier.
@@ -103,6 +105,7 @@ private:
   static bool requiresAttr(Kind kind) {
     switch (kind) {
     case ExplicitlyCDecl:
+    case ExplicitlyCxxDecl:
     case ExplicitlyUnderscoreCDecl:
     case ExplicitlyDynamic:
     case ExplicitlyObjC:
@@ -169,6 +172,8 @@ public:
   ForeignLanguage getForeignLanguage() const {
     if (kind == ExplicitlyCDecl)
       return ForeignLanguage::C;
+    if (kind == ExplicitlyCxxDecl)
+      return ForeignLanguage::Cxx;
     return ForeignLanguage::ObjectiveC;
   }
 

--- a/test/Interop/Cxx/cxx-impl/Inputs/functions.h
+++ b/test/Interop/Cxx/cxx-impl/Inputs/functions.h
@@ -1,10 +1,57 @@
 #ifndef TEST_INTEROP_CXX_CXX_IMPL_FUNCTIONS_H
 #define TEST_INTEROP_CXX_CXX_IMPL_FUNCTIONS_H
 
+struct TrivialStruct {
+  int x;
+  int y;
+};
+
+class NonTrivialClass {
+public:
+  NonTrivialClass() {}
+  NonTrivialClass(const NonTrivialClass &other) : value(other.value) {}
+  ~NonTrivialClass() {}
+  int value;
+};
+
+// Simple functions
+
 int foo(int x);
 int bar(int x);
 
 // A C++ function name that is a Swift keyword.
 int defer(int x);
+
+// Primitives
+
+void takesPrimitives(int i, long l, char c, float f, double d, bool b);
+int returnsInt();
+
+// Pointers
+
+void takesPtrToInt(int *p);
+void takesNullablePtrToInt(int *_Nullable p);
+void takesNonnullPtrToInt(int *_Nonnull p);
+
+void takesPtrToVoid(void *p);
+void takesNullablePtrToVoid(void *_Nullable p);
+void takesNonnullPtrToVoid(void *_Nonnull p);
+
+void takesPtrToConstInt(const int *p);
+void takesNullablePtrToConstInt(const int *_Nullable p);
+void takesNonnullPtrToConstInt(const int *_Nonnull p);
+
+void takesFuncPtr(int (*fn)(int));
+void takesNullableFuncPtr(int (*_Nullable fn)(int));
+void takesNonnullFuncPtr(int (*_Nonnull fn)(int));
+
+int *returnsPtrToInt();
+int *_Nullable returnsNullablePtrToInt();
+int *_Nonnull returnsNonnullPtrToInt();
+
+// Trivial struct
+
+void takesTrivialStruct(TrivialStruct s);
+TrivialStruct returnsTrivialStruct();
 
 #endif // !TEST_INTEROP_CXX_CXX_IMPL_FUNCTIONS_H

--- a/test/Interop/Cxx/cxx-impl/matching-typechecker.swift
+++ b/test/Interop/Cxx/cxx-impl/matching-typechecker.swift
@@ -164,25 +164,3 @@ func variadicFunc(_: Int32) -> Int32 {
 func sameArityOverload(_: Int32) -> Int32 {
   return 0
 }
-
-
-// C++ references
-// TODO: The examples below actually do match, but not necessarily with the
-// types we want. They should use unsafe pointers instead.
-
-// expected-error@+2{{global function 'takesConstRef' cannot implement C++ function 'takesConstRef' because reference parameters and return types are not yet supported}}
-@cxx @implementation
-func takesConstRef(_: Int32) -> Int32 {
-  return 0
-}
-
-// expected-error@+2{{global function 'takesMutableRef' cannot implement C++ function 'takesMutableRef' because reference parameters and return types are not yet supported}}
-@cxx @implementation
-func takesMutableRef(_: inout Int32) {
-}
-
-// expected-error@+2{{global function 'returnsMutableRef()' cannot implement C++ function 'returnsMutableRef' because reference parameters and return types are not yet supported}}
-@cxx @implementation
-func returnsMutableRef() -> UnsafeMutablePointer<Int32> {
-  fatalError()
-}

--- a/test/Interop/Cxx/cxx-impl/representability-typechecker.swift
+++ b/test/Interop/Cxx/cxx-impl/representability-typechecker.swift
@@ -1,0 +1,132 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -Xcc -Wno-nullability-completeness \
+// RUN:   -I %S/Inputs
+
+// REQUIRES: swift_feature_CxxImplementation
+
+import Functions
+import Matching
+
+
+// Primitives
+
+@cxx @implementation
+func takesPrimitives(_ i: CInt, _ l: CLong, _ c: CChar, _ f: CFloat, _ d: CDouble, _ b: CBool) {}
+
+@cxx @implementation
+func returnsInt() -> CInt { return 0 }
+
+
+// Pointers
+
+@cxx @implementation
+func takesPtrToInt(_ p: UnsafeMutablePointer<CInt>?) {}
+
+@cxx @implementation
+func takesNullablePtrToInt(_ p: UnsafeMutablePointer<CInt>?) {}
+
+@cxx @implementation
+func takesNonnullPtrToInt(_ p: UnsafeMutablePointer<CInt>) {}
+
+@cxx @implementation
+func takesPtrToVoid(_ p: UnsafeMutableRawPointer?) {}
+
+@cxx @implementation
+func takesNullablePtrToVoid(_ p: UnsafeMutableRawPointer?) {}
+
+@cxx @implementation
+func takesNonnullPtrToVoid(_ p: UnsafeMutableRawPointer) {}
+
+@cxx @implementation
+func takesPtrToConstInt(_ p: UnsafePointer<CInt>?) {}
+
+@cxx @implementation
+func takesNullablePtrToConstInt(_ p: UnsafePointer<CInt>?) {}
+
+@cxx @implementation
+func takesNonnullPtrToConstInt(_ p: UnsafePointer<CInt>) {}
+
+@cxx @implementation
+func takesFuncPtr(_ fn: (@convention(c) (CInt) -> CInt)?) {}
+
+@cxx @implementation
+func takesNullableFuncPtr(_ fn: (@convention(c) (CInt) -> CInt)?) {}
+
+@cxx @implementation
+func takesNonnullFuncPtr(_ fn: @convention(c) (CInt) -> CInt) {}
+
+@cxx @implementation
+func returnsPtrToInt() -> UnsafeMutablePointer<CInt>? { fatalError() }
+
+@cxx @implementation
+func returnsNullablePtrToInt() -> UnsafeMutablePointer<CInt>? { fatalError() }
+
+@cxx @implementation
+func returnsNonnullPtrToInt() -> UnsafeMutablePointer<CInt> { fatalError() }
+
+
+// C++ references
+
+// expected-error@+2{{global function 'takesConstRef' cannot implement C++ function 'takesConstRef' because reference parameters and return types are not yet supported}}
+@cxx @implementation
+func takesConstRef(_ x: Int32) -> Int32 { return x }
+
+// expected-error@+2{{global function cannot be marked '@cxx' because inout parameters cannot be represented in C++}}
+@cxx @implementation
+func takesMutableRef(_ x: inout Int32) {}
+
+// expected-error@+2{{global function 'returnsMutableRef()' cannot implement C++ function 'returnsMutableRef' because reference parameters and return types are not yet supported}}
+@cxx @implementation
+func returnsMutableRef() -> UnsafeMutablePointer<Int32> { fatalError() }
+
+
+// Trivial struct
+
+@cxx @implementation
+func takesTrivialStruct(_ s: TrivialStruct) {}
+
+@cxx @implementation
+func returnsTrivialStruct() -> TrivialStruct { fatalError() }
+
+
+// Non-trivial classes
+
+// expected-error@+3{{global function cannot be marked '@cxx' because the type of the parameter cannot be represented in C++}}
+// expected-note@+2{{non-trivial C++ classes cannot be represented in C++}}
+@cxx @implementation
+func takesNonTrivial(_ obj: NonTrivialClass) {}
+
+// expected-error@+3{{global function cannot be marked '@cxx' because its result type cannot be represented in C++}}
+// expected-note@+2{{non-trivial C++ classes cannot be represented in C++}}
+@cxx @implementation
+func returnsNonTrivial() -> NonTrivialClass { fatalError() }
+
+
+// Swift String
+
+// expected-error@+3{{global function cannot be marked '@cxx' because the type of the parameter cannot be represented in C++}}
+// expected-note@+2{{Swift structs cannot be represented in C++}}
+@cxx @implementation
+func takesSwiftString(_ s: String) {}
+
+// expected-error@+3{{global function cannot be marked '@cxx' because its result type cannot be represented in C++}}
+// expected-note@+2{{Swift structs cannot be represented in C++}}
+@cxx @implementation
+func returnsSwiftString() -> String { return "" }
+
+
+// Swift specials: async, throwing, generic
+
+// expected-error@+1{{@cxx global function cannot be asynchronous}}
+@cxx @implementation
+func asyncFunc() async {}
+
+// expected-error@+1{{raising errors from @cxx functions is not supported}}
+@cxx @implementation
+func throwingFunc() throws {}
+
+// expected-error@+2{{global function cannot be marked '@cxx' because it has generic parameters}}
+@cxx @implementation
+func genericFunc<T>(_ x: T) -> T { return x }

--- a/test/Interop/SwiftToCxx/functions/Inputs/cxx-functions.h
+++ b/test/Interop/SwiftToCxx/functions/Inputs/cxx-functions.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int foo(int x);

--- a/test/Interop/SwiftToCxx/functions/Inputs/module.modulemap
+++ b/test/Interop/SwiftToCxx/functions/Inputs/module.modulemap
@@ -2,3 +2,9 @@ module CPointerTypes {
   header "c-pointer-types.h"
   export *
 }
+
+module CxxFunctions {
+  header "cxx-functions.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/SwiftToCxx/functions/cxx-implementation-func-not-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/functions/cxx-implementation-func-not-in-cxx.swift
@@ -1,0 +1,37 @@
+// Ensure that `@cxx` functions are never emitted into a generated clang
+// header: they implement declarations that already exist in the imported
+// C++ header.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -verify %s \
+// RUN:   -module-name Functions \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -I %S/Inputs \
+// RUN:   -clang-header-expose-decls=all-public \
+// RUN:   -emit-clang-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// The C++ header that declares `foo` and the generated header must be usable
+// together in one translation unit.
+// RUN: echo '#include "cxx-functions.h"' > %t/combined.h
+// RUN: cat %t/functions.h >> %t/combined.h
+// RUN: %check-interop-cxx-header-in-clang(-I %S/Inputs %t/combined.h)
+
+// REQUIRES: swift_feature_CxxImplementation
+
+import CxxFunctions
+
+@cxx @implementation
+public func foo(_ x: Int32) -> Int32 {
+  return x
+}
+
+// CHECK-NOT: foo
+// CHECK-LABEL: namespace Functions SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Functions") {
+// CHECK-NOT: foo
+// CHECK: // Unavailable in C++: Swift global function 'foo(_:)'.
+// CHECK-NOT: foo
+// CHECK: } // namespace Functions
+// CHECK-NOT: foo


### PR DESCRIPTION
Add ForeignLanguage::Cxx and extend the type-check function request to check for C++ representability.

Ensure that a @cxx function is never printed in the generated header. A @cxx function implements a declaration that already exists in the imported C++ header.

rdar://185905761
