### PR TITLE
Platform: refactor windows SDK modules

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -205,7 +205,6 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -empty-abi-descriptor>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
   "$<$<AND:$<NOT:$<BOOL:${SwiftCore_ENABLE_OBJC_INTEROP}>>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -disable-objc-interop>"
-  "$<$<AND:$<PLATFORM_ID:Windows>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules>"
   "$<$<AND:$<BOOL:${SwiftCore_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<AND:$<BOOL:${SwiftCore_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
 

--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -15,15 +15,21 @@ version: 0
 case-sensitive: false
 use-external-names: true
 roots:
+  - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk.modulemap"
+      - name: WinSDK.apinotes
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/WinSDK.apinotes"
   - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um"
     type: directory
     contents:
       - name: module.modulemap
         type: file
         external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk_um.modulemap"
-      - name: WinSDK.apinotes
-        type: file
-        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/WinSDK.apinotes"
   - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared"
     type: directory
     contents:
@@ -53,7 +59,8 @@ ESCAPE_QUOTES @ONLY NEWLINE_STYLE LF)
 
 add_library(ClangModules INTERFACE)
 target_compile_options(ClangModules INTERFACE
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-overlay.yaml>")
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-overlay.yaml>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=\"${WindowsSdkDir}/Include/${WindowsSDKVersion}/module.modulemap\">")
 
 install(TARGETS ClangModules
   EXPORT SwiftOverlayTargets)
@@ -63,6 +70,7 @@ install(FILES
   WinSDK.apinotes
   vcruntime.apinotes
   vcruntime.modulemap
+  winsdk.modulemap
   winsdk_um.modulemap
   winsdk_shared.modulemap
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})

--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -4,6 +4,8 @@ file(TO_CMAKE_PATH "$ENV{WindowsSDKVersion}" WindowsSDKVersion)
 file(TO_CMAKE_PATH "$ENV{UniversalCRTSdkDir}" UniversalCRTSdkDir)
 file(TO_CMAKE_PATH "$ENV{UCRTVersion}" UCRTVersion)
 file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}" VCToolsInstallDir)
