### PR TITLE
Optimizer: refactor SimplifyDestroyValue and support multiple destroys

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestroyValue.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestroyValue.swift
@@ -27,104 +27,17 @@ extension DestroyValueInst : OnoneSimplifiable, SILCombineSimplifiable {
       return
     }
 
-    tryRemoveForwardingOperandInstruction(context)
+    if let phi = Phi(destroyedValue) {
+      tryHoistDestroysIntoPredecessors(of: phi, context)
+      return
+    }
+
+    if let forwardingInst = destroyedValue.asOptimizableForwardingInstruction {
+      tryRemoveForwardingInstruction(forwardingInst, context)
+    }
   }
 
-  /// Attempt to optimize by forwarding the destroy to operands of forwarding instructions.
-  ///
-  /// ```
-  ///   %3 = struct $S (%1, %2)
-  ///   destroy_value %3         // the only use of %3
-  /// ```
-  /// ->
-  /// ```
-  ///   destroy_value %1
-  ///   destroy_value %2
-  /// ```
-  ///
-  /// The benefit of this transformation is that the forwarding instruction can be removed.
-  ///
-  private func tryRemoveForwardingOperandInstruction(_ context: SimplifyContext) {
-    switch destroyedValue {
-    case is StructInst,
-         is EnumInst:
-      if destroyedValue.type.nominal!.valueTypeDestructor != nil {
-        // Moving the destroy to a non-copyable struct/enum's operands would drop the deinit call!
-        return
-      }
-
-    // Handle various "forwarding" instructions that simply pass through values
-    // without performing operations that would affect destruction semantics.
-    //
-    // We are intentionally _not_ handling `unchecked_enum_data`, because that would not necessarily be
-    // a simplification, because destroying the whole enum is more effort than to destroy an enum payload.
-    // We are also not handling `destructure_struct` and `destructure_tuple`. That would end up in
-    // an infinite simplification loop in MandatoryPerformanceOptimizations because there we "split" such
-    // destroys again when de-virtualizing deinits of non-copyable types.
-    //
-    case is TupleInst,
-         is RefToBridgeObjectInst,
-         is ConvertFunctionInst,
-         is ThinToThickFunctionInst,
-         is UpcastInst,
-         is UncheckedRefCastInst,
-         is UnconditionalCheckedCastInst,
-         is BridgeObjectToRefInst,
-         is InitExistentialRefInst,
-         is OpenExistentialRefInst:
-      break
-
-    case let arg as Argument:
-      if isDeadEnd {
-        // Dead-end destroys are no-ops, anyway. Don't try to move them away from an `unreachable` instruction.
-        return
-      }
-      guard destroyedValue.hasSingleUse(ignoringFixLifetime: false, context) else {
-        return
-      }
-      tryRemovePhiArgument(arg, context)
-      return
-      
-    default:
-      return
-    }
-
-    // Support fix_lifetime as use:
-    // ```
-    //   %3 = struct $S (%1, %2)
-    //   fix_lifetime %3
-    //   destroy_value %3         // the only use of %3, except `fix_lifetime`
-    // ```
-    // ->
-    // ```
-    //   fix_lifetime %1
-    //   fix_lifetime %2
-    //   destroy_value %1
-    //   destroy_value %2
-    // ```
-    guard destroyedValue.hasSingleUse(ignoringFixLifetime: true, context) else {
-      return
-    }
-    let destroyedInst = destroyedValue as! SingleValueInstruction
-
-    let builder = Builder(before: self, context)
-    for op in destroyedInst.definedOperands where op.value.ownership == .owned {
-      builder.createDestroyValue(operand: op.value, isDeadEnd: isDeadEnd)
-    }
-    for fixLifetime in destroyedValue.uses.users(ofType: FixLifetimeInst.self) {
-      let builder = Builder(before: fixLifetime, context)
-      for op in destroyedInst.definedOperands where op.value.ownership == .owned {
-        builder.createFixLifetime(operand: op.value)
-      }
-    }
-
-    // Users include `debug_value` instructions and this `destroy_value`
-    context.erase(instructionIncludingAllUsers: destroyedInst)
-  }
-
-  /// Handles the optimization of `destroy_value` instructions for phi arguments.
-  /// This is a more complex case where the destroyed value comes from different predecessors
-  /// via a phi argument. The optimization moves the `destroy_value` to each predecessor block.
+  /// Moves a `destroy_value` of a phi argument to the phi's predecessor blocks.
   ///
   /// ```
   /// bb1:
