### PR TITLE
[6.4.x] AST: Don't narrow base platform availability constraints

### DIFF
--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -14,6 +14,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/PlatformKindUtils.h"
 
 using namespace swift;
 
@@ -203,6 +204,32 @@ static bool canIgnoreConstraintInUnavailableContexts(
   }
 }
 
+/// Returns the domain for the target platform if \p constraint may be narrowed
+/// to apply to that domain when determining whether the constraint may be
+/// ignored in an unavailable context. Returns `std::nullopt` otherwise.
+static std::optional<AvailabilityDomain>
+getSubstituteDomainForConstraint(const AvailabilityConstraint &constraint,
+                                 const ASTContext &ctx) {
+  // Only narrow anyAppleOS availability constraints.
+  if (!constraint.getDomain().contains(
+          AvailabilityDomain::forPlatform(PlatformKind::anyAppleOS)))
+    return std::nullopt;
+
+  auto targetDomain = ctx.getTargetAvailabilityDomain();
+
+  // Don't narrow to an app extension domain. A module compiled with
+  // -application-extension cannot safely use declarations that are unavailable
+  // in the base platform domain.
+  if (auto basePlatform =
+          basePlatformForExtensionPlatform(targetDomain.getPlatformKind()))
+    targetDomain = AvailabilityDomain::forPlatform(*basePlatform);
+
+  if (constraint.getDomain().isSupersetOf(targetDomain))
+    return targetDomain;
+
+  return std::nullopt;
+}
+
 static bool
 shouldIgnoreConstraintInContext(const Decl *decl,
                                 const AvailabilityConstraint &constraint,
@@ -214,16 +241,10 @@ shouldIgnoreConstraintInContext(const Decl *decl,
   if (!canIgnoreConstraintInUnavailableContexts(decl, constraint, flags))
     return false;
 
-  // If the constraint's domain is a superset of the compilation's target
-  // availability domain, use the more specific target availability domain
-  // instead. This allows declarations that are @available(macOS, unavailable)
-  // to be used in contexts that are @available(macOSApplicationExtension,
-  // unavailable), for example.
-  auto &ctx = decl->getASTContext();
   auto domain = constraint.getDomain();
-  auto targetDomain = ctx.getTargetAvailabilityDomain();
-  if (domain.isSupersetOf(targetDomain))
-    domain = targetDomain;
+  if (auto substituteDomain =
+          getSubstituteDomainForConstraint(constraint, decl->getASTContext()))
+    domain = *substituteDomain;
 
   return context.isUnavailableForDomain(domain);
 }

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -49,7 +49,15 @@ func introducedLaterOnMacCatalyst() {
 }
 
 @available(iOS 57.0, macCatalyst 56.0, *)
-func introducedLaterOnIOS() {
+func introducedEarlierOnMacCatalyst() {
+}
+
+@available(iOS 57.0, *)
+func introducedLaterOniOS() {
+}
+
+@available(anyAppleOS 56.0, *)
+func introducedLaterOnAnyAppleOS() {
 }
 
 // expected-note@+1 *{{add '@available' attribute to enclosing global function}}
@@ -58,7 +66,11 @@ func testPoundAvailable() {
   if #available(macCatalyst 55.0, *) {
     introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
+    introducedEarlierOnMacCatalyst() // expected-error {{'introducedEarlierOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS() // expected-error {{'introducedLaterOnAnyAppleOS()' is only available in iOS 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
   }
 
@@ -67,18 +79,28 @@ func testPoundAvailable() {
   if #available(iOS 56.0, macCatalyst 55.0, *) {
     introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
+    introducedEarlierOnMacCatalyst() // expected-error {{'introducedEarlierOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS() // expected-error {{'introducedLaterOnAnyAppleOS()' is only available in iOS 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
   }
 
   if #available(iOS 55.0, macCatalyst 56.0, *) {
     introducedLaterOnMacCatalyst() // no-warning
-    introducedLaterOnIOS() // no-error
+    introducedEarlierOnMacCatalyst() // no-error
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS()
   }
 
   if #available(iOS 57.0, macCatalyst 56.0, *) {
     introducedLaterOnMacCatalyst() // no-warning
-    introducedLaterOnIOS() // no-error
+    introducedEarlierOnMacCatalyst() // no-error
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS()
   }
 
   // iOS availability should be inherited when macCatalyst is not present
