### PR TITLE
[cxx-interop] Correctly import function templates as initializers

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3571,7 +3571,9 @@ namespace {
     Decl *
     importGlobalAsInitializer(const clang::FunctionDecl *decl, DeclName name,
                               DeclContext *dc, CtorInitializerKind initKind,
-                              std::optional<ImportedName> correctSwiftName);
+                              std::optional<ImportedName> correctSwiftName,
+                              const clang::FunctionTemplateDecl *funcTemplate,
+                              ArrayRef<GenericTypeParamDecl *> templateParams);
 
     /// Create an implicit property given the imported name of one of
     /// the accessors.
@@ -3969,19 +3971,37 @@ namespace {
       DeclName name = accessorInfo ? DeclName() : importedName.getDeclName();
       auto selfIdx = importedName.getSelfIndex();
 
+      SmallVector<GenericTypeParamDecl *, 4> templateParams;
+      if (funcTemplate) {
+        unsigned i = 0;
+        for (auto *param : *funcTemplate->getTemplateParameters()) {
+          if (unusedTemplateParams.contains(param))
+            continue;
+          auto *typeParam = Impl.createDeclWithClangNode<GenericTypeParamDecl>(
+              param, AccessLevel::Public, dc,
+              Impl.SwiftContext.getIdentifier(param->getName()),
+              /*nameLoc*/ Impl.importSourceLoc(param->getLocation()),
+              /*specifierLoc*/ SourceLoc(),
+              /*depth*/ 0, /*index*/ i, GenericTypeParamKind::Type);
+          templateParams.push_back(typeParam);
+          (void)++i;
+        }
+      }
+
       if (auto *method = dyn_cast<clang::CXXMethodDecl>(decl);
           method && method->isStatic() && name.getBaseName().isConstructor()) {
         return importGlobalAsInitializer(
-            decl, name, dc, importedName.getInitKind(), correctSwiftName);
+            decl, name, dc, importedName.getInitKind(), correctSwiftName,
+            funcTemplate, templateParams);
       }
 
       if (!dc->isModuleScopeContext() && !isClangNamespace(dc) &&
           !isa<clang::CXXMethodDecl>(decl)) {
         if (name.getBaseName().isConstructor()) {
           ASSERT(!accessorInfo && "accessor should not be constructor()");
-          return importGlobalAsInitializer(decl, name, dc,
-                                           importedName.getInitKind(),
-                                           correctSwiftName);
+          return importGlobalAsInitializer(
+              decl, name, dc, importedName.getInitKind(), correctSwiftName,
+              funcTemplate, templateParams);
         }
 
         if (dc->getSelfProtocolDecl() && !selfIdx) {
@@ -3999,29 +4019,12 @@ namespace {
         }
       }
 
-      SmallVector<GenericTypeParamDecl *, 4> templateParams;
-      if (funcTemplate) {
-        unsigned i = 0;
-        for (auto *param : *funcTemplate->getTemplateParameters()) {
-          if (unusedTemplateParams.contains(param))
-            continue;
-          auto *typeParam = Impl.createDeclWithClangNode<GenericTypeParamDecl>(
-              param, AccessLevel::Public, dc,
-              Impl.SwiftContext.getIdentifier(param->getName()),
-              /*nameLoc*/ Impl.importSourceLoc(param->getLocation()),
-              /*specifierLoc*/ SourceLoc(),
-              /*depth*/ 0, /*index*/ i, GenericTypeParamKind::Type);
-          templateParams.push_back(typeParam);
-          (void)++i;
-        }
-      }
       auto getGenericParams = [&]() -> GenericParamList * {
         if (templateParams.empty())
           return nullptr;
         return GenericParamList::create(Impl.SwiftContext, SourceLoc(),
                                         templateParams, SourceLoc());
       };
-
       ImportedType resultType;
       bool selfIsInOut = false;
       bool selfIsConsuming = false;
@@ -7371,8 +7374,9 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
 
 Decl *SwiftDeclConverter::importGlobalAsInitializer(
     const clang::FunctionDecl *decl, DeclName name, DeclContext *dc,
-    CtorInitializerKind initKind,
-    std::optional<ImportedName> correctSwiftName) {
+    CtorInitializerKind initKind, std::optional<ImportedName> correctSwiftName,
+    const clang::FunctionTemplateDecl *funcTemplate,
+    ArrayRef<GenericTypeParamDecl *> templateParams) {
   // TODO: Should this be an error? How can this come up?
   assert(dc->isTypeContext() && "cannot import as member onto non-type");
 
@@ -7406,7 +7410,7 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
   } else {
     parameterList = Impl.importFunctionParameterList(
         dc, decl, {decl->param_begin(), decl->param_end()}, decl->isVariadic(),
-        allowNSUIntegerAsInt, argNames, /*genericParams=*/{},
+        allowNSUIntegerAsInt, argNames, templateParams,
         /*resultType=*/nullptr);
 
     if (name && parameterList && argNames.size() != parameterList->size()) {
@@ -7450,13 +7454,25 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
     failable = true;
   }
 
+  // Use the FunctionTemplateDecl as the ClangNode rather than the templated
+  // FunctionDecl, matching what importFunctionDecl() does for other members.
+  ClangNode clangNode = decl;
+  if (funcTemplate)
+    clangNode = funcTemplate;
+
+  auto *genericParams =
+      templateParams.empty()
+          ? nullptr
+          : GenericParamList::create(Impl.SwiftContext, SourceLoc(),
+                                     templateParams, SourceLoc());
+
   auto result = Impl.createDeclWithClangNode<ConstructorDecl>(
-      decl, importer::convertClangAccess(decl->getAccess()), name,
+      clangNode, importer::convertClangAccess(decl->getAccess()), name,
       Impl.importSourceLoc(decl->getLocation()), failable,
       /*FailabilityLoc=*/SourceLoc(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
-      parameterList, /*GenericParams=*/nullptr, dc);
+      parameterList, genericParams, dc);
   result->setImplicitlyUnwrappedOptional(isIUO);
   result->getASTContext().evaluator.cacheOutput(InitKindRequest{result},
                                                 std::move(initKind));

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -204,3 +204,13 @@ module BitFields {
   header "bit-fields.h"
   requires cplusplus
 }
+
+module StaticFactoryAsInit {
+  header "static-factory-as-init.h"
+  requires cplusplus
+}
+
+module StaticFactoryAsInitGeneric {
+  header "static-factory-as-init-generic.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/Inputs/static-factory-as-init-generic.h
+++ b/test/Interop/Cxx/class/Inputs/static-factory-as-init-generic.h
@@ -1,0 +1,42 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_STATIC_FACTORY_AS_INIT_GENERIC_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_STATIC_FACTORY_AS_INIT_GENERIC_H
+
+// Static member function templates renamed to 'init(...)' with SWIFT_NAME,
+// where the template parameter appears in the signature so the initializer has
+// to be imported as a generic initializer.
+
+/// One template parameter, used as the only parameter.
+struct GenericFactory {
+  int value;
+
+  template <class T>
+  __attribute__((swift_name("init(fromGeneric:)"))) static GenericFactory
+  make(T v) {
+    return GenericFactory{static_cast<int>(v)};
+  }
+};
+
+/// Two template parameters, both used.
+struct MultiGenericFactory {
+  int value;
+
+  template <class T, class U>
+  __attribute__((swift_name("init(_:other:)"))) static MultiGenericFactory
+  make(T v, U w) {
+    return MultiGenericFactory{static_cast<int>(v) + static_cast<int>(w)};
+  }
+};
+
+/// A template parameter used alongside a concrete parameter.
+struct MixedGenericFactory {
+  int value;
+
+  template <class T>
+  __attribute__((swift_name("init(generic:concrete:)"))) static
+      MixedGenericFactory
+      make(T v, int w) {
+    return MixedGenericFactory{static_cast<int>(v) + w};
+  }
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_STATIC_FACTORY_AS_INIT_GENERIC_H

--- a/test/Interop/Cxx/class/Inputs/static-factory-as-init.h
+++ b/test/Interop/Cxx/class/Inputs/static-factory-as-init.h
@@ -1,0 +1,64 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_STATIC_FACTORY_AS_INIT_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_STATIC_FACTORY_AS_INIT_H
+
+// A static member function annotated with SWIFT_NAME("init(...)") is imported
+// as a Swift initializer even though it is not a C++ constructor.
+
+/// The static factory is an ordinary (non-template) member function.
+struct NonTemplateFactory {
+  int value;
+
+  __attribute__((swift_name("init(fromInt:)"))) static NonTemplateFactory
+  make(int v) {
+    return NonTemplateFactory{v};
+  }
+};
+
+/// The static factory is a member function template whose only template
+/// parameter is defaulted and does not appear in the signature.
+///
+/// Imported as a non-generic initializer.
+struct DefaultedTemplateParamFactory {
+  int value;
+
+  template <class T = int>
+  __attribute__((swift_name("init(fromDefaultedTemplate:)")))
+  static DefaultedTemplateParamFactory
+  make(int v) {
+    return DefaultedTemplateParamFactory{v};
+  }
+};
+
+/// Overloaded static factories, mixing templated and non-templated overloads.
+struct OverloadedFactories {
+  int value;
+
+  __attribute__((swift_name("init(overload:)")))
+  static OverloadedFactories
+  make(int v) {
+    return OverloadedFactories{v};
+  }
+
+  template <class T = int>
+  __attribute__((swift_name("init(overload:extra:)")))
+  static OverloadedFactories
+  make(int v, int w) {
+    return OverloadedFactories{v + w};
+  }
+};
+
+/// A static factory named 'init(...)' alongside a real C++ constructor, which
+/// it must not interfere with.
+struct FactoryAndConstructor {
+  int value;
+
+  FactoryAndConstructor(int v) : value(v) {}
+
+  __attribute__((swift_name("init(fromFactory:)")))
+  static FactoryAndConstructor
+  make(int v) {
+    return FactoryAndConstructor{v};
+  }
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_STATIC_FACTORY_AS_INIT_H

--- a/test/Interop/Cxx/class/static-factory-as-init-executable.swift
+++ b/test/Interop/Cxx/class/static-factory-as-init-executable.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StaticFactoryAsInit
+
+var Suite = TestSuite("Static factory as initializer")
+
+Suite.test("NonTemplateFactory") {
+  let instance = NonTemplateFactory(fromInt: 7)
+  expectEqual(7, instance.value)
+}
+
+Suite.test("DefaultedTemplateParamFactory") {
+  let instance = DefaultedTemplateParamFactory(fromDefaultedTemplate: 8)
+  expectEqual(8, instance.value)
+}
+
+Suite.test("OverloadedFactories") {
+  let one = OverloadedFactories(overload: 3)
+  expectEqual(3, one.value)
+
+  let two = OverloadedFactories(overload: 3, extra: 4)
+  expectEqual(7, two.value)
+}
+
+Suite.test("FactoryAndConstructor") {
+  // The real C++ constructor.
+  let fromCtor = FactoryAndConstructor(5)
+  expectEqual(5, fromCtor.value)
+
+  // The static factory renamed to 'init(fromFactory:)'.
+  let fromFactory = FactoryAndConstructor(fromFactory: 6)
+  expectEqual(6, fromFactory.value)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/static-factory-as-init-generic-executable.swift
+++ b/test/Interop/Cxx/class/static-factory-as-init-generic-executable.swift
@@ -1,0 +1,40 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -cxx-interoperability-mode=default)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StaticFactoryAsInitGeneric
+
+var Suite = TestSuite("Generic static factory as initializer")
+
+Suite.test("GenericFactory") {
+  // T == int
+  let fromInt = GenericFactory(fromGeneric: 1 as CInt)
+  expectEqual(1, fromInt.value)
+
+  // T == double; the factory truncates via static_cast<int>.
+  let fromDouble = GenericFactory(fromGeneric: 2.75 as Double)
+  expectEqual(2, fromDouble.value)
+}
+
+Suite.test("MultiGenericFactory") {
+  // T == U == int
+  let bothInt = MultiGenericFactory(2 as CInt, other: 3 as CInt)
+  expectEqual(5, bothInt.value)
+
+  // T == int, U == double; the factory truncates via static_cast<int>.
+  let mixed = MultiGenericFactory(2 as CInt, other: 4.5 as Double)
+  expectEqual(6, mixed.value)
+}
+
+Suite.test("MixedGenericFactory") {
+  // T == int, alongside a concrete int parameter.
+  let fromInt = MixedGenericFactory(generic: 4 as CInt, concrete: 5)
+  expectEqual(9, fromInt.value)
+
+  // T == double, alongside the same concrete int parameter.
+  let fromDouble = MixedGenericFactory(generic: 6.5 as Double, concrete: 5)
+  expectEqual(11, fromDouble.value)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/static-factory-as-init-generic-module-interface.swift
+++ b/test/Interop/Cxx/class/static-factory-as-init-generic-module-interface.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -print-module -module-to-print=StaticFactoryAsInitGeneric -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default > %t/interface.txt
+
+// RUN: %FileCheck --check-prefix=ONE-PARAM %s < %t/interface.txt
+// RUN: %FileCheck --check-prefix=TWO-PARAMS %s < %t/interface.txt
+// RUN: %FileCheck --check-prefix=MIXED %s < %t/interface.txt
+
+// Each spelling gets its own FileCheck prefix so the assertions do not depend on
+// member print order.
+
+// ONE-PARAM-COUNT-1: init<T>(fromGeneric v: T)
+// ONE-PARAM-NOT:     init<T>(fromGeneric v: T)
+
+// TWO-PARAMS-COUNT-1: init<T, U>(_ v: T, other w: U)
+// TWO-PARAMS-NOT:     init<T, U>(_ v: T, other w: U)
+
+// MIXED-COUNT-1: init<T>(generic v: T, concrete w: CInt)
+// MIXED-NOT:     init<T>(generic v: T, concrete w: CInt)

--- a/test/Interop/Cxx/class/static-factory-as-init-generic-typechecker.swift
+++ b/test/Interop/Cxx/class/static-factory-as-init-generic-typechecker.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+
+import StaticFactoryAsInitGeneric
+
+let generic = GenericFactory(fromGeneric: 1 as CInt)
+let _: CInt = generic.value
+
+let multi = MultiGenericFactory(2 as CInt, other: 3 as CInt)
+let _: CInt = multi.value
+
+let mixed = MixedGenericFactory(generic: 4 as CInt, concrete: 5)
+let _: CInt = mixed.value

--- a/test/Interop/Cxx/class/static-factory-as-init-module-interface.swift
+++ b/test/Interop/Cxx/class/static-factory-as-init-module-interface.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -print-module -module-to-print=StaticFactoryAsInit -I %S/Inputs -source-filename=x -cxx-interoperability-mode=default > %t/interface.txt
+
+// RUN: %FileCheck --check-prefix=FROM-INT %s < %t/interface.txt
+// RUN: %FileCheck --check-prefix=DEFAULTED-TEMPLATE %s < %t/interface.txt
+// RUN: %FileCheck --check-prefix=OVERLOAD %s < %t/interface.txt
+// RUN: %FileCheck --check-prefix=OVERLOAD-EXTRA %s < %t/interface.txt
+// RUN: %FileCheck --check-prefix=REAL-CTOR %s < %t/interface.txt
+// RUN: %FileCheck --check-prefix=FROM-FACTORY %s < %t/interface.txt
+
+// Each spelling gets its own FileCheck prefix so that the assertions do not
+// depend on the order in which members are printed.
+
+// FROM-INT-COUNT-1: init(fromInt v: CInt)
+// FROM-INT-NOT:     init(fromInt v: CInt)
+
+// DEFAULTED-TEMPLATE-COUNT-1: init(fromDefaultedTemplate v: CInt)
+// DEFAULTED-TEMPLATE-NOT:     init(fromDefaultedTemplate v: CInt)
+
+// OVERLOAD-COUNT-1: init(overload v: CInt)
+// OVERLOAD-NOT:     init(overload v: CInt)
+
+// OVERLOAD-EXTRA-COUNT-1: init(overload v: CInt, extra w: CInt)
+// OVERLOAD-EXTRA-NOT:     init(overload v: CInt, extra w: CInt)
+
+// REAL-CTOR-COUNT-1: init(_ v: CInt)
+// REAL-CTOR-NOT:     init(_ v: CInt)
+
+// FROM-FACTORY-COUNT-1: init(fromFactory v: CInt)
+// FROM-FACTORY-NOT:     init(fromFactory v: CInt)

--- a/test/Interop/Cxx/class/static-factory-as-init-typechecker.swift
+++ b/test/Interop/Cxx/class/static-factory-as-init-typechecker.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+
+import StaticFactoryAsInit
+
+let nonTemplate = NonTemplateFactory(fromInt: 1)
+let _: CInt = nonTemplate.value
+
+let defaultedTemplate = DefaultedTemplateParamFactory(fromDefaultedTemplate: 2)
+let _: CInt = defaultedTemplate.value
+
+let overload = OverloadedFactories(overload: 3)
+let _: CInt = overload.value
+
+let overloadExtra = OverloadedFactories(overload: 4, extra: 5)
+let _: CInt = overloadExtra.value
+
+// The real C++ constructor and the static factory coexist.
+let fromConstructor = FactoryAndConstructor(6)
+let _: CInt = fromConstructor.value
+
+let fromFactory = FactoryAndConstructor(fromFactory: 7)
+let _: CInt = fromFactory.value


### PR DESCRIPTION
When we have a templated static function member that is imported as annotated as a constructor via `SWIFT_NAME`, we hit the following crash:

    Assertion failed: (genericParamIter != genericParams.end() && "Could not find generic paramtype in generic params.")

This patch updates `importGlobalAsInitializer` to properly support templates to fix this crash.

rdar://185939342