### PR TITLE
Optimizer: simplify phi arguments

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -41,6 +41,7 @@ swift_compiler_sources(Optimizer
   SimplifyMoveValue.swift
   SimplifyOpenExistentialRef.swift
   SimplifyPartialApply.swift
+  SimplifyPhiArgument.swift
   SimplifyPointerToAddress.swift
   SimplifyRefCasts.swift
   SimplifyRetainReleaseValue.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBranch.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBranch.swift
@@ -14,7 +14,30 @@ import SIL
 
 extension BranchInst : OnoneSimplifiable {
   func simplify(_ context: SimplifyContext) {
+
+    simplifyPhiArgumentsInTargetBlock(context)
+    if isDeleted {
+      return
+    }
+
     tryMergeWithTargetBlock(context)
+  }
+}
+
+private extension BranchInst {
+  func simplifyPhiArgumentsInTargetBlock(_ context: SimplifyContext) {
+    // Need to store all arguments into a temporary array because when a phi argument is
+    // deleted, we would crash when iterating over the argument array.
+    var phiArgs = Stack<Argument>(context)
+    defer { phiArgs.deinitialize() }
+    phiArgs.append(contentsOf: targetBlock.arguments)
+
+    for argument in phiArgs {
+      guard let phi = Phi(argument) else {
+        fatalError("argument of branch in target block is always a Phi")
+      }
+      phi.simplify(context)
+    }
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPhiArgument.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPhiArgument.swift
@@ -1,0 +1,104 @@
+//===--- SimplifyPhiArgument.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+extension Phi {
+  // Triggered from `BranchInst.simplify`
+  func simplify(_ context: SimplifyContext) {
+    if replacePhiWithIncomingValue(phi: self, context) {
+      return
+    }
+    if replaceReborrowOfBeginBorrows(context) {
+      return
+    }
+  }
+
+  /// If `phi` is a re-borrow phi where all incoming operands are `begin_borrow`s of the same
+  /// value, the re-borrow is redundant and can be replaced by a single `begin_borrow` of that
+  /// value in the phi's block.
+  ///
+  /// ```
+  ///   bb1:
+  ///     %2 = begin_borrow %0
+  ///     br bb3(%2)
+  ///   bb2:
+  ///     %3 = begin_borrow %0
+  ///     br bb3(%3)
+  ///   bb3(%4 : @reborrow $T):
+  ///     %5 = borrowed %4 from (%0)
+  ///     // ... uses of %5
+  ///     end_borrow %5
+  /// ```
+  /// ->
+  /// ```
+  ///   bb1:
+  ///     br bb3
+  ///   bb2:
+  ///     br bb3
+  ///   bb3:
+  ///     %5 = begin_borrow %0
+  ///     // ... uses of %5
+  ///     end_borrow %5
+  /// ```
+  private func replaceReborrowOfBeginBorrows(_ context: SimplifyContext) -> Bool {
+    guard isReborrow,
+          // All incoming operands must be `begin_borrow`s of the same value. As that value is borrowed
+          // in every predecessor, it dominates the phi's block.
+          let borrowedValue = getUniqueSourceOfIncomingBeginBorrows()
+    else {
+      return false
+    }
+
+    let block = value.parentBlock
+
+    // Create a new borrow of the common value at the beginning of the phi's block and replace
+    // the re-borrow (via its `borrowed_from` user) with it.
+    let newBorrow = Builder(atBeginOf: block, context).createBeginBorrow(of: borrowedValue)
+    let borrowedFrom = borrowedFrom!
+    borrowedFrom.uses.replaceAll(with: newBorrow, context)
+    context.erase(instruction: borrowedFrom)
+
+    // Remove the phi operand from all predecessor branches and erase the now-dead incoming
+    // `begin_borrow`s.
+    for incomingOp in incomingOperands {
+      let beginBorrow = incomingOp.value as! BeginBorrowInst
+      let existingBranch = incomingOp.instruction as! BranchInst
+      let argsWithRemovedPhiOp = existingBranch.operands.filter{ $0 != incomingOp }.map{ $0.value }
+      Builder(before: existingBranch, context).createBranch(to: block, arguments: argsWithRemovedPhiOp)
+      context.erase(instruction: existingBranch)
+      context.erase(instruction: beginBorrow)
+    }
+    block.eraseArgument(at: value.index, context)
+    return true
+  }
+
+  private func getUniqueSourceOfIncomingBeginBorrows() -> Value? {
+    var borrowedValue: Value? = nil
+    for incomingValue in incomingValues {
+      guard let beginBorrow = incomingValue as? BeginBorrowInst,
+            // The `begin_borrow`'s only purpose must be to feed the re-borrow.
+            beginBorrow.uses.singleUse != nil
+      else {
+        return nil
+      }
+      if let borrowedValue {
+        if beginBorrow.borrowedValue != borrowedValue {
+          return nil
+        }
+      } else {
+        borrowedValue = beginBorrow.borrowedValue
+      }
+    }
+    return borrowedValue
+  }
+}

--- a/test/AutoDiff/SILGen/throw.swift
+++ b/test/AutoDiff/SILGen/throw.swift
@@ -39,17 +39,18 @@ func catching(input: Float) -> Float {
 
 // See if pullback correctly unwraps the Optional
 // CHECK-LABEL: sil {{.*}} @$s5throw8catching5inputS2f_tFTJpSpSr
-// CHECK: bb{{.*}}(%[[ADJ:.*]] : $Float, %[[PAYLOAD:.*]] : $(_: Optional<@callee_guaranteed (Float) -> Float>)):
-// CHECK:   %[[OPT_PULLBACK:.*]] = tuple_extract %[[PAYLOAD]] : $(_: Optional<@callee_guaranteed (Float) -> Float>), 0
+// CHECK: bb0(%[[SEED:.*]] : $Float, %{{.*}} : $_AD__{{.*}}):
+// CHECK:   %[[ZERO:.*]] = float_literal $Builtin.FPIEEE32, 0x0
+// CHECK:   %[[ZERO_ADJ:.*]] = struct $Float (%[[ZERO]] : $Builtin.FPIEEE32)
+// CHECK:   %[[OPT_PULLBACK:.*]] = tuple_extract %{{.*}} : $(_: Optional<@callee_guaranteed (Float) -> Float>), 0
 // CHECK:   switch_enum %[[OPT_PULLBACK]] : $Optional<@callee_guaranteed (Float) -> Float>, case #Optional.some!enumelt: [[BB_NORMAL:.*]], case #Optional.none!enumelt: [[BB_ERROR:.*]] //
 // CHECK: [[BB_NORMAL]](%[[PULLBACK:.*]] : $@callee_guaranteed (Float) -> Float)
-// Call pullback and accumulate adjoints
-// CHECK:   %[[CALLEE_ADJ:.*]] = apply %[[PULLBACK]](%{{.*}}) : $@callee_guaranteed (Float) -> Float
-// CHECK-DAG:   %[[FLOAT_ADJ:.*]] = struct_extract %[[ADJ]] : $Float, #Float._value
-// CHECK-DAG:   %[[FLOAT_CALLEE_ADJ:.*]] = struct_extract %[[CALLEE_ADJ]] : $Float, #Float._value
-// CHECK:   %[[NEW_FLOAT_ADJ:.*]] = builtin "fadd_FPIEEE32"(%[[FLOAT_CALLEE_ADJ]] : $Builtin.FPIEEE32, %[[FLOAT_ADJ]] : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+// Call pullback (with the incoming adjoint seed) and accumulate adjoints
+// CHECK:   %[[CALLEE_ADJ:.*]] = apply %[[PULLBACK]](%[[SEED]]) : $@callee_guaranteed (Float) -> Float
+// CHECK:   %[[FLOAT_CALLEE_ADJ:.*]] = struct_extract %[[CALLEE_ADJ]] : $Float, #Float._value
+// CHECK:   %[[NEW_FLOAT_ADJ:.*]] = builtin "fadd_FPIEEE32"(%[[FLOAT_CALLEE_ADJ]] : $Builtin.FPIEEE32, %[[ZERO]] : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %[[NEW_ADJ:.*]] = struct $Float (%[[NEW_FLOAT_ADJ]] : $Builtin.FPIEEE32)
 // CHECK:   br {{.*}}(%[[NEW_ADJ]] : $Float)
 // CHECK: [[BB_ERROR]]:
-// Just forward input adjoint w/o any accumulation
-// CHECK:   br bb{{.}}(%[[ADJ]] : $Float)
+// Just forward the zero adjoint w/o any accumulation
+// CHECK:   br bb{{.}}(%[[ZERO_ADJ]] : $Float)

--- a/test/SILOptimizer/simplify_branch.sil
+++ b/test/SILOptimizer/simplify_branch.sil
@@ -5,6 +5,8 @@
 import Swift
 import Builtin
 
+class C {}
+
 // CHECK-LABEL: sil @merge_blocks_same_location1
 // CHECK:         %0 = integer_literal $Builtin.Int64, 0
 // CHECK:         fix_lifetime %0 : $Builtin.Int64
@@ -96,5 +98,84 @@ bb1(%2 : $Builtin.Int64):
 
 bb2:
   br bb1(%2 : $Builtin.Int64)
+}
+
+// A phi with the same incoming value on all edges is replaced by that value.
+// CHECK-LABEL: sil [ossa] @replace_phi_with_same_incoming
+// CHECK:       bb3:
+// CHECK-NEXT:    return %0
+// CHECK:       } // end sil function 'replace_phi_with_same_incoming'
+sil [ossa] @replace_phi_with_same_incoming : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $Builtin.Int64):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%0 : $Builtin.Int64)
+
+bb2:
+  br bb3(%0 : $Builtin.Int64)
+
+bb3(%3 : $Builtin.Int64):
+  return %3 : $Builtin.Int64
+}
+
+// A re-borrow phi whose incoming operands are all `begin_borrow`s of the same value
+// is replaced by a single `begin_borrow` in the phi's block.
+// CHECK-LABEL: sil [ossa] @replace_reborrow_of_begin_borrows
+// CHECK:       bb1:
+// CHECK-NEXT:    br bb3
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb3
+// CHECK:       bb3:
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow %0 : $C
+// CHECK-NEXT:    fix_lifetime [[B]] : $C
+// CHECK-NEXT:    end_borrow [[B]] : $C
+// CHECK-NEXT:    destroy_value %0 : $C
+// CHECK:       } // end sil function 'replace_reborrow_of_begin_borrows'
+sil [ossa] @replace_reborrow_of_begin_borrows : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %b1 = begin_borrow %0 : $C
+  br bb3(%b1 : $C)
+
+bb2:
+  %b2 = begin_borrow %0 : $C
+  br bb3(%b2 : $C)
+
+bb3(%r : @reborrow $C):
+  %bf = borrowed %r : $C from (%0 : $C)
+  fix_lifetime %bf : $C
+  end_borrow %bf : $C
+  destroy_value %0 : $C
+  %t = tuple ()
+  return %t : $()
+}
+
+// A re-borrow phi whose incoming `begin_borrow`s borrow different values must not be replaced.
+// CHECK-LABEL: sil [ossa] @dont_replace_reborrow_of_different_values
+// CHECK:       bb3([[R:%.*]] : @reborrow $C):
+// CHECK-NEXT:    borrowed [[R]] : $C from
+// CHECK:       } // end sil function 'dont_replace_reborrow_of_different_values'
+sil [ossa] @dont_replace_reborrow_of_different_values : $@convention(thin) (@owned C, @owned C) -> () {
+bb0(%0 : @owned $C, %1 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %b1 = begin_borrow %0 : $C
+  br bb3(%b1 : $C)
+
+bb2:
+  %b2 = begin_borrow %1 : $C
+  br bb3(%b2 : $C)
+
+bb3(%r : @reborrow $C):
+  %bf = borrowed %r : $C from (%0 : $C, %1 : $C)
+  end_borrow %bf : $C
+  destroy_value %0 : $C
+  destroy_value %1 : $C
+  %t = tuple ()
+  return %t : $()
 }
 


### PR DESCRIPTION
Trigger a phi simplification from `BranchInst.simplify` that
1. replaces a phi whose incoming operands are all identical, and
2. replaces a re-borrow phi whose incoming operands are all `begin_borrow`s of the same value with a single `begin_borrow` in the phi's block:

```
  bb1:
    %2 = begin_borrow %0
    br bb3(%2)
  bb2:
    %3 = begin_borrow %0
    br bb3(%3)
  bb3(%4 : @reborrow $T):
    %5 = borrowed %4 from (%0)
    // ... uses of %5
    end_borrow %5
```
->
```
  bb1:
    br bb3
  bb2:
    br bb3
  bb3:
    %5 = begin_borrow %0
    // ... uses of %5
    end_borrow %5
```