@@ -147,49 +60,143 @@ extension DestroyValueInst : OnoneSimplifiable, SILCombineSimplifiable {
   ///   ...
   /// ```
   ///
-  private func tryRemovePhiArgument(_ arg: Argument, _ context: SimplifyContext) {
-    guard let phi = Phi(arg),
-          arg.parentBlock == parentBlock,
+  private func tryHoistDestroysIntoPredecessors(of phi: Phi, _ context: SimplifyContext) {
+    let phiBlock = phi.value.parentBlock
+
+    guard phiBlock == parentBlock,
+          // Dead-end destroys are no-ops, anyway. Don't try to move them away from an `unreachable` instruction.
+          !isDeadEnd,
+          phi.value.isOnlyDestroyed(ignoringFixLifetime: false, context),
           !isDeinitBarrierInBlock(before: self, context)
     else {
       return
     }
-    
+
     for incomingOp in phi.incomingOperands {
       let oldBranch = incomingOp.instruction as! BranchInst
       let builder = Builder(before: oldBranch, context)
       builder.createDestroyValue(operand: incomingOp.value)
-      builder.createBranch(to: parentBlock, arguments: oldBranch.arguments(excluding: incomingOp))
+      builder.createBranch(to: phiBlock, arguments: oldBranch.arguments(excluding: incomingOp))
       context.erase(instruction: oldBranch)
     }
-    
-    // Users of `arg` include `debug_value` instructions and this `destroy_value`
-    context.erase(instructions: arg.uses.users)
 
-    arg.parentBlock.eraseArgument(at: arg.index, context)
+    // Users of `phi` include `debug_value` instructions and this `destroy_value`
+    context.erase(instructions: phi.value.users)
+
+    phiBlock.eraseArgument(at: phi.value.index, context)
   }
 }
 
+/// If `forwardingInst` has no other users than `destroy_value` (except `fix_lifetime` and `debug_value`),
+/// remove the `forwardingInst` and destroy its (owned) operands instead.
+///
+/// ```
+///   %3 = struct $S (%1, %2)
+///   destroy_value %3         // the only use of %3
+/// ```
+/// ->
+/// ```
+///   destroy_value %1
+///   destroy_value %2
+/// ```
+///
+private func tryRemoveForwardingInstruction(_ forwardingInst: SingleValueInstruction, _ context: SimplifyContext) {
+
+  // Support fix_lifetime as use:
+  // ```
+  //   %3 = struct $S (%1, %2)
+  //   fix_lifetime %3
+  //   destroy_value %3         // the only use of %3, except `fix_lifetime`
+  // ```
+  // ->
+  // ```
+  //   fix_lifetime %1
+  //   fix_lifetime %2
+  //   destroy_value %1
+  //   destroy_value %2
+  // ```
+  guard forwardingInst.isOnlyDestroyed(ignoringFixLifetime: true, context) else {
+    return
+  }
+
+  for user in forwardingInst.users {
+    switch user {
+    case is DebugValueInst:
+      break
+    case let destroy as DestroyValueInst:
+      let builder = Builder(before: destroy, context)
+      for op in forwardingInst.definedOperands where op.value.ownership == .owned {
+        builder.createDestroyValue(operand: op.value, isDeadEnd: destroy.isDeadEnd)
+      }
+    case let fixLifetime as FixLifetimeInst:
+      let builder = Builder(before: fixLifetime, context)
+      for op in forwardingInst.definedOperands where op.value.ownership == .owned {
+        builder.createFixLifetime(operand: op.value)
+      }
+    default:
+      fatalError("unexpected user")
+    }
+  }
+
+  // Users include `destroy_value`, `fix_lifetime` and `debug_value` instructions.
+  context.erase(instructionIncludingAllUsers: forwardingInst)
+}
+
 private extension Value {
-  func hasSingleUse(ignoringFixLifetime: Bool, _ context: SimplifyContext) -> Bool {
-    var foundRelevantUse = false
-    for use in uses {
-      switch use.instruction {
+  func isOnlyDestroyed(ignoringFixLifetime: Bool, _ context: SimplifyContext) -> Bool {
+    for user in users {
+      switch user {
+      case is DestroyValueInst:
+        break
       case is DebugValueInst where !context.preserveDebugInfo:
         break
       case is FixLifetimeInst where ignoringFixLifetime:
         break
       default:
-        if foundRelevantUse {
-          return false
-        }
-        foundRelevantUse = true
+        return false
       }
     }
-    return foundRelevantUse
+    return true
+  }
+
+  /// Return this value as a SingleValueInstruction if it is a forwarding instruction which can
+  /// be optimized by `tryRemoveForwardingInstruction`.
+  var asOptimizableForwardingInstruction: SingleValueInstruction? {
+    switch self {
+    case is StructInst,
+         is EnumInst:
+      guard type.nominal!.valueTypeDestructor == nil else {
+        // Moving the destroy to a non-copyable struct/enum's operands would drop the deinit call!
+        return nil
+      }
+      return self as? SingleValueInstruction
+
+    // Handle various "forwarding" instructions that simply pass through values
+    // without performing operations that would affect destruction semantics.
+    //
+    // We are intentionally _not_ handling `unchecked_enum_data`, because that would not necessarily be
+    // a simplification, because destroying the whole enum is more effort than to destroy an enum payload.
+    // We are also not handling `destructure_struct` and `destructure_tuple`. That would end up in
+    // an infinite simplification loop in MandatoryPerformanceOptimizations because there we "split" such
+    // destroys again when de-virtualizing deinits of non-copyable types.
+    //
+    case is TupleInst,
+         is RefToBridgeObjectInst,
+         is ConvertFunctionInst,
+         is ThinToThickFunctionInst,
+         is UpcastInst,
+         is UncheckedRefCastInst,
+         is UnconditionalCheckedCastInst,
+         is BridgeObjectToRefInst,
+         is InitExistentialRefInst,
+         is OpenExistentialRefInst:
+      return self as? SingleValueInstruction
+
+    default:
+      return nil
+    }
   }
 }
-
 
 private func isDeinitBarrierInBlock(before instruction: Instruction, _ context: SimplifyContext) -> Bool {
   return ReverseInstructionList(first: instruction.previous).contains(where: {

--- a/test/SILOptimizer/simplify_destroy_value.sil
+++ b/test/SILOptimizer/simplify_destroy_value.sil
@@ -79,6 +79,31 @@ bb0(%0 : @owned $C, %1 : @owned $C, %2 : $Int):
   unreachable
 }
 
+// CHECK-LABEL: sil [ossa] @remove_struct_with_two_destroys :
+// CHECK:       bb1:
+// CHECK-NEXT:    destroy_value [dead_end] %0
+// CHECK-NEXT:    destroy_value [dead_end] %1
+// CHECK-NEXT:    unreachable
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    destroy_value %1
+// CHECK-NEXT:    tuple
+// CHECK:       } // end sil function 'remove_struct_with_two_destroys'
+sil [ossa] @remove_struct_with_two_destroys : $@convention(thin) (@owned C, @owned C, Int) -> () {
+bb0(%0 : @owned $C, %1 : @owned $C, %2 : $Int):
+  %3 = struct $S (%0, %1, %2)
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value [dead_end] %3
+  unreachable
+
+bb2:
+  destroy_value %3
+  %r = tuple ()
+  return %r
+}
+
 // CHECK-LABEL: sil [ossa] @remove_struct_with_fixlifetime :
 // CHECK:       bb1:
 // CHECK-NEXT:    fix_lifetime %0


### PR DESCRIPTION
Support removing a forwarding instruction that has more than one `destroy_value` user. An owned value is consumed once per path, so multiple destroys sit on mutually-exclusive paths; each is replaced by destroys of the forwarding instruction's owned operands. Previously this case required a single use and was left unoptimized:

```
    %3 = struct $S (%0, %1)
  bb1:
    destroy_value [dead_end] %3
    unreachable
  bb2:
    destroy_value %3
```
  ->
```
  bb1:
    destroy_value [dead_end] %0
    destroy_value [dead_end] %1
    unreachable
  bb2:
    destroy_value %0
    destroy_value %1
```
