### PR TITLE
[test] xfail only in the configuration that causes an issue

### DIFF
--- a/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
+++ b/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
@@ -13,8 +13,9 @@
 // RUN: %target-run-stdlib-swift
 
 // REQUIRES: executable_test
-// REQUIRES: rdar185887158
 // REQUIRES: objc_interop
+
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 


### PR DESCRIPTION
test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift started failing in "opaque values" mode, so disable that configuration specifically.