### PR TITLE
[Optimization] Teach LLVM that `range.lowerBound`<=`range.upperBound`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -458,6 +458,8 @@ struct AliasAnalysis {
         return .init(read: true)
       }
       return .noEffects
+    case .AssumeTrue:
+      return .noEffects
     default:
       if builtin.memoryEffects == .noEffects {
         return .noEffects

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -250,7 +250,7 @@ private struct CollectedEffects {
       is CondFailInst:
       break
 
-    case let bi as BuiltinInst where bi.id == .TSanInoutAccess:
+    case let bi as BuiltinInst where bi.id == .TSanInoutAccess || bi.id == .AssumeTrue:
       break
 
     case is BeginCOWMutationInst:

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
@@ -567,7 +567,7 @@ private extension Function {
         return !store.destination.lookThroughRawLayoutAddress.isAddressOfStack(orGlobal: global)
       case let injectEnum as InjectEnumAddrInst:
         return !injectEnum.enum.isAddressOfStack(orGlobal: global)
-      case let bi as BuiltinInst where bi.id == .PrepareInitialization:
+      case let bi as BuiltinInst where bi.id == .PrepareInitialization || bi.id == .AssumeTrue:
         return false
       default:
         return inst.hasUnspecifiedSideEffects

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -136,6 +136,8 @@ private func analyzeInstructions(
       switch inst {
       case is FixLifetimeInst:
         continue // We can ignore the side effects of FixLifetimes
+      case let bi as BuiltinInst where bi.id == .AssumeTrue:
+        continue // An assume observes nothing, so nothing can conflict with it
       case let loadInst as LoadInst:
         analyzedInstructions.loads.append(loadInst)
         continue // Don't set `hasOtherMemReadingInsts`

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -175,6 +175,11 @@ public class Instruction : CustomStringConvertible, Hashable {
       return true
 
     case let builtin as BuiltinInst:
+      // The assume builtin's conservative memory effects only exist to keep it from being
+      // moved or deleted. It does not access memory.
+      if builtin.id == .AssumeTrue {
+        return false
+      }
       // A memory accessing builtin can be an implicit load weak, a synchronization point or a
       // pointer access.
       return builtin.mayReadOrWriteMemory

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -799,11 +799,13 @@ extension Array: RandomAccessCollection, MutableCollection {
   @inlinable
   public subscript(bounds: Range<Int>) -> ArraySlice<Element> {
     get {
+      bounds._assumeValid()
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
       return ArraySlice(_buffer: _buffer[bounds])
     }
     set(rhs) {
+      bounds._assumeValid()
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
       // If the replacement buffer has same identity, and the ranges match,

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -588,11 +588,13 @@ extension ArraySlice: RandomAccessCollection, MutableCollection {
   @inlinable
   public subscript(bounds: Range<Int>) -> ArraySlice<Element> {
     get {
+      bounds._assumeValid()
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
       return ArraySlice(_buffer: _buffer[bounds])
     }
     set(rhs) {
+      bounds._assumeValid()
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
       // If the replacement buffer has same identity, and the ranges match,

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1030,6 +1030,7 @@ extension Collection where SubSequence == Slice<Self> {
   /// - Complexity: O(1)
   @inlinable
   public subscript(bounds: Range<Index>) -> Slice<Self> {
+    bounds._assumeValid()
     _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
     return Slice(base: self, bounds: bounds)
   }

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -459,11 +459,13 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
   @inlinable
   public subscript(bounds: Range<Int>) -> ArraySlice<Element> {
     get {
+      bounds._assumeValid()
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
       return ArraySlice(_buffer: _buffer[bounds])
     }
     set(rhs) {
+      bounds._assumeValid()
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
       // If the replacement buffer has same identity, and the ranges match,

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -211,6 +211,14 @@ public struct Range<Bound: Comparable> {
   public var isEmpty: Bool {
     return lowerBound == upperBound
   }
+
+  /// Specifies that the range's lower bound is not greater than its upper bound.
+  /// It has only an effect on the optimizer; no code is generated.
+  @_transparent
+  public func _assumeValid() {
+    _internalInvariant(lowerBound <= upperBound)
+    unsafe _uncheckedUnsafeAssume(lowerBound <= upperBound)
+  }
 }
 
 extension Range: Sequence
@@ -228,10 +236,16 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   public typealias SubSequence = Range<Bound>
 
   @inlinable
-  public var startIndex: Index { return lowerBound }
+  public var startIndex: Index {
+    _assumeValid()
+    return lowerBound
+  }
 
   @inlinable
-  public var endIndex: Index { return upperBound }
+  public var endIndex: Index {
+    _assumeValid()
+    return upperBound
+  }
 
   @inlinable
   @inline(__always)

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -214,7 +214,7 @@ public struct Range<Bound: Comparable> {
 
   /// Specifies that the range's lower bound is not greater than its upper bound.
   /// It has only an effect on the optimizer; no code is generated.
-  @_transparent
+  @export(implementation) @_transparent
   public func _assumeValid() {
     _internalInvariant(lowerBound <= upperBound)
     unsafe _uncheckedUnsafeAssume(lowerBound <= upperBound)

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -170,6 +170,7 @@ extension Slice: Collection {
   @inlinable // generic-performance
   public subscript(bounds: Range<Index>) -> Slice<Base> {
     get {
+      bounds._assumeValid()
       _failEarlyRangeCheck(bounds, bounds: _bounds)
       return Slice(base: _base, bounds: bounds)
     }

--- a/test/SILOptimizer/init_static_globals.sil
+++ b/test/SILOptimizer/init_static_globals.sil
@@ -61,6 +61,13 @@ sil_global hidden [let] @$trivialglobal : $TStruct
 sil_global private @globalinit_trivialglobal_token : $Builtin.Word
 
 
+// CHECK-LABEL: sil_global hidden [let] @$assumeglobal : $TStruct = {
+// CHECK:  [[CONST:%.*]] = integer_literal $Builtin.Int32, 27
+// CHECK:  [[INT:%.*]] = struct $Int32 ([[CONST]])
+// CHECK:  %initval = struct $TStruct ([[INT]])
+sil_global hidden [let] @$assumeglobal : $TStruct
+sil_global private @globalinit_assumeglobal_token : $Builtin.Word
+
 // CHECK-LABEL: sil_global hidden [let] @$nontrivialglobal : $TClass{{$}}
 sil_global hidden [let] @$nontrivialglobal : $TClass
 sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
@@ -214,6 +221,25 @@ bb0:
   store %4 to [trivial] %1 : $*TStruct
   %6 = tuple ()
   return %6 : $()
+}
+
+// An assume is not a side effect which prevents static initialization.
+// CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_assumeglobal_func :
+// CHECK-NOT:     store
+// CHECK:       } // end sil function 'globalinit_assumeglobal_func'
+sil [global_init_once_fn] [ossa] @globalinit_assumeglobal_func : $@convention(c) () -> () {
+bb0:
+  alloc_global @$assumeglobal
+  %1 = global_addr @$assumeglobal : $*TStruct
+  %2 = integer_literal $Builtin.Int32, 27
+  %3 = integer_literal $Builtin.Int32, 0
+  %4 = builtin "cmp_sgt_Int32"(%2 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+  %5 = builtin "assume_Int1"(%4 : $Builtin.Int1) : $Builtin.Int1
+  %6 = struct $Int32 (%2 : $Builtin.Int32)
+  %7 = struct $TStruct (%6 : $Int32)
+  store %7 to [trivial] %1 : $*TStruct
+  %9 = tuple ()
+  return %9 : $()
 }
 
 // CHECK-LABEL: sil [global_init_once_fn] [ossa] @globalinit_nontrivialglobal_func :

--- a/test/SILOptimizer/licm_apply.sil
+++ b/test/SILOptimizer/licm_apply.sil
@@ -59,6 +59,69 @@ bb3:
   return %15 : $()
 }
 
+// An assume in the loop body must not stop the read-only apply from being hoisted.
+//CHECK-LABEL: sil @licm_readonly_apply_with_assume
+//CHECK:   %{{[0-9]+}} = apply
+//CHECK: bb1({{.*}} : $Int64):
+//CHECK-NOT: {{ apply}}
+//CHECK: bb2:
+sil @licm_readonly_apply_with_assume : $@convention(thin) (Int64, @inout Int64) -> () {
+bb0(%0 : $Int64, %1 : $*Int64):
+  %2 = alloc_stack $Int64
+  store %0 to %2 : $*Int64
+  %9 = function_ref @read_from_param : $@convention(thin) (@inout Int64, Int64) -> Int64
+  %10 = integer_literal $Builtin.Int64, 3
+  %11 = struct $Int64 (%10 : $Builtin.Int64)
+  %12 = struct_element_addr %1 : $*Int64, #Int64._value
+  %13 = integer_literal $Builtin.Int1, -1
+  %14 = struct_extract %0 : $Int64, #Int64._value
+  br bb1
+
+bb1:
+  %20 = builtin "cmp_sgt_Int64"(%14 : $Builtin.Int64, %10 : $Builtin.Int64) : $Builtin.Int1
+  %21 = builtin "assume_Int1"(%20 : $Builtin.Int1) : $Builtin.Int1
+  %22 = apply %9(%2, %11) : $@convention(thin) (@inout Int64, Int64) -> Int64
+  %23 = load %12 : $*Builtin.Int64
+  %24 = struct_extract %22 : $Int64, #Int64._value
+  %25 = builtin "sadd_with_overflow_Int64"(%23 : $Builtin.Int64, %24 : $Builtin.Int64, %13 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %26 = tuple_extract %25 : $(Builtin.Int64, Builtin.Int1), 0
+  %27 = struct $Int64 (%26 : $Builtin.Int64)
+  store %27 to %1 : $*Int64
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  %30 = tuple ()
+  dealloc_stack %2 : $*Int64
+  return %30 : $()
+}
+
+// The assume itself is not loop invariant code: it must stay where it is.
+//CHECK-LABEL: sil @dont_hoist_assume
+//CHECK: bb1:
+//CHECK:   builtin "assume_Int1"
+//CHECK: bb2:
+sil @dont_hoist_assume : $@convention(thin) (Int64, @inout Int64) -> () {
+bb0(%0 : $Int64, %1 : $*Int64):
+  %10 = integer_literal $Builtin.Int64, 3
+  %14 = struct_extract %0 : $Int64, #Int64._value
+  br bb1
+
+bb1:
+  %20 = builtin "cmp_sgt_Int64"(%14 : $Builtin.Int64, %10 : $Builtin.Int64) : $Builtin.Int1
+  %21 = builtin "assume_Int1"(%20 : $Builtin.Int1) : $Builtin.Int1
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  %30 = tuple ()
+  return %30 : $()
+}
+
 //CHECK-LABEL: sil @dont_licm_readonly_apply
 //CHECK: bb1:
 //CHECK: %{{[0-9]+}} = apply

--- a/test/SILOptimizer/licm_apply.sil
+++ b/test/SILOptimizer/licm_apply.sil
@@ -98,10 +98,12 @@ bb3:
   return %30 : $()
 }
 
-// The assume itself is not loop invariant code: it must stay where it is.
+// The assume's loop-invariant condition is hoisted like any other side-effect-free
+// instruction, but the assume itself must stay in the loop: it is not safe to speculate.
 //CHECK-LABEL: sil @dont_hoist_assume
+//CHECK:   [[CMP:%[0-9]+]] = builtin "cmp_sgt_Int64"
 //CHECK: bb1:
-//CHECK:   builtin "assume_Int1"
+//CHECK-NEXT:   builtin "assume_Int1"([[CMP]] : $Builtin.Int1)
 //CHECK: bb2:
 sil @dont_hoist_assume : $@convention(thin) (Int64, @inout Int64) -> () {
 bb0(%0 : $Int64, %1 : $*Int64):

--- a/test/SILOptimizer/range_assume.swift
+++ b/test/SILOptimizer/range_assume.swift
@@ -1,0 +1,88 @@
+// RUN: %target-swift-frontend %s -emit-sil -O | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-swift-frontend %s -emit-ir -O | %FileCheck %s --check-prefix=CHECK-IR
+
+// REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
+
+// Check that the assume of Range's lowerBound <= upperBound invariant survives
+// the SIL pipeline and reaches LLVM as llvm.assume, for each of the standard
+// library entry points which state it.
+
+// Array's range subscript, getter.
+// CHECK-SIL-LABEL: sil [noinline] @$s12range_assume15arraySliceCountySiSaySiG_SnySiGtF :
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:       } // end sil function '$s12range_assume15arraySliceCountySiSaySiG_SnySiGtF'
+
+// CHECK-IR-LABEL: define{{.*}} @"$s12range_assume15arraySliceCountySiSaySiG_SnySiGtF"
+// CHECK-IR:         [[CMP:%[0-9]+]] = icmp sge i64 %2, %1
+// CHECK-IR:         call void @llvm.assume(i1 [[CMP]])
+@inline(never)
+public func arraySliceCount(_ a: [Int], _ r: Range<Int>) -> Int {
+  return a[r].count
+}
+
+// ContiguousArray's range subscript, getter.
+// CHECK-SIL-LABEL: sil [noinline] @$s12range_assume25contiguousArraySliceCountySis010ContiguousD0VySiG_SnySiGtF :
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:       } // end sil function '$s12range_assume25contiguousArraySliceCountySis010ContiguousD0VySiG_SnySiGtF'
+@inline(never)
+public func contiguousArraySliceCount(_ a: ContiguousArray<Int>, _ r: Range<Int>) -> Int {
+  return a[r].count
+}
+
+// ArraySlice's range subscript, getter.
+// CHECK-SIL-LABEL: sil [noinline] @$s12range_assume010arraySliceD5CountySis05ArrayD0VySiG_SnySiGtF :
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:       } // end sil function '$s12range_assume010arraySliceD5CountySis05ArrayD0VySiG_SnySiGtF'
+@inline(never)
+public func arraySliceSliceCount(_ a: ArraySlice<Int>, _ r: Range<Int>) -> Int {
+  return a[r].count
+}
+
+public struct TestCollection: RandomAccessCollection {
+  public var startIndex: Int { 0 }
+  public var endIndex: Int { 100 }
+  public subscript(i: Int) -> Int { i }
+}
+
+// The default Collection slicing subscript (SubSequence == Slice<Self>).
+// CHECK-SIL-LABEL: sil [noinline] @$s12range_assume20collectionSliceCountySiAA14TestCollectionV_SnySiGtF :
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:       } // end sil function '$s12range_assume20collectionSliceCountySiAA14TestCollectionV_SnySiGtF'
+@inline(never)
+public func collectionSliceCount(_ c: TestCollection, _ r: Range<Int>) -> Int {
+  return c[r].count
+}
+
+// Slice's own range subscript: the second slicing goes through
+// Slice.subscript(bounds:), the first through the Collection default.
+// CHECK-SIL-LABEL: sil [noinline] @$s12range_assume17sliceOfSliceCountySiAA14TestCollectionV_SnySiGAEtF :
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:       } // end sil function '$s12range_assume17sliceOfSliceCountySiAA14TestCollectionV_SnySiGAEtF'
+@inline(never)
+public func sliceOfSliceCount(_ c: TestCollection, _ r: Range<Int>, _ q: Range<Int>) -> Int {
+  return c[r][q].count
+}
+
+// Range's own startIndex/endIndex.
+// CHECK-SIL-LABEL: sil [noinline] @$s12range_assume0A6BoundsySi_SitSnySiGF :
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:       } // end sil function '$s12range_assume0A6BoundsySi_SitSnySiGF'
+
+// CHECK-IR-LABEL: define{{.*}} @"$s12range_assume0A6BoundsySi_SitSnySiGF"
+// CHECK-IR:         [[CMP:%[0-9]+]] = icmp sge i64 %1, %0
+// CHECK-IR:         call void @llvm.assume(i1 [[CMP]])
+@inline(never)
+public func rangeBounds(_ r: Range<Int>) -> (Int, Int) {
+  return (r.startIndex, r.endIndex)
+}
+
+// Array's range subscript, setter. The probe's body is moved into a specialized
+// function; the assume must be in there.
+// CHECK-SIL-LABEL: sil shared @$sSays10ArraySliceVyxGSnySiGcisSi_{{.*}} :
+// CHECK-SIL:         builtin "assume_Int1"
+// CHECK-SIL:       } // end sil function '$sSays10ArraySliceVyxGSnySiGcisSi_
+@inline(never)
+public func arraySliceSet(_ a: inout [Int], _ r: Range<Int>, _ v: ArraySlice<Int>) {
+  a[r] = v
+}

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -177,6 +177,18 @@ bb0(%0 : $AB, %1 : $Int):
   return %6 : $Int
 }
 
+// The assume builtin does not access memory, so it must not block load forwarding.
+// CHECK-LABEL: sil hidden @load_forward_across_assume
+// CHECK-NOT: = load
+// CHECK: return %1
+sil hidden @load_forward_across_assume : $@convention(thin) (@inout Int, Int, Builtin.Int1) -> Int {
+bb0(%0 : $*Int, %1 : $Int, %2 : $Builtin.Int1):
+  store %1 to %0 : $*Int
+  %4 = builtin "assume_Int1"(%2 : $Builtin.Int1) : $Builtin.Int1
+  %5 = load %0 : $*Int
+  return %5 : $Int
+}
+
 // CHECK-LABEL: sil hidden @redundant_load_across_fixlifetime_inst
 // CHECK: = load
 // CHECK-NOT: = load

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -315,6 +315,20 @@ bb0(%0 : $Builtin.NativeObject, %1 : $X):
   return %r : $()
 }
 
+// The assume builtin's conservative memory effects only keep it from being moved or
+// removed. It must not show up in the function's side effect summary.
+// CHECK-LABEL: sil @test_assume_builtin
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @test_assume_builtin : $@convention(thin) (Builtin.Int64) -> () {
+bb0(%0 : $Builtin.Int64):
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = builtin "cmp_sgt_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %3 = builtin "assume_Int1"(%2 : $Builtin.Int1) : $Builtin.Int1
+  %r = tuple ()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil @test_project_box
 // CHECK-NEXT:  [%0: read c0.v**]
 // CHECK-NEXT:  [global: ]


### PR DESCRIPTION
Teach LLVM that Swift's `Range` guarantees `lowerBound <= upperBound`.
This enables LLVM to shave some instructions.

The files for the following examples: [swift-pr-91772-showcase.zip](https://github.com/user-attachments/files/31516124/swift-pr-91772-showcase.zip).
Contains all 3 cases + asm, LLVM IR and SIL before vs after outputs.

## Example 1

For the following code:
```swift
@inline(never)
public func sumRange(_ r: Range<Int>) -> Int {
  var s = 0
  for i in r {
    s = s &+ i
  }
  return s
}
```

asm comparison (before vs after):
<kbd> <img width="1001" height="446" alt="Screenshot 2026-08-27 at 4 18 54 PM" src="https://github.com/user-attachments/assets/aa7820ba-98c9-4cea-8d2d-51988daa9813" /> </kbd>

## Example 2

```swift
@inline(never)
public func sliceCount(_ a: [Int], _ r: Range<Int>) -> Int {
  return a[r].count
}

@inline(never)
public func sliceOfSliceCount(_ a: [Int], _ r: Range<Int>, _ q: Range<Int>) -> Int {
  return a[r][q].count
}
```

<kbd> <img width="1736" height="1009" alt="Screenshot 2026-08-27 at 4 32 17 PM" src="https://github.com/user-attachments/assets/ce39e89e-6895-4393-b1a7-7c1ed2e02ce3" /> </kbd>

## Example 3

```swift
@inline(never)
func sliceCount(_ a: [Int], _ r: Range<Int>) -> Int {
  return a[r].count
}

@inline(never)
public func sumOfSliceCounts(_ a: [Int], _ r: Range<Int>, _ n: Int) -> Int {
  var s = 0
  for _ in 0..<n {
    s = s &+ sliceCount(a, r)
  }
  return s
}
```

<kbd> <img width="1514" height="480" alt="Screenshot 2026-08-27 at 4 31 14 PM" src="https://github.com/user-attachments/assets/ede09837-1c85-486c-9fde-00e26702ab11" /> </kbd>

## Alternatives Considered

Add a `@_semantics("range.bounds_ordered")` and inject `_assumeValid()` to LLVM via that.
Do you think that's more appropriate? I already have half a impl, and looks ok.


