### PR TITLE
[SILOptimizer] Fix compiler performance in closure specialization pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -58,10 +58,10 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let closureSpecialization = FunctionPass(name: "closure-specialization") {
   (function: Function, context: FunctionPassContext) in
 
-  runClosureSpecialization(function: function, context: context)
+  runClosureSpecialization(function: function, isRootInvocation: true, context: context)
 }
 
-func runClosureSpecialization(function: Function, context: FunctionPassContext) {
+func runClosureSpecialization(function: Function, isRootInvocation: Bool, context: FunctionPassContext) {
   guard function.hasOwnership else {
     return
   }
@@ -73,7 +73,7 @@ func runClosureSpecialization(function: Function, context: FunctionPassContext) 
 
     for inst in function.instructions {
       if let apply = inst as? FullApplySite {
-        if trySpecialize(apply: apply, context) {
+        if trySpecialize(apply: apply, isRootInvocation: isRootInvocation, context) {
           changed = true
         }
       }
@@ -200,7 +200,7 @@ let autodiffClosureSpecialization = FunctionPass(name: "autodiff-closure-special
       break
     }
 
-    if trySpecialize(apply: partialApplyInst, context) {
+    if trySpecialize(apply: partialApplyInst, isRootInvocation: true, context) {
       changed = true
     }
 
@@ -217,7 +217,7 @@ let autodiffClosureSpecialization = FunctionPass(name: "autodiff-closure-special
 
 // ===================== Utility functions and extensions ===================== //
 
-private func trySpecialize(apply: ApplySite, _ context: FunctionPassContext) -> Bool {
+private func trySpecialize(apply: ApplySite, isRootInvocation: Bool, _ context: FunctionPassContext) -> Bool {
   guard isCalleeSpecializable(of: apply),
         let specialization = analyzeArguments(of: apply, context)
   else {
@@ -255,7 +255,7 @@ private func trySpecialize(apply: ApplySite, _ context: FunctionPassContext) -> 
 
   specialization.deleteDeadClosures(context)
 
-  if isNewFunction {
+  if isNewFunction && isRootInvocation {
     /// Further specialization rounds can leave the cloned callee holding a specializable closure and an `apply` which
     /// takes this closure as an argument. Consider the case when this specializable closure captures an argument from
     /// the cloned callee, and this argument by itself is a specializable closure constructed in caller and passed to
@@ -321,7 +321,7 @@ private func trySpecialize(apply: ApplySite, _ context: FunctionPassContext) -> 
 
     context.buildSpecializedFunction(specializedFunction: specializedFunction) {
       (specializedFunction, specializedContext) in
-      runClosureSpecialization(function: specializedFunction, context: specializedContext)
+      runClosureSpecialization(function: specializedFunction, isRootInvocation: false, context: specializedContext)
     }
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -272,8 +272,8 @@ private func trySpecialize(apply: ApplySite, isRootInvocation: Bool, _ context: 
     /// Running `runClosureSpecialization` synchronously on the cloned callee we've just produced fully specializes it
     /// before the caller's next specialization round, so the caller re-inspects the same apply, now sees `closure0` as
     /// transitively applied, and specializes it - leaving no `partial_apply` of a specializable closure in the caller.
-    /// This recursion terminates: `runClosureSpecialization` performs at most 5 rounds per function, and
-    /// `findSpecializableClosure` only specializes closures whose callee has `specializationLevel <= 2`.
+    /// This recursion terminates: recursive specialization run on the just-specialized callee is only triggered from the
+    /// actual pass invocation (`isRootInvocation`), so we won't trigger specialization of callees nested deeper.
     ///
     /// Round 2 for caller: specialize apply of specialized_callee_r1.
     ///

--- a/test/SILOptimizer/closure_specialization_recurse_timeout.swift
+++ b/test/SILOptimizer/closure_specialization_recurse_timeout.swift
@@ -1,0 +1,26 @@
+// RUN: %{python} %S/../Inputs/timeout.py 20 %target-swift-frontend -O %s -emit-sil
+
+func genericChain<T, U, V>(
+  input: T, depth: Int, toU: @escaping (T) -> U,
+  toV: @escaping (U) -> V, toT: @escaping (V) -> T
+) -> T {
+  if depth
+    <= 0
+  {
+    return toT(toV(toU(input)))
+  }
+  return genericChain(
+    input: toT(toV(toU(input))), depth: depth - 1,
+    toU: { t in toU(toT(toV(toU(t)))) },
+    toV: { u in toV(toU(toT(toV(u)))) },
+    toT: { v in toT(toV(toU(toT(v)))) })
+}
+
+let result4 = genericChain(
+  input: 10,
+  depth: 0,
+  toU: { Double($0) },
+  toV: { String(Int($0) % 10000) },
+  toT: { Int($0) ?? 0 }
+)
+print("genericChain result: \(result4)")


### PR DESCRIPTION
After #91103, compiling code with certain closure chains takes enormous amount of time: see report
https://github.com/swiftlang/swift/pull/91103#issuecomment-5430613745

The root cause of the issue is unbounded amount of triggers for iterative specialization of just-specialized callees.

This patch resolves the issue by allowing iterative specialization call only from root pass invocation. This way, iteration depth does not exceed 1, while expected optimizations are still performed.
