### PR TITLE
Allow @main to suppress parsing of top level code

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6611,6 +6611,7 @@ public:
   getResultExprs(SmallVectorImpl<Expr *> &scratch) const;
 
   DeclContext *getDeclContext() const { return DC; }
+  void setDeclContext(DeclContext *dc) { DC = dc; }
 
   SourceRange getSourceRange() const;
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -172,6 +172,10 @@ private:
   /// The source location of the main type.
   SourceLoc MainDeclDiagLoc;
 
+  /// `true` if top level code should be disabled in this source file regardless
+  /// of its `SourceFileKind`
+  bool TopLevelCodeDisabled = false;
+
   /// A hash of all interface-contributing tokens that have been lexed for
   /// this source file.
   ///
@@ -754,7 +758,7 @@ public:
   bool isScriptMode() const {
     switch (Kind) {
     case SourceFileKind::Main:
-      return true;
+      return !TopLevelCodeDisabled;
 
     case SourceFileKind::Library:
     case SourceFileKind::Interface:
@@ -766,6 +770,8 @@ public:
     }
     llvm_unreachable("bad SourceFileKind");
   }
+
+  void disableTopLevelCode();
 
   ValueDecl *getMainDecl() const override { return MainDecl; }
   SourceLoc getMainDeclDiagLoc() const {

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -80,6 +80,9 @@ void swift_ASTGen_buildTopLevelASTNodes(
     BridgedASTContext astContext, void *_Nonnull outputContext,
     void (*_Nonnull)(BridgedASTNode, void *_Nonnull));
 
+bool swift_ASTGen_sourceFileHasMainTypeDecl(BridgedASTContext astContext,
+                                            void *_Nonnull sourceFile);
+
 BridgedFingerprint
 swift_ASTGen_getSourceFileFingerprint(void *_Nonnull sourceFile,
                                       BridgedASTContext astContext);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2068,6 +2068,11 @@ bool SourceFile::registerMainDecl(ValueDecl *mainDecl, SourceLoc diagLoc) {
   return false;
 }
 
+void SourceFile::disableTopLevelCode() {
+  assert(Kind == SourceFileKind::Main);
+  TopLevelCodeDisabled = true;
+}
+
 NominalTypeDecl *ModuleDecl::getMainTypeDecl() const {
   if (!EntryPointInfo.hasEntryPoint())
     return nullptr;
@@ -3583,12 +3588,6 @@ SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
 
   assert(!IsPrimary || M.isMainModule() &&
          "A primary cannot appear outside the main module");
-
-  if (isScriptMode()) {
-    bool problem = M.registerEntryPointFile(this, SourceLoc(), std::nullopt);
-    assert(!problem && "multiple main files?");
-    (void)problem;
-  }
 
   M.getASTContext().SourceMgr.recordSourceFile(bufferID, this);
 }

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -600,3 +600,98 @@ public func buildTopLevelASTNodes(
   // Diagnose any errors from evaluating #ifs.
   visitor.diagnoseAll(visitor.configuredRegions.diagnostics)
 }
+
+/// Whether the given attribute list contains an '@main'-style attribute.
+private func hasMainTypeAttr(
+  _ attributes: AttributeListSyntax,
+  configuredRegions: ConfiguredRegions
+) -> Bool {
+  attributes.contains { element in
+    switch element {
+    case .ifConfigDecl(let ifConfigDecl):
+      guard let activeClause = configuredRegions.activeClause(for: ifConfigDecl),
+        let activeElements = activeClause.elements?._syntaxNode.as(AttributeListSyntax.self)
+      else {
+        return false
+      }
+      return hasMainTypeAttr(activeElements, configuredRegions: configuredRegions)
+
+    case .attribute(let attribute):
+      guard let identTy = attribute.attributeName.as(IdentifierTypeSyntax.self),
+        identTy.moduleSelector == nil
+      else {
+        return false
+      }
+      let kind = BridgedOptionalDeclAttrKind(from: identTy.name.rawText.bridged)
+      guard kind.hasValue else {
+        return false
+      }
+      switch kind.value {
+      case .MainType, .NSApplicationMain, .UIApplicationMain:
+        return true
+      default:
+        return false
+      }
+    }
+  }
+}
+
+private final class MainTypeDeclFinder: SyntaxAnyVisitor {
+  let configuredRegions: ConfiguredRegions
+  var foundMainTypeDecl = false
+
+  init(configuredRegions: ConfiguredRegions) {
+    self.configuredRegions = configuredRegions
+    super.init(viewMode: .sourceAccurate)
+  }
+
+  override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    if foundMainTypeDecl {
+      return .skipChildren
+    }
+
+    if let ifConfigDecl = node.as(IfConfigDeclSyntax.self) {
+      if let activeElements = configuredRegions.activeClause(for: ifConfigDecl)?.elements {
+        self.walk(activeElements._syntaxNode)
+      }
+      return .skipChildren
+    }
+
+    if let declGroup = node.asProtocol(DeclGroupSyntax.self),
+      hasMainTypeAttr(declGroup.attributes, configuredRegions: configuredRegions)
+    {
+      foundMainTypeDecl = true
+      return .skipChildren
+    }
+
+    return .visitChildren
+  }
+}
+
+/// Whether the given code block items declare a type annotated with an
+/// '@main'-style attribute.
+private func hasMainTypeDecl(
+  _ items: CodeBlockItemListSyntax,
+  configuredRegions: ConfiguredRegions
+) -> Bool {
+  let finder = MainTypeDeclFinder(configuredRegions: configuredRegions)
+  finder.walk(items)
+  return finder.foundMainTypeDecl
+}
+
+/// Determine whether the given source file declares a top-level type annotated
+/// with an '@main'-style attribute.
+@_cdecl("swift_ASTGen_sourceFileHasMainTypeDecl")
+public func sourceFileHasMainTypeDecl(
+  astContext: BridgedASTContext,
+  sourceFilePtr: UnsafeMutableRawPointer
+) -> Bool {
+  let sourceFile = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+  guard case .sourceFile(let node) = sourceFile.pointee.syntax.as(SyntaxEnum.self) else {
+    return false
+  }
+  return hasMainTypeDecl(
+    node.statements,
+    configuredRegions: sourceFile.pointee.configuredRegions(astContext: astContext)
+  )
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -165,6 +165,183 @@ namespace {
   };
 } // end anonymous namespace
 
