### PR TITLE
OpaqueValues: lower trivial loadable @guaranteed_address apply results

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -185,6 +185,30 @@ static SILFunctionConventions getLoweredCallConv(ApplySite call) {
       SILAddressConventions::forFullyLoweredModule(call.getModule()));
 }
 
+/// Does \p call return a @guaranteed_address result of trivial loadable type?
+///
+/// Such a result becomes a directly-returned address after lowering, but has no
+/// storage in `valueStorageMap` because it isn't address-only. ApplyRewriter
+/// therefore reloads it at the call site so that uses expecting an object keep
+/// working.
+///
+/// An address-only @guaranteed_address result needs none of this: it is mapped
+/// through `valueStorageMap` and rewritten by the DefRewriter.
+///
+/// FIXME: A non-trivial loadable result is not handled. Reloading it would need
+/// a load_borrow whose end_borrows are placed at the lifetime ends of its uses,
+/// and a borrowed value cannot satisfy a consuming use.
+static bool hasTrivialGuaranteedAddressResult(ApplySite call,
+                                              SILFunction *function) {
+  if (!getLoweredCallConv(call).hasGuaranteedAddressResult())
+    return false;
+  auto fullApply = call.asFullApplySite();
+  if (!fullApply || fullApply.getKind() != FullApplySiteKind::ApplyInst)
+    return false;
+  auto resultTy = fullApply.getResult()->getType();
+  return !resultTy.isAddressOnly(*function) && resultTy.isTrivial(*function);
+}
+
 //===----------------------------------------------------------------------===//
 //                                Multi-Result
 //
@@ -861,7 +885,10 @@ void OpaqueValueVisitor::checkForIndirectApply(ApplySite applySite) {
 
   if (applySite.getSubstCalleeType()->hasIndirectFormalResults() ||
       applySite.getSubstCalleeType()->hasIndirectFormalYields() ||
-      applySite.getSubstCalleeType()->hasIndirectErrorResult()) {
+      applySite.getSubstCalleeType()->hasIndirectErrorResult() ||
+      // A @guaranteed_address result is a *direct* address return rather than
+      // an indirect formal result, so it would otherwise be missed here.
+      hasTrivialGuaranteedAddressResult(applySite, pass.function)) {
     pass.indirectApplies.insert(applySite);
   }
 }
@@ -2773,8 +2800,19 @@ void ApplyRewriter::rewriteApply(ArrayRef<SILValue> newCallArgs) {
   // address returned by the apply after lowering.
   if (guaranteedResult) {
     SILValue newResult = apply.getResult();
-    pass.valueStorageMap.setStorageAddress(guaranteedResult, newResult);
-    pass.valueStorageMap.getStorage(guaranteedResult).markRewritten();
+    if (guaranteedResult->getType().isAddressOnly(*pass.function)) {
+      pass.valueStorageMap.setStorageAddress(guaranteedResult, newResult);
+      pass.valueStorageMap.getStorage(guaranteedResult).markRewritten();
+    } else if (hasTrivialGuaranteedAddressResult(ApplySite(oldCall),
+                                                 pass.function) &&
+               !guaranteedResult->use_empty()) {
+      // A loadable result has no mapped storage, so its uses still expect an
+      // object. Reload it from the address the callee now returns.
+      auto reloadBuilder = pass.getBuilder(getResultInsertionPoint());
+      auto *load = reloadBuilder.createLoad(callLoc, newResult,
+                                           LoadOwnershipQualifier::Trivial);
+      guaranteedResult->replaceAllUsesWith(load);
+    }
   }
 }
 