@@ -86,18 +108,29 @@ func testPoundAvailable() {
   if #available(iOS 55.0, *) {
     introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
-    introducedLaterOnIOS() // expected-error {{'introducedLaterOnIOS()' is only available in Mac Catalyst 56.0 or newer}}
+    introducedEarlierOnMacCatalyst() // expected-error {{'introducedEarlierOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS() // expected-error {{'introducedLaterOnAnyAppleOS()' is only available in iOS 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
   }
 
   if #available(iOS 56.0, *) {
     introducedLaterOnMacCatalyst() // no-warning
-    introducedLaterOnIOS() // no-error
+    introducedEarlierOnMacCatalyst() // no-error
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS()
   }
 
   // macOS availability doesn't count on macCatalyst for Swift.
   if #available(macOS 9999.0, *) {
     introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS() // expected-error {{'introducedLaterOnAnyAppleOS()' is only available in iOS 56.0 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
   }
 }
@@ -152,6 +185,9 @@ struct UnavailableOnMacCatalyst { } // expected-note * {{'UnavailableOnMacCataly
 @available(iOS, unavailable)
 struct UnavailableOniOS { } // expected-note * {{'UnavailableOniOS' has been explicitly marked unavailable here}}
 
+@available(anyAppleOS, unavailable)
+struct UnavailableOnAnyAppleOS { } // expected-note * {{'UnavailableOnAnyAppleOS' has been explicitly marked unavailable here}}
+
 @available(iOS, unavailable)
 @available(macCatalyst, introduced: 13.0)
 struct AvailableOnMacCatalystButUnavailableOniOS { }
@@ -162,10 +198,16 @@ extension AvailableOnMacCatalystButUnavailableOniOS { } // ok
 
 @available(macCatalyst, unavailable)
 extension UnavailableOnMacCatalyst {
-  func extensionMethod() {
-    takesAnything(UnavailableOniOS())
+  func extensionMethod() { // expected-note {{add '@available' attribute to enclosing instance method}}
+    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS())
+    introducedLaterOnMacCatalyst()
+    introducedEarlierOnMacCatalyst()
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS()
   }
 
   @available(iOS, unavailable)
@@ -173,13 +215,23 @@ extension UnavailableOnMacCatalyst {
     takesAnything(UnavailableOniOS())
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS())
+    introducedLaterOnMacCatalyst()
+    introducedEarlierOnMacCatalyst()
+    introducedLaterOnAnyAppleOS()
   }
 
   @available(iOS, introduced: 15)
   func extensionMethodIntroducedOniOS() {
-    takesAnything(UnavailableOniOS())
+    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS())
+    introducedLaterOnMacCatalyst()
+    introducedEarlierOnMacCatalyst()
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS()
   }
 
 }
@@ -190,6 +242,11 @@ extension UnavailableOniOS {
     takesAnything(UnavailableOniOS())
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS())
+    introducedLaterOnMacCatalyst()
+    introducedEarlierOnMacCatalyst()
+    introducedLaterOniOS()
+    introducedLaterOnAnyAppleOS()
   }
 
   @available(macCatalyst, unavailable)
@@ -197,6 +254,11 @@ extension UnavailableOniOS {
     takesAnything(UnavailableOniOS())
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS())
+    introducedLaterOnMacCatalyst()
+    introducedEarlierOnMacCatalyst()
+    introducedLaterOniOS()
+    introducedLaterOnAnyAppleOS()
   }
 
   @available(macCatalyst, introduced: 13.0)