+namespace {
+class MainTypeDeclFinder : public ASTWalker {
+  bool Found = false;
+
+public:
+  bool found() const { return Found; }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    if (isa<NominalTypeDecl>(D) || isa<ExtensionDecl>(D)) {
+      auto &attrs = D->getAttrs();
+      if (attrs.hasAttribute<MainTypeAttr>() ||
+          attrs.hasAttribute<UIApplicationMainAttr>() ||
+          attrs.hasAttribute<NSApplicationMainAttr>()) {
+        Found = true;
+        return Action::Stop();
+      }
+    }
+
+    if (auto *IDC = dyn_cast<IterableDeclContext>(D)) {
+      auto &evaluator = D->getASTContext().evaluator;
+      ParseMembersRequest req(IDC);
+      // Only walk into cached parsed members to avoid invoking lazy parsing.
+      // We force eager parsing of function bodies that might contain an @main
+      // type in a main source file.
+      if (evaluator.hasCachedResult(req)) {
+        for (auto *member : evaluateOrFatal(evaluator, req).members) {
+          member->walk(*this);
+          if (Found)
+            return Action::Stop();
+        }
+      }
+      return Action::SkipNode();
+    }
+
+    return Action::Continue();
+  }
+};
+} // end anonymous namespace
+
+static bool hasMainTypeDecl(ArrayRef<ASTNode> items) {
+  MainTypeDeclFinder finder;
+  for (auto item : items) {
+    item.walk(finder);
+    if (finder.found())
+      return true;
+  }
+  return false;
+}
+
+namespace {
+class ReparentInitializerWalker : public ASTWalker {
+  DeclContext *DC;
+
+public:
+  explicit ReparentInitializerWalker(DeclContext *DC) : DC(DC) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
+  LazyInitializerWalking getLazyInitializerWalkingBehavior() override {
+    return LazyInitializerWalking::None;
+  }
+
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+    if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
+      CE->setParent(DC);
+      return Action::SkipNode(E);
+    }
+    if (auto *ME = dyn_cast<MacroExpansionExpr>(E))
+      ME->setDeclContext(DC);
+    if (auto *SVE = dyn_cast<SingleValueStmtExpr>(E))
+      SVE->setDeclContext(DC);
+    if (auto *TE = dyn_cast<TapExpr>(E)) {
+      if (auto *var = TE->getVar())
+        var->setDeclContext(DC);
+    }
+
+    return Action::Continue(E);
+  }
+
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+    if (auto *EP = dyn_cast<ExprPattern>(P))
+      EP->setDeclContext(DC);
+    if (auto *EP = dyn_cast<EnumElementPattern>(P))
+      EP->setDeclContext(DC);
+
+    return Action::Continue(P);
+  }
+
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+    if (auto *CS = dyn_cast<CaseStmt>(S)) {
+      for (auto *caseVar : CS->getCaseBodyVariables())
+        caseVar->setDeclContext(DC);
+    }
+    if (auto *BS = dyn_cast<BreakStmt>(S))
+      BS->setDeclContext(DC);
+    if (auto *CS = dyn_cast<ContinueStmt>(S))
+      CS->setDeclContext(DC);
+    if (auto *FS = dyn_cast<FallthroughStmt>(S))
+      FS->setDeclContext(DC);
+    if (auto *FES = dyn_cast<ForEachStmt>(S))
+      FES->setDeclContext(DC);
+
+    return Action::Continue(S);
+  }
+
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    if (!D->getDeclContext()->isLocalContext())
+      return Action::SkipNode();
+
+    D->setDeclContext(DC);
+
+    return Action::SkipNodeIf(isa<DeclContext>(D));
+  }
+};
+} // end anonymous namespace
+
+/// Rewrite the AST of code parsed in script mode as if it was parsed in library mode.
+static void rewriteTopLevelCodeAsLibraryCode(Parser &P, MutableArrayRef<ASTNode> items) {
+  auto &SF = P.SF;
+  for (auto &item : items) {
+    auto *TLCD = dyn_cast_or_null<TopLevelCodeDecl>(item.dyn_cast<Decl *>());
+    if (!TLCD)
+      continue;
+
+    // Currently a TopLevelCodeDecl will only ever have 0 or 1 elements.
+    auto elements = TLCD->getBody()->getElements();
+    if (elements.empty())
+      continue;
+    assert(elements.size() == 1 && "Expected TopLevelCodeDecl body to have only a single element");
+    auto element = elements.front();
+
+    // Rewrite top level bindings as globals.
+    if (auto *PBD =
+            dyn_cast_or_null<PatternBindingDecl>(element.dyn_cast<Decl *>())) {
+      PBD->setDeclContext(&SF);
+
+      for (auto idx : range(PBD->getNumPatternEntries())) {
+        auto *initContext = PatternBindingInitializer::create(&SF);
+
+        PBD->getPattern(idx)->forEachVariable([&](VarDecl *VD) {
+          VD->setTopLevelGlobal(false);
+          for (auto *custom : VD->getAttrs().getAttributes<CustomAttr>()) {
+            if (auto *attrInit = custom->getInitContext())
+              attrInit->setEnclosingInitializer(initContext);
+          }
+        });
+        PBD->setInitContext(idx, initContext);
+
+        if (auto *init = PBD->getInit(idx))
+          init->walk(ReparentInitializerWalker(initContext));
+      }
+      item = PBD;
+      continue;
+    }
+
+    // Rewrite expression macro expansions as declaration macro expansions.
+    if (auto *MEE = dyn_cast_or_null<MacroExpansionExpr>(element.dyn_cast<Expr *>())) {
+      item = MEE->createSubstituteDecl();
+      continue;
+    }
+
+    // Diagnose constructs which aren't allowed in library mode.
+    if (isa<Stmt *>(element))
+      P.diagnose(element.getStartLoc(), diag::illegal_top_level_stmt);
+    else if (isa<Expr *>(element))
+      P.diagnose(element.getStartLoc(), diag::illegal_top_level_expr);
+    else
+      assert(false && "unexpected TopLevelCodeDecl element");
+  }
+}
+
 /// Main entrypoint for the parser.
 ///
 /// \verbatim
