### PR TITLE
[cxx-interop] Reland "Use borrowing seq for all cxx borrowing seq"

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3748,8 +3748,17 @@ bool swift::shouldUseIterable(ASTContext &ctx, Type seqTy,
   if (!borrowingSeqProto) {
     return false;
   }
+  
+  // Always try to use Iterable for sequences that conform to
+  // CxxIterable when it is available.
+  if (auto cxxIterable =
+          ctx.getProtocol(KnownProtocolKind::CxxIterable)) {
+    if (auto conf = lookupConformance(seqTy, cxxIterable)) {
+      return !conf.getAvailabilityRestriction(dc, loc);
+    }
+  }
 
-  // Always prefer conformance to Sequence over Iterable when
+  // Else, always prefer conformance to Sequence over Iterable when
   // both are available.
   if (lookupConformance(seqTy, ctx.getProtocol(KnownProtocolKind::Sequence))) {
     return false;

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterable.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterable.swift
@@ -92,4 +92,30 @@ CxxIterableTestSuite.test("ContiguousNonCopyableSequence as Swift.Iterable, with
   expectEqual(outerCounter, 2)
 }
 
+CxxIterableTestSuite.test("ContiguousNonCopyableSequence borrowing for loop") {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+  let seq = ContiguousNonCopyableSequence()
+  let arr : [Int32] = [10, 20, 30, 40, 50]
+
+  var counter = 0
+  for el in seq {
+    expectEqual(el, arr[counter])
+    counter += 1
+  }
+  expectEqual(counter, 5)
+}
+
+CxxIterableTestSuite.test("DifferentResultsDereferenceOperatorSequence borrowing for loop") {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+  let seq = DifferentResultsDereferenceOperatorSequence()
+  let arr : [Int32] = [2, 3, 4, 5]
+
+  var counter = 0
+  for el in seq {
+    expectEqual(el, arr[counter])
+    counter += 1
+  }
+  expectEqual(counter, 4)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-list.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list.swift
@@ -54,4 +54,52 @@ StdListTestSuite.test("ListOfNonCopyable conforms to CxxIterable") {
     expectEqual(counter, lst.size())
 }
 
+StdListTestSuite.test("ListOfInt borrowing for loop") {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let arr : [Int32] = [1, 2, 3]
+    let constLst = makeListInt()
+    expectEqual(constLst.size(), 3)
+    expectFalse(constLst.empty())
+    var counter = 0
+    for el in constLst {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, constLst.size())
+
+    var mutLst = makeListInt()
+    expectEqual(mutLst.size(), 3)
+    expectFalse(mutLst.empty())
+    counter = 0
+    for el in mutLst {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, mutLst.size())
+}
+
+StdListTestSuite.test("ListOfNonCopyable borrowing for loop") {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let arr : [Int32] = [1, 2, 3]
+    var constLst = makeListOfNonCopyable()
+    expectEqual(constLst.size(), 3)
+    expectFalse(constLst.empty())
+    var counter = 0
+    for el in constLst {
+        expectEqual(getNumber(el), arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, constLst.size())
+
+    var mutLst = makeListOfNonCopyable()
+    expectEqual(mutLst.size(), 3)
+    expectFalse(mutLst.empty())
+    counter = 0
+    for el in mutLst {
+        expectEqual(getNumber(el), arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, mutLst.size())
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -16,6 +16,7 @@
 // Undefined hidden symbol to C++ voidify in libcxx
 // rdar://121551667
 // XFAIL: OS=freebsd
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import StdlibUnittest
 #if !BRIDGING_HEADER

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -640,6 +640,18 @@ StdMapTestSuite.test("UnorderedMap.merge(CxxDictionary)") {
   expectEqual(map[4], 7)
 }
 
+StdMapTestSuite.test("MapNonCopyableValue Borrowing Iterators").require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let map = initMapNonCopyableValue()
+  var counter = 0
+  for el in map {
+    expectEqual(el.first, el.second.number)
+    counter += 1
+  }
+  expectEqual(counter, 3)
+}
+
 // `merging` is implemented by calling `merge`, so we can skip this test
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -195,4 +195,62 @@ StdSetTestSuite.test("SetOfCIntWithCustomComparator") {
 //     expectTrue(s.contains(5))
 }
 
+StdSetTestSuite.test("SetOfCInt Borrowing Iterators").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+
+    let constSet = initSetOfCInt()
+    expectTrue(constSet.contains(1))
+    expectFalse(constSet.contains(2))
+    expectTrue(constSet.contains(3))
+
+    let arr : [Int32] = [1, 3, 5]
+    var counter = 0
+    for el in constSet {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+
+    var mutSet = initSetOfCInt()
+    expectTrue(mutSet.contains(1))
+    expectFalse(mutSet.contains(2))
+    expectTrue(mutSet.contains(3))
+
+    counter = 0
+    for el in mutSet {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+}
+
+StdSetTestSuite.test("MultisetOfCInt Borrowing Iterators").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+
+    let constSet = initMultisetOfCInt()
+    expectTrue(constSet.contains(2))
+    expectFalse(constSet.contains(3))
+    expectTrue(constSet.contains(4))
+
+    let arr : [Int32] = [2, 2, 4, 6]
+    var counter = 0
+    for el in constSet {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 4)
+
+    var mutSet = initMultisetOfCInt()
+    expectTrue(mutSet.contains(2))
+    expectFalse(mutSet.contains(3))
+    expectTrue(mutSet.contains(4))
+
+    counter = 0
+    for el in mutSet {
+        expectEqual(el, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 4)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -20,6 +20,8 @@
 // UNSUPPORTED: LinuxDistribution=rhel-10.2
 // UNSUPPORTED: LinuxDistribution=ubuntu-26.04
 
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
 import StdlibUnittest
 #if !BRIDGING_HEADER
 import StdSet

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -34,8 +34,12 @@ takesSpan(s1)
 
 let s2 = makeSpanOfNonCopyable()
 for _ in s2 {}
-// expected-darwin-error@-1 {{conform to 'Iterable', which is only available in}}
-// expected-darwin-note@-2 {{add 'if #available' version check}}
+// expected-darwin-error@-1 {{conform to 'Sequence'}} 
+
+if #available(SwiftStdlib 6.4, *) {
+for _ in s2 {} // no error
+}
+
 takesSequence(s2)
 // expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
 takesIterable(s2)

--- a/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
@@ -22,6 +22,10 @@ import StdVector
 #endif
 import CxxStdlib
 
+// This test makes sure that, after C++20 and on platforms where std::contiguous_iterator_tag is available, 
+// we pick up the conformance to `UnsafeCxxContiguousIterator`. 
+// This conformances allows `nextSpan()` to return a span containing all std::vector elements, 
+// instead of a single element (like it does for C++ iterators that conform only to `UnsafeCxxInputIterator`).
 var StdVectorBorrowingIteratorTestSuite = TestSuite("StdVectorBorrowingIterator")
 
 StdVectorBorrowingIteratorTestSuite.test("VecOfInt has contiguous iterator").require(.stdlib_6_4).code {

--- a/test/Interop/Cxx/stdlib/use-std-vector-emit-sil.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-emit-sil.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend %s -emit-sil -cxx-interoperability-mode=default -I %S/Inputs -Xcc -fignore-exceptions -verify
+
+import StdVector
+import CxxStdlib
+
+@available(SwiftStdlib 6.4, *)
+func pushToVectorDuringIter() {
+  var vec = Vector([1, 2, 3])
+  for el in vec { // expected-note {{conflicting access is here}}
+    vec.push_back(el) // expected-error {{overlapping accesses to 'vec', but modification requires exclusive access; consider copying to a local variable}}
+  }
+}

--- a/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-typechecker.swift
@@ -1,25 +1,20 @@
-// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -verify
 
 import StdVector
 import StdVectorNoCPlusPlusRequirement
 import CxxStdlib
 
-func takeCopyable<T: Copyable>(_ x: T) {} 
-func takeCxxVector<V: CxxVector>(_ v: V) {} 
+func takeCopyable<T: Copyable>(_ x: T) {} // expected-note *{{'where T: Copyable' is implicit here}}
+func takeCxxVector<V: CxxVector>(_ v: V) {} // expected-note {{where 'V' = 'VectorOfNonCopyable'}}
 
 let vecNC = VectorOfNonCopyable()
-takeCopyable(vecNC)
-// CHECK: error: global function 'takeCopyable' requires that 'VectorOfNonCopyable' {{.*}} conform to 'Copyable'
-// CHECK: note: 'where T: Copyable' is implicit here
+takeCopyable(vecNC) // expected-error {{global function 'takeCopyable' requires that 'VectorOfNonCopyable'}}
 
-takeCxxVector(vecNC) 
-// CHECK: error: global function 'takeCxxVector' requires that 'VectorOfNonCopyable' {{.*}} conform to 'CxxVector'
-// CHECK: note: where 'V' = 'VectorOfNonCopyable' {{.*}}
+takeCxxVector(vecNC) // expected-error {{global function 'takeCxxVector' requires that 'VectorOfNonCopyable'}}
 
 let vecPointer = VectorOfPointer()
 takeCopyable(vecPointer)
 takeCxxVector(vecPointer)
-// CHECK-NOT: error
 
 // Make sure that a specialization of std::vector that is declared in a Clang
 // module which does not declare 'requires cplusplus' is still conformed to
@@ -27,12 +22,9 @@ takeCxxVector(vecPointer)
 let vecFloat = VectorOfFloat()
 takeCopyable(vecFloat)
 takeCxxVector(vecFloat)
-// CHECK-NOT: error
 
 let hasVector = HasVector()
-takeCopyable(hasVector)
-// CHECK: error: global function 'takeCopyable' requires that 'HasVector' conform to 'Copyable'
+takeCopyable(hasVector) // expected-error {{global function 'takeCopyable' requires that 'HasVector' conform to 'Copyable'}}
 
 let baseHasVector = BaseHasVector()
-takeCopyable(baseHasVector)
-// CHECK: error: global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'
+takeCopyable(baseHasVector) // expected-error {{global function 'takeCopyable' requires that 'BaseHasVector' conform to 'Copyable'}}

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -233,5 +233,49 @@ StdVectorTestSuite.test("Subscript of VectorOfNonCopyable") {
     expectEqual(getNumber(v[2]), 3)
 }
 
+StdVectorTestSuite.test("VectorOfInt borrowing for loop").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let constArr : [Int32] = [1, 2, 3]
+    let constVec = Vector(constArr)
+    expectEqual(constVec.size(), constArr.count)
+    var counter = 0
+    for el in constVec {
+        expectEqual(el, constArr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+
+    var mutArr : [Int32] = [4, 5, 6, 7]
+    var mutVec = Vector(mutArr)
+    expectEqual(mutVec.size(), mutArr.count)
+    counter = 0
+    for el in mutVec {
+        expectEqual(el, mutArr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 4)
+}
+
+StdVectorTestSuite.test("VectorOfNonCopyable borrowing for loop").require(.stdlib_6_4).code {
+    guard #available(SwiftStdlib 6.4, *) else { return }
+    let constVec = makeVectorOfNonCopyable()
+    let arr : [Int32] = [1, 2, 3]
+    expectEqual(constVec.size(), arr.count)
+    var counter = 0
+    for el in constVec {
+        expectEqual(el.number, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+
+    var mutVec = makeVectorOfNonCopyable()
+    expectEqual(mutVec.size(), arr.count)
+    counter = 0
+    for el in mutVec {
+        expectEqual(el.number, arr[counter])
+        counter += 1
+    }
+    expectEqual(counter, 3)
+}
 
 runAllTests()


### PR DESCRIPTION
When a given type conforms to `CxxIterable`, always use the available `Iterable` conformance as well as the Borrowing for loop desugaring when enabled.

This brings back https://github.com/swiftlang/swift/pull/87702, which was reverted in https://github.com/swiftlang/swift/pull/88271.

rdar://171063716
