### PR TITLE
[test] Match `optimized_stdlib` requirement in ConstValues tests

### DIFF
--- a/test/ConstValues/LiteralExpressionsInteraction.swift
+++ b/test/ConstValues/LiteralExpressionsInteraction.swift
@@ -9,6 +9,7 @@
 // REQUIRES: swift_feature_CompileTimeValues
 // REQUIRES: swift_feature_CompileTimeValuesPreview
 // REQUIRES: swift_feature_LiteralExpressions
+// REQUIRES: optimized_stdlib
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -verify-additional-prefix preview- -enable-experimental-feature CompileTimeValues -enable-experimental-feature CompileTimeValuesPreview
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -verify-additional-prefix preview- -enable-experimental-feature CompileTimeValues -enable-experimental-feature CompileTimeValuesPreview -enable-experimental-feature LiteralExpressions
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -verify-additional-prefix const- -enable-experimental-feature CompileTimeValues

--- a/test/ConstValues/LiteralExpressionsPreviewOnly.swift
+++ b/test/ConstValues/LiteralExpressionsPreviewOnly.swift
@@ -8,6 +8,7 @@
 // perturb the Preview regime.
 // REQUIRES: swift_feature_CompileTimeValuesPreview
 // REQUIRES: swift_feature_LiteralExpressions
+// REQUIRES: optimized_stdlib
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -enable-experimental-feature CompileTimeValuesPreview
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -verify -enable-experimental-feature CompileTimeValuesPreview -enable-experimental-feature LiteralExpressions
 


### PR DESCRIPTION
Both new files initialize a global with 'Int(17.0 / 3.5)', which the SIL folder only folds against an optimized stdlib. `IntegerExpressions.swift` and `IntegerExpressionsSyntactic.swift` use the same expression behind the same requirement. Without it, the stdlib-DebugAssert bots report a spurious "'@const' value should be initialized with a compile-time value".