+string(REGEX REPLACE "/+$" "" WindowsSDKVersion "${WindowsSDKVersion}")
+string(REGEX REPLACE "/+$" "" UCRTVersion "${UCRTVersion}")
 
 file(CONFIGURE
   OUTPUT windows-sdk-overlay.yaml
@@ -34,6 +36,9 @@ roots:
       - name: module.modulemap
         type: file
         external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/ucrt.modulemap"
+      - name: SwiftUCRT.h
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/SwiftUCRT.h"
   - name: "@VCToolsInstallDir@/include"
     type: directory
     contents:
@@ -53,6 +58,7 @@ target_compile_options(ClangModules INTERFACE
 install(TARGETS ClangModules
   EXPORT SwiftOverlayTargets)
 install(FILES
+  SwiftUCRT.h
   ucrt.modulemap
   WinSDK.apinotes
   vcruntime.apinotes

--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -36,6 +36,15 @@ roots:
       - name: module.modulemap
         type: file
         external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk_shared.modulemap"
+  - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/winrt"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winrt.modulemap"
+      - name: SwiftWinRT.h
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/SwiftWinRT.h"
   - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/ucrt"
     type: directory
     contents:
@@ -67,9 +76,11 @@ install(TARGETS ClangModules
 install(FILES
   SwiftUCRT.h
   ucrt.modulemap
+  SwiftWinRT.h
   WinSDK.apinotes
   vcruntime.apinotes
   vcruntime.modulemap
+  winrt.modulemap
   winsdk.modulemap
   winsdk_um.modulemap
   winsdk_shared.modulemap

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -201,6 +201,7 @@ copy_files(public/Platform Overlay/Windows/clang
     ucrt.modulemap
     SwiftUCRT.h
     WinSDK.apinotes
+    winsdk.modulemap
     winsdk_um.modulemap
     winsdk_shared.modulemap
     vcruntime.modulemap

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -200,7 +200,9 @@ copy_files(public/Platform Overlay/Windows/clang
   FILES
     ucrt.modulemap
     SwiftUCRT.h
+    SwiftWinRT.h
     WinSDK.apinotes
+    winrt.modulemap
     winsdk.modulemap
     winsdk_um.modulemap
     winsdk_shared.modulemap

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -199,6 +199,7 @@ message(STATUS "Windows modulemaps[${StdlibSources}/Platform] -> ${CMAKE_CURRENT
 copy_files(public/Platform Overlay/Windows/clang
   FILES
     ucrt.modulemap
+    SwiftUCRT.h
     WinSDK.apinotes
     winsdk_um.modulemap
     winsdk_shared.modulemap

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -19,6 +19,8 @@ function(_report_sdk prefix)
   message(STATUS "  Static link only: ${SWIFT_SDK_${prefix}_STATIC_ONLY}")
 
   if("${prefix}" STREQUAL "WINDOWS")
+    message(STATUS "  Windows SDK Version: ${WindowsSDKVersion}")
+    message(STATUS "  Windows SDK Path: ${WindowsSdkDir}")
     message(STATUS "  UCRT Version: ${UCRTVersion}")
     message(STATUS "  UCRT SDK Path: ${UniversalCRTSdkDir}")
     message(STATUS "  VC Path: ${VCToolsInstallDir}")
@@ -547,10 +549,10 @@ macro(configure_sdk_windows name environment architectures)
     # NOTE(compnerd) workaround incorrectly extensioned import libraries from
     # the Windows SDK on case sensitive file systems.
     swift_windows_arch_spelling(${arch} WinSDKArchitecture)
-    set(WinSDK${arch}UMDir "${UniversalCRTSdkDir}/Lib/${UCRTVersion}/um/${WinSDKArchitecture}")
+    set(WinSDK${arch}UMDir "${WindowsSdkDir}/Lib/${WindowsSDKVersion}/um/${WinSDKArchitecture}")
     set(OverlayDirectory "${CMAKE_BINARY_DIR}/winsdk_lib_${arch}_symlinks")
 
-    if(NOT EXISTS "${UniversalCRTSdkDir}/Include/${UCRTVersion}/um/WINDOWS.H")
+    if(NOT EXISTS "${WindowsSdkDir}/Include/${WindowsSDKVersion}/um/WINDOWS.H")
       file(MAKE_DIRECTORY ${OverlayDirectory})
 
       file(GLOB libraries RELATIVE "${WinSDK${arch}UMDir}" "${WinSDK${arch}UMDir}/*")
@@ -597,4 +599,3 @@ function(configure_target_variant prefix name sdk build_config lib_subdir)
   set(SWIFT_VARIANT_${prefix}_STATIC_ONLY ${SWIFT_SDK_${sdk}_STATIC_ONLY})
   get_threading_package(${prefix} ${SWIFT_SDK_${sdk}_THREADING_PACKAGE} SWIFT_VARIANT_${prefix}_THREADING_PACKAGE)
 endfunction()
-

--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -19,8 +19,9 @@ function(swift_windows_include_for_arch arch var)
   set(paths
       "${VCToolsInstallDir}/include"
       "${UniversalCRTSdkDir}/Include/${UCRTVersion}/ucrt"
-      "${UniversalCRTSdkDir}/Include/${UCRTVersion}/shared"
-      "${UniversalCRTSdkDir}/Include/${UCRTVersion}/um")
+      "${WindowsSdkDir}/Include/${WindowsSDKVersion}/shared"
+      "${WindowsSdkDir}/Include/${WindowsSDKVersion}/um"
+      "${WindowsSdkDir}/Include/${WindowsSDKVersion}/winrt")
   set(${var} ${paths} PARENT_SCOPE)
 endfunction()
 
@@ -44,7 +45,7 @@ function(swift_windows_lib_for_arch arch var)
 
   list(APPEND paths
           "${UniversalCRTSdkDir}/Lib/${UCRTVersion}/ucrt/${ARCH}"
-          "${UniversalCRTSdkDir}/Lib/${UCRTVersion}/um/${ARCH}")
+          "${WindowsSdkDir}/Lib/${WindowsSDKVersion}/um/${ARCH}")
 
   set(${var} ${paths} PARENT_SCOPE)
 endfunction()
@@ -52,7 +53,9 @@ endfunction()
 function(swift_windows_get_sdk_vfs_overlay overlay)
   get_filename_component(VCToolsInstallDir ${VCToolsInstallDir} ABSOLUTE)
   get_filename_component(UniversalCRTSdkDir ${UniversalCRTSdkDir} ABSOLUTE)
+  get_filename_component(WindowsSdkDir ${WindowsSdkDir} ABSOLUTE)
   set(UCRTVersion ${UCRTVersion})
+  set(WindowsSDKVersion ${WindowsSDKVersion})
 
   # TODO(compnerd) use a target to avoid re-creating this file all the time
   configure_file("${SWIFT_SOURCE_DIR}/utils/WindowsSDKVFSOverlay.yaml.in"
@@ -72,10 +75,20 @@ function(swift_windows_cache_VCVARS)
   swift_verify_windows_VCVAR(VCToolsInstallDir)
   swift_verify_windows_VCVAR(UniversalCRTSdkDir)
   swift_verify_windows_VCVAR(UCRTVersion)
+  swift_verify_windows_VCVAR(WindowsSdkDir)
+  swift_verify_windows_VCVAR(WindowsSDKVersion)
 
   set(VCToolsInstallDir $ENV{VCToolsInstallDir} CACHE STRING "")
   set(UniversalCRTSdkDir $ENV{UniversalCRTSdkDir} CACHE STRING "")
   set(UCRTVersion $ENV{UCRTVersion} CACHE STRING "")
+  set(WindowsSdkDir $ENV{WindowsSdkDir} CACHE STRING "")
+  set(WindowsSDKVersion $ENV{WindowsSDKVersion} CACHE STRING "")
+
+  # VsDevCmd spells WindowsSDKVersion with a trailing path separator.
+  # Keep the cached value suitable for composing include and library paths.
+  string(REGEX REPLACE "[/\\\\]+$" "" WindowsSDKVersion
+         "${WindowsSDKVersion}")
+  set(WindowsSDKVersion "${WindowsSDKVersion}" CACHE STRING "" FORCE)
 endfunction()
 
 # NOTE(compnerd) we use a macro here as this modifies global variables
@@ -111,4 +124,3 @@ macro(swift_swap_compiler_if_needed target)
     endif()
   endif()
 endmacro()
-

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1344,6 +1344,15 @@ ClangImporter::getClangDriverArguments(ASTContext &ctx, bool ignoreClangTarget) 
       /*needSystemVFSOverlay=*/!clangFileMapping.redirectedFiles.empty() &&
           !ctx.CASOpts.HasImmutableFileSystem,
       ignoreClangTarget);
+  if (ctx.LangOpts.Target.isWindowsMSVCEnvironment()) {
+    auto iterator = llvm::find_if(clangFileMapping.redirectedFiles,
+                                  [](const auto &mapping) {
+        return llvm::sys::path::filename(mapping.second) == "winsdk.modulemap";
+    });
+    if (iterator != clangFileMapping.redirectedFiles.end())
+      invocationArgStrs
+          .push_back((Twine("-fmodule-map-file=") + iterator->first).str());
+  }
   return invocationArgStrs;
 }
 

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -507,8 +507,7 @@ std::string GetPlatformAuxiliaryFile(StringRef Platform, StringRef File,
 
 void GetWindowsFileMappings(
     ClangInvocationFileMapping &fileMapping, const ASTContext &Context,
-    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &driverVFS,
-    bool &requiresBuiltinHeadersInSystemModules) {
+    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &driverVFS) {
   const llvm::Triple &Triple = Context.LangOpts.Target;
   const SearchPathOptions &SearchPathOpts = Context.SearchPathOpts;
   std::string AuxiliaryFile;
@@ -579,21 +578,33 @@ void GetWindowsFileMappings(
 
     AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "ucrt.modulemap", VFS,
                                              SearchPathOpts);
-    if (!AuxiliaryFile.empty()) {
-      // The ucrt module map has the C standard library headers all together.
-      // That leads to module cycles with the clang _Builtin_ modules. e.g.
-      // <fenv.h> on ucrt includes <float.h>. The clang builtin <float.h>
-      // include-nexts <float.h>. When both of those UCRT headers are in the
-      // ucrt module, there's a module cycle ucrt -> _Builtin_float -> ucrt
-      // (i.e. fenv.h (ucrt) -> float.h (builtin) -> float.h (ucrt)). Until the
-      // ucrt module map is updated, the builtin headers need to join the system
-      // modules. i.e. when the builtin float.h is in the ucrt module too, the
-      // cycle goes away. Note that -fbuiltin-headers-in-system-modules does
-      // nothing to fix the same problem with C++ headers, and is generally
-      // fragile.
+    if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(std::string(UCRTInjection),
                                                AuxiliaryFile);
-      requiresBuiltinHeadersInSystemModules = true;
+
+    llvm::SmallString<261> UCRTInclude{UCRTInjection};
+    llvm::sys::path::remove_filename(UCRTInclude);
+    llvm::SmallString<261> SwiftUCRT{UCRTInclude};
+    llvm::sys::path::append(SwiftUCRT, "SwiftUCRT.h");
+    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "SwiftUCRT.h", VFS,
+                                             SearchPathOpts);
+    if (!AuxiliaryFile.empty())
+      fileMapping.redirectedFiles.emplace_back(std::string(SwiftUCRT),
+                                               AuxiliaryFile);
+
+    // stdalign.h and stdnoreturn.h were added to the UCRT in Windows SDK
+    // 10.0.20348. Older SDKs do not provide their definitions, but the files
+    // must exist for the common module map to remain available.
+    static constexpr StringLiteral CompatibilityHeaders[] = {
+        "stdalign.h", "stdnoreturn.h"};
+    for (StringRef Header : CompatibilityHeaders) {
+      llvm::SmallString<261> SDKHeader{UCRTInclude};
+      llvm::sys::path::append(SDKHeader, Header);
+      if (VFS.exists(SDKHeader))
+        continue;
+
+      fileMapping.overridenFiles.emplace_back(
+          llvm::MemoryBuffer::getMemBufferCopy("", SDKHeader));
     }
   }
 
@@ -747,8 +758,7 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
   if (ctx.LangOpts.EnableCXXInterop)
     getLibStdCxxFileMapping(result, ctx, vfs, suppressDiagnostic);
 
-  GetWindowsFileMappings(result, ctx, vfs,
-                         result.requiresBuiltinHeadersInSystemModules);
+  GetWindowsFileMappings(result, ctx, vfs);
 
   // push the redirect files into a YAML vfs overlay file.
   if (!result.redirectedFiles.empty()) {

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -571,6 +571,19 @@ void GetWindowsFileMappings(
     if (!AuxiliaryFile.empty())
       fileMapping.redirectedFiles.emplace_back(path.str(), AuxiliaryFile);
 
+    path.assign(WinSDKInjection);
+    llvm::sys::path::append(path, "winrt", "module.modulemap");
+    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "winrt.modulemap", VFS,
+                                             SearchPathOpts);
+    if (!AuxiliaryFile.empty())
+      fileMapping.redirectedFiles.emplace_back(path.str(), AuxiliaryFile);
+
+    path.assign(WinSDKInjection);
+    llvm::sys::path::append(path, "winrt", "SwiftWinRT.h");
+    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "SwiftWinRT.h", VFS,
+                                             SearchPathOpts);
+    if (!AuxiliaryFile.empty())
+      fileMapping.redirectedFiles.emplace_back(path.str(), AuxiliaryFile);
   }
 
   struct {

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -537,32 +537,40 @@ void GetWindowsFileMappings(
                              WindowsSDK.LibraryVersion)) {
     assert(WindowsSDK.MajorVersion > 8);
     llvm::SmallString<261> WinSDKInjection{WindowsSDK.Path};
-    llvm::sys::path::append(WinSDKInjection, "Include");
-    llvm::sys::path::append(WinSDKInjection, WindowsSDK.IncludeVersion, "um");
-    llvm::sys::path::append(WinSDKInjection, "module.modulemap");
+    llvm::sys::path::append(WinSDKInjection, "Include",
+                            WindowsSDK.IncludeVersion);
+
+    llvm::SmallString<261> path{WinSDKInjection};
+
+    llvm::sys::path::append(path, "module.modulemap");
+    AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "winsdk.modulemap",
+                                             VFS, SearchPathOpts);
+    if (!AuxiliaryFile.empty())
+      fileMapping.redirectedFiles.emplace_back(path.str(), AuxiliaryFile);
+
+    path.assign(WinSDKInjection);
+    llvm::sys::path::append(path, "um", "module.modulemap");
 
     AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "winsdk_um.modulemap",
                                              VFS, SearchPathOpts);
     if (!AuxiliaryFile.empty())
-      fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
-                                               AuxiliaryFile);
+      fileMapping.redirectedFiles.emplace_back(path.str(), AuxiliaryFile);
 
-    llvm::sys::path::remove_filename(WinSDKInjection);
-    llvm::sys::path::append(WinSDKInjection, "WinSDK.apinotes");
+    path.assign(WinSDKInjection);
+    llvm::sys::path::append(path, "WinSDK.apinotes");
     AuxiliaryFile = GetPlatformAuxiliaryFile("windows", "WinSDK.apinotes",
                                              VFS, SearchPathOpts);
     if (!AuxiliaryFile.empty())
-      fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
-                                               AuxiliaryFile);
+      fileMapping.redirectedFiles.emplace_back(path.str(), AuxiliaryFile);
 
-    llvm::sys::path::remove_filename(WinSDKInjection);
-    llvm::sys::path::remove_filename(WinSDKInjection);
-    llvm::sys::path::append(WinSDKInjection, "shared", "module.modulemap");
-    AuxiliaryFile = GetPlatformAuxiliaryFile(
-        "windows", "winsdk_shared.modulemap", VFS, SearchPathOpts);
+    path.assign(WinSDKInjection);
+    llvm::sys::path::append(path, "shared", "module.modulemap");
+    AuxiliaryFile =
+        GetPlatformAuxiliaryFile("windows", "winsdk_shared.modulemap", VFS,
+                                 SearchPathOpts);
     if (!AuxiliaryFile.empty())
-      fileMapping.redirectedFiles.emplace_back(std::string(WinSDKInjection),
-                                               AuxiliaryFile);
+      fileMapping.redirectedFiles.emplace_back(path.str(), AuxiliaryFile);
+
   }
 
   struct {

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -44,6 +44,8 @@ if(WINDOWS IN_LIST SWIFT_SDKS)
   generate_windows_vfs_overlay()
   file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/windows-vfs-overlay.yaml"
        SWIFT_WINDOWS_VFS_OVERLAY)
+  set(SWIFT_WINDOWS_MODULE_MAP
+      "${WindowsSdkDir}/Include/${WindowsSDKVersion}/module.modulemap")
 endif()
 
 #

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 function(generate_windows_vfs_overlay)
   file(TO_CMAKE_PATH ${VCToolsInstallDir} VCToolsInstallDir)
   file(TO_CMAKE_PATH ${UniversalCRTSdkDir} UniversalCRTSdkDir)
+  file(TO_CMAKE_PATH ${WindowsSdkDir} WindowsSdkDir)
+  string(REGEX REPLACE "[/\\\\]+$" "" WindowsSDKVersion
+         "${WindowsSDKVersion}")
   configure_file("${PROJECT_SOURCE_DIR}/cmake/WindowsVFS.yaml.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/windows-vfs-overlay.yaml"
                  @ONLY)

--- a/stdlib/cmake/WindowsVFS.yaml.in
+++ b/stdlib/cmake/WindowsVFS.yaml.in
@@ -24,6 +24,9 @@ roots:
       - name: module.modulemap
         type: file
         external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\ucrt.modulemap"
+      - name: SwiftUCRT.h
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\SwiftUCRT.h"
   - name: "@VCToolsInstallDir@\\include"
     type: directory
     contents:

--- a/stdlib/cmake/WindowsVFS.yaml.in
+++ b/stdlib/cmake/WindowsVFS.yaml.in
@@ -24,6 +24,15 @@ roots:
       - name: module.modulemap
         type: file
         external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk_shared.modulemap"
+  - name: "@WindowsSdkDir@\\Include\\@WindowsSDKVersion@\\winrt"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winrt.modulemap"
+      - name: SwiftWinRT.h
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\SwiftWinRT.h"
   - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\ucrt"
     type: directory
     contents:

--- a/stdlib/cmake/WindowsVFS.yaml.in
+++ b/stdlib/cmake/WindowsVFS.yaml.in
@@ -3,16 +3,22 @@ version: 0
 case-sensitive: false
 use-external-names: false
 roots:
-  - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\um"
+  - name: "@WindowsSdkDir@\\Include\\@WindowsSDKVersion@"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk.modulemap"
+      - name: WinSDK.apinotes
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\WinSDK.apinotes"
+  - name: "@WindowsSdkDir@\\Include\\@WindowsSDKVersion@\\um"
     type: directory
     contents:
       - name: module.modulemap
         type: file
         external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk_um.modulemap"
-      - name: WinSDK.apinotes
-        type: file
-        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\WinSDK.apinotes"
-  - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\shared"
+  - name: "@WindowsSdkDir@\\Include\\@WindowsSDKVersion@\\shared"
     type: directory
     contents:
       - name: module.modulemap

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1082,7 +1082,7 @@ function(add_swift_target_library_single target name)
         -Xcc;-Xclang;-Xcc;-ivfsoverlay;-Xcc;-Xclang;-Xcc;${SWIFTLIB_SINGLE_VFS_OVERLAY})
     endif()
     list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
-      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";-Xfrontend;-strict-implicit-module-context;-Xcc;-Xclang;-Xcc;-fbuiltin-headers-in-system-modules)
+      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";-Xfrontend;-strict-implicit-module-context)
     if(NOT CMAKE_HOST_SYSTEM MATCHES Windows)
       swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE} SWIFTLIB_INCLUDE)
       foreach(directory ${SWIFTLIB_INCLUDE})
