### PR TITLE
[cxx-interop] Mark functions that use LIBKERN_CONSUME annotations as unavailable

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4554,6 +4554,19 @@ namespace {
           "'returns_twice' attribute) are unavailable in Swift");
       }
 
+      bool hasConsumedAttr =
+          llvm::any_of(decl->parameters(), [](const clang::ParmVarDecl *param) {
+            return param->hasAttr<clang::OSConsumedAttr>();
+          });
+
+      if (hasConsumedAttr)
+        Impl.markUnavailable(result,
+                             "LIBKERN_CONSUMED annotation is not supported");
+
+      if (decl->hasAttr<clang::OSConsumesThisAttr>())
+        Impl.markUnavailable(
+            result, "LIBKERN_CONSUMES_THIS annotation is not supported");
+
       recordObjCOverride(result);
       Impl.swiftify(result);
     }
@@ -4780,6 +4793,13 @@ namespace {
                            Impl.SwiftContext.getIdentifier(staticCallName),
                            funcDecl->getName().getArgumentNames()));
               Impl.virtualThunkToOriginal[result] = funcDecl;
+
+              // Propagate availability attributes from the original Swift
+              // funcDecl.
+              if (auto unavailable = funcDecl->getUnavailableAttr())
+                result->addAttribute(unavailable->getParsedAttr()->clone(
+                    Impl.SwiftContext, /*implicit=*/true));
+
               // swiftify is called on import, but the virtualThunkToOriginal
               // mapping is not yet ready at that time, so call it again.
               Impl.swiftify(result);

--- a/test/Interop/Cxx/foreign-reference/Inputs/libkern-ownership.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/libkern-ownership.hpp
@@ -6,6 +6,8 @@
 
 #define LIBKERN_RETURNS_RETAINED __attribute__((os_returns_retained))
 #define LIBKERN_RETURNS_NOT_RETAINED __attribute__((os_returns_not_retained))
+#define LIBKERN_CONSUMED __attribute__((os_consumed))
+#define LIBKERN_CONSUMES_THIS __attribute__((os_consumes_this))
 
 class ObjectManager {
   mutable int totalRetains = 0;
@@ -154,6 +156,14 @@ public:
   virtual Service *_Nonnull virtualNoAnnotationCopyService() const {
     return new Service(id);
   }
+
+  static void consumesService(LIBKERN_CONSUMED Service *service) { 
+    // expected-note@-1 {{'consumesService' has been explicitly marked unavailable here}}
+    if (service)
+      service->release();
+  }
+
+  virtual void LIBKERN_CONSUMES_THIS consumeMyself() { release(); }
 };
 
 class NastyService : public Service {

--- a/test/Interop/Cxx/foreign-reference/Inputs/libkern-ownership.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/libkern-ownership.hpp
@@ -164,6 +164,13 @@ public:
   }
 
   virtual void LIBKERN_CONSUMES_THIS consumeMyself() { release(); }
+
+  // _RETURNS_RETAINED and _RETURNS_UNRETAINED attributes are ignored on out
+  // parameters
+  static bool initializeService(int id, Service **service) {
+    *service = new Service(id);
+    return (*service)->getID() == id;
+  }
 };
 
 class NastyService : public Service {

--- a/test/Interop/Cxx/foreign-reference/libkern-ownership-executable.swift
+++ b/test/Interop/Cxx/foreign-reference/libkern-ownership-executable.swift
@@ -204,4 +204,15 @@ Tests.test("DerivedService") {
   expectEqual(manager.getTotalRetains() + 1, manager.getTotalReleases())
 }
 
+Tests.test("Out parameters are always assumed to return retained") {
+  manager.reset()
+
+  do {
+    var service: Service!
+    Service.initializeService(47, &service)
+  }
+
+  expectEqual(manager.getTotalRetains() + 1, manager.getTotalReleases())
+}
+
 runAllTests()

--- a/test/Interop/Cxx/foreign-reference/libkern-ownership-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/libkern-ownership-module-interface.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=default -print-implicit-attrs -module-to-print=LibkernOwnership -I %S/Inputs -source-filename=x | %FileCheck %s
+
+// CHECK: class Service {
+// CHECK:   @available(*, unavailable, message: "LIBKERN_CONSUMED annotation is not supported")
+// CHECK:   class func consumesService(_ service: Service!)
+// CHECK:   @available(*, unavailable, message: "LIBKERN_CONSUMES_THIS annotation is not supported")
+// CHECK:   func consumeMyself()
+// CHECK: }
+
+// CHECK: class DerivedService {
+// CHECK:   @available(*, unavailable, message: "LIBKERN_CONSUMES_THIS annotation is not supported")
+// CHECK:   func consumeMyself()
+// CHECK: }

--- a/test/Interop/Cxx/foreign-reference/libkern-ownership-typecheck.swift
+++ b/test/Interop/Cxx/foreign-reference/libkern-ownership-typecheck.swift
@@ -1,14 +1,24 @@
-// RUN: %target-typecheck-verify-swift -I %S%{fs-sep}Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -cxx-interoperability-mode=default -disable-availability-checking -Xcc -Wno-nullability-completeness -verify-ignore-unknown -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}libkern-ownership.hpp -enable-experimental-feature LibkernOwnershipConventions
+// RUN: %target-typecheck-verify-swift -I %S%{fs-sep}Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -cxx-interoperability-mode=default -Xcc -Wno-nullability-completeness -verify-ignore-unknown -verify-ignore-unrelated -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}libkern-ownership.hpp -enable-experimental-feature LibkernOwnershipConventions
 
 // REQUIRES: swift_feature_LibkernOwnershipConventions
 
 import LibkernOwnership
 
-let service = Service.withID(3)
-_ = service.getProvider() // no warning expected
+if #available(SwiftStdlib 5.8, *) {
+  let service = Service.withID(3)
+  _ = service.getProvider() // no warning expected
 
-_ = service.copyService() // no warning expected
+  _ = service.copyService() // no warning expected
 
-_ = OSIterator.getIterator() // no warning expected
+  _ = OSIterator.getIterator() // no warning expected
 
-let _ = NastyService.toRetainOrNotToRetain()
+  _ = NastyService.toRetainOrNotToRetain()
+
+  service.consumeMyself() // expected-error {{'consumeMyself()' is unavailable: LIBKERN_CONSUMES_THIS annotation is not supported}}
+
+  Service.consumesService(service) // expected-error {{'consumesService' is unavailable: LIBKERN_CONSUMED annotation is not supported}}
+
+  let derivedService = DerivedService.derivedWithID(9)
+
+  derivedService.consumeMyself() // expected-error {{'consumeMyself()' is unavailable: LIBKERN_CONSUMES_THIS annotation is not supported}}
+}


### PR DESCRIPTION
The `LIBKERN_CONSUMED` and `LIBKERN_CONSUMES_THIS` annotations specify that the function is expected to consume the reference to the annotated parameter or "this", respectively.

We currently don't support these annotations, so we mark any function that uses them as unavailable, as a precaution.

rdar://184722822