### PR TITLE
[DebugInfo] Add subpass support to lost variables stats

### DIFF
--- a/docs/OptimizerCountersAnalysis.md
+++ b/docs/OptimizerCountersAnalysis.md
@@ -129,6 +129,26 @@ not track the number of debug variables: it counts the number of debug variables
 that were present, but aren't anymore. If a variable changes location or scope,
 which is not allowed, it will be counted as lost.
 
+### Subpass level counters
+Passes which transform one instruction or value at a time report each of those
+steps as a subpass, through `SILPassManager::continueWithNextSubpassRun`. The
+`-Xllvm -sil-stats-subpass` command-line option attributes the counters to the
+subpass which produced them, instead of to the whole pass. This makes it
+possible to tell which kind of instruction a monolithic pass such as SILCombine
+loses debug variables on, as it will be included in the pass name (e.g.:
+`SILCombine alloc_stack`).
+
+The option does not enable any counter by itself, it only changes what they are
+attributed to: `-Xllvm -sil-stats-lost-variables` is needed as well, as lost
+debug variables are the only counter attributed to subpasses so far. Passes
+which do not report subpasses are unaffected, and what a pass does outside of
+its subpasses is still attributed to the pass itself.
+
+
+Note that this is more expensive than the pass level counters: the debug
+variables of a function are recomputed after every subpass during which an
+instruction was created or removed.
+
 ## Configuring which counters changes should be recorded
 
 The user has a possibility to configure a number of thresholds, which control
@@ -202,11 +222,18 @@ And for counter stats it looks like this:
    kinds of SIL instructions.
 * `Symbol` is e.g. the name of a function
 * `StageName` is the name of the current optimizer pipeline stage
-* `TransformName` is the name of the current optimizer transformation/pass
+* `TransformName` is the name of the current optimizer transformation/pass. The
+   subpass name is appended, if applicable
 * `Duration` is the duration of the transformation
-* `TransformPassNumber` is the optimizer pass number. It is useful if you 
-   want to reproduce the result later using 
-   `-Xllvm -sil-opt-pass-count -Xllvm TransformPassNumber`
+* `TransformPassNumber` is the optimizer pass number, counted from 0. With
+   `-Xllvm -sil-stats-subpass`, the subpass number is appended to it as
+   `PassNumber.SubpassNumber`. It is useful if you want to reproduce the result
+   later using `-Xllvm -sil-opt-pass-count=N`, keeping in mind that this
+   option takes the number of passes and subpasses to run: use
+   `TransformPassNumber + 1` to run up to and including the pass which produced
+   the counter, and `TransformPassNumber` to stop right before it. The same
+   applies to the subpass number, so a counter recorded at `4390.7` is
+   reproduced with `-Xllvm -sil-opt-pass-count -Xllvm 4391.8`
 
 ## Extract Lost Variables per Pass
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -1147,6 +1147,12 @@ public:
     return !scheduledForDeletion.empty();
   }
 
+  /// The number of instructions which are removed from their basic blocks, but
+  /// not deleted for real yet. See scheduledForDeletion for details.
+  size_t getNumInstructionsScheduledForDeletion() const {
+    return scheduledForDeletion.size();
+  }
+
   /// Looks up the llvm intrinsic ID and type for the builtin function.
   ///
   /// \returns Returns llvm::Intrinsic::not_intrinsic if the function is not an

--- a/include/swift/SILOptimizer/Utils/OptimizerStatsUtils.h
+++ b/include/swift/SILOptimizer/Utils/OptimizerStatsUtils.h
@@ -13,7 +13,10 @@
 #ifndef SWIFT_OPTIMIZER_STATS_UTILS_H
 #define SWIFT_OPTIMIZER_STATS_UTILS_H
 