@@ -3186,7 +3186,7 @@ function(_add_swift_target_executable_single name)
 
   if(SWIFTEXE_SINGLE_SDK STREQUAL "WINDOWS")
     list(APPEND SWIFTEXE_SINGLE_COMPILE_FLAGS
-      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";-Xfrontend;-strict-implicit-module-context;-Xcc;-Xclang;-Xcc;-fbuiltin-headers-in-system-modules)
+      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";-Xfrontend;-strict-implicit-module-context)
   endif()
 
   if ("${SWIFTEXE_SINGLE_SDK}" STREQUAL "LINUX")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1082,7 +1082,9 @@ function(add_swift_target_library_single target name)
         -Xcc;-Xclang;-Xcc;-ivfsoverlay;-Xcc;-Xclang;-Xcc;${SWIFTLIB_SINGLE_VFS_OVERLAY})
     endif()
     list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
-      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";-Xfrontend;-strict-implicit-module-context)
+      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";
+      -Xcc;"-fmodule-map-file=${SWIFT_WINDOWS_MODULE_MAP}";
+      -Xfrontend;-strict-implicit-module-context)
     if(NOT CMAKE_HOST_SYSTEM MATCHES Windows)
       swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE} SWIFTLIB_INCLUDE)
       foreach(directory ${SWIFTLIB_INCLUDE})
