### PR TITLE
[cxx-interop] Modularize more `__msvc_*` headers on Windows

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -634,11 +634,30 @@ void GetWindowsFileMappings(
     // with empty files to allow a single module definition to work across
     // different MSVC STL releases.
     //
-    // __msvc_bit_utils.hpp was introduced in VS 2022 STL release 17.8.
-    // __msvc_string_view.hpp was introduced in VS 2022 STL release 17.11.
+    // Each entry is annotated with the STL release that introduced the header.
+    // Once we no longer support Visual Studio releases older than a given
+    // release, the corresponding entries can be removed from this list.
     static const char * const kInjectedHeaders[] = {
-      "__msvc_bit_utils.hpp",
-      "__msvc_string_view.hpp",
+      "__msvc_bit_utils.hpp",                    // VS 2022 17.8
+      "__msvc_chrono.hpp",                       // VS 2022 17.3
+      "__msvc_cxx_stdatomic.hpp",                // VS 2022 17.5
+      "__msvc_filebuf.hpp",                      // VS 2022 17.7
+      "__msvc_format_ucd_tables.hpp",            // VS 2022 17.3
+      "__msvc_formatter.hpp",                    // VS 2022 17.10
+      "__msvc_heap_algorithms.hpp",              // VS 2022 17.12
+      "__msvc_int128.hpp",                       // VS 2022 17.2
+      "__msvc_iter_core.hpp",                    // VS 2022 17.4
+      "__msvc_minmax.hpp",                       // VS 2022 17.10
+      "__msvc_ostream.hpp",                      // VS 2022 17.13
+      "__msvc_print.hpp",                        // VS 2022 17.7
+      "__msvc_ranges_to.hpp",                    // VS 2022 17.12
+      "__msvc_ranges_tuple_formatter.hpp",       // VS 2022 17.13
+      "__msvc_sanitizer_annotate_container.hpp", // VS 2022 17.6
+      "__msvc_string_view.hpp",                  // VS 2022 17.11
+      "__msvc_system_error_abi.hpp",             // VS 2019 16.6
+      "__msvc_threads_core.hpp",                 // VS 2022 17.11
+      "__msvc_tzdb.hpp",                         // VS 2019 16.10
+      "__msvc_xlocinfo_types.hpp",               // VS 2022 17.0
     };
 
     for (const char * const header : kInjectedHeaders) {

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -737,8 +737,102 @@ module std [system] {
       export *
     }
 
+    explicit module __msvc_chrono {
+      header "__msvc_chrono.hpp"
+      export *
+    }
+
+    explicit module __msvc_cxx_stdatomic {
+      header "__msvc_cxx_stdatomic.hpp"
+      export *
+    }
+
+    explicit module __msvc_filebuf {
+      header "__msvc_filebuf.hpp"
+      export *
+    }
+
+    explicit module __msvc_format_ucd_tables {
+      header "__msvc_format_ucd_tables.hpp"
+      export *
+    }
+
+    explicit module __msvc_formatter {
+      header "__msvc_formatter.hpp"
+      requires cplusplus20
+      export *
+    }
+
+    explicit module __msvc_heap_algorithms {
+      header "__msvc_heap_algorithms.hpp"
+      export *
+    }
+
+    explicit module __msvc_int128 {
+      header "__msvc_int128.hpp"
+      export *
+    }
+
+    explicit module __msvc_iter_core {
+      header "__msvc_iter_core.hpp"
+      export *
+    }
+
+    explicit module __msvc_minmax {
+      header "__msvc_minmax.hpp"
+      export *
+    }
+
+    explicit module __msvc_ostream {
+      header "__msvc_ostream.hpp"
+      export *
+    }
+
+    explicit module __msvc_print {
+      header "__msvc_print.hpp"
+      requires cplusplus20
+      export *
+    }
+
+    explicit module __msvc_ranges_to {
+      header "__msvc_ranges_to.hpp"
+      requires cplusplus20
+      export *
+    }
+
+    explicit module __msvc_ranges_tuple_formatter {
+      header "__msvc_ranges_tuple_formatter.hpp"
+      requires cplusplus20
+      export *
+    }
+
+    explicit module __msvc_sanitizer_annotate_container {
+      header "__msvc_sanitizer_annotate_container.hpp"
+      export *
+    }
+
     explicit module __msvc_string_view {
       header "__msvc_string_view.hpp"
+      export *
+    }
+
+    explicit module __msvc_system_error_abi {
+      header "__msvc_system_error_abi.hpp"
+      export *
+    }
+
+    explicit module __msvc_threads_core {
+      header "__msvc_threads_core.hpp"
+      export *
+    }
+
+    explicit module __msvc_tzdb {
+      header "__msvc_tzdb.hpp"
+      export *
+    }
+
+    explicit module __msvc_xlocinfo_types {
+      header "__msvc_xlocinfo_types.hpp"
       export *
     }
 

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -70,6 +70,12 @@ module StdPair {
   export *
 }
 
+module StdRanges {
+  header "std-ranges.h"
+  requires cplusplus
+  export *
+}
+
 module MsvcUseVecIt {
   header "msvc-std-vector-it.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-ranges.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-ranges.h
@@ -1,0 +1,4 @@
+#include <ranges>
+
+static auto dereferenceV = std::views::transform(
+        [](auto &&x) -> decltype(auto) { return *x; });

--- a/test/Interop/Cxx/stdlib/use-std-ranges-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-ranges-typechecker.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20
+
+import StdRanges
+
+let x = dereferenceV


### PR DESCRIPTION
This extends the VCRuntime modulemap to cover more STL headers. Fixes errors such as:
```
error: missing '#include <__msvc_ranges_to.hpp>'; 'transform' must be declared before it is used
```

rdar://185507163

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