@@ -4646,7 +4684,11 @@ static void rewriteIndirectApply(ApplySite anyApply,
   case FullApplySiteKind::TryApplyInst: {
     auto calleeFnTy = apply.getSubstCalleeType();
     if (!calleeFnTy->hasIndirectFormalResults() &&
-        !calleeFnTy->hasIndirectErrorResult()) {
+        !calleeFnTy->hasIndirectErrorResult() &&
+        // A @guaranteed_address result is a direct address return rather than
+        // an indirect formal result, but still needs the call rewritten so the
+        // result becomes the address the callee returns.
+        !hasTrivialGuaranteedAddressResult(apply, pass.function)) {
       return;
     }
     // If the call has indirect results and wasn't already rewritten, rewrite it

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -8,9 +8,6 @@
 //
 // REQUIRES: executable_test
 
-// Blocked by rdar://181604244 (opaque values borrow accessors)
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
-
 import StdlibUnittest
 import CxxStdlib
 #if USE_CUSTOM_STRING_API

--- a/test/Interpreter/inline_array_enum_tags.swift
+++ b/test/Interpreter/inline_array_enum_tags.swift
@@ -4,7 +4,6 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 struct Foo {
     let x: UInt64

--- a/test/Interpreter/inline_array_memory_rebound.swift
+++ b/test/Interpreter/inline_array_memory_rebound.swift
@@ -5,9 +5,6 @@
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
 
-// Reading an InlineArray element is not supported with opaque values, yet.
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
-
 typealias Tuple16 = (UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,
                      UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8,UInt8)
 

--- a/test/SIL/borrow_accessor_e2e.swift
+++ b/test/SIL/borrow_accessor_e2e.swift
@@ -4,7 +4,6 @@
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 public struct Container<Element: ~Copyable >: ~Copyable {
   var _storage: UnsafeMutableBufferPointer<Element>

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -537,6 +537,45 @@ bb0(%0 : $Builtin.RawPointer):
   return_borrow %3 from_scopes (%3)
 }
 
+sil @f067_borrow_accessor_trivial : $@convention(method) <T> (@in_guaranteed Box<T>) -> @guaranteed_address Int
+
+// Unlike f062, this borrow accessor's @guaranteed_address result is a *trivial
+// loadable* type, so it has no storage in the valueStorageMap. The apply's
+// result still becomes the address the callee returns, so the caller reloads
+// from it for uses that expect an object.
+// CHECK-LABEL: sil [ossa] @f067_call_borrow_trivial : $@convention(thin) <T> (@inout Box<T>) -> Builtin.Int64 {
+// CHECK: bb0(%0 : $*Box<T>):
+// CHECK:   [[FN:%.*]] = function_ref @f067_borrow_accessor_trivial
+// CHECK:   [[ADR:%.*]] = apply [[FN]]<T>(%0) : $@convention(method) <τ_0_0> (@in_guaranteed Box<τ_0_0>) -> @guaranteed_address Builtin.Int64
+// CHECK:   [[VAL:%.*]] = load [trivial] [[ADR]] : $*Builtin.Int64
+// CHECK:   return [[VAL]] : $Builtin.Int64
+// CHECK-LABEL: } // end sil function 'f067_call_borrow_trivial'
+sil [ossa] @f067_call_borrow_trivial : $@convention(thin) <T> (@inout Box<T>) -> Int {
+bb0(%0 : $*Box<T>):
+  %1 = function_ref @f067_borrow_accessor_trivial : $@convention(method) <T> (@in_guaranteed Box<T>) -> @guaranteed_address Int
+  %2 = load_borrow %0 : $*Box<T>
+  %3 = apply %1<T>(%2) : $@convention(method) <T> (@in_guaranteed Box<T>) -> @guaranteed_address Int
+  end_borrow %2 : $Box<T>
+  return %3 : $Int
+}
+
+sil @f068_borrow_accessor_direct_self : $@convention(method) (@guaranteed LoadableNontrivial) -> @guaranteed_address Int
+
+// Same as f067, but self is passed directly rather than indirectly, so the
+// call has no indirect arguments at all and only its result needs rewriting.
+// CHECK-LABEL: sil [ossa] @f068_call_borrow_direct_self : $@convention(thin) (@guaranteed LoadableNontrivial) -> Builtin.Int64 {
+// CHECK: bb0(%0 : @guaranteed $LoadableNontrivial):
+// CHECK:   [[FN:%.*]] = function_ref @f068_borrow_accessor_direct_self
+// CHECK:   [[ADR:%.*]] = apply [[FN]](%0) : $@convention(method) (@guaranteed LoadableNontrivial) -> @guaranteed_address Builtin.Int64
+// CHECK:   [[VAL:%.*]] = load [trivial] [[ADR]] : $*Builtin.Int64
+// CHECK:   return [[VAL]] : $Builtin.Int64
+sil [ossa] @f068_call_borrow_direct_self : $@convention(thin) (@guaranteed LoadableNontrivial) -> Int {
+bb0(%0 : @guaranteed $LoadableNontrivial):
+  %1 = function_ref @f068_borrow_accessor_direct_self : $@convention(method) (@guaranteed LoadableNontrivial) -> @guaranteed_address Int
+  %2 = apply %1(%0) : $@convention(method) (@guaranteed LoadableNontrivial) -> @guaranteed_address Int
+  return %2 : $Int
+}
+
 // CHECK-LABEL: sil [ossa] @f070_mixedResult1 : $@convention(thin) <T> (@in T, @owned any C) -> (@out T, @owned any C) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : @owned $any C):
 // CHECK:   copy_addr [take] %1 to [init] %0 : $*T

--- a/test/SILOptimizer/address_lowering_borrow_accessor_loadable.swift
+++ b/test/SILOptimizer/address_lowering_borrow_accessor_loadable.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-sil -sil-verify-all -disable-availability-checking -enable-sil-opaque-values -o /dev/null %s
+
+// Subscripting an InlineArray or Span calls the stdlib's borrow accessor, whose
+// result convention is @guaranteed_address: an object before AddressLowering,
+// and a directly-returned address after it. When the element type is loadable
+// the apply's result has no storage in the valueStorageMap, so AddressLowering
+// has to reload it from the returned address; otherwise the address escapes into
+// code that still expects an object.
+
+func check<T>(_ t: T) {}
+
+// The address reached `return`, which wants an object.
+func returnElement(_ a: InlineArray<5, Int>) -> Int {
+  a[0]
+}
+
+// The address became the source of a store while materializing the
+// @in_guaranteed argument of a generic call.
+func passElement(_ a: InlineArray<5, Int>) {
+  check(a[0])
+}
+
+// The address reached `struct_extract`, an object-only operation.
+func compareElement(_ a: InlineArray<5, UInt8>) -> Bool {
+  a[0] == 0
+}
+
+func spanElement(_ s: Span<Int>) -> Int {
+  s[0]
+}
+
+// An address-only element takes the other path: its result *is* mapped into the
+// valueStorageMap and rewritten by the DefRewriter. Kept here so both paths stay
+// covered by one test.
+func returnAddressOnlyElement<T>(_ a: InlineArray<5, T>) -> T {
+  a[0]
+}

--- a/test/SILOptimizer/inline_array_loop_mutation.swift
+++ b/test/SILOptimizer/inline_array_loop_mutation.swift
@@ -4,7 +4,6 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: back_deployment_runtime || use_os_stdlib
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Regression test for a miscompile where TBAA failed to recurse into
 // `Builtin.FixedArray`'s element type, allowing LICM to hoist a load out

--- a/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
+++ b/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
@@ -15,8 +15,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
-
 import StdlibUnittest
 
 import Foundation

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -14,9 +14,6 @@
 
 // REQUIRES: executable_test
 
-// Blocked by rdar://181604244 (opaque values borrow accessors)
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
-
 import StdlibUnittest
 
 var suite = TestSuite("MutableRawSpan Tests")

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -14,9 +14,6 @@
 
 // REQUIRES: executable_test
 
-// Blocked by rdar://181604244 (opaque values borrow accessors)
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
-
 import StdlibUnittest
 
 var suite = TestSuite("Span Tests")

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -14,9 +14,6 @@
 
 // REQUIRES: executable_test
 
-// Blocked by rdar://181604244 (opaque values borrow accessors)
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
-
 import StdlibUnittest
 
 var suite = TestSuite("StringUTF8StorageProperty")


### PR DESCRIPTION
Under -enable-sil-opaque-values, calling a borrow accessor — result convention ResultConvention::GuaranteedAddress, e.g.
InlineArray/Span subscript.borrow — produces invalid SIL when the result type is loadable. Address-only result types
are handled correctly.

@guaranteed_address is stage-dependent: an object before AddressLowering, a directly-returned address after it
(SILAddressConventions::isAddressResult returns loweredAddresses for it). This is what SILGen emits directly when addresses are already lowered:
%9  = apply %8<5, Int>(…) -> @guaranteed_address τ_0_1   // $*Int
%10 = load [trivial] %9                                  // $Int

It doesn't do this for loadable results, for two reasons:

1. The result never enters valueStorageMap — OpaqueValueVisitor::visitValue only maps address-only values — so
DefRewriter never visits the apply.
2. Every gate that would otherwise route the apply to ApplyRewriter tests hasIndirectFormalResults(), which is false for
a @guaranteed_address result: it's a direct address return, not an indirect formal one. checkForIndirectApply and
rewriteIndirectApply both miss it on that basis.

AddressLowering::run() then calls setHasLoweredAddresses(true) unconditionally, so the function is flagged as lowered
while still containing a @guaranteed_address apply result that is an object. That inconsistency is latent and surfaces
later, in whichever pass first trips over it.

Partly resolves rdar://185988659, #91708, #91661 (only trivial  loadable result).