### PR TITLE
[any ~Copyable] Fix borrowing type(of:)

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4132,6 +4132,16 @@ public:
             "value_metatype instruction must have a metatype representation");
     require(MI->getOperand()->getType().isAnyExistentialType(),
             "existential_metatype operand must be of protocol type");
+    // Only an opaque existential container can be inspected in place. A class,
+    // boxed, or metatype container is read as a value, and IRGen has no way to
+    // interpret an address as one of those.
+    require(!MI->getOperand()->getType().isAddress() ||
+                MI->getOperand()
+                        ->getType()
+                        .getPreferredExistentialRepresentation() ==
+                    ExistentialRepresentation::Opaque,
+            "existential_metatype operand may only be an address when the "
+            "existential uses opaque representation");
 
     // The result of an existential_metatype instruction is an existential
     // metatype with the same constraint type as its existential operand.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3145,6 +3145,12 @@ static SILValue emitMetatypeOfDelegatingInitExclusivelyBorrowedSelf(
 /// retain/release, and it's what lets `type(of:)` apply to a noncopyable value,
 /// where the copy would otherwise be diagnosed as a consume.
 ///
+/// Only an address-only operand may be left in memory. `existential_metatype`
+/// accepts an address only for an address-only (opaque) existential; for a
+/// class, boxed, or metatype existential it reads the container as a value, and
+/// IRGen has no way to interpret an address there. So a loadable operand is
+/// loaded -- with `load_borrow`, which still doesn't consume it.
+///
 /// The caller must have established a `FormalEvaluationScope` covering the use
 /// of the returned value.
 static ManagedValue emitMetatypeOperand(SILGenFunction &SGF, Expr *baseExpr) {
@@ -3153,7 +3159,13 @@ static ManagedValue emitMetatypeOperand(SILGenFunction &SGF, Expr *baseExpr) {
                           ? SGFAccessKind::BorrowedAddressRead
                           : SGFAccessKind::BorrowedObjectRead;
     LValue lv = SGF.emitLValue(load->getSubExpr(), accessKind);
-    return SGF.emitBorrowedLValue(load, std::move(lv));
+    auto base = SGF.emitBorrowedLValue(load, std::move(lv));
+
+    // A borrowed read of physical storage comes back as the address of that
+    // storage, whether or not the type is loadable, so the load happens here.
+    if (base.getType().isAddress() && base.getType().isLoadable(SGF.F))
+      base = SGF.B.createFormalAccessLoadBorrow(load, base);
+    return base;
   }
 
   // Otherwise the operand produces a temporary of its own, which we can just

--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -245,6 +245,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(UncheckedTakeEnumDataAddr)
   NO_UPDATE_NEEDED(UncheckedBorrowEnumDataAddr)
   NO_UPDATE_NEEDED(UncheckedInPlaceEnumDataAddr)
+  NO_UPDATE_NEEDED(ValueMetatype)
   NO_UPDATE_NEEDED(MakeBorrow)
   NO_UPDATE_NEEDED(MakeAddrBorrow)
   NO_UPDATE_NEEDED(InitBorrowAddr)

--- a/test/Concurrency/Inputs/TypeOfActionBase/TypeOfActionBase.h
+++ b/test/Concurrency/Inputs/TypeOfActionBase/TypeOfActionBase.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BaseAction : NSObject
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/Concurrency/Inputs/TypeOfActionBase/module.modulemap
+++ b/test/Concurrency/Inputs/TypeOfActionBase/module.modulemap
@@ -1,0 +1,4 @@
+module TypeOfActionBase {
+    header "TypeOfActionBase.h"
+    export *
+}

--- a/test/Concurrency/Inputs/TypeOfActionDerived/TypeOfActionDerived.h
+++ b/test/Concurrency/Inputs/TypeOfActionDerived/TypeOfActionDerived.h
@@ -1,0 +1,8 @@
+@import TypeOfActionBase;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DerivedAction : BaseAction
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/Concurrency/Inputs/TypeOfActionDerived/module.modulemap
+++ b/test/Concurrency/Inputs/TypeOfActionDerived/module.modulemap
@@ -1,0 +1,4 @@
+module TypeOfActionDerived {
+    header "TypeOfActionDerived.h"
+    export *
+}

--- a/test/Concurrency/transfernonsendable_type_of.swift
+++ b/test/Concurrency/transfernonsendable_type_of.swift
@@ -1,0 +1,56 @@
+// RUN: %target-swift-frontend -I %S/Inputs/TypeOfActionBase -I %S/Inputs/TypeOfActionDerived %s -emit-sil -o /dev/null -verify -swift-version 6
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// `type(of:)` borrows its operand instead of copying it. When the operand is a
+// loadable value held in storage, that borrow has to be loaded before it is
+// handed to `value_metatype`; passing the address of the storage instead used to
+// trip "Can only accept non-Sendable values" in RegionAnalysis, which classifies
+// the address of a capture box differently than the value inside it.
+//
+// Reproducing that takes several things at once: the operand has to be read out
+// of a capture box (so an escaping closure -- here an escaping autoclosure), it
+// has to be a `sending` parameter whose region is then sent onward, and the base
+// class has to come from a `@preconcurrency` import while the class it is cast
+// to comes from an ordinary one. That split is what makes the two Sendable
+// classifications disagree.
+
+@preconcurrency import TypeOfActionBase
+import TypeOfActionDerived
+
+enum ActionError: Error { case unsupported }
+
+func log(_ message: @autoclosure @escaping () -> Any.Type) {}
+
+struct Handler {
+  func handle(from action: sending BaseAction) throws {
+    log(type(of: action))
+    switch action {
+    case let action as DerivedAction:
+      return try handleDerived(action)
+    default:
+      throw ActionError.unsupported
+    }
+  }
+
+  func handleDerived(_ action: DerivedAction) throws { fatalError() }
+}
+
+// An address-only operand is legitimately read in place, so it has to keep
+// working through the same path.
+protocol ActionProtocol {}
+struct OpaqueAction: ActionProtocol { var action = BaseAction() }
+
+func addressOnlyOperand(from action: sending any ActionProtocol) {
+  log(type(of: action))
+}
+
+func genericOperand<T>(from action: sending T) {
+  log(type(of: action))
+}
+
+// The same shape in an async context, where region analysis tracks more.
+func asyncOperand(from action: sending BaseAction) async {
+  log(type(of: action))
+}

--- a/test/Interpreter/typeof.swift
+++ b/test/Interpreter/typeof.swift
@@ -87,3 +87,28 @@ print(boxedExistentialMetatype(GrilledCheese()))
 print(boxedExistentialMetatype(GrilledCheese() as Meltdown))
 // CHECK: (x: Int, y: Int, Double)
 print(type(of: labeledTuple()))
+
+// Reading the operand out of storage goes through a different SILGen path than
+// reading a parameter or a temporary: the storage is borrowed in place. Cover
+// each existential representation there, since only an opaque existential may
+// be left in memory -- the rest have to be loaded.
+
+protocol ClassBound : AnyObject {}
+class ClassBoundImpl : ClassBound {}
+
+var opaqueExistential: Fooable = S()
+var classExistential: ClassBound = ClassBoundImpl()
+var boxedExistentialVar: Error = Hangry.Hungry
+var existentialMetatype: Fooable.Type = S.self
+var classInstance: B = D()
+
+// CHECK: S
+print(type(of: opaqueExistential))
+// CHECK: ClassBoundImpl
+print(type(of: classExistential))
+// CHECK: Hangry
+print(type(of: boxedExistentialVar))
+// CHECK: S.Type
+print(type(of: existentialMetatype))
+// CHECK: D
+print(type(of: classInstance))

--- a/test/SIL/OwnershipVerifier/use_verifier.sil
+++ b/test/SIL/OwnershipVerifier/use_verifier.sil
@@ -63,6 +63,12 @@ protocol SwiftKlassP : AnyObject {
   func foo()
 }
 
+// Not class-constrained, so an existential of this type is address-only and
+// `existential_metatype` can read it in place.
+protocol SwiftOpaqueP {
+  func foo()
+}
+
 struct Val {
 }
 class Ref {
@@ -295,12 +301,12 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
-sil [ossa] @existential_metatype_test : $@convention(thin) (@owned SwiftKlassP, @in SwiftKlassP) -> () {
-bb0(%0 : @owned $SwiftKlassP, %1 : $*SwiftKlassP):
+sil [ossa] @existential_metatype_test : $@convention(thin) (@owned SwiftKlassP, @in SwiftOpaqueP) -> () {
+bb0(%0 : @owned $SwiftKlassP, %1 : $*SwiftOpaqueP):
   %2 = existential_metatype $@thick SwiftKlassP.Type, %0 : $SwiftKlassP
-  %3 = existential_metatype $@thick SwiftKlassP.Type, %1 : $*SwiftKlassP
+  %3 = existential_metatype $@thick SwiftOpaqueP.Type, %1 : $*SwiftOpaqueP
   destroy_value %0 : $SwiftKlassP
-  destroy_addr %1 : $*SwiftKlassP
+  destroy_addr %1 : $*SwiftOpaqueP
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -60,8 +60,10 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
-  // -- 'type(of:)' only reads its operand, so it borrows the storage in place.
-  // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[READ]] : $*AnyObject
+  // -- 'type(of:)' only reads its operand, so it borrows rather than copies.
+  // CHECK-NEXT: [[OBJ:%[0-9]+]] = load_borrow [[READ]] : $*AnyObject
+  // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[OBJ]] : $AnyObject
+  // CHECK-NEXT: end_borrow [[OBJ]]
   // CHECK-NEXT: end_access [[READ]]
   // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick any AnyObject.Type to $@thick (@opened([[UUID:.*]], AnyObject) Self).Type
   // CHECK-NEXT: [[METHOD:%[0-9]+]] = objc_method [[OPENMETA]] : $@thick (@opened([[UUID]], AnyObject) Self).Type, #X.staticF!foreign : (X.Type) -> () -> (), $@convention(objc_method) (@thick (@opened([[UUID]], AnyObject) Self).Type) -> ()
@@ -157,8 +159,10 @@ func opt_to_static_method(_ obj: AnyObject) {
   // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [var_decl] [[OPTBOX]]
   // CHECK:   [[PBO:%.*]] = project_box [[OPTLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
-  // -- 'type(of:)' only reads its operand, so it borrows the storage in place.
-  // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[READ]] : $*AnyObject
+  // -- 'type(of:)' only reads its operand, so it borrows rather than copies.
+  // CHECK:   [[OBJVAL:%[0-9]+]] = load_borrow [[READ]] : $*AnyObject
+  // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick any AnyObject.Type, [[OBJVAL]] : $AnyObject
+  // CHECK:   end_borrow [[OBJVAL]]
   // CHECK:   end_access [[READ]]
   // CHECK:   [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick any AnyObject.Type to $@thick (@opened
   // CHECK:   [[OBJCMETA:%[0-9]+]] = thick_to_objc_metatype [[OPENMETA]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -174,9 +174,11 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // -- Curry the Type onto static method argument lists.
 
-  // -- 'type(of:)' only reads its operand, so it borrows the storage in place.
+  // -- 'type(of:)' only reads its operand, so it borrows rather than copies.
   // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
-  // CHECK: [[META:%.*]] = value_metatype $@thick SomeClass.Type, [[READC]]
+  // CHECK: [[C:%[0-9]+]] = load_borrow [[READC]]
+  // CHECK: [[META:%.*]] = value_metatype $@thick SomeClass.Type, [[C]]
+  // CHECK: end_borrow [[C]]
   // CHECK: end_access [[READC]]
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -292,6 +292,12 @@ public protocol P : AnyObject {
   func boo() -> Int32
 }
 
+// Not class-constrained, so an existential of this type is address-only and
+// `existential_metatype` can read it in place.
+public protocol OpaqueP {
+  func foo() -> Int32
+}
+
 // Check that LICM does not hoist a metatype instruction before
 // the open_existential instruction which creates the archetype,
 // because this would break the dominance relation between them.
@@ -337,22 +343,22 @@ bb4:
 // CHECK: existential_metatype
 // CHECK: cond_br
 // CHECK: bb2:
-sil @dont_hoist_existential_meta_type : $@convention(thin) (@in P) -> () {
-bb0(%0 : $*P):
-  %1 = alloc_stack $P
+sil @dont_hoist_existential_meta_type : $@convention(thin) (@in OpaqueP) -> () {
+bb0(%0 : $*OpaqueP):
+  %1 = alloc_stack $OpaqueP
   br bb1
 
 bb1:
-  copy_addr %0 to [init] %1 : $*P
-  %2 = existential_metatype $@thick P.Type, %1 : $*P
+  copy_addr %0 to [init] %1 : $*OpaqueP
+  %2 = existential_metatype $@thick OpaqueP.Type, %1 : $*OpaqueP
   cond_br undef, bb3, bb2
 
 bb3:
   br bb1
 
 bb2:
-  dealloc_stack %1 : $*P
-  destroy_addr %0 : $*P
+  dealloc_stack %1 : $*OpaqueP
+  destroy_addr %0 : $*OpaqueP
   %52 = tuple ()
   return %52 : $()
 }

--- a/test/SILOptimizer/moveonly_type_of.swift
+++ b/test/SILOptimizer/moveonly_type_of.swift
@@ -172,3 +172,25 @@ func stillDiagnosed<T: ~Copyable>(_ v: consuming T) { // expected-error {{'v' us
   consume(v) // expected-note {{consumed here}}
   _ = type(of: v) // expected-note {{used here}}
 }
+
+// MARK: copyable operands held in a move-only wrapped box
+
+// A `consuming` parameter of a *copyable* type is stored in a box whose type is
+// move-only wrapped, to enforce the consuming semantics. Because `type(of:)`
+// borrows that storage directly instead of copying out of it, `value_metatype`
+// ends up with a wrapped operand, so MoveOnlyWrappedTypeEliminator has to know
+// to leave the instruction alone rather than reporting it as unhandled.
+
+class Klass {}
+
+func copyableConsumingClass(_ v: consuming Klass) -> Any.Type {
+  return type(of: v)
+}
+
+func copyableConsumingGeneric<T>(_ v: consuming T) -> Any.Type {
+  return type(of: v)
+}
+
+func copyableConsumingExistential(_ v: consuming any Any) -> Any.Type {
+  return type(of: v)
+}


### PR DESCRIPTION
Follow-up to #91614

This corrects a number of mistakes in the initial implementation:
* Fixes support for existential metatypes
* Use `load_borrow` to borrow the original value instead of trying to load it directly
* Fills in missing `value_metatype` support in MoveOnlyWrappedTypeEliminator

In addition to new tests and test updates inspired by bug reports, this also add a new check to the SILVerifier to help ensure that similar mistakes don't recur.

Resolves rdar://185642335