@@ -220,6 +397,11 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
                diag::unexpected_conditional_compilation_block_terminator);
       consumeToken();
     }
+  }
+
+  if (SF.isScriptMode() && hasMainTypeDecl(items)) {
+    SF.disableTopLevelCode();
+    rewriteTopLevelCodeAsLibraryCode(*this, items);
   }
 
 #if SWIFT_BUILD_SWIFT_SYNTAX
@@ -5930,7 +6112,8 @@ static unsigned skipUntilMatchingRBrace(Parser &P, bool &HasPoundDirective,
                                         bool &HasNestedClassDeclarations,
                                         bool &HasNestedTypeDeclarations,
                                         bool &HasPotentialRegexLiteral,
-                                        bool &HasDerivativeDeclarations) {
+                                        bool &HasDerivativeDeclarations,
+                                        bool &HasMainTypeDeclarations) {
   HasPoundDirective = false;
   HasPoundSourceLocation = false;
   HasOperatorDeclarations = false;
@@ -5938,6 +6121,7 @@ static unsigned skipUntilMatchingRBrace(Parser &P, bool &HasPoundDirective,
   HasNestedTypeDeclarations = false;
   HasPotentialRegexLiteral = false;
   HasDerivativeDeclarations = false;
+  HasMainTypeDeclarations = false;
 
   unsigned OpenBraces = 1;
   unsigned OpenPoundIf = 0;
@@ -5970,9 +6154,21 @@ static unsigned skipUntilMatchingRBrace(Parser &P, bool &HasPoundDirective,
       if (P.Tok.is(tok::identifier)) {
         std::optional<DeclAttrKind> DK =
             DeclAttribute::getAttrKindFromString(P.Tok.getText());
-        if (DK && *DK == DeclAttrKind::Derivative) {
-          HasDerivativeDeclarations = true;
-          P.consumeToken();
+        if (DK) {
+          switch (*DK) {
+          case DeclAttrKind::Derivative:
+            HasDerivativeDeclarations = true;
+            P.consumeToken();
+            break;
+          case DeclAttrKind::MainType:
+          case DeclAttrKind::UIApplicationMain:
+          case DeclAttrKind::NSApplicationMain:
+            HasMainTypeDeclarations = true;
+            P.consumeToken();
+            break;
+          default:
+            break;
+          }
         }
       }
       continue;
@@ -7543,10 +7739,18 @@ bool Parser::canDelayMemberDeclParsing(bool &HasOperatorDeclarations,
   bool HasPoundSourceLocation;
   bool HasNestedTypeDeclarations;
   bool HasPotentialRegexLiteral;
+  bool HasMainTypeDeclarations;
   skipUntilMatchingRBrace(*this, HasPoundDirective, HasPoundSourceLocation,
                           HasOperatorDeclarations, HasNestedClassDeclarations,
                           HasNestedTypeDeclarations, HasPotentialRegexLiteral,
-                          HasDerivativeDeclarations);
+                          HasDerivativeDeclarations, HasMainTypeDeclarations);
+
+  // If this member list may declare an '@main' type, parse it eagerly, because
+  // otherwise we can't tell whether top-level code needs to be suppressed in
+  // this file.
+  if (HasMainTypeDeclarations && SF.Kind == SourceFileKind::Main)
+    return false;
+
   if (!HasPoundDirective && !HasPotentialRegexLiteral) {
     // If we didn't see any pound directive, we must not have seen
     // #sourceLocation either.
@@ -8157,11 +8361,17 @@ bool Parser::canDelayFunctionBodyParsing(bool &HasNestedTypeDeclarations,
   bool HasNestedClassDeclarations;
   bool HasPotentialRegexLiteral;
   bool HasDerivativeDeclarations;
+  bool HasMainTypeDeclarations;
   skipUntilMatchingRBrace(*this, HasPoundDirectives, HasPoundSourceLocation,
                           HasOperatorDeclarations, HasNestedClassDeclarations,
                           HasNestedTypeDeclarations, HasPotentialRegexLiteral,
-                          HasDerivativeDeclarations);
+                          HasDerivativeDeclarations, HasMainTypeDeclarations);
   if (HasPoundSourceLocation || HasPotentialRegexLiteral)
+    return false;
+
+  // If this body may declare an '@main' type, parse it eagerly, because otherwise we
+  // can't tell whether top-level code needs to be suppressed in this file.
+  if (HasMainTypeDeclarations && SF.Kind == SourceFileKind::Main)
     return false;
 
   BackTrack.cancelBacktrack();

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -391,6 +391,10 @@ SourceFileParsingResult parseSourceFileViaASTGen(SourceFile &SF) {
   // regions cache.
   swift_ASTGen_evaluateConfiguredRegionsForDiagnostics(Ctx, exportedSourceFile);
 
+  if (SF.isScriptMode() &&
+      swift_ASTGen_sourceFileHasMainTypeDecl(Ctx, exportedSourceFile))
+    SF.disableTopLevelCode();
+
   // Emit parser diagnostics.
   (void)swift_ASTGen_emitParserDiagnostics(
       Ctx, &Diags, exportedSourceFile, /*emitOnlyErrors=*/false,
@@ -569,12 +573,21 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   diags.setSuppressWarnings(didSuppressWarnings || shouldSuppress);
   SWIFT_DEFER { diags.setSuppressWarnings(didSuppressWarnings); };
 
+  auto result = [&] {
 #if SWIFT_BUILD_SWIFT_SYNTAX
-  if (shouldParseViaASTGen(*SF))
-    return parseSourceFileViaASTGen(*SF);
+    if (shouldParseViaASTGen(*SF))
+      return parseSourceFileViaASTGen(*SF);
 #endif
 
-  return parseSourceFile(*SF);
+    return parseSourceFile(*SF);
+  }();
+
+  if (SF->isScriptMode()) {
+    (void)SF->getParentModule()->registerEntryPointFile(
+        SF, SourceLoc(), /*kind=*/std::nullopt);
+  }
+
+  return result;
 }
 
 evaluator::DependencySource ParseSourceFileRequest::readDependencySource(

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -521,7 +521,7 @@ bool Parser::shouldEvaluatePoundIfDecls() const {
 }
 
 bool Parser::allowTopLevelCode() const {
-  return SF.isScriptMode();
+  return SF.Kind == SourceFileKind::Main;
 }
 
 bool Parser::isInMacroExpansion(SourceLoc loc) const {

--- a/test/ASTGen/main_attr_nested_top_level_code.swift
+++ b/test/ASTGen/main_attr_nested_top_level_code.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-dump-ast -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-ast \
+// RUN:    | %sanitize-address > %t/cpp-parser.ast
+// RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
+
+// RUN: %target-swift-frontend-dump-ast -DHIDE_MAIN_TYPE -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.not-main.ast
+// RUN: %target-swift-frontend-dump-ast -DHIDE_MAIN_TYPE \
+// RUN:    | %sanitize-address > %t/cpp-parser.not-main.ast
+// RUN: %diff -u %t/astgen.not-main.ast %t/cpp-parser.not-main.ast
+
+// RUN: %target-swift-frontend-dump-ast -parse-as-library -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.library.ast
+// RUN: %target-swift-frontend-dump-ast -parse-as-library \
+// RUN:    | %sanitize-address > %t/cpp-parser.library.ast
+// RUN: %diff -u %t/astgen.library.ast %t/cpp-parser.library.ast
+
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift -DHIDE_MAIN_TYPE -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -DHIDE_MAIN_TYPE
+
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_ParserASTGen
+
+// The '@main' type may be nested inside another declaration, or even inside a
+// function body. ASTGen searches the syntax tree for it while the C++ parser
+// inspects the AST it has built so far, so make sure the two agree about
+// whether top-level code is suppressed.
+
+func asyncFunc() async -> Int { 0 }
+func takesClosure(_ f: () -> Int) -> Int { f() }
+let ifExpr = if Bool.random() { takesClosure { 1 } } else { 2 }
+let nested = takesClosure { takesClosure { 3 } }
+#if HIDE_MAIN_TYPE
+let asyncValue = await asyncFunc()
+#endif
+
+enum Outer {
+  enum Middle {
+#if !HIDE_MAIN_TYPE
+    @main
+#endif
+    struct App {
+      static func main() {
+        print(ifExpr, nested)
+        nestsAnEntryPoint()
+      }
+    }
+  }
+}
+
+func nestsAnEntryPoint() {
+#if NEVER
+  @main
+  struct Unused {
+    static func main() {}
+  }
+#endif
+}

--- a/test/ASTGen/main_attr_top_level_code.swift
+++ b/test/ASTGen/main_attr_top_level_code.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-dump-ast -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.ast
+// RUN: %target-swift-frontend-dump-ast \
+// RUN:    | %sanitize-address > %t/cpp-parser.ast
+// RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
+
+// RUN: %target-swift-frontend-dump-ast -DHIDE_MAIN_TYPE -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.not-main.ast
+// RUN: %target-swift-frontend-dump-ast -DHIDE_MAIN_TYPE \
+// RUN:    | %sanitize-address > %t/cpp-parser.not-main.ast
+// RUN: %diff -u %t/astgen.not-main.ast %t/cpp-parser.not-main.ast
+
+// RUN: %target-swift-frontend-dump-ast -parse-as-library -enable-experimental-feature ParserASTGen \
+// RUN:    | %sanitize-address > %t/astgen.library.ast
+// RUN: %target-swift-frontend-dump-ast -parse-as-library \
+// RUN:    | %sanitize-address > %t/cpp-parser.library.ast
+// RUN: %diff -u %t/astgen.library.ast %t/cpp-parser.library.ast
+
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift -DHIDE_MAIN_TYPE -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -DHIDE_MAIN_TYPE
+
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_ParserASTGen
+
+// ASTGen and the C++ parser handle @main in top level code differently, ensure they produce equivalent ASTs, especially
+// when the C++ parser needs to fix up declarations of globals after encountering @main.
+
+func asyncFunc() async -> Int { 0 }
+func takesClosure(_ f: () -> Int) -> Int { f() }
+let ifExpr = if Bool.random() { takesClosure { 1 } } else { 2 }
+let nested = takesClosure { takesClosure { 3 } }
+let first = takesClosure { 1 }, second = takesClosure { 2 }
+#if HIDE_MAIN_TYPE
+let asyncValue = await asyncFunc()
+#endif
+
+#if !HIDE_MAIN_TYPE
+@main
+struct App {
+  static func main() {
+    print(ifExpr, nested, first, second)
+  }
+}
+#endif

--- a/test/Macros/top_level_freestanding_main_type.swift
+++ b/test/Macros/top_level_freestanding_main_type.swift
@@ -1,0 +1,19 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s
+
+// When top-level code parsing is suppressed by @main, a top-level macro reference should be interpreted
+// as a freestanding decl macro.
+
+@freestanding(declaration, names: named(value)) macro varValue() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
+
+@main
+struct Entry {
+  static func main() {
+    print(value)
+  }
+}
+
+#varValue

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_infer_no_top_level_code.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_infer_no_top_level_code.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+import AppKit
+
+@NSApplicationMain
+class MyDelegate: NSObject, NSApplicationDelegate {
+  func hi() { print(greeting) }
+}
+
+let greeting = "hello"

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_infer_no_top_level_code.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_infer_no_top_level_code.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+import UIKit
+
+@UIApplicationMain
+class MyDelegate: NSObject, UIApplicationDelegate {
+  func hi() { print(greeting) }
+}
+
+let greeting = "hello"

--- a/test/attr/ApplicationMain/attr_main_conditional_compilation.swift
+++ b/test/attr/ApplicationMain/attr_main_conditional_compilation.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify -DHAS_MAIN %s
+
+// @main should only suppress top level code parsing if it's in an active
+// conditional compilation branch.
+
+#if HAS_MAIN
+@main
+#endif
+struct Entry {
+  static func main() {
+    print(greeting)
+  }
+}
+
+let greeting = "hello"
+
+#if !HAS_MAIN
+print(greeting)
+#endif

--- a/test/attr/ApplicationMain/attr_main_diagnose_top_level_code.swift
+++ b/test/attr/ApplicationMain/attr_main_diagnose_top_level_code.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// If @main suppressed parsing of top level code parsing, we should diagnose.
+
+@main
+struct Entry {
+  static func main() {}
+}
+
+1 + 1 // expected-error {{expressions are not allowed at the top level}}
+// expected-warning@-1 {{result of operator '+' is unused}}
+
+if Bool.random() {} // expected-error {{statements are not allowed at the top level}}
+
+func isAsync() async -> Int { 42 }
+let rider = await isAsync() // expected-error {{'async' call cannot occur in a global variable initializer}}

--- a/test/attr/ApplicationMain/attr_main_infer_maindotswift.swift
+++ b/test/attr/ApplicationMain/attr_main_infer_maindotswift.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/helper.swift
+
+//--- main.swift
+
+@main
+struct Entry {
+  static func main() {
+    hi()
+  }
+}
+
+//--- helper.swift
+
+func hi() {}

--- a/test/attr/ApplicationMain/attr_main_nested_type.swift
+++ b/test/attr/ApplicationMain/attr_main_nested_type.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t/nested_in_struct.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/deeply_nested.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/in_extension.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/in_function_body.swift
+
+//--- nested_in_struct.swift
+
+struct Outer {
+  @main
+  struct Entry {
+    static func main() {
+      print(greeting)
+    }
+  }
+}
+
+let greeting = "hello"
+
+//--- deeply_nested.swift
+
+func takesClosure(_ f: () -> String) -> String { f() }
+
+enum Outer {
+  enum Middle {
+    @main
+    struct Entry {
+      static func main() {
+        print(greeting)
+      }
+    }
+  }
+}
+
+let greeting = takesClosure { "hello" }
+
+//--- in_extension.swift
+
+struct Outer {}
+
+extension Outer {
+  @main
+  final class Entry {
+    static func main() {
+      print(greeting)
+    }
+  }
+}
+
+let greeting = "hello"
+
+//--- in_function_body.swift
+
+func takesClosure(_ f: () -> String) -> String { f() }
+
+func nestsTheEntryPoint() {
+  @main
+  struct Entry {
+    static func main() {
+      print(greeting)
+    }
+  }
+}
+
+let greeting = takesClosure { "hello" }

--- a/test/attr/ApplicationMain/attr_main_outside_maindotswift.swift
+++ b/test/attr/ApplicationMain/attr_main_outside_maindotswift.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/helper.swift
+
+// The diagnostic doesn't depend on the order the files are given in, even though
+// that determines whether the script file or the '@main' attribute claims the
+// module's entry point first.
+// RUN: %target-swift-frontend -typecheck -verify %t/helper.swift %t/main.swift
+
+// Nor does it depend on which file is primary.
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/helper.swift %t/main.swift
+
+// @main does not suppress top level code parsing if it doesn't appear in the "main" file
+
+//--- main.swift
+func hi() {} // expected-note {{top-level code defined in this source file}}
+// expected-note@-1 {{pass '-parse-as-library' to compiler invocation if this is intentional}}
+
+//--- helper.swift
+
+@main // expected-error {{'main' attribute cannot be used in a module that contains top-level code}}
+struct Entry {
+  static func main() {
+    hi()
+  }
+}

--- a/test/attr/ApplicationMain/attr_main_top_level_code_ast_fixup.swift
+++ b/test/attr/ApplicationMain/attr_main_top_level_code_ast_fixup.swift
@@ -1,0 +1,76 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -dump-ast -parse-as-library %s | %sanitize-address > %t/library.ast
+// RUN: %target-swift-frontend -dump-ast %s | %sanitize-address > %t/inferred.ast
+// RUN: %diff -u %t/library.ast %t/inferred.ast
+
+// Ensure that parsing this file in top-level code mode and then fixing up
+// the AST is equivalent to parsing it in library mode in the first place.
+
+
+func take(_ f: () -> Int) -> Int { f() }
+
+@propertyWrapper
+struct Wrap { var wrappedValue: Int }
+
+@globalActor
+actor GA { static let shared = GA() }
+
+enum E { case a, b }
+
+let ifExpr = if Bool.random() { take { 1 } } else { 2 }
+let switchExpr = switch E.a {
+case .a: take { 3 }
+case .b: 4
+}
+
+let interpolated = "a\(1)b\(take { 4 })c"
+let interpolatedInBranch = if Bool.random() { "d\(5)e" } else { "f" }
+
+let matched = switch Optional(5) {
+case .some(let n): n
+case .none: 0
+}
+
+let captured = take { [c = matched] in c }
+
+let loops = if Bool.random() {
+  take {
+    var total = 0
+    outer: for i in 0 ..< 3 {
+      for j in 0 ..< 3 {
+        if j == 1 { continue outer }
+        total += i * j
+      }
+    }
+    return total
+  }
+} else { 0 }
+
+let attributed = take {
+  @GA func helper() -> Int { 1 }
+  return 2
+}
+
+let lazily = take { lazy var v: Int = 7
+                    return v }
+let wrapped = take { @Wrap var w: Int = 3
+                     return w }
+
+let deferred = take {
+  defer { print("done") }
+  return 8
+}
+
+let nested = take { take { 2 } }
+
+let first = take { 1 }, second = take { 2 }
+
+@main
+struct App {
+  static func main() {
+    print(ifExpr, switchExpr, interpolated, interpolatedInBranch, matched)
+    print(captured, loops, attributed, deferred)
+    print(lazily, wrapped, nested, first, second)
+  }
+}

--- a/test/attr/lit.local.cfg
+++ b/test/attr/lit.local.cfg
@@ -1,0 +1,1 @@
+config.substitutions.append( ('%sanitize-address', '%s %s/sanitize-address.py' % (config.python, config.swift_utils)) )


### PR DESCRIPTION
I haven't pitched this yet, but some of the rationale is described in https://github.com/owenv/swift-evolution/blob/owenv/tlc/proposals/NNNN-improve-interaction-between-at-main-and-top-level-code.md

This change allows use of @main in files which were inferred to contain top level code either based on the filename (main.swift) or the fact that the module only has 1 source file. This avoids confusing users who didn't intend for their file to be parsed as top level code, and means build systems no longer need to resort to -parse-as-library hacks.

In the C++ parser, this is implemented by parsing the file normally, and then later fixing up the AST if we discovered an @main decl during parsing. This approach is messier than I'd like, but relatively self contained. When using ASTGen, we avoid this by doing an initial traversal of the syntax tree for a SourceFileKind::Main to determine whether ASTGen should construct the AST in top level code mode or not.