@@ -204,23 +266,43 @@ extension UnavailableOniOS {
     takesAnything(UnavailableOniOS())
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS())
+    introducedLaterOnMacCatalyst()
+    introducedEarlierOnMacCatalyst()
+    introducedLaterOniOS()
+    introducedLaterOnAnyAppleOS()
   }
 }
 
 @available(iOS, unavailable)
 @available(macCatalyst, introduced: 13.0)
 extension AvailableOnMacCatalystButUnavailableOniOS {
-  func extensionMethod() {
+  func extensionMethod() { // expected-note 4 {{add '@available' attribute to enclosing instance method}}
     takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
     takesAnything(UnavailableOnMacCatalyst()) // expected-error {{'UnavailableOnMacCatalyst' is unavailable in Mac Catalyst}}
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS()) // expected-error {{'UnavailableOnAnyAppleOS' is unavailable in iOS}}
+    introducedLaterOnMacCatalyst() // expected-error {{'introducedLaterOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedEarlierOnMacCatalyst() // expected-error {{'introducedEarlierOnMacCatalyst()' is only available in Mac Catalyst 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS() // expected-error {{'introducedLaterOnAnyAppleOS()' is only available in iOS 56.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
   }
 
   @available(macCatalyst, unavailable)
   func extensionMethodUnavailableOnMacCatalyst() {
-    takesAnything(UnavailableOniOS())
+    takesAnything(UnavailableOniOS()) // expected-error {{'UnavailableOniOS' is unavailable in iOS}}
     takesAnything(UnavailableOnMacCatalyst())
     takesAnything(AvailableOnMacCatalystButUnavailableOniOS())
+    takesAnything(UnavailableOnAnyAppleOS())
+    introducedLaterOnMacCatalyst()
+    introducedEarlierOnMacCatalyst()
+    introducedLaterOniOS() // expected-error {{'introducedLaterOniOS()' is only available in iOS 57.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    introducedLaterOnAnyAppleOS()
   }
 }
 

--- a/test/attr/attr_availability_transitive_ios_appext.swift
+++ b/test/attr/attr_availability_transitive_ios_appext.swift
@@ -4,7 +4,7 @@
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
 @available(iOS, unavailable)
-func ios() {} // expected-note {{'ios()' has been explicitly marked unavailable here}}
+func ios() {} // expected-note 2 {{'ios()' has been explicitly marked unavailable here}}
 
 @available(iOSApplicationExtension, unavailable)
 func ios_extension() {} // expected-note {{'ios_extension()' has been explicitly marked unavailable here}}