+#include "swift/Basic/LLVM.h"
+
 namespace swift {
+class SILFunction;
 class SILModule;
 class SILTransform;
 class SILPassManager;
@@ -35,6 +38,21 @@ void updateSILModuleStatsBeforeTransform(SILModule &M, SILTransform *Transform,
 void updateSILModuleStatsAfterTransform(SILModule &M, SILTransform *Transform,
                                         SILPassManager &PM, int PassNumber,
                                         int Duration);
+
+/// Updates SILModule stats before executing a new subpass of \p Transform.
+/// Only called when -sil-stats-subpass is enabled.
+///
+/// \param F the function the subpass is running on
+/// \param Label identifies the subpass within the transform, typically the
+///              name of the instruction being transformed
+/// \param Transform the SIL transformation the subpass belongs to
+/// \param PM the PassManager being used
+/// \param PassNumber the pass number of the transformation
+/// \param SubpassNumber the number of subpasses the transform already ran
+void updateSILModuleStatsBeforeSubpass(SILFunction *F, StringRef Label,
+                                       SILTransform *Transform,
+                                       SILPassManager &PM, int PassNumber,
+                                       unsigned SubpassNumber);
 
 } // end namespace swift
 

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -236,6 +236,12 @@ static llvm::cl::opt<bool> SILPrintEverySubpass(
     llvm::cl::desc("Print the function before every subpass run of passes that "
                    "have multiple subpasses"));
 
+/// Attribute SILModuleStats to the subpass which produced them, instead of
+/// the pass. Passes which do not use subpasses are unaffected.
+static llvm::cl::opt<bool> SILStatsSubpass(
+    "sil-stats-subpass", llvm::cl::init(false),
+    llvm::cl::desc("Attribute stats to subpasses of the passes producing them"));
+
 static llvm::cl::opt<std::string> SILViewDom(
     "sil-view-dom", llvm::cl::init(""),
     llvm::cl::desc("View the dominator tree of a function at a given pass "
@@ -517,6 +523,33 @@ bool SILPassManager::continueTransforming() {
   return NumPassesRun < maxNumPassesToRun;
 }
 
+/// The name of the kind of value or instruction a subpass is transforming, used
+/// to identify the subpass in the optimizer statistics.
+static StringRef
+getTransformeeName(std::optional<SILPassManager::Transformee> transformee) {
+  if (!transformee)
+    return "<none>";
+  SILValue value = dyn_cast<SILValue>(*transformee);
+  if (!value)
+    return getSILInstructionName(
+        cast<SILInstruction *>(*transformee)->getKind());
+  if (SILInstruction *inst = value->getDefiningInstruction())
+    return getSILInstructionName(inst->getKind());
+  // The value is not defined by an instruction: name its kind instead.
+  switch (value->getKind()) {
+  case ValueKind::SILFunctionArgument:
+    return "function_argument";
+  case ValueKind::SILPhiArgument:
+    return "phi_argument";
+  case ValueKind::SILUndef:
+    return "undef";
+  case ValueKind::PlaceholderValue:
+    return "placeholder";
+  default:
+    return "<value>";
+  }
+}
+
 bool SILPassManager::continueWithNextSubpassRun(
     std::optional<Transformee> origTransformee, SILFunction *function,
     SILTransform *trans) {
@@ -532,6 +565,12 @@ bool SILPassManager::continueWithNextSubpassRun(
   }
 
   unsigned subPass = numSubpassesRun++;
+
+  if (SILStatsSubpass) {
+    StringRef subpassLabel = getTransformeeName(forTransformee);
+    updateSILModuleStatsBeforeSubpass(function, subpassLabel, trans, *this,
+                                      NumPassesRun, subPass);
+  }
 
   if (SILPrintEverySubpass && isFunctionSelectedForPrinting(function) &&
       doPrintBefore(trans, function)) {

--- a/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
@@ -62,6 +62,8 @@
 ///       Symbol is e.g. the name of a function.
 ///       StageName and TransformName are the names of the current optimizer
 ///       pipeline stage and current transform.
+///       TransformPassNumber is the number of the pass run, followed by the
+///       number of the subpass when the counter is attributed to one.
 ///       Duration is the duration of the transformation.
 //===----------------------------------------------------------------------===//
 
@@ -458,6 +460,11 @@ class TransformationContext {
   int Duration;
   /// The pass number in the optimizer pipeline.
   int PassNumber;
+  /// The subpass of the transformation the statistics are attributed to, or
+  /// nothing if they are attributed to the transformation itself.
+  StringRef SubpassLabel;
+  /// The number of subpasses the transformation ran before that subpass.
+  unsigned SubpassNumber = 0;
 
 public:
   TransformationContext(SILModule &M, SILPassManager &PM,
@@ -475,6 +482,23 @@ public:
 
   StringRef getTransformId() const {
     return Transform->getID();
+  }
+
+  /// Attributes the statistics reported with this context to the subpass
+  /// identified by \p Label and \p Number.
+  void setSubpass(StringRef Label, unsigned Number) {
+    SubpassLabel = Label;
+    SubpassNumber = Number;
+  }
+
+  /// Printed right after the name of the transformation, so that a subpass has
+  /// its own statistics.
+  StringRef getSubpassLabel() const {
+    return SubpassLabel;
+  }
+
+  unsigned getSubpassNumber() const {
+    return SubpassNumber;
   }
 
   StringRef getStageName() const {
@@ -514,12 +538,47 @@ public:
   }
 };
 
+/// A counter which increases every time an instruction is created or removed
+/// from its basic block, anywhere in \p M.
+///
+/// This is used for subpasses, when deleted instructions haven't been flushed
+/// yet, so instructions scheduled for deletion are counted too.
+size_t getInstructionChangeCount(SILModule &M) {
+  return (size_t)SILInstruction::getNumCreatedInstructions() +
+         (size_t)SILInstruction::getNumDeletedInstructions() +
+         M.getNumInstructionsScheduledForDeletion();
+}
+
 /// A helper class to represent the module stats as an analysis,
 /// so that it is preserved across multiple passes.
 class OptimizerStatsAnalysis : public SILAnalysis {
   SILModule &M;
   /// The actual cache holding all the statistics.
   std::unique_ptr<AccumulatedOptimizerStats> Cache;
+
+  /// The subpass which is currently running, if any. The debug variables which
+  /// disappear while it runs are attributed to it instead of to its whole pass.
+  struct {
+    /// The function the running subpass is transforming, or null if no subpass
+    /// is running.
+    SILFunction *F = nullptr;
+    /// Identifies the running subpass within its transformation. It is printed
+    /// as a suffix of the transformation name, and has a space prefixed.
+    std::string Label;
+    /// The number of subpasses the transformation ran before this one.
+    unsigned Number = 0;
+    /// The instruction change count (from `getInstructionChangeCount`), for
+    /// the last time the FunctionStats for `F` were changed.
+    size_t ChangeCount = 0;
+  } CurrentSubpass;
+
+  /// Reports the debug variables which disappeared from \p F since its debug
+  /// variables were last refreshed, attributing them to the running subpass.
+  ///
+  /// Debug variables are the only counter tracked per subpass: the other ones
+  /// are aggregated in the module stats, which are only consistent at the
+  /// boundaries of a pass run.
+  void reportSubpassStats(SILFunction *F, TransformationContext &Ctx);
 
   /// Sets of functions changed, deleted or added since the last
   /// computation of statistics. These sets are used to avoid complete
@@ -585,6 +644,17 @@ public:
     return Cache->getModuleStat();
   }
 
+  /// Ends the running subpass, if any, and starts a new one, which transforms
+  /// \p F and is identified by \p Label and \p SubpassNumber.
+  void startSubpass(SILFunction *F, StringRef Label, unsigned SubpassNumber,
+                    TransformationContext &Ctx);
+
+  /// Ends the running subpass, if any.
+  ///
+  /// Must be called before the end of a pass run: afterwards the function the
+  /// subpass was running on may be deleted.
+  void endSubpass(TransformationContext &Ctx);
+
   /// Update module stats after running the Transform.
   void updateModuleStats(TransformationContext &Ctx);
 };
@@ -634,6 +704,13 @@ llvm::raw_ostream &stats_os() {
   return *stats_output_stream.get();
 }
 
+/// Prints the pass number with the subpass number, if applicable.
+void printPassNumber(TransformationContext &Ctx) {
+  stats_os() << Ctx.getPassNumber();
+  if (!Ctx.getSubpassLabel().empty())
+    stats_os() << "." << Ctx.getSubpassNumber();
+}
+
 /// A helper function to dump the counter value.
 void printCounterValue(StringRef Kind, StringRef CounterName, int CounterValue,
                        StringRef Symbol, TransformationContext &Ctx) {
@@ -647,9 +724,10 @@ void printCounterValue(StringRef Kind, StringRef CounterName, int CounterValue,
   stats_os() << ", ";
 
   stats_os() << Ctx.getTransformId();
+  stats_os() << Ctx.getSubpassLabel();
   stats_os() << ", ";
 
-  stats_os() << Ctx.getPassNumber();
+  printPassNumber(Ctx);
   stats_os() << ", ";
 
   stats_os() << CounterValue;
@@ -676,9 +754,10 @@ void printCounterChange(StringRef Kind, StringRef CounterName, double Delta,
   stats_os() << ", ";
 
   stats_os() << Ctx.getTransformId();
+  stats_os() << Ctx.getSubpassLabel();
   stats_os() << ", ";
 
-  stats_os() << Ctx.getPassNumber();
+  printPassNumber(Ctx);
   stats_os() << ", ";
 
   llvm::format_provider<double>::format(Delta, stats_os(), "f8");
@@ -797,6 +876,7 @@ int computeLostVariables(SILFunction *F, FunctionStat &Old, FunctionStat &New,
                 F->getASTContext().SourceMgr.getPresumedLineAndColumnForLoc(
                     std::get<2>(Var), 0);
           llvm::dbgs() << Ctx.getStageName() << ": " << Ctx.getTransformId()
+                       << Ctx.getSubpassLabel()
                        << ": Lost Variable: " << std::get<1>(Var) << " line "
                        << line << " col " << col << " in function "
                        << F->getName() << " in scope ";
@@ -1096,6 +1176,56 @@ FunctionStat::FunctionStat(SILFunction *F) {
   InstCount = V.getInstCount();
 }
 
+void OptimizerStatsAnalysis::reportSubpassStats(SILFunction *F,
+                                                TransformationContext &Ctx) {
+  FunctionStat &Stat = getFunctionStat(F);
+  // Transparent functions cannot be debugged, so dropping their variables is
+  // acceptable.
+  if (F->isTransparent())
+    return;
+  // Skip all computations if nothing changed during the subpass. Analyses are
+  // only invalidated once a pass ends, so invalidation cannot be used to
+  // detect this.
+  size_t ChangeCount = getInstructionChangeCount(F->getModule());
+  if (CurrentSubpass.ChangeCount == ChangeCount)
+    return;
+
+  FunctionStat NewStat(F);
+  // Report the statistics against the current subpass, not the new one.
+  TransformationContext SubpassCtx = Ctx;
+  SubpassCtx.setSubpass(CurrentSubpass.Label, CurrentSubpass.Number);
+  if (int LostVariables = computeLostVariables(F, Stat, NewStat, SubpassCtx))
+    printCounterValue("function", "lostvars", LostVariables, F->getName(),
+                      SubpassCtx);
+
+  // Only update lost variables statistics.
+  Stat.VarNames = std::move(NewStat.VarNames);
+  Stat.DebugVariables = std::move(NewStat.DebugVariables);
+  CurrentSubpass.ChangeCount = ChangeCount;
+}
+
+void OptimizerStatsAnalysis::startSubpass(SILFunction *F, StringRef Label,
+                                          unsigned SubpassNumber,
+                                          TransformationContext &Ctx) {
+  // If the new subpass is on a different function, end the old subpass.
+  if (CurrentSubpass.F != F)
+    endSubpass(Ctx);
+  // Then, report on the new function, attributing any change to the previous
+  // subpass, or to the pass itself when there was none or if it was ended.
+  reportSubpassStats(F, Ctx);
+  // Keeping the change count allows us to not recompute statistics if nothing
+  // changes between subpasses.
+  CurrentSubpass = {F, " " + Label.str(), SubpassNumber,
+                    CurrentSubpass.ChangeCount};
+}
+
+void OptimizerStatsAnalysis::endSubpass(TransformationContext &Ctx) {
+  if (!CurrentSubpass.F)
+    return;
+  reportSubpassStats(CurrentSubpass.F, Ctx);
+  CurrentSubpass = {};
+}
+
 } // end anonymous namespace
 
 /// Updates SILModule stats after finishing executing the
@@ -1113,7 +1243,22 @@ void swift::updateSILModuleStatsAfterTransform(SILModule &M,
     return;
   TransformationContext Ctx(M, PM, Transform, PassNumber, Duration);
   OptimizerStatsAnalysis *Stats = PM.getAnalysis<OptimizerStatsAnalysis>();
+  Stats->endSubpass(Ctx);
   Stats->updateModuleStats(Ctx);
+}
+
+void swift::updateSILModuleStatsBeforeSubpass(SILFunction *F, StringRef Label,
+                                              SILTransform *Transform,
+                                              SILPassManager &PM,
+                                              int PassNumber,
+                                              unsigned SubpassNumber) {
+  // Lost variables are the only statistics supported for subpasses.
+  if (!SILStatsLostVariables || !F || Label.empty())
+    return;
+  TransformationContext Ctx(F->getModule(), PM, Transform, PassNumber,
+                            /*Duration=*/0);
+  OptimizerStatsAnalysis *Stats = PM.getAnalysis<OptimizerStatsAnalysis>();
+  Stats->startSubpass(F, Label, SubpassNumber, Ctx);
 }
 
 // This is just a hook for possible extensions in the future.

--- a/test/DebugInfo/dropped-var-subpass.sil
+++ b/test/DebugInfo/dropped-var-subpass.sil
@@ -1,0 +1,41 @@
+// RUN: %target-sil-opt --dce --sil-combine -o /dev/null %s -sil-stats-lost-variables 2>&1 | %FileCheck %s --check-prefixes=PASS,CHECK
+// RUN: %target-sil-opt --dce --sil-combine -o /dev/null %s -sil-stats-lost-variables -sil-stats-subpass 2>&1 | %FileCheck %s --check-prefixes=FIRST,SECOND,CHECK
+// RUN: %target-sil-opt --dce --sil-combine -o /dev/null %s -sil-stats-lost-variables -sil-stats-subpass -sil-opt-pass-count 2.1 2>&1 | %FileCheck %s --check-prefixes=FIRST,CHECK
+// RUN: %target-sil-opt --dce --sil-combine -o /dev/null %s -sil-stats-subpass 2>&1 | %FileCheck %s --allow-empty
+// RUN: %target-sil-opt --dce --sil-combine -o /dev/null %s -sil-stats-lost-variables -sil-stats-subpass -sil-opt-pass-count 2.0 2>&1 | %FileCheck %s --allow-empty
+// RUN: %target-sil-opt --dce --sil-deadfuncelim --sil-combine -o /dev/null %s -sil-stats-lost-variables -sil-stats-subpass 2>&1 | %FileCheck %s --allow-empty
+
+// SILCombine removes the dead alloc_stacks, dropping the variables "x" and "y"
+// with them. Each variable is reported against the subpass which dropped it.
+
+// Note that this loss is expected. Stores to the alloc_stack should be salvaged.
+// An alloc_stack with debug info but no stores shouldn't exist.
+
+// DCE runs first, as OptimizerStats only run after a pass, so there is no
+// baseline for the first pass.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil_scope 1 { loc "file.swift":1:6 parent @foo : $@convention(thin) (Int) -> Int }
+
+// Both variables are attributed to the whole pass.
+// PASS: function, lostvars, {{.*}}, SILCombine, 1, 2, {{[0-9]+}}, foo
+
+// One row per subpass instead, numbered <pass number>.<subpass number>.
+// FIRST: function, lostvars, {{.*}}, SILCombine alloc_stack, 1.0, 1, {{[0-9]+}}, foo
+// SECOND: function, lostvars, {{.*}}, SILCombine alloc_stack, 1.1, 1, {{[0-9]+}}, foo
+
+// No further lostvars reported.
+// CHECK-NOT: lostvars
+
+sil private [ossa] @foo : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Int, var, name "x", loc "file.swift":2:5, scope 1
+  dealloc_stack %1 : $*Int, loc "file.swift":2:5, scope 1
+  %2 = alloc_stack $Int, var, name "y", loc "file.swift":3:5, scope 1
+  dealloc_stack %2 : $*Int, loc "file.swift":3:5, scope 1
+  return %0 : $Int, loc "file.swift":4:5, scope 1
+} // end sil function 'foo'


### PR DESCRIPTION
Add a `-Xllvm -sil-stats-subpass` flag to run the OptimizerStats between each subpasses. The only statistic updated is the lost variables statistics, which will allow us to pinpoint which SILCombine subpass has the most impact on debug info.

For compiling `Swift.o`, this slows down the run from ~2min (with pass-level lost variables statistics) to ~7min (with subpass granularity)

Issue: false positives for SimplifyCFG increase considerably, as the snapshot is taken before the rest of the scope gets eliminated.