### PR TITLE
Derive `Hashable` via macro

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -20,6 +20,7 @@ add_swift_macro_library(SwiftMacros
   TypeInfoParser.swift
   DerivedConformances/DeriveCaseIterable.swift
   DerivedConformances/DeriveEquatable.swift
+  DerivedConformances/DeriveHashable.swift
   SWIFT_DEPENDENCIES
     SwiftDiagnostics
     SwiftSyntax

--- a/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveHashable.swift
+++ b/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveHashable.swift
@@ -81,14 +81,27 @@ extension HashableRequirement: TypeInfoProtocol {
       """
     }
   }
+
+  var isUnsafe: Bool {
+    switch self {
+    case .hashValue(let isUnsafe):
+      isUnsafe
+    case .compatHash(let isUnsafe):
+      isUnsafe
+    case .hashRawValue(let isUnsafe):
+      isUnsafe
+    case .hash(let info):
+      info.isUnsafe
+    }
+  }
 }
 
 public struct DeriveHashableMacro: DeclarationMacro {
 
-  let isUnsafe: Bool
+  let requirement: HashableRequirement
 
   var unsafeMark: String {
-    isUnsafe ? "unsafe " : ""
+    requirement.isUnsafe ? "unsafe " : ""
   }
 
   public static func expansion(
@@ -98,45 +111,42 @@ public struct DeriveHashableMacro: DeclarationMacro {
     // Parse the requirement and then expand it.
     let req = try node.arguments.expect(
       .init(parser: HashableRequirement.fromStringLit))
-    return [Self.expand(req)]
+    return [Self(requirement: req).expand]
   }
 
   /// Returns the expansion for `hashValue` var using `_hashValue`. When the
   /// conformance is unsafe, the call is combined through an `unsafe` expression.
-  func expandHashValue() -> DeclSyntax {
-    return
-      """
-      var hashValue: Swift::Int {
-        return \(raw: unsafeMark)Swift::_hashValue(for: self)
-      }
-      """
+  var expandHashValue: DeclSyntax {
+    """
+    var hashValue: Swift::Int {
+      return \(raw: unsafeMark)Swift::_hashValue(for: self)
+    }
+    """
   }
 
   /// Returns the signature of the `hash(into:)` method.
-  static func getHashSignature() -> DeclSyntax {
+  static var getHashSignature: DeclSyntax {
     """
     func hash(into hasher: inout Swift::Hasher)
     """
   }
 
   /// Returns the expansion of the `hash(into:)` method using the `hashValue` var.
-  func expandCompatHash() -> DeclSyntax {
-    return
-      """
-      \(Self.getHashSignature()) {
-        \(raw: unsafeMark)hasher.combine(self.hashValue)
-      }
-      """
+  var expandCompatHash: DeclSyntax {
+    """
+    \(Self.getHashSignature) {
+      \(raw: unsafeMark)hasher.combine(self.hashValue)
+    }
+    """
   }
 
   /// Returns the expansion of the `hash(into:)` method using the enum's raw value.
-  func expandHashRawValue() -> DeclSyntax {
-    return
-      """
-      \(Self.getHashSignature()) {
-        \(raw: unsafeMark)hasher.combine(self.rawValue)
-      }
-      """
+  var expandHashRawValue: DeclSyntax {
+    """
+    \(Self.getHashSignature) {
+      \(raw: unsafeMark)hasher.combine(self.rawValue)
+    }
+    """
   }
 
   /// Derives the body of `hash(into:)` for an enum with no associated values
@@ -160,10 +170,7 @@ public struct DeriveHashableMacro: DeclarationMacro {
   /// Derives the body of `hash(into:)` for an enum with associated values. When
   /// the conformance is unsafe, each associated value is combined through an
   /// `unsafe` expression, since it relies on the value's Hashable conformance.
-  static func getHashBodyHasAssociatedValues(
-    _ infos: EnumTypeInfo, isUnsafe: Bool
-  ) -> CodeBlockItemListSyntax {
-    let unsafeMark = isUnsafe ? "unsafe " : ""
+  func getHashBodyHasAssociatedValues(_ infos: EnumTypeInfo) -> CodeBlockItemListSyntax {
     var idx = 0
     let cases: [SwitchCaseSyntax] =
       infos.cases.map { caseInfo in
@@ -207,19 +214,18 @@ public struct DeriveHashableMacro: DeclarationMacro {
   }
 
   /// Derives the body of `hash(into:)` for an enum
-  static func getHashBody(_ infos: EnumTypeInfo, isUnsafe: Bool) -> CodeBlockItemListSyntax {
+  func getHashBody(_ infos: EnumTypeInfo) -> CodeBlockItemListSyntax {
     if infos.hasNoAssociatedValues() {
-      getHashBodyNoAssociatedValues(infos)
+      Self.getHashBodyNoAssociatedValues(infos)
     } else {
-      getHashBodyHasAssociatedValues(infos, isUnsafe: isUnsafe)
+      getHashBodyHasAssociatedValues(infos)
     }
   }
 
   /// Derives the body of `hash(into:)` for a struct. When the conformance is
   /// unsafe, each property is combined through an `unsafe` expression, since it
   /// relies on the property's Hashable conformance.
-  static func getHashBody(_ infos: StructTypeInfo, isUnsafe: Bool) -> CodeBlockItemListSyntax {
-    let unsafeMark = isUnsafe ? "unsafe " : ""
+  func getHashBody(_ infos: StructTypeInfo) -> CodeBlockItemListSyntax {
     var items: [CodeBlockItemSyntax] = []
     for prop in infos.properties {
       if !prop.isUserAccessible {
@@ -235,35 +241,31 @@ public struct DeriveHashableMacro: DeclarationMacro {
   }
 
   /// Derives the body of `hash(into:)`
-  static func getHashBody(_ infos: NominalTypeInfo) -> CodeBlockItemListSyntax {
+  func getHashBody(_ infos: NominalTypeInfo) -> CodeBlockItemListSyntax {
     switch infos.kind {
     case .enumLike(let enum_infos):
-      return getHashBody(enum_infos, isUnsafe: infos.isUnsafe)
+      return getHashBody(enum_infos)
     case .structLike(let struct_infos):
-      return getHashBody(struct_infos, isUnsafe: infos.isUnsafe)
+      return getHashBody(struct_infos)
     }
   }
 
   /// Derives the `hash(into:)` method
-  static func expandHash(_ infos: NominalTypeInfo) -> DeclSyntax {
+  func expandHash(_ infos: NominalTypeInfo) -> DeclSyntax {
     """
-    \(getHashSignature()) {
+    \(Self.getHashSignature) {
       \(getHashBody(infos))
     }
     """
   }
 
   /// Derives a requirement for `Hashable`
-  static func expand(_ req: HashableRequirement) -> DeclSyntax {
-    switch req {
-    case .hashValue(let isUnsafe):
-      Self(isUnsafe: isUnsafe).expandHashValue()
-    case .compatHash(let isUnsafe):
-      Self(isUnsafe: isUnsafe).expandCompatHash()
-    case .hashRawValue(let isUnsafe):
-      Self(isUnsafe: isUnsafe).expandHashRawValue()
-    case .hash(let infos):
-      Self.expandHash(infos)
+  var expand: DeclSyntax {
+    switch requirement {
+    case .hashValue: expandHashValue
+    case .compatHash: expandCompatHash
+    case .hashRawValue: expandHashRawValue
+    case .hash(let infos): expandHash(infos)
     }
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveHashable.swift
+++ b/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveHashable.swift
@@ -1,0 +1,269 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Represents which witness we want to derive and how.
+enum HashableRequirement {
+  /// Derive the `hashValue` var using `_hashValue`
+  case hashValue(isUnsafe: Bool)
+
+  /// Derive the `hash(into:)` method using the deprecated way
+  case compatHash(isUnsafe: Bool)
+
+  /// Derive the `hash(into:)` method using the enum's raw value
+  case hashRawValue(isUnsafe: Bool)
+
+  /// Derive the `hash(into:)` method using the type's elements
+  case hash(NominalTypeInfo)
+}
+
+/// Error type thrown by calling `HashableRequirement.fromSyntax` with ill-formed input
+enum HashableRequirementParseError: Error {
+
+  /// Expected \p node as an `FunctionCallExprSyntax` but got \p node instead
+  case expectedFunctionCallLikeExpr(node: ExprSyntax)
+
+  /// Expected `hash`, `hashValue`, `compatHash` or `hashRawValue` but got \p name
+  case unknownRequirementName(name: String)
+}
+
+// Parsing utilities for HashableRequirement
+extension HashableRequirement: TypeInfoProtocol {
+  static func fromSyntax(node: ExprSyntax) throws -> Self {
+    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+      throw HashableRequirementParseError.expectedFunctionCallLikeExpr(node: node)
+    }
+    let requirementName = fcall.calledExpression.trimmedDescription
+    switch requirementName {
+    case "hash":
+      let typeInfo = try fcall.arguments.expect(.init(parser: NominalTypeInfo.fromSyntax))
+      return .hash(typeInfo)
+    case "hashValue":
+      return .hashValue(isUnsafe: try fcall.arguments.expect(.boolArg("isUnsafe")))
+    case "compatHash":
+      return .compatHash(isUnsafe: try fcall.arguments.expect(.boolArg("isUnsafe")))
+    case "hashRawValue":
+      return .hashRawValue(isUnsafe: try fcall.arguments.expect(.boolArg("isUnsafe")))
+    default:
+      throw HashableRequirementParseError.unknownRequirementName(name: requirementName)
+    }
+  }
+
+  var syntax: ExprSyntax {
+    switch self {
+    case .hashValue(let isUnsafe):
+      """
+      hashValue(isUnsafe: \(raw: isUnsafe))
+      """
+    case .compatHash(let isUnsafe):
+      """
+      compatHash(isUnsafe: \(raw: isUnsafe))
+      """
+    case .hashRawValue(let isUnsafe):
+      """
+      hashRawValue(isUnsafe: \(raw: isUnsafe))
+      """
+    case .hash(let info):
+      """
+      hash(\(info.syntax))
+      """
+    }
+  }
+}
+
+public struct DeriveHashableMacro: DeclarationMacro {
+
+  let isUnsafe: Bool
+
+  var unsafeMark: String {
+    isUnsafe ? "unsafe " : ""
+  }
+
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Parse the requirement and then expand it.
+    let req = try node.arguments.expect(
+      .init(parser: HashableRequirement.fromStringLit))
+    return [Self.expand(req)]
+  }
+
+  /// Returns the expansion for `hashValue` var using `_hashValue`. When the
+  /// conformance is unsafe, the call is combined through an `unsafe` expression.
+  func expandHashValue() -> DeclSyntax {
+    return
+      """
+      var hashValue: Swift::Int {
+        return \(raw: unsafeMark)Swift::_hashValue(for: self)
+      }
+      """
+  }
+
+  /// Returns the signature of the `hash(into:)` method.
+  static func getHashSignature() -> DeclSyntax {
+    """
+    func hash(into hasher: inout Swift::Hasher)
+    """
+  }
+
+  /// Returns the expansion of the `hash(into:)` method using the `hashValue` var.
+  func expandCompatHash() -> DeclSyntax {
+    return
+      """
+      \(Self.getHashSignature()) {
+        \(raw: unsafeMark)hasher.combine(self.hashValue)
+      }
+      """
+  }
+
+  /// Returns the expansion of the `hash(into:)` method using the enum's raw value.
+  func expandHashRawValue() -> DeclSyntax {
+    return
+      """
+      \(Self.getHashSignature()) {
+        \(raw: unsafeMark)hasher.combine(self.rawValue)
+      }
+      """
+  }
+
+  /// Derives the body of `hash(into:)` for an enum with no associated values
+  static func getHashBodyNoAssociatedValues(_ infos: EnumTypeInfo) -> CodeBlockItemListSyntax {
+    if infos.cases.isEmpty {
+      return [
+        """
+        switch self {}
+        """
+      ]
+    }
+    var items = getDiscriminant(infos, scrutinee: "self", discrName: "discriminator")
+    items += [
+      """
+      hasher.combine(discriminator)
+      """
+    ]
+    return items
+  }
+
+  /// Derives the body of `hash(into:)` for an enum with associated values. When
+  /// the conformance is unsafe, each associated value is combined through an
+  /// `unsafe` expression, since it relies on the value's Hashable conformance.
+  static func getHashBodyHasAssociatedValues(
+    _ infos: EnumTypeInfo, isUnsafe: Bool
+  ) -> CodeBlockItemListSyntax {
+    let unsafeMark = isUnsafe ? "unsafe " : ""
+    var idx = 0
+    let cases: [SwitchCaseSyntax] =
+      infos.cases.map { caseInfo in
+        let fstStmt: [CodeBlockItemSyntax]
+        /// Combine the element's index
+        if caseInfo.isReachable {
+          fstStmt = [
+            """
+            hasher.combine(\(raw: idx))
+            """
+          ]
+          idx += 1
+        } else {
+          fstStmt = []
+        }
+
+        /// Combine each associated value in order
+        let stmtsInCase: [CodeBlockItemSyntax] =
+          if caseInfo.isReachable {
+            (0..<caseInfo.associatedValueLabels.count).map { i in
+              """
+              \(raw: unsafeMark)hasher.combine(a\(raw: i))
+              """
+            }
+          } else {
+            [getUnreachableStatement()]
+          }
+        let pat = getEnumElementPayloadPattern(caseInfo, varPrefix: "a")
+        return
+          """
+          case \(pat): 
+            \(CodeBlockItemListSyntax(fstStmt + stmtsInCase))
+          """
+      }
+    return
+      """
+      switch self {
+      \(raw: cases.map { $0.trimmedDescription }.joined(separator: "\n"))
+      }
+      """
+  }
+
+  /// Derives the body of `hash(into:)` for an enum
+  static func getHashBody(_ infos: EnumTypeInfo, isUnsafe: Bool) -> CodeBlockItemListSyntax {
+    if infos.hasNoAssociatedValues() {
+      getHashBodyNoAssociatedValues(infos)
+    } else {
+      getHashBodyHasAssociatedValues(infos, isUnsafe: isUnsafe)
+    }
+  }
+
+  /// Derives the body of `hash(into:)` for a struct. When the conformance is
+  /// unsafe, each property is combined through an `unsafe` expression, since it
+  /// relies on the property's Hashable conformance.
+  static func getHashBody(_ infos: StructTypeInfo, isUnsafe: Bool) -> CodeBlockItemListSyntax {
+    let unsafeMark = isUnsafe ? "unsafe " : ""
+    var items: [CodeBlockItemSyntax] = []
+    for prop in infos.properties {
+      if !prop.isUserAccessible {
+        continue
+      }
+      items.append(
+        """
+        \(raw: unsafeMark)hasher.combine(self.\(raw: prop.name))
+        """
+      )
+    }
+    return .init(items)
+  }
+
+  /// Derives the body of `hash(into:)`
+  static func getHashBody(_ infos: NominalTypeInfo) -> CodeBlockItemListSyntax {
+    switch infos.kind {
+    case .enumLike(let enum_infos):
+      return getHashBody(enum_infos, isUnsafe: infos.isUnsafe)
+    case .structLike(let struct_infos):
+      return getHashBody(struct_infos, isUnsafe: infos.isUnsafe)
+    }
+  }
+
+  /// Derives the `hash(into:)` method
+  static func expandHash(_ infos: NominalTypeInfo) -> DeclSyntax {
+    """
+    \(getHashSignature()) {
+      \(getHashBody(infos))
+    }
+    """
+  }
+
+  /// Derives a requirement for `Hashable`
+  static func expand(_ req: HashableRequirement) -> DeclSyntax {
+    switch req {
+    case .hashValue(let isUnsafe):
+      Self(isUnsafe: isUnsafe).expandHashValue()
+    case .compatHash(let isUnsafe):
+      Self(isUnsafe: isUnsafe).expandCompatHash()
+    case .hashRawValue(let isUnsafe):
+      Self(isUnsafe: isUnsafe).expandHashRawValue()
+    case .hash(let infos):
+      Self.expandHash(infos)
+    }
+  }
+}

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1342,7 +1342,8 @@ static void printNominalTypeKind(llvm::raw_ostream &out,
 
 std::string swift::getNominalTypeInfoString(DerivedConformance &derived) {
   bool isUnsafe =
-      derived.Conformance->getExplicitSafety() == ExplicitSafety::Unsafe;
+      derived.Conformance->getExplicitSafety() == ExplicitSafety::Unsafe ||
+      derived.Nominal->getExplicitSafety() == ExplicitSafety::Unsafe;
 
   // A parameter of noncopyable type has to state its ownership explicitly.
   // The old synthesis built parameters without a TypeRepr, which is the only

--- a/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
@@ -933,11 +933,65 @@ void DerivedConformance::tryDiagnoseFailedHashableDerivation(
   diagnoseIfSynthesisUnsupportedForDecl(nominal, hashableProto);
 }
 
+static std::string getHashableMacroArg(DerivedConformance &derived,
+                                       ValueDecl *requirement) {
+  ASTContext &C = derived.Context;
+  bool isUnsafe =
+      derived.Conformance->getExplicitSafety() == ExplicitSafety::Unsafe ||
+      derived.Nominal->getExplicitSafety() == ExplicitSafety::Unsafe;
+  const char *isUnsafeArg = isUnsafe ? "true" : "false";
+
+  if (requirement->getBaseName() == C.Id_hashValue) {
+    return std::string("hashValue(isUnsafe: ") + isUnsafeArg + ")";
+  }
+
+  ASSERT(requirement->getBaseName() == C.Id_hash);
+
+  auto hashValueReq = getHashValueRequirement(C);
+  auto hashValueDecl = derived.Conformance->getWitnessDecl(hashValueReq);
+  ASSERT(hashValueDecl &&
+         "hash(into:) macro arg requested without a resolved hashValue "
+         "witness; caller should have bailed out already");
+
+  bool isSynthesized = hashValueDecl->isImplicit() ||
+                       hashValueDecl->isFromSyntheticMacroExpansion();
+  if (!isSynthesized)
+    return std::string("compatHash(isUnsafe: ") + isUnsafeArg + ")";
+  if (derived.Nominal->isObjC())
+    return std::string("hashRawValue(isUnsafe: ") + isUnsafeArg + ")";
+
+  return "hash(" + getNominalTypeInfoString(derived) + ")";
+}
+
+static std::string getHashableMacroDecl(DerivedConformance &derived,
+                                        ValueDecl *requirement) {
+  std::string res;
+  auto os = llvm::raw_string_ostream(res);
+  auto arg = getHashableMacroArg(derived, requirement);
+  os << "#_deriveHashable(" << QuotedString(arg) << ")";
+  return res;
+}
+
+static ValueDecl *deriveHashableViaMacro(DerivedConformance &derived,
+                                         ValueDecl *requirement) {
+  auto macro = getHashableMacroDecl(derived, requirement);
+  return deriveRequirementViaMacro(
+      derived, requirement, macro,
+      BuiltinDerivedConformanceMacroKind::DeriveHashable);
+}
+
 ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
   // var hashValue: Int
+
+  bool shouldUseMacro =
+      Context.LangOpts.hasFeature(Feature::DeriveConformancesViaMacros);
+
   if (requirement->getBaseName() == Context.Id_hashValue) {
     // We always allow hashValue to be synthesized; invalid cases are diagnosed
     // during hash(into:) synthesis.
+    if (shouldUseMacro)
+      return deriveHashableViaMacro(*this, requirement);
+
     return deriveHashable_hashValue(*this);
   }
 
@@ -951,7 +1005,8 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
       // The hashValue failure will produce a diagnostic elsewhere.
       return nullptr;
     }
-    if (hashValueDecl->isImplicit()) {
+    if (hashValueDecl->isImplicit() ||
+        (shouldUseMacro && hashValueDecl->isFromSyntheticMacroExpansion())) {
       // Neither hashValue nor hash(into:) is explicitly defined; we need to do
       // a full Hashable derivation.
       
@@ -976,6 +1031,9 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
       if (checkAndDiagnoseDisallowedContext(requirement))
         return nullptr;
 
+      if (shouldUseMacro)
+        return deriveHashableViaMacro(*this, requirement);
+
       if (auto ED = dyn_cast<EnumDecl>(Nominal)) {
         std::pair<BraceStmt *, bool> (*bodySynthesizer)(
             AbstractFunctionDecl *, void *);
@@ -998,6 +1056,9 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
       // hashValue.
       hashValueDecl->diagnose(diag::hashvalue_implementation,
                               Nominal->getDeclaredType());
+      if (shouldUseMacro)
+        return deriveHashableViaMacro(*this, requirement);
+
       return deriveHashable_hashInto(*this,
                                      &deriveBodyHashable_compat_hashInto);
     }

--- a/test/SILGen/synthesized_conformance_class_macros.swift
+++ b/test/SILGen/synthesized_conformance_class_macros.swift
@@ -11,12 +11,11 @@ final class Final<T> {
 // CHECK:   @_hasStorage final var x: T { get set }
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
-// CHECK:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Final<T>.CodingKeys, _ rhs: Final<T>.CodingKeys) -> Bool
-// CHECK:     case x
-// CHECK:     init?(stringValue: String)
-// CHECK:     init?(intValue: Int)
 // CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:     var hashValue: Int { get }
+// CHECK:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Final<T>.CodingKeys, _ rhs: Final<T>.CodingKeys) -> Bool
+// CHECK:     init?(stringValue: String)
+// CHECK:     init?(intValue: Int)
 // CHECK:     var intValue: Int? { get }
 // CHECK:     var stringValue: String { get }
 // CHECK:   }
@@ -31,12 +30,12 @@ class Nonfinal<T> {
 // CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
-// CHECK:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Nonfinal<T>.CodingKeys, _ rhs: Nonfinal<T>.CodingKeys) -> Bool
-// CHECK:     case x
-// CHECK-DAG:     init?(stringValue: String)
-// CHECK-DAG:     init?(intValue: Int)
 // CHECK:     func hash(into hasher: inout Hasher)
 // CHECK:     var hashValue: Int { get }
+// CHECK:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Nonfinal<T>.CodingKeys, _ rhs: Nonfinal<T>.CodingKeys) -> Bool
+// CHECK:     case x
+// CHECK-DAG: init?(stringValue: String)
+// CHECK-DAG: init?(intValue: Int)
 // CHECK:     var intValue: Int? { get }
 // CHECK:     var stringValue: String { get }
 // CHECK:   }

--- a/test/SILGen/synthesized_conformance_struct_macros.swift
+++ b/test/SILGen/synthesized_conformance_struct_macros.swift
@@ -10,13 +10,13 @@ struct Struct<T> {
 // CHECK-LABEL: struct Struct<T> {
 // CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   enum CodingKeys : CodingKey {
+// CHECK:     func hash(into hasher: inout Hasher)
+// CHECK:     var hashValue: Int { get }
 // CHECK-FRAGILE:   @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Struct<T>.CodingKeys, _ rhs: Struct<T>.CodingKeys) -> Bool
 // CHECK-RESILIENT: static func == (lhs: Struct<T>.CodingKeys, rhs: Struct<T>.CodingKeys) -> Bool
 // CHECK:     case x
 // CHECK-DAG:     init?(stringValue: String)
 // CHECK-DAG:     init?(intValue: Int)
-// CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var hashValue: Int { get }
 // CHECK:     var intValue: Int? { get }
 // CHECK:     var stringValue: String { get }
 // CHECK:   }

--- a/test/SourceKit/Macros/expand_derived_conformance.swift
+++ b/test/SourceKit/Macros/expand_derived_conformance.swift
@@ -27,10 +27,17 @@ struct ViaTypealias: EquatableAndHashable {
   var x: Int = 0
 }
 // VIA_TYPEALIAS: source.edit.kind.active:
-// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}[[@LINE-4]]:44-[[@LINE-4]]:44 ({{.*}}_deriveEquatablefMf_.swift) "
+// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}[[@LINE-4]]:44-[[@LINE-4]]:44 ({{.*}}_deriveHashablefMf_.swift) "
+// VIA_TYPEALIAS-NEXT: var hashValue: Swift::Int {
+// VIA_TYPEALIAS: source.edit.kind.active:
+// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}[[@LINE-7]]:44-[[@LINE-7]]:44 ({{.*}}_deriveHashablefMf0_.swift) "
+// VIA_TYPEALIAS-NEXT: func hash(into hasher: inout Swift::Hasher) {
+// VIA_TYPEALIAS-NEXT: hasher.combine(self.x)
+// VIA_TYPEALIAS: source.edit.kind.active:
+// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}[[@LINE-11]]:44-[[@LINE-11]]:44 ({{.*}}_deriveEquatablefMf_.swift) "
 // VIA_TYPEALIAS-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-// VIA_TYPEALIAS-NOT: [[@LINE-7]]:44-[[@LINE-7]]:44
+// VIA_TYPEALIAS-NOT: source.edit.kind.active
 
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+1):12 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=ENUM %s
 enum Enum: Hashable {
@@ -38,10 +45,23 @@ enum Enum: Hashable {
   case b(Int)
 }
 // ENUM: source.edit.kind.active:
-// ENUM-NEXT: {{^}}{{ +}}[[@LINE-5]]:22-[[@LINE-5]]:22 ({{.*}}_deriveEquatablefMf_.swift) "
+// ENUM-NEXT: {{^}}{{ +}}[[@LINE-5]]:22-[[@LINE-5]]:22 ({{.*}}_deriveHashablefMf_.swift) "
+// ENUM-NEXT: var hashValue: Swift::Int {
+// ENUM: source.edit.kind.active:
+// ENUM-NEXT: {{^}}{{ +}}[[@LINE-8]]:22-[[@LINE-8]]:22 ({{.*}}_deriveHashablefMf0_.swift) "
+// ENUM-NEXT: func hash(into hasher: inout Swift::Hasher) {
+// ENUM-NEXT: switch self {
+// ENUM-NEXT: case .a:
+// ENUM-NEXT: hasher.combine(0)
+// ENUM-NEXT: case .b(let a0):
+// ENUM-NEXT: hasher.combine(1)
+// ENUM-NEXT: hasher.combine(a0)
+// ENUM: source.edit.kind.active:
+// ENUM-NEXT: {{^}}{{ +}}[[@LINE-17]]:22-[[@LINE-17]]:22 ({{.*}}_deriveEquatablefMf_.swift) "
 // ENUM-NEXT: @_semantics("derived_enum_equals")
 // ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // ENUM-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+// ENUM-NOT: source.edit.kind.active
 
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+2):16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck --allow-empty -check-prefix=NO_EXPANSION %s
 class Base {}

--- a/test/decl/enum/derived_hashable_equatable_macos_macros.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos_macros.swift
@@ -8,6 +8,32 @@
 
 // CHECK-LABEL: internal enum HasElementsWithAvailability : Hashable
 enum HasElementsWithAvailability: Hashable {
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    var discriminator: Int
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      discriminator = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
+  // CHECK-NEXT:    case .obsoleted50:
+  // CHECK-NEXT:      discriminator = 1
+  // CHECK-NEXT:    case .introduced50:
+  // CHECK-NEXT:      discriminator = 2
+  // CHECK-NEXT:    case .unavailableMacOSAppExtension:
+  // CHECK-NEXT:      discriminator = 3
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hasher.combine(discriminator)
+  // CHECK-NEXT:  }
+  
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return Swift::_hashValue(for: self)
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
   // CHECK:    @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ lhs: `Self`, _ rhs: `Self`) -> Bool {
   // CHECK-NEXT:    var index_lhs: Int
   // CHECK-EMPTY:
@@ -66,29 +92,4 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:  case unavailableMacOSAppExtension
   @available(macOSApplicationExtension, unavailable)
   case unavailableMacOSAppExtension
-
-  // CHECK:       internal func hash(into hasher: inout Hasher) {
-  // CHECK-NEXT:    var discriminator: Int
-  // CHECK-NEXT:    switch self {
-  // CHECK-NEXT:    case .alwaysAvailable:
-  // CHECK-NEXT:      discriminator = 0
-  // CHECK-NEXT:    case .neverAvailable:
-  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
-  // CHECK-NEXT:    case .unavailableMacOS:
-  // CHECK-NEXT:      _diagnoseUnavailableCodeReached()
-  // CHECK-NEXT:    case .obsoleted50:
-  // CHECK-NEXT:      discriminator = 1
-  // CHECK-NEXT:    case .introduced50:
-  // CHECK-NEXT:      discriminator = 2
-  // CHECK-NEXT:    case .unavailableMacOSAppExtension:
-  // CHECK-NEXT:      discriminator = 3
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:    hasher.combine(discriminator)
-  // CHECK-NEXT:  }
-
-  // CHECK:       internal var hashValue: Int {
-  // CHECK-NEXT:    get {
-  // CHECK-NEXT:      return _hashValue(for: self)
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:  }
 }

--- a/test/decl/enum/derived_hashable_equatable_macos_zippered_macros.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos_zippered_macros.swift
@@ -4,6 +4,34 @@
 
 // CHECK-LABEL: internal enum HasElementsWithAvailability : Hashable
 enum HasElementsWithAvailability: Hashable {
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    var discriminator: Int
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      discriminator = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      discriminator = 1
+  // CHECK-NEXT:    case .unavailableiOS:
+  // CHECK-NEXT:      discriminator = 2
+  // CHECK-NEXT:    case .unavailableMacCatalyst:
+  // CHECK-NEXT:      discriminator = 3
+  // CHECK-NEXT:    case .unavailableMacOSAndiOS:
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
+  // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
+  // CHECK-NEXT:      discriminator = 4
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hasher.combine(discriminator)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return Swift::_hashValue(for: self)
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+  
   // CHECK:       @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ lhs: `Self`, _ rhs: `Self`) -> Bool {
   // CHECK-NEXT:    var index_lhs: Int
   // CHECK-EMPTY:
@@ -11,7 +39,7 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:    case .alwaysAvailable:
   // CHECK-NEXT:      index_lhs = 0
   // CHECK-NEXT:    case .neverAvailable:
-  // CHECK-NEXT:    fatalError("Unavailable code reached")
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
   // CHECK-NEXT:    case .unavailableMacOS:
   // CHECK-NEXT:      index_lhs = 1
   // CHECK-NEXT:    case .unavailableiOS:
@@ -19,7 +47,7 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:    case .unavailableMacCatalyst:
   // CHECK-NEXT:      index_lhs = 3
   // CHECK-NEXT:    case .unavailableMacOSAndiOS:
-  // CHECK-NEXT:    fatalError("Unavailable code reached")
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
   // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
   // CHECK-NEXT:      index_lhs = 4
   // CHECK-NEXT:    }
@@ -29,7 +57,7 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:    case .alwaysAvailable:
   // CHECK-NEXT:      index_rhs = 0
   // CHECK-NEXT:    case .neverAvailable:
-  // CHECK-NEXT:    fatalError("Unavailable code reached")
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
   // CHECK-NEXT:    case .unavailableMacOS:
   // CHECK-NEXT:      index_rhs = 1
   // CHECK-NEXT:    case .unavailableiOS:
@@ -37,7 +65,7 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:    case .unavailableMacCatalyst:
   // CHECK-NEXT:      index_rhs = 3
   // CHECK-NEXT:    case .unavailableMacOSAndiOS:
-  // CHECK-NEXT:    fatalError("Unavailable code reached")
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
   // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
   // CHECK-NEXT:      index_rhs = 4
   // CHECK-NEXT:    }
@@ -74,31 +102,4 @@ enum HasElementsWithAvailability: Hashable {
   @available(macOS, unavailable)
   @available(macCatalyst, unavailable)
   case unavailableMacOSAndMacCatalyst
-
-  // CHECK:       internal func hash(into hasher: inout Hasher) {
-  // CHECK-NEXT:    var discriminator: Int
-  // CHECK-NEXT:    switch self {
-  // CHECK-NEXT:    case .alwaysAvailable:
-  // CHECK-NEXT:      discriminator = 0
-  // CHECK-NEXT:    case .neverAvailable:
-  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
-  // CHECK-NEXT:    case .unavailableMacOS:
-  // CHECK-NEXT:      discriminator = 1
-  // CHECK-NEXT:    case .unavailableiOS:
-  // CHECK-NEXT:      discriminator = 2
-  // CHECK-NEXT:    case .unavailableMacCatalyst:
-  // CHECK-NEXT:      discriminator = 3
-  // CHECK-NEXT:    case .unavailableMacOSAndiOS:
-  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
-  // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
-  // CHECK-NEXT:      discriminator = 4
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:    hasher.combine(discriminator)
-  // CHECK-NEXT:  }
-
-  // CHECK:       internal var hashValue: Int {
-  // CHECK-NEXT:    get {
-  // CHECK-NEXT:      return _hashValue(for: self)
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:  }
 }

--- a/test/decl/enum/derived_hashable_equatable_macros.swift
+++ b/test/decl/enum/derived_hashable_equatable_macros.swift
@@ -4,6 +4,24 @@
 
 // CHECK-LABEL: internal enum Simple : Hashable
 enum Simple: Hashable {
+  // CHECK:        internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:     var discriminator: Int
+  // CHECK-EMPTY:
+  // CHECK-NEXT:     switch self {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       discriminator = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       discriminator = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     hasher.combine(discriminator)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var hashValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return Swift::_hashValue(for: self)
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
   // CHECK:        @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ lhs: `Self`, _ rhs: `Self`) -> Bool {
   // CHECK-NEXT:     var index_lhs: Int
   // CHECK-EMPTY:
@@ -28,23 +46,6 @@ enum Simple: Hashable {
   case a
   // CHECK:        case b
   case b
-
-  // CHECK:        internal func hash(into hasher: inout Hasher) {
-  // CHECK-NEXT:     var discriminator: Int
-  // CHECK-NEXT:     switch self {
-  // CHECK-NEXT:     case .a:
-  // CHECK-NEXT:       discriminator = 0
-  // CHECK-NEXT:     case .b:
-  // CHECK-NEXT:       discriminator = 1
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:     hasher.combine(discriminator)
-  // CHECK-NEXT:   }
-
-  // CHECK:        internal var hashValue: Int {
-  // CHECK-NEXT:     get {
-  // CHECK-NEXT:       return _hashValue(for: self)
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:   }
 }
 
 // CHECK-LABEL: internal enum HasAssociatedValues : Hashable
@@ -68,13 +69,6 @@ enum HasAssociatedValues: Hashable {
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
 
-  // CHECK:        case a(Int)
-  case a(Int)
-  // CHECK:        case b(String)
-  case b(String)
-  // CHECK:        case c
-  case c
-
   // CHECK:        internal func hash(into hasher: inout Hasher) {
   // CHECK-NEXT:     switch self {
   // CHECK-NEXT:     case .a(let a0):
@@ -90,13 +84,38 @@ enum HasAssociatedValues: Hashable {
 
   // CHECK:        internal var hashValue: Int {
   // CHECK-NEXT:     get {
-  // CHECK-NEXT:       return _hashValue(for: self)
+  // CHECK-NEXT:       return Swift::_hashValue(for: self)
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
+
+  // CHECK:        case a(Int)
+  case a(Int)
+  // CHECK:        case b(String)
+  case b(String)
+  // CHECK:        case c
+  case c
 }
 
 // CHECK-LABEL: internal enum HasUnavailableElement : Hashable
 enum HasUnavailableElement: Hashable {
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    var discriminator: Int
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .a:
+  // CHECK-NEXT:      discriminator = 0
+  // CHECK-NEXT:    case .b:
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hasher.combine(discriminator)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return Swift::_hashValue(for: self)
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
   // CHECK:       @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ lhs: `Self`, _ rhs: `Self`) -> Bool {
   // CHECK-NEXT:    var index_lhs: Int
   // CHECK-EMPTY:
@@ -104,7 +123,7 @@ enum HasUnavailableElement: Hashable {
   // CHECK-NEXT:    case .a:
   // CHECK-NEXT:      index_lhs = 0
   // CHECK-NEXT:    case .b:
-  // CHECK-NEXT:      fatalError({{.*}})
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
   // CHECK-NEXT:    }
   // CHECK-NEXT:    var index_rhs: Int
   // CHECK-EMPTY:
@@ -112,7 +131,7 @@ enum HasUnavailableElement: Hashable {
   // CHECK-NEXT:    case .a:
   // CHECK-NEXT:      index_rhs = 0
   // CHECK-NEXT:    case .b:
-  // CHECK-NEXT:      fatalError({{.*}})  
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
   // CHECK-NEXT:    }
   // CHECK-NEXT:    return index_lhs == index_rhs
   // CHECK-NEXT:  }
@@ -124,22 +143,6 @@ enum HasUnavailableElement: Hashable {
   @available(*, unavailable)
   case b
 
-  // CHECK:       internal func hash(into hasher: inout Hasher) {
-  // CHECK-NEXT:    var discriminator: Int
-  // CHECK-NEXT:    switch self {
-  // CHECK-NEXT:    case .a:
-  // CHECK-NEXT:      discriminator = 0
-  // CHECK-NEXT:    case .b:
-  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}()
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:    hasher.combine(discriminator)
-  // CHECK-NEXT:  }
-
-  // CHECK:       internal var hashValue: Int {
-  // CHECK-NEXT:    get {
-  // CHECK-NEXT:      return _hashValue(for: self)
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:  }
 }
 
 // CHECK-LABEL: internal enum HasAssociatedValuesAndUnavailableElement : Hashable
@@ -152,9 +155,25 @@ enum HasAssociatedValuesAndUnavailableElement: Hashable {
   // CHECK-NEXT:      }
   // CHECK-NEXT:      return true
   // CHECK-NEXT:    case (.b, .b):
-  // CHECK-NEXT:      fatalError({{.*}})
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
   // CHECK-NEXT:    default:
   // CHECK-NEXT:      return false
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .a(let a0):
+  // CHECK-NEXT:      hasher.combine(0)
+  // CHECK-NEXT:      hasher.combine(a0)
+  // CHECK-NEXT:    case .b:
+  // CHECK-NEXT:      Swift::fatalError("Unavailable code reached")
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return Swift::_hashValue(for: self)
   // CHECK-NEXT:    }
   // CHECK-NEXT:  }
 
@@ -164,27 +183,30 @@ enum HasAssociatedValuesAndUnavailableElement: Hashable {
   // CHECK-NEXT:  case b(String)
   @available(*, unavailable)
   case b(String)
-
-  // CHECK:       internal func hash(into hasher: inout Hasher) {
-  // CHECK-NEXT:    switch self {
-  // CHECK-NEXT:    case .a(let a0):
-  // CHECK-NEXT:      hasher.combine(0)
-  // CHECK-NEXT:      hasher.combine(a0)
-  // CHECK-NEXT:    case .b:
-  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}()
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:  }
-
-  // CHECK:       internal var hashValue: Int {
-  // CHECK-NEXT:    get {
-  // CHECK-NEXT:      return _hashValue(for: self)
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:  }
 }
 
 // CHECK-LABEL: internal enum UnavailableEnum : Hashable
 @available(*, unavailable)
 enum UnavailableEnum: Hashable {
+
+  // CHECK:        internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:     var discriminator: Int
+  // CHECK-EMPTY:
+  // CHECK-NEXT:     switch self {
+  // CHECK-NEXT:     case .a:
+  // CHECK-NEXT:       discriminator = 0
+  // CHECK-NEXT:     case .b:
+  // CHECK-NEXT:       discriminator = 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     hasher.combine(discriminator)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var hashValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return Swift::_hashValue(for: self)
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
   // CHECK:        @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ lhs: `Self`, _ rhs: `Self`) -> Bool {
   // CHECK-NEXT:     var index_lhs: Int
   // CHECK-EMPTY:
@@ -209,24 +231,6 @@ enum UnavailableEnum: Hashable {
   case a
   // CHECK:        case b
   case b
-
-  // CHECK:        internal func hash(into hasher: inout Hasher) {
-  // CHECK-NEXT:     var discriminator: Int
-  // CHECK-NEXT:     switch self {
-  // CHECK-NEXT:     case .a:
-  // CHECK-NEXT:       discriminator = 0
-  // CHECK-NEXT:     case .b:
-  // CHECK-NEXT:       discriminator = 1
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:     hasher.combine(discriminator)
-  // CHECK-NEXT:   }
-
-  // CHECK:        internal var hashValue: Int {
-  // CHECK-NEXT:     get {
-  // CHECK-NEXT:       return _hashValue(for: self)
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:   }
-
 }
 
 // CHECK-LABEL: internal enum MultipleCasesInLine : Hashable
@@ -248,9 +252,6 @@ enum MultipleCasesInLine: Hashable {
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
 
-  // CHECK:        case a(Int), b(String)
-  case a(Int), b(String)
-
   // CHECK:        internal func hash(into hasher: inout Hasher) {
   // CHECK-NEXT:     switch self {
   // CHECK-NEXT:     case .a(let a0):
@@ -264,9 +265,12 @@ enum MultipleCasesInLine: Hashable {
 
   // CHECK:        internal var hashValue: Int {
   // CHECK-NEXT:     get {
-  // CHECK-NEXT:       return _hashValue(for: self)
+  // CHECK-NEXT:       return Swift::_hashValue(for: self)
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
+
+  // CHECK:        case a(Int), b(String)
+  case a(Int), b(String)
 }
 
 // CHECK-LABEL: internal enum MultipleAssociatedValues : Hashable
@@ -297,11 +301,6 @@ enum MultipleAssociatedValues: Hashable {
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
 
-  // CHECK:        case a(Int, String)
-  case a(Int, String)
-  // CHECK:        case b(Int, String, Bool)
-  case b(Int, String, Bool)
-
   // CHECK:        internal func hash(into hasher: inout Hasher) {
   // CHECK-NEXT:     switch self {
   // CHECK-NEXT:     case .a(let a0, let a1):
@@ -318,9 +317,14 @@ enum MultipleAssociatedValues: Hashable {
 
   // CHECK:        internal var hashValue: Int {
   // CHECK-NEXT:     get {
-  // CHECK-NEXT:       return _hashValue(for: self)
+  // CHECK-NEXT:       return Swift::_hashValue(for: self)
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
+
+  // CHECK:        case a(Int, String)
+  case a(Int, String)
+  // CHECK:        case b(Int, String, Bool)
+  case b(Int, String, Bool)
 }
 
 // CHECK-LABEL: internal enum WithArgumentLabels : Hashable
@@ -345,16 +349,16 @@ enum WithArgumentLabels: Hashable {
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
 
+  // CHECK:        internal var hashValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return Swift::_hashValue(for: self)
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
   // CHECK:        case a(x: Int, y: String)
   case a(x: Int, y: String)
   // CHECK:        case b(value: Bool)
   case b(value: Bool)
-  
-  // CHECK:        internal var hashValue: Int {
-  // CHECK-NEXT:     get {
-  // CHECK-NEXT:       return _hashValue(for: self)
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:   }
 }
 
 // CHECK-LABEL: internal enum WithRawIdentifiers : Hashable
@@ -378,13 +382,6 @@ enum WithRawIdentifiers: Hashable {
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
 
-  // CHECK:        case `foo bar`
-  case `foo bar`
-  // CHECK:        case `default`(Int)
-  case `default`(Int)
-  // CHECK:        case a(`foo bar`: String)
-  case a(`foo bar`: String)
-
   // CHECK:        internal func hash(into hasher: inout Hasher) {
   // CHECK-NEXT:     switch self {
   // CHECK-NEXT:     case .foo bar:
@@ -392,7 +389,7 @@ enum WithRawIdentifiers: Hashable {
   // CHECK-NEXT:     case .default(let a0):
   // CHECK-NEXT:       hasher.combine(1)
   // CHECK-NEXT:       hasher.combine(a0)
-  // CHECK-NEXT:     case .a(let a0):
+  // CHECK-NEXT:     case .a(foo bar: let a0):
   // CHECK-NEXT:       hasher.combine(2)
   // CHECK-NEXT:       hasher.combine(a0)
   // CHECK-NEXT:     }
@@ -400,7 +397,14 @@ enum WithRawIdentifiers: Hashable {
 
   // CHECK:        internal var hashValue: Int {
   // CHECK-NEXT:     get {
-  // CHECK-NEXT:       return _hashValue(for: self)
+  // CHECK-NEXT:       return Swift::_hashValue(for: self)
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
+
+  // CHECK:        case `foo bar`
+  case `foo bar`
+  // CHECK:        case `default`(Int)
+  case `default`(Int)
+  // CHECK:        case a(`foo bar`: String)
+  case a(`foo bar`: String)
 }

--- a/test/decl/enum/derived_hashable_equatable_macros_expansion.swift
+++ b/test/decl/enum/derived_hashable_equatable_macros_expansion.swift
@@ -8,30 +8,62 @@ enum Simple: Hashable {
 }
 
 // CHECK: @_semantics("derived_enum_equals")
-// CHECK: @_implements(Swift::Equatable, ==(_:_:))
-// CHECK: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-// CHECK:   var index_lhs: Swift::Int
-// CHECK:   switch lhs {
-// CHECK:   case .a:
-// CHECK:     index_lhs = 0
-// CHECK:   case .b:
-// CHECK:     index_lhs = 1
-// CHECK:   }
-// CHECK:   var index_rhs: Swift::Int
-// CHECK:   switch rhs {
-// CHECK:   case .a:
-// CHECK:     index_rhs = 0
-// CHECK:   case .b:
-// CHECK:     index_rhs = 1
-// CHECK:   }
-// CHECK:   return index_lhs == index_rhs
-// CHECK: }
+// CHECK-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// CHECK-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+// CHECK-NEXT:   var index_lhs: Swift::Int
+// CHECK-NEXT:   switch lhs {
+// CHECK-NEXT:   case .a:
+// CHECK-NEXT:     index_lhs = 0
+// CHECK-NEXT:   case .b:
+// CHECK-NEXT:     index_lhs = 1
+// CHECK-NEXT:   }
+// CHECK-NEXT:   var index_rhs: Swift::Int
+// CHECK-NEXT:   switch rhs {
+// CHECK-NEXT:   case .a:
+// CHECK-NEXT:     index_rhs = 0
+// CHECK-NEXT:   case .b:
+// CHECK-NEXT:     index_rhs = 1
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return index_lhs == index_rhs
+// CHECK-NEXT: }
+
+// CHECK: var hashValue: Swift::Int {
+// CHECK-NEXT:   return Swift::_hashValue(for: self)
+// CHECK-NEXT: }
+
+//CHECK: func hash(into hasher: inout Swift::Hasher) {
+//CHECK-NEXT:   var discriminator: Swift::Int
+//CHECK-NEXT:   switch self {
+//CHECK-NEXT:   case .a:
+//CHECK-NEXT:     discriminator = 0
+//CHECK-NEXT:   case .b:
+//CHECK-NEXT:     discriminator = 1
+//CHECK-NEXT:   }
+//CHECK-NEXT:   hasher.combine(discriminator)
+//CHECK-NEXT: }
 
 enum WithValues: Hashable {
   case a(Int)
   case b(String)
   case c
 }
+
+// CHECK: var hashValue: Swift::Int {
+// CHECK-NEXT:   return Swift::_hashValue(for: self)
+// CHECK-NEXT: }
+
+// CHECK: func hash(into hasher: inout Swift::Hasher) {
+// CHECK-NEXT:   switch self {
+// CHECK-NEXT:   case .a(let a0):
+// CHECK-NEXT:     hasher.combine(0)
+// CHECK-NEXT:     hasher.combine(a0)
+// CHECK-NEXT:   case .b(let a0):
+// CHECK-NEXT:     hasher.combine(1)
+// CHECK-NEXT:     hasher.combine(a0)
+// CHECK-NEXT:   case .c:
+// CHECK-NEXT:     hasher.combine(2)
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 // CHECK: @_semantics("derived_enum_equals")
 // CHECK-NEXT: @_implements(Swift::Equatable, ==(_:_:))
@@ -52,12 +84,28 @@ enum WithValues: Hashable {
 // CHECK-NEXT:   default:
 // CHECK-NEXT:       return false
 // CHECK-NEXT:   }
-// CHECK-NEX: }
+// CHECK-NEXT: }
 
 enum MultipleValues: Hashable {
   case a(Int, String)
   case b(Bool)
 }
+
+// CHECK: var hashValue: Swift::Int {
+// CHECK-NEXT:   return Swift::_hashValue(for: self)
+// CHECK-NEXT: }
+
+//CHECK: func hash(into hasher: inout Swift::Hasher) {
+//CHECK-NEXT:   switch self {
+//CHECK-NEXT:   case .a(let a0, let a1):
+//CHECK-NEXT:     hasher.combine(0)
+//CHECK-NEXT:     hasher.combine(a0)
+//CHECK-NEXT:     hasher.combine(a1)
+//CHECK-NEXT:   case .b(let a0):
+//CHECK-NEXT:     hasher.combine(1)
+//CHECK-NEXT:     hasher.combine(a0)
+//CHECK-NEXT:   }
+//CHECK-NEXT: }
 
 // CHECK: @_semantics("derived_enum_equals")
 // CHECK-NEXT: @_implements(Swift::Equatable, ==(_:_:))
@@ -86,6 +134,22 @@ enum WithLabels: Hashable {
   case b(value: Bool)
 }
 
+//CHECK: var hashValue: Swift::Int {
+//CHECK-NEXT:   return Swift::_hashValue(for: self)
+//CHECK-NEXT: }
+
+//CHECK: func hash(into hasher: inout Swift::Hasher) {
+//CHECK-NEXT:   switch self {
+//CHECK-NEXT:   case .a(x: let a0, y: let a1):
+//CHECK-NEXT:     hasher.combine(0)
+//CHECK-NEXT:     hasher.combine(a0)
+//CHECK-NEXT:     hasher.combine(a1)
+//CHECK-NEXT:   case .b(value: let a0):
+//CHECK-NEXT:     hasher.combine(1)
+//CHECK-NEXT:     hasher.combine(a0)
+//CHECK-NEXT:   }
+//CHECK-NEXT: }
+
 // CHECK: @_semantics("derived_enum_equals")
 // CHECK-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // CHECK-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
@@ -113,6 +177,23 @@ enum WithRawIdentifiers: Hashable {
   case `default`(Int)
   case a(`foo bar`: String)
 }
+
+// CHECK: var hashValue: Swift::Int {
+// CHECK-NEXT:   return Swift::_hashValue(for: self)
+// CHECK-NEXT: }
+
+// CHECK: func hash(into hasher: inout Swift::Hasher) {
+// CHECK-NEXT:   switch self {
+// CHECK-NEXT:   case .`foo bar`:
+// CHECK-NEXT:     hasher.combine(0)
+// CHECK-NEXT:   case .`default`(let a0):
+// CHECK-NEXT:     hasher.combine(1)
+// CHECK-NEXT:     hasher.combine(a0)
+// CHECK-NEXT:   case .a(`foo bar`: let a0):
+// CHECK-NEXT:     hasher.combine(2)
+// CHECK-NEXT:     hasher.combine(a0)
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 // CHECK: @_semantics("derived_enum_equals")
 // CHECK-NEXT: @_implements(Swift::Equatable, ==(_:_:))

--- a/test/refactoring/Macros/expand_derived_conformance.swift
+++ b/test/refactoring/Macros/expand_derived_conformance.swift
@@ -33,9 +33,16 @@ struct ViaTypealias: EquatableAndHashable {
 }
 // VIA_TYPEALIAS: {{.*}}.swift [[@LINE-3]]:44 -> [[@LINE-3]]:44
 // VIA_TYPEALIAS-EMPTY:
+// VIA_TYPEALIAS-NEXT: var hashValue: Swift::Int {
+// VIA_TYPEALIAS: {{.*}}.swift [[@LINE-6]]:44 -> [[@LINE-6]]:44
+// VIA_TYPEALIAS-EMPTY:
+// VIA_TYPEALIAS-NEXT: func hash(into hasher: inout Swift::Hasher) {
+// VIA_TYPEALIAS-NEXT: hasher.combine(self.x)
+// VIA_TYPEALIAS: {{.*}}.swift [[@LINE-10]]:44 -> [[@LINE-10]]:44
+// VIA_TYPEALIAS-EMPTY:
 // VIA_TYPEALIAS-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-// VIA_TYPEALIAS-NOT: {{.*}}.swift [[@LINE-7]]:44 -> [[@LINE-7]]:44
+// VIA_TYPEALIAS-NOT: {{.*}}.swift {{.*}} -> {{.*}}
 
 // RUN: %refactor-check-compiles -expand-derived-conformance -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+1):17 | %FileCheck -check-prefix=ENUM %s
 enum Enum: Hashable {
@@ -44,6 +51,19 @@ enum Enum: Hashable {
 }
 // ENUM: {{.*}}.swift [[@LINE-4]]:22 -> [[@LINE-4]]:22
 // ENUM-EMPTY:
+// ENUM-NEXT: var hashValue: Swift::Int {
+// ENUM: {{.*}}.swift [[@LINE-7]]:22 -> [[@LINE-7]]:22
+// ENUM-EMPTY:
+// ENUM-NEXT: func hash(into hasher: inout Swift::Hasher) {
+// ENUM-NEXT: switch self {
+// ENUM-NEXT: case .a:
+// ENUM-NEXT: hasher.combine(0)
+// ENUM-NEXT: case .b(let a0):
+// ENUM-NEXT: hasher.combine(1)
+// ENUM-NEXT: hasher.combine(a0)
+// ENUM: {{.*}}.swift [[@LINE-16]]:22 -> [[@LINE-16]]:22
+// ENUM-EMPTY:
 // ENUM-NEXT: @_semantics("derived_enum_equals")
 // ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // ENUM-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+// ENUM-NOT: {{.*}}.swift {{.*}} -> {{.*}}


### PR DESCRIPTION
Move Hashable derivation to a macro under a feature flag

Adds a `DeriveConformancesViaMacros` feature flag path for deriving `hashValue`
and `hash(into:)` on structs and enums. When enabled,
`DerivedConformance::deriveHashable` builds a `#_deriveHashable(...)` macro call
instead of hand-crafting the AST nodes, and the new `DeriveHashableMacro` (in
`SwiftMacros`) expands it.

The requirement being derived is passed to the macro as a string-encoded argument that also selects the kind of derivation. Type info is encoded the same way as for `Equatable`, reusing `getNominalTypeInfoString`.

The non-macro path is untouched. This is opt-in via the feature flag.