@@ -3186,7 +3188,9 @@ function(_add_swift_target_executable_single name)
 
   if(SWIFTEXE_SINGLE_SDK STREQUAL "WINDOWS")
     list(APPEND SWIFTEXE_SINGLE_COMPILE_FLAGS
-      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";-Xfrontend;-strict-implicit-module-context)
+      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}";
+      -Xcc;"-fmodule-map-file=${SWIFT_WINDOWS_MODULE_MAP}";
+      -Xfrontend;-strict-implicit-module-context)
   endif()
 
   if ("${SWIFTEXE_SINGLE_SDK}" STREQUAL "LINUX")

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -570,6 +570,7 @@ add_dependencies(sdk-overlay emscriptenlibc_modulemap)
 if(WINDOWS IN_LIST SWIFT_SDKS)
   swift_install_in_component(FILES
       ucrt.modulemap
+      SwiftUCRT.h
       WinSDK.apinotes
       vcruntime.apinotes
       vcruntime.modulemap

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -574,6 +574,7 @@ if(WINDOWS IN_LIST SWIFT_SDKS)
       WinSDK.apinotes
       vcruntime.apinotes
       vcruntime.modulemap
+      winsdk.modulemap
       winsdk_um.modulemap
       winsdk_shared.modulemap
     DESTINATION "share"

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -571,9 +571,11 @@ if(WINDOWS IN_LIST SWIFT_SDKS)
   swift_install_in_component(FILES
       ucrt.modulemap
       SwiftUCRT.h
+      SwiftWinRT.h
       WinSDK.apinotes
       vcruntime.apinotes
       vcruntime.modulemap
+      winrt.modulemap
       winsdk.modulemap
       winsdk_um.modulemap
       winsdk_shared.modulemap

--- a/stdlib/public/Platform/SwiftUCRT.h
+++ b/stdlib/public/Platform/SwiftUCRT.h
@@ -1,0 +1,23 @@
+//===--- SwiftUCRT.h -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_UCRT_H
+#define SWIFT_UCRT_H
+
+#pragma clang module import vcruntime
+#pragma clang module import corecrt
+#pragma clang module import _float
+#pragma clang module import _fenv
+#pragma clang module import _malloc
+#pragma clang module import _stdlib
+
+#endif

--- a/stdlib/public/Platform/SwiftWinRT.h
+++ b/stdlib/public/Platform/SwiftWinRT.h
@@ -1,4 +1,4 @@
-//===--- WinSDK.modulemap -------------------------------------------------===//
+//===--- SwiftWinRT.h -----------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-module WinSDK [system] {
-  extern module UM "um/module.modulemap"
-  extern module Shared "shared/module.modulemap"
-  extern module WinRT "winrt/module.modulemap"
-}
+#ifndef SWIFT_WINRT_H
+#define SWIFT_WINRT_H
+
+#include <Windows.h>
+#include <roapi.h>
+
+#endif

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// The following modules have to be standalone top-level modules to deal with
-// version 10.0.26100 of the Windows SDK.
+// These internal top-level modules break cycles among the UCRT, Clang builtin,
+// and C++ standard-library headers. Keep the ownership graph independent of the
+// installed Windows SDK version.
 module _complex [system] [no_undeclared_includes] {
   use corecrt
   use std
@@ -38,7 +39,8 @@ module _malloc [system] [no_undeclared_includes] {
   export *
 }
 
-module _stdlib [system] [no_undeclared_includes] {
+module _stdlib [system] {
+  use _Builtin_limits
   use corecrt
   use vcruntime
   header "stdlib.h"
@@ -46,13 +48,18 @@ module _stdlib [system] [no_undeclared_includes] {
 }
 
 module ucrt [system] {
+  header "SwiftUCRT.h"
+  config_macros NDEBUG
+
+  export *
 
   module C {
-    export _complex
-    export _fenv
-    export _float
-    export _malloc
-    export _stdlib
+    export *
+
+    module assert {
+      header "assert.h"
+      export *
+    }
 
     module ctype {
       header "ctype.h"
@@ -64,16 +71,6 @@ module ucrt [system] {
       export *
     }
 
-    module fenv {
-      header "fenv.h"
-      export *
-    }
-
-    module float {
-      header "float.h"
-      export *
-    }
-
     module inttypes {
       header "inttypes.h"
       export *
@@ -81,11 +78,6 @@ module ucrt [system] {
 
     module locale {
       header "locale.h"
-      export *
-    }
-
-    module malloc {
-      header "malloc.h"
       export *
     }
 
@@ -121,11 +113,6 @@ module ucrt [system] {
       link "legacy_stdio_definitions"
     }
 
-    module stdlib {
-      header "stdlib.h"
-      export *
-    }
-
     module stdnoreturn {
       textual header "stdnoreturn.h"
       export *
@@ -141,35 +128,62 @@ module ucrt [system] {
       export *
     }
 
-    module POSIX {
-      module fcntl {
-        header "fcntl.h"
+    module tgmath {
+      textual header "tgmath.h"
+      export *
+    }
+
+    module uchar {
+      header "uchar.h"
+      export *
+    }
+
+    module wchar {
+      header "wchar.h"
+      export *
+    }
+
+    module wctype {
+      header "wctype.h"
+      export *
+    }
+  }
+
+  module POSIX {
+    module fcntl {
+      header "fcntl.h"
+      export *
+    }
+
+    module sys {
+      module locking {
+        header "sys/locking.h"
         export *
       }
 
-      module sys {
+      module stat {
+        header "sys/stat.h"
         export *
+      }
 
-        module stat {
-          header "sys/stat.h"
-          header "direct.h"
-          export *
-        }
+      module direct {
+        header "direct.h"
+        export *
+      }
 
-        module timeb {
-          header "sys/timeb.h"
-          export *
-        }
+      module timeb {
+        header "sys/timeb.h"
+        export *
+      }
 
-        module types {
-          header "sys/types.h"
-          export *
-        }
+      module types {
+        header "sys/types.h"
+        export *
+      }
 
-        module utime {
-          header "sys/utime.h"
-          export *
-        }
+      module utime {
+        header "sys/utime.h"
+        export *
       }
     }
   }
@@ -184,13 +198,45 @@ module ucrt [system] {
     export *
   }
 
+  module debug {
+    header "crtdbg.h"
+    export *
+  }
+
+  module fpieee {
+    header "fpieee.h"
+    export *
+  }
+
+  module io {
+    header "io.h"
+    export *
+  }
+
+  module memory {
+    header "memory.h"
+    export *
+  }
+
   module minmax {
     header "minmax.h"
     export *
   }
 
   module multibyte {
-    header "mbstring.h"
+    module ctype {
+      header "mbctype.h"
+      export *
+    }
+
+    module string {
+      header "mbstring.h"
+      export *
+    }
+  }
+
+  module new {
+    header "new.h"
     export *
   }
 
@@ -199,18 +245,49 @@ module ucrt [system] {
     export *
   }
 
-  module wchar {
-    header "wchar.h"
+  explicit module safeint {
+    requires cplusplus
+    header "safeint.h"
+    // This is the private implementation of safeint.h, not an independent
+    // public header surface.
+    private textual header "safeint_internal.h"
+    export *
+  }
+
+  module search {
+    header "search.h"
+    export *
+  }
+
+  module share {
+    header "share.h"
+    export *
+  }
+
+  module startup {
+    header "corecrt_startup.h"
+    export *
+  }
+
+  module tchar {
+    header "tchar.h"
     export *
   }
 }
 
 module corecrt [system] {
   use vcruntime
-
-  header "corecrt.h"
-  header "corecrt_stdio_config.h"
   export *
+
+  module base {
+    header "corecrt.h"
+    export *
+  }
+
+  module stdio_config {
+    header "corecrt_stdio_config.h"
+    export *
+  }
 
   module conio {
     header "corecrt_wconio.h"
@@ -224,6 +301,10 @@ module corecrt [system] {
 
   module io {
     header "corecrt_io.h"
+    export *
+  }
+
+  module wio {
     header "corecrt_wio.h"
     export *
   }
@@ -235,6 +316,11 @@ module corecrt [system] {
 
   module math {
     header "corecrt_math.h"
+    export *
+  }
+
+  module math_defines {
+    textual header "corecrt_math_defines.h"
     export *
   }
 
@@ -287,4 +373,11 @@ module corecrt [system] {
     header "corecrt_wtime.h"
     export *
   }
+}
+
+module _corecrt_terminate [system] [no_undeclared_includes] {
+  requires cplusplus
+  use corecrt
+  header "corecrt_terminate.h"
+  export *
 }

--- a/stdlib/public/Platform/ucrt.swift
+++ b/stdlib/public/Platform/ucrt.swift
@@ -11,8 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import ucrt // Clang module
-// Extra clang module that's split out from ucrt:
+// Extra Clang modules that are split out from ucrt to break cycles:
 @_exported import _complex
+@_exported import _fenv
+@_exported import _float
+@_exported import _malloc
+@_exported import _stdlib
 
 @available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
 public let M_PI = Double.pi

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -14,21 +14,28 @@ module _visualc_intrinsics [system] [extern_c] {
   explicit module arm {
     requires armv7
     header "armintr.h"
-
-    explicit module neon {
-      requires neon
-      header "arm_neon.h"
-    }
   }
 
   explicit module aarch64 {
     requires aarch64
-    header "arm64intr.h"
+    export *
+
+    explicit module intrinsics {
+      header "arm64intr.h"
+    }
 
     explicit module neon {
       requires neon
       header "arm64_neon.h"
     }
+  }
+
+  // arm_neon.h is the public entry point for both the historical ARM32
+  // implementation and current ARM64 toolsets, where it includes
+  // arm64_neon.h.
+  explicit module neon {
+    requires neon
+    header "arm_neon.h"
   }
 
   explicit module intel {
@@ -42,40 +49,39 @@ module _visualc_intrinsics [system] [extern_c] {
     }
 
     explicit module sse {
-      export mmx
       header "xmmintrin.h"
+      export mmx
     }
 
     explicit module sse2 {
-      export sse
       header "emmintrin.h"
+      export sse
     }
 
     explicit module sse3 {
-      export sse2
       header "pmmintrin.h"
+      export sse2
     }
 
     explicit module ssse3 {
-      export sse3
       header "tmmintrin.h"
+      export sse3
     }
 
     explicit module sse4_1 {
-      export ssse3
       header "smmintrin.h"
+      export ssse3
     }
 
     explicit module sse4_2 {
-      export sse4_1
       header "nmmintrin.h"
+      export sse4_1
     }
 
     explicit module sse4a {
-      export sse3
       header "ammintrin.h"
+      export sse3
     }
-
     explicit module aes_pclmul {
       header "wmmintrin.h"
       export aes
@@ -99,6 +105,7 @@ module vcruntime [system] {
   export SAL
 
   header "vcruntime.h"
+  export *
 
   module iso646 {
     header "iso646.h"
@@ -106,12 +113,10 @@ module vcruntime [system] {
   }
 
   module limits {
-    header "limits.h"
-    export *
-  }
-
-  module setjmp {
-    header "setjmp.h"
+    // Clang's _Builtin_limits module owns the modular limits declarations and
+    // includes the toolset header as needed. Keep the latter textual to avoid
+    // exposing a second Swift-visible copy of constants such as LONG_MAX.
+    textual header "limits.h"
     export *
   }
 
@@ -122,7 +127,7 @@ module vcruntime [system] {
 
   module stdbool {
     header "stdbool.h"
-    export  *
+    export *
   }
 
   module stdint {
@@ -139,12 +144,28 @@ module vcruntime [system] {
     header "vadefs.h"
     export *
   }
+
+  // setjmp.h includes vcruntime.h for its ABI and SAL definitions. Keep it in
+  // a submodule so that include resolves through the parent module instead of
+  // depending on the order in which the fused module headers are parsed.
+  module setjmp {
+    header "setjmp.h"
+    export *
+  }
 }
 
 module std_config [system] {
-  header "crtdefs.h"
-  header "crtversion.h"
   export *
+
+  module definitions {
+    header "crtdefs.h"
+    export *
+  }
+
+  module version {
+    header "crtversion.h"
+    export *
+  }
 }
 
 module std [system] {

--- a/stdlib/public/Platform/winrt.modulemap
+++ b/stdlib/public/Platform/winrt.modulemap
@@ -1,4 +1,4 @@
-//===--- WinSDK.modulemap -------------------------------------------------===//
+//===--- WinRT.modulemap -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-module WinSDK [system] {
-  extern module UM "um/module.modulemap"
-  extern module Shared "shared/module.modulemap"
-  extern module WinRT "winrt/module.modulemap"
+module WinSDK.WinRT [system] {
+  // The shim breaks the unavoidable Windows.h/roapi.h dependency across the
+  // UM and WinRT SDK directories without assigning either header to two
+  // modules.
+  header "SwiftWinRT.h"
+  export *
 }

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -1,0 +1,16 @@
+//===--- WinSDK.modulemap -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+module WinSDK [system] {
+  extern module UM "um/module.modulemap"
+  extern module Shared "shared/module.modulemap"
+}

--- a/stdlib/public/Platform/winsdk_shared.modulemap
+++ b/stdlib/public/Platform/winsdk_shared.modulemap
@@ -10,12 +10,68 @@
 //
 //===----------------------------------------------------------------------===//
 
-module _GUIDDef {
-  header "guiddef.h"
-  export *
-}
+module WinSDK.Shared [system] {
+  module AFUnix {
+    header "afunix.h"
+    export *
+  }
 
-module WinAPIFamily {
-  header "winapifamily.h"
-  export *
+  module DXGI {
+    header "dxgi1_6.h"
+    export *
+
+    link "dxgi.lib"
+  }
+
+  module GUIDDef {
+    header "guiddef.h"
+    export *
+  }
+
+  module APIFamily {
+    header "winapifamily.h"
+    export *
+  }
+
+  module MinWinDef {
+    header "minwindef.h"
+    export *
+  }
+
+  module RPC {
+    header "rpc.h"
+    export *
+
+    link "RpcRT4.Lib"
+  }
+
+  module RPCNDR {
+    header "rpcndr.h"
+    export *
+  }
+
+  module SDDL {
+    header "sddl.h"
+    export *
+  }
+
+  module SDKDDKVer {
+    header "sdkddkver.h"
+    export *
+  }
+
+  module WinError {
+    header "winerror.h"
+    export *
+  }
+
+  module WTypesBase {
+    header "wtypesbase.h"
+    export *
+  }
+
+  module WTypes {
+    header "wtypes.h"
+    export *
+  }
 }

--- a/stdlib/public/Platform/winsdk_um.modulemap
+++ b/stdlib/public/Platform/winsdk_um.modulemap
@@ -10,13 +10,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-module WinSDK [system] {
+module WinSDK.UM [system] {
   module WinSock2 {
-    header "WinSock2.h"
-    header "WS2tcpip.h"
-    header "MSWSock.h"
-    header "../shared/afunix.h"
     export *
+
+    module Core {
+      header "WinSock2.h"
+      export *
+    }
+
+    module TCPIP {
+      header "WS2tcpip.h"
+      export *
+    }
+
+    module Extensions {
+      header "MSWSock.h"
+      export *
+    }
 
     link "WS2_32.Lib"
   }
@@ -42,10 +53,22 @@ module WinSDK [system] {
     }
 
     module console {
-      header "consoleapi.h"
-      header "consoleapi2.h"
-      header "consoleapi3.h"
       export *
+
+      module Base {
+        header "consoleapi.h"
+        export *
+      }
+
+      module V2 {
+        header "consoleapi2.h"
+        export *
+      }
+
+      module V3 {
+        header "consoleapi3.h"
+        export *
+      }
     }
 
     // api-ms-win-appmodel-runtime-l1
@@ -176,12 +199,32 @@ module WinSDK [system] {
 
   explicit module DirectX {
     module Direct3D11 {
-      header "d3d11.h"
-      header "d3d11_1.h"
-      header "d3d11_2.h"
-      header "d3d11_3.h"
-      header "d3d11_4.h"
       export *
+
+      module Base {
+        header "d3d11.h"
+        export *
+      }
+
+      module V1 {
+        header "d3d11_1.h"
+        export *
+      }
+
+      module V2 {
+        header "d3d11_2.h"
+        export *
+      }
+
+      module V3 {
+        header "d3d11_3.h"
+        export *
+      }
+
+      module V4 {
+        header "d3d11_4.h"
+        export *
+      }
 
       link "d3d11.lib"
       link "dxgi.lib"
@@ -196,11 +239,27 @@ module WinSDK [system] {
     }
 
     module Direct2D {
-      header "d2d1.h"
-      header "d2d1_1.h"
-      header "d2d1_2.h"
-      header "d2d1_3.h"
       export *
+
+      module Base {
+        header "d2d1.h"
+        export *
+      }
+
+      module V1 {
+        header "d2d1_1.h"
+        export *
+      }
+
+      module V2 {
+        header "d2d1_2.h"
+        export *
+      }
+
+      module V3 {
+        header "d2d1_3.h"
+        export *
+      }
 
       link "d2d1.lib"
       link "dxgi.lib"
@@ -210,7 +269,6 @@ module WinSDK [system] {
     // should split it out, but because it is part of the D3D11 interfaces, this
     // separate module is meant to augment the uncovered portions only.
     module _DXGI {
-      header "../shared/dxgi1_6.h"
       header "dxgidebug.h"
       export *
 
@@ -225,9 +283,17 @@ module WinSDK [system] {
     }
 
     module XAudio29 {
-      header "xaudio2.h"
-      header "xaudio2fx.h"
       export *
+
+      module Core {
+        header "xaudio2.h"
+        export *
+      }
+
+      module Effects {
+        header "xaudio2fx.h"
+        export *
+      }
 
       link "xaudio2.lib"
 
@@ -242,7 +308,7 @@ module WinSDK [system] {
 
       link "xinput.lib"
     }
-    
+
     module DirectInput8 {
       header "dinput.h"
       export *
@@ -260,15 +326,31 @@ module WinSDK [system] {
   }
 
   module DDE {
-    header "dde.h"
-    header "ddeml.h"
     export *
+
+    module Core {
+      header "dde.h"
+      export *
+    }
+
+    module Management {
+      header "ddeml.h"
+      export *
+    }
   }
 
   module DFS {
-    header "LMDFS.h"
-    header "LM.h"
     export *
+
+    module DFS {
+      header "LMDFS.h"
+      export *
+    }
+
+    module Management {
+      header "LM.h"
+      export *
+    }
 
     link "NetAPI32.Lib"
   }
@@ -303,9 +385,17 @@ module WinSDK [system] {
     }
 
     module IMM {
-      header "immdev.h"
-      header "imm.h"
       export *
+
+      module Device {
+        header "immdev.h"
+        export *
+      }
+
+      module Core {
+        header "imm.h"
+        export *
+      }
 
       link "Imm32.lib"
     }
@@ -331,12 +421,35 @@ module WinSDK [system] {
       link "Vfw32.Lib"
     }
 
-    header "mmeapi.h"
-    header "mmddk.h"
-    header "mmsystem.h"
-    header "mmiscapi.h"
-    header "timeapi.h"
-    header "joystickapi.h"
+    module MME {
+      header "mmeapi.h"
+      export *
+    }
+
+    module DDK {
+      header "mmddk.h"
+      export *
+    }
+
+    module System {
+      header "mmsystem.h"
+      export *
+    }
+
+    module Misc {
+      header "mmiscapi.h"
+      export *
+    }
+
+    module Time {
+      header "timeapi.h"
+      export *
+    }
+
+    module Joystick {
+      header "joystickapi.h"
+      export *
+    }
     export *
 
     link "WinMM.Lib"
@@ -355,8 +468,6 @@ module WinSDK [system] {
   }
 
   module Security {
-    header "../shared/sddl.h"
-
     module AuthZ {
       header "AuthZ.h"
       export *
@@ -392,9 +503,17 @@ module WinSDK [system] {
   }
 
   module ShellAPI {
-    header "shellapi.h"
-    header "Shlwapi.h"
     export *
+
+    module Shell {
+      header "shellapi.h"
+      export *
+    }
+
+    module Lightweight {
+      header "Shlwapi.h"
+      export *
+    }
 
     link "shell32.lib"
     link "ShLwApi.Lib"
@@ -434,9 +553,17 @@ module WinSDK [system] {
   }
 
   module OLE32 {
-    header "oaidl.h"
-    header "oleauto.h"
     export *
+
+    module AutomationInterface {
+      header "oaidl.h"
+      export *
+    }
+
+    module Automation {
+      header "oleauto.h"
+      export *
+    }
 
     link "OleAut32.Lib"
   }
@@ -456,7 +583,10 @@ module WinSDK [system] {
       link "Pdh.Lib"
     }
 
-    header "winperf.h"
+    module Core {
+      header "winperf.h"
+      export *
+    }
     export *
   }
 
@@ -480,9 +610,17 @@ module WinSDK [system] {
   }
 
   module Sensors {
-    header "sensors.h"
-    header "SensorsApi.h"
     export *
+
+    module Types {
+      header "sensors.h"
+      export *
+    }
+
+    module API {
+      header "SensorsApi.h"
+      export *
+    }
 
     link "sensorsapi.lib"
   }
@@ -571,14 +709,6 @@ module WinSDK [system] {
     link "AdvAPI32.Lib"
   }
 
-  module WinRPC {
-    header "../shared/rpc.h"
-    header "../shared/rpcndr.h"
-    export *
-
-    link "RpcRT4.Lib"
-  }
-
   module WinSVC {
     header "winsvc.h"
     export *
@@ -592,32 +722,33 @@ module WinSDK [system] {
 
     link "AdvAPI32.Lib"
   }
-  
+
   module WinUSB {
     header "winusb.h"
     export *
-    
+
     link "winusb.lib"
   }
 
   // TODO(compnerd) does it make sense to implicitly export this API surface?
   // It seems to be meant for device drivers.
   module WLANAPI {
-    header "wlanapi.h"
-    header "wlanihv.h"
-    header "wlclient.h"
+    module API {
+      header "wlanapi.h"
+      export *
+    }
+
+    module IHV {
+      header "wlanihv.h"
+      export *
+    }
+
+    module Client {
+      header "wlclient.h"
+      export *
+    }
 
     link "wlanapi.lib"
-  }
-
-  module WTypesBase {
-    header "../shared/wtypesbase.h"
-    export *
-  }
-
-  module WTypes {
-    header "../shared/wtypes.h"
-    export *
   }
 
   module RoApi {
@@ -625,19 +756,4 @@ module WinSDK [system] {
     export *
   }
 
-  module MinWinDef {
-    header "../shared/minwindef.h"
-    export *
-  }
-
-  module SDKDDKVer {
-    header "../shared/sdkddkver.h"
-    export *
-  }
-
-  module WinError {
-    header "../shared/winerror.h"
-    export *
-  }
 }
-

--- a/stdlib/public/Platform/winsdk_um.modulemap
+++ b/stdlib/public/Platform/winsdk_um.modulemap
@@ -751,9 +751,4 @@ module WinSDK.UM [system] {
     link "wlanapi.lib"
   }
 
-  module RoApi {
-    header "../winrt/roapi.h"
-    export *
-  }
-
 }

--- a/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcOverlayShims.h
@@ -26,6 +26,7 @@
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include <errno.h>
 #include <io.h>
+#include <stdio.h>
 typedef int mode_t;
 #else
 #include <semaphore.h>

--- a/stdlib/public/SwiftShims/swift/shims/RuntimeStubs.h
+++ b/stdlib/public/SwiftShims/swift/shims/RuntimeStubs.h
@@ -36,7 +36,7 @@ swift_stdlib_readLine_stdin(unsigned char * _Nullable * _Nonnull LinePtr);
 #if defined(__wasm__)
 // Wasm can't access call frame for security purposes
 #define get_return_address() ((void*) 0)
-#elif __GNUC__
+#elif defined(__clang__) || defined(__GNUC__)
 #define get_return_address() __builtin_return_address(0)
 #elif _MSC_VER
 #include <intrin.h>

--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -24,7 +24,10 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__wasi__) && !defined(__swift_embedded__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) &&     \
+    !defined(__FreeBSD__) && !defined(__wasi__) &&                             \
+    !defined(__swift_embedded__) &&                                            \
+    !(defined(_WIN32) && defined(__clang__))
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;

--- a/stdlib/public/Synchronization/Mutex/WindowsImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WindowsImpl.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import WinSDK.core.synch
+import WinSDK.UM.core.synch
 
 @available(SwiftStdlib 6.0, *)
 @frozen

--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import ucrt
-@_exported import _GUIDDef
 @_exported import WinSDK // Clang module
 
 // WinBase.h
@@ -61,7 +60,7 @@ public var FIONBIO: Int32 {
 
 @inlinable
 public var QS_INPUT: UINT {
-  QS_MOUSE | UINT(QS_KEY | QS_RAWINPUT | QS_TOUCH | QS_POINTER)
+  UINT(QS_MOUSE) | UINT(QS_KEY | QS_RAWINPUT | QS_TOUCH | QS_POINTER)
 }
 
 @inlinable
@@ -280,10 +279,7 @@ extension GUID {
   }
 }
 
-// These conformances are marked @retroactive because the GUID type nominally
-// comes from the _GUIDDef clang module rather than the WinSDK clang module.
-
-extension GUID: @retroactive Equatable {
+extension GUID: Equatable {
   // When C++ interop is enabled, Swift imports a == operator from guiddef.h
   // that conflicts with the definition of == here, so we've renamed it to
   // __equals to avoid the conflict.
@@ -294,7 +290,7 @@ extension GUID: @retroactive Equatable {
   }
 }
 
-extension GUID: @retroactive Hashable {
+extension GUID: Hashable {
   @_transparent
   public func hash(into hasher: inout Hasher) {
     hasher.combine(uint128Value)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -349,6 +349,12 @@ if(NOT SWIFT_HOST_SDKROOT)
   set(SWIFT_HOST_SDKROOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
 endif()
 
+if(WINDOWS IN_LIST SWIFT_SDKS)
+  file(TO_CMAKE_PATH
+       "${WindowsSdkDir}/Include/${WindowsSDKVersion}/module.modulemap"
+       SWIFT_WINDOWS_MODULE_MAP)
+endif()
+
 set(profdata_merge_worker
     "${CMAKE_CURRENT_SOURCE_DIR}/../utils/profdata_merge/main.py")
 

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -29,9 +29,9 @@ if is_cf_options_interop_updated:
 if get_target_os() in ['windows-msvc']:
     import os
     config.substitutions.insert(0, ('%target-abi', 'WIN'))
-    # ucrt.modulemap currently requires -fbuiltin-headers-in-system-modules. -strict-implicit-module-context
-    # is necessary for -Xcc arguments to be passed through ModuleInterfaceLoader.
-    config.substitutions.insert(0, ('%target-swift-flags', '-vfsoverlay {} -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules'.format(
+    # -strict-implicit-module-context is necessary for -Xcc arguments to be
+    # passed through ModuleInterfaceLoader.
+    config.substitutions.insert(0, ('%target-swift-flags', '-vfsoverlay {} -strict-implicit-module-context'.format(
                                                             os.path.join(config.swift_obj_root,
                                                                          'stdlib',
                                                                          'windows-vfs-overlay.yaml'))))

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -27,14 +27,9 @@ if is_cf_options_interop_updated:
     config.available_features.add('cxx-interop-fixed-cf_options')
 
 if get_target_os() in ['windows-msvc']:
-    import os
     config.substitutions.insert(0, ('%target-abi', 'WIN'))
-    # -strict-implicit-module-context is necessary for -Xcc arguments to be
-    # passed through ModuleInterfaceLoader.
-    config.substitutions.insert(0, ('%target-swift-flags', '-vfsoverlay {} -strict-implicit-module-context'.format(
-                                                            os.path.join(config.swift_obj_root,
-                                                                         'stdlib',
-                                                                         'windows-vfs-overlay.yaml'))))
+    config.substitutions.insert(0, ('%target-swift-flags',
+                                    config.swift_system_overlay_opt))
 else:
     # FIXME(compnerd) do all the targets we currently support use SysV ABI?
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))

--- a/test/ScanDependencies/win-crt-explicit-cxx.swift
+++ b/test/ScanDependencies/win-crt-explicit-cxx.swift
@@ -14,8 +14,16 @@
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:vcruntime > %t/vcruntime.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json Swift > %t/Swift.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json _Builtin_float > %t/SwiftBuiltinFloat.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_stddef > %t/_Builtin_stddef.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_limits > %t/_Builtin_limits.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_stdint > %t/_Builtin_stdint.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_stdbool > %t/_Builtin_stdbool.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_stdarg > %t/_Builtin_stdarg.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_iso646 > %t/_Builtin_iso646.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_float > %t/_Builtin_float.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:corecrt > %t/corecrt.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_corecrt_terminate > %t/_corecrt_terminate.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:std_config > %t/std_config.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_float > %t/_float.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_fenv > %t/_fenv.cmd
@@ -23,6 +31,7 @@
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_malloc > %t/_malloc.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_intrinsics > %t/_Builtin_intrinsics.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:ucrt > %t/ucrt.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_Builtin_inttypes > %t/_Builtin_inttypes.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:std > %t/std.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:_complex > %t/_complex.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftOverlayShims > %t/SwiftOverlayShims.cmd
@@ -34,7 +43,14 @@
 // RUN: %swift_frontend_plain @%t/SAL.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/vcruntime.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/_Builtin_stddef.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_Builtin_limits.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_Builtin_stdint.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_Builtin_stdbool.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_Builtin_stdarg.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_Builtin_iso646.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_Builtin_float.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/corecrt.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_corecrt_terminate.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/std_config.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/_float.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/_fenv.cmd 2>&1
@@ -43,7 +59,9 @@
 // RUN: %swift_frontend_plain @%t/_Builtin_intrinsics.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/SwiftShims.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/Swift.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/SwiftBuiltinFloat.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/ucrt.cmd 2>&1
+// RUN: %swift_frontend_plain @%t/_Builtin_inttypes.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/std.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/_complex.cmd 2>&1
 // RUN: %swift_frontend_plain @%t/SwiftOverlayShims.cmd 2>&1
@@ -51,4 +69,3 @@
 
 //--- Test.swift
 import CRT
-

--- a/test/TypeRoundTrip/Inputs/build-modules.py
+++ b/test/TypeRoundTrip/Inputs/build-modules.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 #
-# Usage: build-modules.py tmp_dir testcases_dir build_cmd lib_pattern
+# Usage: build-modules.py tmp_dir testcases_dir lib_pattern -- build_cmd...
 
 import sys
 import os
 import subprocess
-import shlex
 
 tmp = sys.argv[1]
 testcases = sys.argv[2]
-build_cmd = sys.argv[3].replace("\\", "/")
-lib_pattern = sys.argv[4]
+lib_pattern = sys.argv[3]
+separator = sys.argv.index("--", 4)
+build_cmd = sys.argv[separator + 1 :]
 
 imports = []
 body = []
@@ -24,8 +24,7 @@ for test in os.listdir(testcases):
     lib_name = lib_pattern.replace("PLACEHOLDER", modname)
     test_path = os.path.join(testcases, test)
 
-    # shlex.split handles quoted availability flags in build_cmd
-    cmd = shlex.split(build_cmd) + [
+    cmd = build_cmd + [
         "-g",
         "-static",
         "-emit-module-path",

--- a/test/TypeRoundTrip/round-trip.swift
+++ b/test/TypeRoundTrip/round-trip.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -std=c++17 -fno-exceptions %target-threading-opt %target-rtti-opt %target-pic-opt %target-msvc-runtime-opt -DSWIFT_INLINE_NAMESPACE=__runtime -g -c %S/Inputs/RoundTrip/RoundTrip.cpp -I%swift_obj_root/include -I%swift_src_root/include -I%swift_src_root/stdlib/include -I%swift_src_root/stdlib/public/runtime -I %swift_src_root/stdlib/public/SwiftShims/ -I%llvm_src_root/include -I%llvm_obj_root/include -o %t/RoundTrip.cpp.o
 // RUN: %target-build-swift -g -static -emit-module-path %t/RoundTrip.swiftmodule -emit-module -emit-library -module-name RoundTrip -o %t/%target-static-library-name(RoundTrip) %S/Inputs/RoundTrip/RoundTrip.swift %t/RoundTrip.cpp.o
-// RUN: %{python} %S/Inputs/build-modules.py %t %S/Inputs/testcases "%target-build-swift" %target-static-library-name(PLACEHOLDER)
+// RUN: %{python} %S/Inputs/build-modules.py %t %S/Inputs/testcases %target-static-library-name(PLACEHOLDER) -- %target-build-swift
 // RUN: %target-build-swift -g -I%t -o %t/round-trip %s %t/all-tests.swift -L%t %target-cxx-lib @%t/link.txt %if !OS=windows-msvc %{ -lm %} -lRoundTrip -L%swift-lib-dir/swift/%target-sdk-name -lswiftRemoteInspection
 // RUN: %target-codesign %t/round-trip
 // RUN: %target-run %t/round-trip | %FileCheck %s

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -511,18 +511,20 @@ config.swift_system_overlay_opt = ""
 config.clang_system_overlay_opt = ""
 config.windows_vfs_overlay_opt = ""
 if kIsWindows and run_os in ['windows-msvc']:
+    windows_sdk_module_map_opt = "-fmodule-map-file={}".format(shell_quote(config.windows_sdk_module_map))
+    windows_vfs_overlay = os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     # -strict-implicit-module-context is necessary for -Xcc arguments to be
     # passed through ModuleInterfaceLoader.
-    config.swift_system_overlay_opt = "-vfsoverlay {} -strict-implicit-module-context".format(
-        os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
+    config.swift_system_overlay_opt = "-vfsoverlay {} -Xcc {} -strict-implicit-module-context".format(
+        shell_quote(windows_vfs_overlay), windows_sdk_module_map_opt
     )
     # this variant is for extract-symbolgraph which doesn't accept all the same arugments as swiftc
     # so the extra ceremony lets us pass in the relevant pieces needed for Windows SDK access.
-    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {}".format(
-        os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
+    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc {}".format(
+        shell_quote(windows_vfs_overlay), windows_sdk_module_map_opt
     )
-    config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {}".format(
-        os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
+    config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {} -Xcc {}".format(
+        shell_quote(windows_vfs_overlay), windows_sdk_module_map_opt
     )
 config.substitutions.append( ('%windows_vfs_overlay_opt', config.windows_vfs_overlay_opt) )
 stdlib_resource_dir_opt = config.resource_dir_opt

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -511,17 +511,17 @@ config.swift_system_overlay_opt = ""
 config.clang_system_overlay_opt = ""
 config.windows_vfs_overlay_opt = ""
 if kIsWindows and run_os in ['windows-msvc']:
-    # ucrt.modulemap currently requires -fbuiltin-headers-in-system-modules. -strict-implicit-module-context
-    # is necessary for -Xcc arguments to be passed through ModuleInterfaceLoader.
-    config.swift_system_overlay_opt = "-vfsoverlay {} -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+    # -strict-implicit-module-context is necessary for -Xcc arguments to be
+    # passed through ModuleInterfaceLoader.
+    config.swift_system_overlay_opt = "-vfsoverlay {} -strict-implicit-module-context".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
     # this variant is for extract-symbolgraph which doesn't accept all the same arugments as swiftc
     # so the extra ceremony lets us pass in the relevant pieces needed for Windows SDK access.
-    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {}".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
-    config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {} -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+    config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {}".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
 config.substitutions.append( ('%windows_vfs_overlay_opt', config.windows_vfs_overlay_opt) )

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -63,6 +63,8 @@ config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"
 config.android_api_level = "@SWIFT_ANDROID_API_LEVEL@"
 
 # --- Windows ---
+config.windows_sdk_module_map = r'''@SWIFT_WINDOWS_MODULE_MAP@'''
+
 msvc_runtime_flags = {
   'MultiThreaded': 'MT',
   'MultiThreadedDebug': 'MTd',

--- a/test/stdlib/WinSDK_GUID.swift
+++ b/test/stdlib/WinSDK_GUID.swift
@@ -4,8 +4,8 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=windows-msvc
 
-// Make sure that importing WinSDK brings in the GUID type, which is declared in
-// /shared and not in /um.
+// Make sure that importing WinSDK brings in the GUID type from the external
+// WinSDK.Shared component map.
 
 import WinSDK
 

--- a/test/stdlib/WinSDK_WinRT.swift
+++ b/test/stdlib/WinSDK_WinRT.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: OS=windows-msvc
+
+// WinRT remains part of the API surface imported through WinSDK even though
+// its Clang submodule is defined by an external component module map.
+
+import WinSDK
+
+let _: RO_INIT_TYPE = RO_INIT_MULTITHREADED
+let _ = RoInitialize

--- a/utils/WindowsSDKVFSOverlay.yaml.in
+++ b/utils/WindowsSDKVFSOverlay.yaml.in
@@ -2,172 +2,172 @@
 version: 0
 case-sensitive: false
 roots:
-  - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared"
+  - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared"
     type: directory
     contents:
       - name: Bcrypt.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/bcrypt.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared/bcrypt.h"
       - name: ConcurrencySal.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/concurrencysal.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared/concurrencysal.h"
       - name: DriverSpecs.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/driverspecs.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared/driverspecs.h"
       - name: SpecStrings.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/specstrings.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared/specstrings.h"
       - name: WlanTypes.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/wlantypes.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared/wlantypes.h"
       - name: wtypesbase.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/WTypesbase.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared/WTypesbase.h"
       - name: iprtrmib.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/Iprtrmib.h"
-  - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/shared/Iprtrmib.h"
+  - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um"
     type: directory
     contents:
       - name: accctrl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/AccCtrl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/AccCtrl.h"
       - name: adtgen.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/AdtGen.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/AdtGen.h"
       - name: commctrl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/CommCtrl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/CommCtrl.h"
       - name: docobj.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/DocObj.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/DocObj.h"
       - name: exdisp.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ExDisp.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ExDisp.h"
       - name: ipexport.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/IPExport.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/IPExport.h"
       - name: iptypes.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/IPTypes.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/IPTypes.h"
       - name: isguids.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/IsGuids.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/IsGuids.h"
       - name: knownfolders.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/KnownFolders.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/KnownFolders.h"
       - name: lmaccess.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMaccess.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMaccess.h"
       - name: lmalert.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMalert.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMalert.h"
       - name: lmaudit.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMaudit.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMaudit.h"
       - name: lmconfig.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMConfig.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMConfig.h"
       - name: lmerrlog.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMErrlog.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMErrlog.h"
       - name: lmapibuf.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMAPIbuf.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMAPIbuf.h"
       - name: lmjoin.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMJoin.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMJoin.h"
       - name: lmmsg.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMMsg.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMMsg.h"
       - name: lmremutl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMRemUtl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMRemUtl.h"
       - name: lmrepl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMRepl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMRepl.h"
       - name: lmserver.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMServer.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMServer.h"
       - name: lmshare.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMShare.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMShare.h"
       - name: lmsname.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMSName.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMSName.h"
       - name: lmsvc.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMSvc.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMSvc.h"
       - name: lmuse.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/LMUse.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/LMUse.h"
       - name: oaidl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/OAIdl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/OAIdl.h"
       - name: ocidl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/OCIdl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/OCIdl.h"
       - name: objidl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ObjIdl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ObjIdl.h"
       - name: objidlbase.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ObjIdlbase.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ObjIdlbase.h"
       - name: ole2.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Ole2.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/Ole2.h"
       - name: oleauto.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/OleAuto.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/OleAuto.h"
       - name: propidl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/PropIdl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/PropIdl.h"
       - name: propidlbase.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/PropIdlBase.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/PropIdlBase.h"
       - name: psapi.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Psapi.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/Psapi.h"
       - name: shldisp.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlDisp.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ShlDisp.h"
       - name: shlguid.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlGuid.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ShlGuid.h"
       - name: shlobj.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlObj.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ShlObj.h"
       - name: shlobj_core.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShlObj_core.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ShlObj_core.h"
       - name: shobjidl.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShObjIdl.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ShObjIdl.h"
       - name: shobjidl_core.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/ShObjIdl_core.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/ShObjIdl_core.h"
       - name: unknwn.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Unknwn.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/Unknwn.h"
       - name: uxtheme.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Uxtheme.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/Uxtheme.h"
       - name: unknwnbase.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Unknwnbase.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/Unknwnbase.h"
       - name: winbase.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/WinBase.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/WinBase.h"
       - name: windows.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/Windows.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/Windows.h"
       - name: winnls.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/WinNls.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/WinNls.h"
       - name: winsock2.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/WinSock2.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/WinSock2.h"
       - name: winuser.h
         type: file
-        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/um/WinUser.h"
+        external-contents: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um/WinUser.h"
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1512,6 +1512,7 @@ function Invoke-VsDevShell([Hashtable] $Platform) {
     $env:WindowsSdkBinPath = "$CustomWinSDKRoot\bin"
     $env:WindowsSDKLibVersion = "$WinSDKVersion\"
     $env:WindowsSdkVerBinPath = "$CustomWinSDKRoot\bin\$WinSDKVersion"
+    $env:WindowsSdkDir = $CustomWinSDKRoot
     $env:WindowsSDKVersion = "$WinSDKVersion\"
 
     $env:EXTERNAL_INCLUDE += ";$WinSDKIncludePath"

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -47,6 +47,8 @@ config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"
 config.android_api_level = "@SWIFT_ANDROID_API_LEVEL@"
 
 # --- Windows MSVC Configuration ---
+config.windows_sdk_module_map = r'''@SWIFT_WINDOWS_MODULE_MAP@'''
+
 config.swift_stdlib_msvc_runtime = None
 if "@SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY@" == "MultiThreaded":
     config.swift_stdlib_msvc_runtime = 'MT'


### PR DESCRIPTION
This pull request makes significant improvements to the way Windows SDK module maps and headers are handled in the Swift build system and Clang importer. The changes standardize the overlay and module map structure for Windows, add support for new WinRT overlays, and ensure compatibility with different Windows SDK versions. Additionally, the CMake configuration is updated to better manage and report SDK paths and versions.

**Windows SDK overlays and module maps:**

* Refactored the VFS overlay YAMLs and CMake logic to use the Windows SDK root (`WindowsSdkDir`) and version (`WindowsSDKVersion`) instead of the UCRT SDK for mapping module map and header files, aligning the overlay structure with the actual Windows SDK layout. This includes adding a top-level `module.modulemap`, new `winrt` overlays, and the `SwiftWinRT.h` header. [[1]](diffhunk://#diff-3803aad2d0865aff1487ab8bd047ce07539da1aa6b8f60966843eae63b0dd214R7-R8) [[2]](diffhunk://#diff-3803aad2d0865aff1487ab8bd047ce07539da1aa6b8f60966843eae63b0dd214L16-R47) [[3]](diffhunk://#diff-2104515640a94664d839695206e56b5d18270e58911ec3169c5908c33c6bcb42L6-R35) [[4]](diffhunk://#diff-22ed9b25ef04252614ff382a0248f60764d8624864d81f0d821f2e58427e82afR202-R205)

* Updated installation and build configuration to include new module map files (`winsdk.modulemap`, `winrt.modulemap`) and the `SwiftWinRT.h` header in the overlay and installation targets.

**CMake configuration and SDK path handling:**

* Improved CMake scripts to correctly strip trailing slashes from SDK version variables, cache and report the Windows SDK root and version, and use these consistently when constructing include and library paths. [[1]](diffhunk://#diff-fd2e9322a51d149aecf1db37edfb4cddba52b2b68d5fb8937cc1ab292d7e3b58R78-R91) [[2]](diffhunk://#diff-93f5cec01637ba26aaa5615da2a16fa1dcd382d8eee2b07f3bd18551396b6a85R22-R23) [[3]](diffhunk://#diff-93f5cec01637ba26aaa5615da2a16fa1dcd382d8eee2b07f3bd18551396b6a85L550-R555) [[4]](diffhunk://#diff-fd2e9322a51d149aecf1db37edfb4cddba52b2b68d5fb8937cc1ab292d7e3b58L22-R24) [[5]](diffhunk://#diff-fd2e9322a51d149aecf1db37edfb4cddba52b2b68d5fb8937cc1ab292d7e3b58L47-R58) [[6]](diffhunk://#diff-16566c91343a1660010c4c24db2b29a4fb1375cee942b57e04b194acce6c6861R36-R38) [[7]](diffhunk://#diff-16566c91343a1660010c4c24db2b29a4fb1375cee942b57e04b194acce6c6861R47-R48)

**Clang importer and VFS mapping logic:**

* Enhanced `ClangImporter` and related logic to add VFS mappings for the new Windows SDK overlays, including the new top-level module map and WinRT overlays. Also, updated the logic so that the correct module map is passed to Clang when building for Windows. [[1]](diffhunk://#diff-0062ad3fe872d09412bd3e7c72610b5ad0bd39667ebc00695351ef93c7c6815fR1347-R1355) [[2]](diffhunk://#diff-f768ac8c03b01ed7761b76d70eaa046bd6032a4b7559873d13fd46a5033c9e83L510-R510) [[3]](diffhunk://#diff-f768ac8c03b01ed7761b76d70eaa046bd6032a4b7559873d13fd46a5033c9e83L540-R585) [[4]](diffhunk://#diff-f768ac8c03b01ed7761b76d70eaa046bd6032a4b7559873d13fd46a5033c9e83L581-R619) [[5]](diffhunk://#diff-f768ac8c03b01ed7761b76d70eaa046bd6032a4b7559873d13fd46a5033c9e83L730-R754)

**Other improvements:**

* Added compatibility logic to ensure that missing headers (`stdalign.h`, `stdnoreturn.h`) in older Windows SDKs do not break the build by providing empty files when necessary.

* Cleaned up and modernized CMake and source code by removing obsolete options and ensuring consistency in path handling and overlay generation. [[1]](diffhunk://#diff-58cf1b348980556a26ac2e00976d5dcd6d69264a438140dee54244b8f3d201f7L208) [[2]](diffhunk://#diff-93f5cec01637ba26aaa5615da2a16fa1dcd382d8eee2b07f3bd18551396b6a85L600) [[3]](diffhunk://#diff-fd2e9322a51d149aecf1db37edfb4cddba52b2b68d5fb8937cc1ab292d7e3b58L114) [[4]](diffhunk://#diff-e2e2a250882f66d531f2a42c201e013fa2d8be892b2880a32d6596710761f470L1085-R1087)

These changes collectively improve the reliability and maintainability of Windows SDK integration in Swift, making it easier to support new SDK versions and overlays.