### PR TITLE
[6.4.x] Add a preset for the performance bots.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -321,6 +321,11 @@ skip-build-benchmarks
 skip-test-swift
 skip-test-cmark
 
+[preset: buildbot,performance,macos]
+release
+no-assertions
+reconfigure
+
 #===------------------------------------------------------------------------===#
 # Incremental buildbots for Darwin OSes
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
- **Explanation**: This will support updating the configuration for the performance bots so they can always assume the `buildbot,performance,macos` preset is present, instead of relying on fallback logic that can will be short lived and burdensome to maintain. 
- **Scope**: addition of a preset to `utils/build-presets.ini`
- **Issues**: rdar://185765063
- **Original PRs**: https://github.com/swiftlang/swift/pull/91692
- **Risk**: Low, this adds a preset and does not impact any build logic for the compiler/stdilb.
- **Testing**: CI testing, ensuring the Python tests still passes (especially the one parsing the preset file)
- **Reviewers**: @shahmishal 