@@ -33,5 +33,5 @@ func ios_extension_call_ios_extension() {
 
 @available(iOSApplicationExtension, unavailable)
 func ios_extension_call_ios() {
-    ios()
+    ios() // expected-error {{'ios()' is unavailable}}
 }

--- a/test/attr/attr_availability_transitive_osx_appext.swift
+++ b/test/attr/attr_availability_transitive_osx_appext.swift
@@ -2,8 +2,13 @@
 
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
+struct AlwaysAvailable {}
+
 @available(*, unavailable)
 struct NeverAvailable {} // expected-note * {{'NeverAvailable' has been explicitly marked unavailable here}}
+
+@available(anyAppleOS, unavailable)
+struct AnyAppleOSUnavailable {} // expected-note * {{'AnyAppleOSUnavailable' has been explicitly marked unavailable here}}
 
 @available(OSX, unavailable)
 struct OSXUnavailable {} // expected-note * {{'OSXUnavailable' has been explicitly marked unavailable here}}
@@ -15,6 +20,12 @@ struct OSXAppExtensionsUnavailable {} // expected-note * {{'OSXAppExtensionsUnav
 @discardableResult
 func never() -> NeverAvailable { // expected-note * {{'never()' has been explicitly marked unavailable here}}
   NeverAvailable()
+}
+
+@available(anyAppleOS, unavailable)
+@discardableResult
+func any_apple_os() -> AnyAppleOSUnavailable { // expected-note * {{'any_apple_os()' has been explicitly marked unavailable here}}
+  AnyAppleOSUnavailable()
 }
 
 @available(OSX, unavailable)
@@ -29,134 +40,239 @@ func osx_extension() -> OSXAppExtensionsUnavailable { // expected-note * {{'osx_
   OSXAppExtensionsUnavailable()
 }
 
+@available(anyAppleOS 99, *)
+@discardableResult
+func any_apple_os_future() -> AlwaysAvailable {
+  AlwaysAvailable()
+}
+
+@available(OSX 99, *)
+@discardableResult
+func osx_future() -> AlwaysAvailable {
+  AlwaysAvailable()
+}
+
+@available(OSXApplicationExtension 99, *)
+@discardableResult
+func osx_extension_future() -> AlwaysAvailable {
+  AlwaysAvailable()
+}
+
 // MARK: Global functions
 
-func available_func(
+func available_func( // expected-note 3 {{add '@available' attribute to enclosing global function}}
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
+  _: AnyAppleOSUnavailable, // expected-error {{'AnyAppleOSUnavailable' is unavailable in macOS}}
   _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
   _: OSXAppExtensionsUnavailable // expected-error {{'OSXAppExtensionsUnavailable' is unavailable in application extensions for macOS}}
 ) {
   never() // expected-error {{'never()' is unavailable}}
+  any_apple_os() // expected-error {{'any_apple_os()' is unavailable in macOS}}
   osx() // expected-error {{'osx()' is unavailable}}
   osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+  any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  osx_extension_future() // expected-error {{'osx_extension_future()' is only available in application extensions for macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
 }
 
 @available(*, unavailable)
 func never_available_func(
   _: NeverAvailable,
+  _: AnyAppleOSUnavailable,
   _: OSXUnavailable,
   _: OSXAppExtensionsUnavailable
 ) {
   never() // expected-error {{'never()' is unavailable}}
+  any_apple_os()
   osx()
   osx_extension()
+  any_apple_os_future()
+  osx_future()
+  osx_extension_future()
 }
 
 @available(OSX, unavailable)
 func osx_func(
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
+  _: AnyAppleOSUnavailable,
   _: OSXUnavailable,
   _: OSXAppExtensionsUnavailable
 ) {
   never() // expected-error {{'never()' is unavailable}}
+  any_apple_os()
   osx()
   osx_extension()
+  any_apple_os_future()
+  osx_future()
+  osx_extension_future()
 }
 
 @available(OSXApplicationExtension, unavailable)
 func osx_extension_func(
   _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-  _: OSXUnavailable,
+  _: AnyAppleOSUnavailable, // expected-error {{'AnyAppleOSUnavailable' is unavailable in macOS}}
+  _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
   _: OSXAppExtensionsUnavailable
 ) {
   never() // expected-error {{'never()' is unavailable}}
-  osx()
+  any_apple_os() // expected-error {{'any_apple_os()' is unavailable in macOS}}
+  osx() // expected-error {{'osx()' is unavailable}}
   osx_extension()
+  any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  osx_extension_future()
 }
 
 // MARK: Global vars
 
-var always_var: (
+var always_var: ( // expected-note 3 {{add '@available' attribute to enclosing var}}
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
+  AnyAppleOSUnavailable, // expected-error {{'AnyAppleOSUnavailable' is unavailable in macOS}}
   OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
-  OSXAppExtensionsUnavailable // expected-error {{'OSXAppExtensionsUnavailable' is unavailable in application extensions for macOS}}
+  OSXAppExtensionsUnavailable, // expected-error {{'OSXAppExtensionsUnavailable' is unavailable in application extensions for macOS}}
+  AlwaysAvailable,
+  AlwaysAvailable,
+  AlwaysAvailable
 ) = (
   never(), // expected-error {{'never()' is unavailable}}
+  any_apple_os(), // expected-error {{'any_apple_os()' is unavailable in macOS}}
   osx(), // expected-error {{'osx()' is unavailable}}
-  osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+  osx_extension(), // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+  any_apple_os_future(), // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  osx_future(), // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  osx_extension_future() // expected-error {{'osx_extension_future()' is only available in application extensions for macOS 99 or newer}}
 )
 
 @available(*, unavailable)
 var never_var: (
   NeverAvailable,
+  AnyAppleOSUnavailable,
   OSXUnavailable,
-  OSXAppExtensionsUnavailable
+  OSXAppExtensionsUnavailable,
+  AlwaysAvailable,
+  AlwaysAvailable,
+  AlwaysAvailable
 ) = (
   never(), // expected-error {{'never()' is unavailable}}
+  any_apple_os(),
   osx(),
-  osx_extension()
+  osx_extension(),
+  any_apple_os_future(),
+  osx_future(),
+  osx_extension_future()
 )
 
 @available(OSX, unavailable)
 var osx_var: (
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
+  AnyAppleOSUnavailable,
   OSXUnavailable,
-  OSXAppExtensionsUnavailable
+  OSXAppExtensionsUnavailable,
+  AlwaysAvailable,
+  AlwaysAvailable,
+  AlwaysAvailable
 ) = (
   never(), // expected-error {{'never()' is unavailable}}
+  any_apple_os(),
   osx(),
-  osx_extension()
+  osx_extension(),
+  any_apple_os_future(),
+  osx_future(),
+  osx_extension_future()
 )
 
 @available(OSXApplicationExtension, unavailable)
 var osx_extension_var: (
   NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-  OSXUnavailable,
-  OSXAppExtensionsUnavailable
+  AnyAppleOSUnavailable, // expected-error {{'AnyAppleOSUnavailable' is unavailable in macOS}}
+  OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
+  OSXAppExtensionsUnavailable,
+  AlwaysAvailable,
+  AlwaysAvailable,
+  AlwaysAvailable
 ) = (
   never(), // expected-error {{'never()' is unavailable}}
-  osx(),
-  osx_extension()
+  any_apple_os(), // expected-error {{'any_apple_os()' is unavailable in macOS}}
+  osx(), // expected-error {{'osx()' is unavailable}}
+  osx_extension(),
+  any_apple_os_future(), // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  osx_future(), // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  osx_extension_future()
 )
 
 // MARK: Properties
 
-struct AlwaysAvailabileContainer {
+struct AlwaysAvailabileContainer { // expected-note 3 {{add '@available' attribute to enclosing struct}}
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
   let osx_var: OSXUnavailable = osx() // expected-error {{'osx()' is unavailable}}
   // expected-error@-1 {{'OSXUnavailable' is unavailable in macOS}}
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
   // expected-error@-1 {{'OSXAppExtensionsUnavailable' is unavailable in application extensions for macOS}}
+  let any_apple_os_future_var: AlwaysAvailable = any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  let osx_future_var: AlwaysAvailable = osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  let osx_extension_future_var: AlwaysAvailable = osx_extension_future() // expected-error {{'osx_extension_future()' is only available in application extensions for macOS 99 or newer}}
 }
 
 @available(*, unavailable)
 struct NeverAvailableContainer { // expected-note 3 {{'NeverAvailableContainer' has been explicitly marked unavailable here}}
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
+  let any_apple_os_var: AnyAppleOSUnavailable = any_apple_os()
   let osx_var: OSXUnavailable = osx()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
+  let any_apple_os_future_var: AlwaysAvailable = any_apple_os_future()
+  let osx_future_var: AlwaysAvailable = osx_future()
+  let osx_extension_future_var: AlwaysAvailable = osx_extension_future()
+}
+
+@available(anyAppleOS, unavailable)
+struct AnyAppleOSUnavailableContainer { // expected-note * {{'AnyAppleOSUnavailableContainer' has been explicitly marked unavailable here}}
+  let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
+  // expected-error@-1 {{'NeverAvailable' is unavailable}}
+  let any_apple_os_var: AnyAppleOSUnavailable = any_apple_os()
+  let osx_var: OSXUnavailable = osx()
+  let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
+  let any_apple_os_future_var: AlwaysAvailable = any_apple_os_future()
+  let osx_future_var: AlwaysAvailable = osx_future()
+  let osx_extension_future_var: AlwaysAvailable = osx_extension_future()
 }
 
 @available(OSX, unavailable)
-struct OSXUnavailableContainer { // expected-note {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
+struct OSXUnavailableContainer { // expected-note 2 {{'OSXUnavailableContainer' has been explicitly marked unavailable here}}
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
+  let any_apple_os_var: AnyAppleOSUnavailable = any_apple_os()
   let osx_var: OSXUnavailable = osx()
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
+  let any_apple_os_future_var: AlwaysAvailable = any_apple_os_future()
+  let osx_future_var: AlwaysAvailable = osx_future()
+  let osx_extension_future_var: AlwaysAvailable = osx_extension_future()
 }
 
 @available(OSXApplicationExtension, unavailable)
 struct OSXAppExtensionsUnavailableContainer { // expected-note {{'OSXAppExtensionsUnavailableContainer' has been explicitly marked unavailable here}}
   let never_var: NeverAvailable = never() // expected-error {{'never()' is unavailable}}
   // expected-error@-1 {{'NeverAvailable' is unavailable}}
-  let osx_var: OSXUnavailable = osx()
+  let any_apple_os_var: AnyAppleOSUnavailable = any_apple_os() // expected-error {{'any_apple_os()' is unavailable in macOS}}
+  // expected-error@-1 {{'AnyAppleOSUnavailable' is unavailable in macOS}}
+  let osx_var: OSXUnavailable = osx() // expected-error {{'osx()' is unavailable}}
+  // expected-error@-1 {{'OSXUnavailable' is unavailable in macOS}}
   let osx_extension_var: OSXAppExtensionsUnavailable = osx_extension()
+  let any_apple_os_future_var: AlwaysAvailable = any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+  let osx_future_var: AlwaysAvailable = osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+  let osx_extension_future_var: AlwaysAvailable = osx_extension_future()
 }
 
 // MARK: Extensions
 
 extension AlwaysAvailabileContainer {}
 extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContainer' is unavailable}}
+extension AnyAppleOSUnavailableContainer {} // expected-error {{'AnyAppleOSUnavailableContainer' is unavailable in macOS}}
 extension OSXUnavailableContainer {} // expected-error {{'OSXUnavailableContainer' is unavailable in macOS}}
 extension OSXAppExtensionsUnavailableContainer {} // expected-error {{'OSXAppExtensionsUnavailableContainer' is unavailable in application extensions for macOS}}
 
@@ -165,6 +281,8 @@ extension AlwaysAvailabileContainer {}
 @available(*, unavailable)
 extension NeverAvailableContainer {}
 @available(*, unavailable)
+extension AnyAppleOSUnavailableContainer {}
+@available(*, unavailable)
 extension OSXUnavailableContainer {}
 @available(*, unavailable)
 extension OSXAppExtensionsUnavailableContainer {}
@@ -174,6 +292,8 @@ extension AlwaysAvailabileContainer {}
 @available(OSX, unavailable)
 extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContainer' is unavailable}}
 @available(OSX, unavailable)
+extension AnyAppleOSUnavailableContainer {}
+@available(OSX, unavailable)
 extension OSXUnavailableContainer {}
 @available(OSX, unavailable)
 extension OSXAppExtensionsUnavailableContainer {}
@@ -183,7 +303,9 @@ extension AlwaysAvailabileContainer {}
 @available(OSXApplicationExtension, unavailable)
 extension NeverAvailableContainer {} // expected-error {{'NeverAvailableContainer' is unavailable}}
 @available(OSXApplicationExtension, unavailable)
-extension OSXUnavailableContainer {}
+extension AnyAppleOSUnavailableContainer {} // expected-error {{'AnyAppleOSUnavailableContainer' is unavailable in macOS}}
+@available(OSXApplicationExtension, unavailable)
+extension OSXUnavailableContainer {} // expected-error {{'OSXUnavailableContainer' is unavailable in macOS}}
 @available(OSXApplicationExtension, unavailable)
 extension OSXAppExtensionsUnavailableContainer {}
 
@@ -204,6 +326,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(*, unavailable)
@@ -215,6 +340,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(OSX, unavailable)
@@ -226,6 +354,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(OSXApplicationExtension, unavailable)
@@ -237,24 +368,27 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 }
 
 @available(OSX, unavailable)
 extension ExtendMe {
-  func osx_extension_available_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func osx_extension_available_method() {} // expected-note 2 {{has been explicitly marked unavailable here}}
 
   @available(OSX 99, *)
-  func osx_extension_osx_future_method() {} // expected-note {{has been explicitly marked unavailable here}}
+  func osx_extension_osx_future_method() {} // expected-note 2 {{has been explicitly marked unavailable here}}
 
   @available(*, unavailable)
   func osx_extension_never_available_method() {} // expected-note 3 {{'osx_extension_never_available_method()' has been explicitly marked unavailable here}}
 
   @available(OSX, unavailable)
-  func osx_extension_osx_method() {} // expected-note {{'osx_extension_osx_method()' has been explicitly marked unavailable here}}
+  func osx_extension_osx_method() {} // expected-note 2 {{'osx_extension_osx_method()' has been explicitly marked unavailable here}}
 
   @available(OSXApplicationExtension, unavailable)
-  func osx_extension_osx_app_extension_method() {} // expected-note {{'osx_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
+  func osx_extension_osx_app_extension_method() {} // expected-note 2 {{'osx_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
 
   func osx_extension_available_method(
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
@@ -264,6 +398,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(*, unavailable)
@@ -275,6 +412,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(OSX, unavailable)
@@ -286,6 +426,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(OSXApplicationExtension, unavailable)
@@ -297,6 +440,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 }
 
@@ -311,19 +457,24 @@ extension ExtendMe {
   func osx_app_extension_extension_never_available_method() {} // expected-note 3 {{'osx_app_extension_extension_never_available_method()' has been explicitly marked unavailable here}}
 
   @available(OSX, unavailable)
-  func osx_app_extension_extension_osx_method() {} // expected-note {{'osx_app_extension_extension_osx_method()' has been explicitly marked unavailable here}}
+  func osx_app_extension_extension_osx_method() {} // expected-note 2 {{'osx_app_extension_extension_osx_method()' has been explicitly marked unavailable here}}
 
   @available(OSXApplicationExtension, unavailable)
   func osx_app_extension_extension_osx_app_extension_method() {} // expected-note {{'osx_app_extension_extension_osx_app_extension_method()' has been explicitly marked unavailable here}}
 
-  func osx_app_extension_extension_available_method(
+  func osx_app_extension_extension_available_method( // expected-note 2 {{add '@available' attribute to enclosing instance method}}
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-    _: OSXUnavailable,
+    _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx()
+    osx() // expected-error {{'osx()' is unavailable}}
     osx_extension()
+    any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    osx_extension_future()
   }
 
   @available(*, unavailable)
@@ -335,6 +486,9 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(OSX, unavailable)
@@ -346,17 +500,25 @@ extension ExtendMe {
     never() // expected-error {{'never()' is unavailable}}
     osx()
     osx_extension()
+    any_apple_os_future()
+    osx_future()
+    osx_extension_future()
   }
 
   @available(OSXApplicationExtension, unavailable)
   func osx_app_extension_extension_osx_app_extension_method(
     _: NeverAvailable, // expected-error {{'NeverAvailable' is unavailable}}
-    _: OSXUnavailable,
+    _: OSXUnavailable, // expected-error {{'OSXUnavailable' is unavailable in macOS}}
     _: OSXAppExtensionsUnavailable
   ) {
     never() // expected-error {{'never()' is unavailable}}
-    osx()
+    osx() // expected-error {{'osx()' is unavailable}}
     osx_extension()
+    any_apple_os_future() // expected-error {{'any_apple_os_future()' is only available in macOS 99 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    osx_future() // expected-error {{'osx_future()' is only available in macOS 99 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    osx_extension_future()
   }
 }
 
@@ -396,17 +558,18 @@ func osx_func_call_extension_methods(_ e: ExtendMe) {
 @available(OSXApplicationExtension, unavailable)
 func osx_app_ext_func_call_extension_methods(_ e: ExtendMe) {
   e.never_available_extension_available_method() // expected-error {{'never_available_extension_available_method()' is unavailable}}
-  e.osx_extension_available_method()
+  e.osx_extension_available_method() // expected-error {{'osx_extension_available_method()' is unavailable in macOS}}
   e.osx_app_extension_extension_available_method()
-  e.osx_extension_never_available_method() // expected-error {{'osx_extension_never_available_method()' is unavailable}}
-  e.osx_extension_osx_method()
-  e.osx_extension_osx_app_extension_method()
+  e.osx_extension_never_available_method() // expected-error {{'osx_extension_never_available_method()' is unavailable in macOS}}
+  e.osx_extension_osx_method() // expected-error {{'osx_extension_osx_method()' is unavailable in macOS}}
+  e.osx_extension_osx_app_extension_method() // expected-error {{'osx_extension_osx_app_extension_method()' is unavailable in macOS}}
 
   e.never_available_extension_osx_future_method() // expected-error {{'never_available_extension_osx_future_method()' is unavailable}}
-  e.osx_extension_osx_future_method()
-  e.osx_app_extension_extension_osx_future_method()
+  e.osx_extension_osx_future_method() // expected-error {{'osx_extension_osx_future_method()' is unavailable in macOS}}
+  e.osx_app_extension_extension_osx_future_method() // expected-error {{'osx_app_extension_extension_osx_future_method()' is only available in macOS 99 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
   e.osx_app_extension_extension_never_available_method() // expected-error {{'osx_app_extension_extension_never_available_method()' is unavailable}}
-  e.osx_app_extension_extension_osx_method()
+  e.osx_app_extension_extension_osx_method() // expected-error {{'osx_app_extension_extension_osx_method()' is unavailable in macOS}}
   e.osx_app_extension_extension_osx_app_extension_method()
 }
 


### PR DESCRIPTION
- **Explanation:** A platform availability constraint like `@available(macOS 26, *)` cannot be narrowed to `@available(macOSApplicationExtension 26, *)` when determining whether it is safe to use a declaration with that constraint in an unavailable context. Limit the narrowing logic to constraints in the `anyAppleOS` domain, which can be narrowed to a base platform constraint.
- **Scope:** Affects code with declarations that are marked unavailable in app extension platform domains, e.g. `@available(macOSAppExtension, unavailable)` or `macCatalyst` or `visionOS`.
- **Issue/Radar:** rdar://183038991
- **Original PR:** https://github.com/swiftlang/swift/pull/91747
- **Risk:** Low. This behavior returns availability checking behavior to the baseline it had before Swift 6.4 for contexts that are unavailable in app extension domains. It's unlikely that much code exists that depends on the regressed Swift 6.4 behavior.
- **Testing:** Adjusted compiler tests to match corrected expectations.
- **Reviewer:** @artemcm 