### PR TITLE
AliasAnalysis: Recognise `end_borrow` and `destroy_value` of appropriate types as having no memory effects

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -317,6 +317,12 @@ struct AliasAnalysis {
       return getBuiltinEffect(of: builtin, on: memLoc)
 
     case let endBorrow as EndBorrowInst:
+      let type = endBorrow.borrow.type
+      if type.isNonTrivialOnlyBecauseNonEscapable(in: endBorrow.parentFunction) {
+        // Ending a borrow of a non-Escapable type that is otherwise trivial can
+        // be considered to have no effects.
+        return .noEffects
+      }
       switch endBorrow.borrow {
       case let storeBorrow as StoreBorrowInst:
         precondition(endBorrow.borrow.type.isAddress)

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -347,12 +347,18 @@ struct AliasAnalysis {
       return .noEffects
 
     case let destroy as DestroyValueInst:
-      if destroy.destroyedValue.type.isNoEscapeFunction {
+      let type = destroy.destroyedValue.type
+      if type.isNoEscapeFunction {
         return .noEffects
       }
       if destroy.isDeadEnd {
         // We don't have to take deinit effects into account for a `destroy_value [dead_end]`.
         // Such destroys are lowered to no-ops and will not call any deinit.
+        return .noEffects
+      }
+      if type.isNonTrivialOnlyBecauseNonEscapable(in: destroy.parentFunction) {
+        // If the type is only non-trivial because it is ~Escapable,
+        // destroy_value is still a no-op.
         return .noEffects
       }
       return defaultEffects(of: destroy, on: memLoc)

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -46,6 +46,11 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
     return bridged.isTrivial(function.bridged)
   }
 
+  /// Returns true if the type is non-trivial only because it is non-Escapable.
+  public func isNonTrivialOnlyBecauseNonEscapable(in function: Function) -> Bool {
+    return bridged.isNonTrivialOnlyBecauseNonEscapable(function.bridged)
+  }
+
   /// Returns true if the type is a trivial type and is and does not contain a Builtin.RawPointer.
   public func isTrivialNonPointer(in function: Function) -> Bool {
     return !bridged.isNonTrivialOrContainsRawPointer(function.bridged)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -287,6 +287,8 @@ struct BridgedType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getAddressType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getObjectType() const;
   BRIDGED_INLINE bool isTrivial(BridgedFunction f) const;
+  BRIDGED_INLINE bool
+  isNonTrivialOnlyBecauseNonEscapable(BridgedFunction f) const;
   BRIDGED_INLINE bool isNonTrivialOrContainsRawPointer(BridgedFunction f) const;
   BRIDGED_INLINE bool isLoadable(BridgedFunction f) const;
   BRIDGED_INLINE bool isReferenceCounted(BridgedFunction f) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -373,6 +373,10 @@ bool BridgedType::isTrivial(BridgedFunction f) const {
   return unbridged().isTrivial(f.getFunction());
 }
 
+bool BridgedType::isNonTrivialOnlyBecauseNonEscapable(BridgedFunction f) const {
+  return unbridged().isNonTrivialOnlyBecauseNonEscapable(*f.getFunction());
+}
+
 bool BridgedType::isNonTrivialOrContainsRawPointer(BridgedFunction f) const {
   return unbridged().isNonTrivialOrContainsRawPointer(f.getFunction());
 }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -357,6 +357,10 @@ public:
 
   bool isTrivial(const SILFunction *f) const { return isTrivial(*f); }
 
+  /// True if the underlying AST type is non-trivial only because it is
+  /// non-Escapable.
+  bool isNonTrivialOnlyBecauseNonEscapable(const SILFunction &F) const;
+
   /// True if the type is the Builtin.RawPointer or a struct/tuple/enum which
   /// contains a Builtin.RawPointer.
   /// Returns false for types for which this property is not known, e.g. generic

--- a/include/swift/SIL/SILTypeProperties.h
+++ b/include/swift/SIL/SILTypeProperties.h
@@ -22,6 +22,9 @@ enum IsTrivial_t : bool {
   IsTrivial = true
 };
 
+/// Is the type non-trivial because it is non-Escapable?
+enum IsEscapable_t : bool { IsNonEscapable = false, IsEscapable = true };
+
 /// Is a lowered SIL type the Builtin.RawPointer or a struct/tuple/enum which
 /// contains a Builtin.RawPointer?
 /// HasRawPointer is true only for types that are known to contain
@@ -154,7 +157,8 @@ class SILTypeProperties {
     CustomDeinitFlag                         = 1 << 11,
     IsVeryLargeTypeFlag                      = 1 << 12,
     DefinitelyAddressableForDependenciesFlag = 1 << 13,
-    DefinitelyHasRawLayoutFlag               = 1 << 14
+    DefinitelyHasRawLayoutFlag               = 1 << 14,
+    NonEscapableFlag                         = 1 << 15
   };
   // clang-format on
 
@@ -176,22 +180,24 @@ public:
       HasRawLayout_t hasRawLayout = DoesNotHaveRawLayout,
       MayHaveCustomDeinit_t customDeinit = HasOnlyDefaultDeinit,
       IsVeryLargeType_t largeType = IsNotVeryLargeType,
-      IsAddressableForDependencies_t definitelyIsAFD = IsNotAddressableForDependencies,
-      HasRawLayout_t definitelyHasRawLayout = DoesNotHaveRawLayout)
+      IsAddressableForDependencies_t definitelyIsAFD =
+          IsNotAddressableForDependencies,
+      HasRawLayout_t definitelyHasRawLayout = DoesNotHaveRawLayout,
+      IsEscapable_t isEscapable = IsEscapable)
       : Flags((isTrivial ? 0U : NonTrivialFlag) |
               (isFixedABI ? 0U : NonFixedABIFlag) |
               (isAddressOnly ? AddressOnlyFlag : 0U) |
               (isResilient ? ResilientFlag : 0U) |
               (isTypeExpansionSensitive ? TypeExpansionSensitiveFlag : 0U) |
               (hasRawPointer ? HasRawPointerFlag : 0U) |
-              (isLexical ? LexicalFlag : 0U) |
-              (hasPack ? HasPackFlag : 0U) |
+              (isLexical ? LexicalFlag : 0U) | (hasPack ? HasPackFlag : 0U) |
               (isAFD ? AddressableForDependenciesFlag : 0U) |
               (hasRawLayout ? HasRawLayoutFlag : 0U) |
               (customDeinit ? CustomDeinitFlag : 0U) |
               (largeType ? IsVeryLargeTypeFlag : 0U) |
               (definitelyIsAFD ? AddressableForDependenciesFlag : 0U) |
-              (definitelyHasRawLayout ? HasRawLayoutFlag : 0U)) {}
+              (definitelyHasRawLayout ? HasRawLayoutFlag : 0U) |
+              (isEscapable ? 0U : NonEscapableFlag)) {}
 
   constexpr bool operator==(SILTypeProperties p) const {
     return Flags == p.Flags;
@@ -237,7 +243,16 @@ public:
   }
 
   IsTrivial_t isTrivial() const {
-    return IsTrivial_t((Flags & NonTrivialFlag) == 0);
+    // A non-Escapable type is also considered non-trivial.
+    return IsTrivial_t((Flags & (NonTrivialFlag | NonEscapableFlag)) == 0);
+  }
+  IsEscapable_t isEscapable() const {
+    return IsEscapable_t((Flags & NonEscapableFlag) == 0);
+  }
+  // Is the type non-Trivial, and is the only property of the type that makes it
+  // non-trivial the fact that it is non-Escapable?
+  bool isNonTrivialOnlyBecauseNonEscapable() const {
+    return (Flags & (NonTrivialFlag | NonEscapableFlag)) == NonEscapableFlag;
   }
   HasRawPointer_t isOrContainsRawPointer() const {
     return HasRawPointer_t((Flags & HasRawPointerFlag) != 0);
@@ -298,6 +313,7 @@ public:
   }
 
   void setNonTrivial() { Flags |= NonTrivialFlag; }
+  void setNonEscapable() { Flags |= NonEscapableFlag; }
   void setIsOrContainsRawPointer() { Flags |= HasRawPointerFlag; }
 
   void setNonFixedABI() { Flags |= NonFixedABIFlag; }

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -147,6 +147,12 @@ bool SILType::isTrivial(const SILFunction &F) const {
   return F.getTypeProperties(contextType).isTrivial();
 }
 
+bool SILType::isNonTrivialOnlyBecauseNonEscapable(const SILFunction &F) const {
+  auto contextType =
+      hasTypeParameter() ? F.mapTypeIntoEnvironment(*this) : *this;
+  return F.getTypeProperties(contextType).isNonTrivialOnlyBecauseNonEscapable();
+}
+
 bool SILType::isOrContainsRawPointer(const SILFunction &F) const {
   auto contextType = hasTypeParameter() ? F.mapTypeIntoEnvironment(*this) : *this;
   return F.getTypeProperties(contextType).isOrContainsRawPointer();

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2722,7 +2722,7 @@ namespace {
       // Regardless of their member types, Nonescapable values have ownership
       // for lifetime diagnostics.
       if (!origType.isEscapable(structType)) {
-        properties.setNonTrivial();
+        properties.setNonEscapable();
       }
       // Merge the CustomDeinit properties of the type parameters.
       if (hasConditionalDefaultDeinit(structType, D)) {
@@ -2835,7 +2835,7 @@ namespace {
       // Regardless of their member types, Nonescapable values have ownership
       // for lifetime diagnostics.
       if (!origType.isEscapable(enumType)) {
-        properties.setNonTrivial();
+        properties.setNonEscapable();
       }
       return handleAggregateByProperties<LoadableEnumTypeLowering>(enumType,
                                                                    properties);

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -temp-rvalue-elimination | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OPT
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -mandatory-temp-rvalue-elimination | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ONONE
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -enable-experimental-feature Lifetimes %s -temp-rvalue-elimination | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OPT
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -enable-experimental-feature Lifetimes %s -mandatory-temp-rvalue-elimination | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ONONE
 
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage canonical
 
@@ -55,6 +56,29 @@ struct NCWithDeinit : ~Copyable {
   deinit
 }
 
+struct PointerNCDeinit: ~Copyable {
+  var x: Builtin.RawPointer
+
+  deinit
+}
+
+struct PointerValueDeinit {
+  var x: Builtin.RawPointer
+  var k: Klass
+}
+
+struct PointerNE: ~Escapable {
+  var x: Builtin.RawPointer
+
+  @_lifetime(immortal)
+  init()
+}
+
+
+struct PointerNonTrivial {
+  var x: Builtin.RawPointer
+  var k: Klass
+}
 
 protocol P {
   func foo()
@@ -74,6 +98,8 @@ sil [ossa] @inguaranteed_user_without_result_MOS : $@convention(thin) (@in_guara
 
 sil [ossa] @consuming_indirect_arg : $@convention(thin) (@in Klass) -> ()
 sil @deinit_barrier : $@convention(thin) () -> ()
+
+sil @get_klass_pointer : $@convention(thin) (@guaranteed Klass) -> Builtin.RawPointer
 
 sil [ossa] @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> () {
 bb0(%0 : $*Klass):
@@ -1944,3 +1970,131 @@ bb2:
   return %6
 }
 
+// CHECK-LABEL: sil [ossa] @destroy_no_deinit :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'destroy_no_deinit'
+sil [ossa] @destroy_no_deinit : $@convention(thin) (@owned Span<Int>) -> Int {
+bb0(%0 : @owned $Span<Int>):
+  %borrow = begin_borrow %0
+  %ptr = struct_extract %borrow, #Span._pointer
+  %data = unchecked_enum_data %ptr, #Optional.some!enumelt
+  %raw = struct_extract %data, #UnsafeRawPointer._rawValue
+  end_borrow %borrow
+  %addr = pointer_to_address %raw to [strict] $*Int
+  %int = load [trivial] %addr
+  destroy_value %0
+  %stk = alloc_stack $Int
+  store %int to [trivial] %stk
+  %val = load [trivial] %stk
+  dealloc_stack %stk
+  return %val
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_class :
+// CHECK: alloc_stack
+// CHECK-LABEL: } // end sil function 'destroy_class'
+sil [ossa] @destroy_class : $@convention(thin) (@owned Klass) -> Int {
+bb0(%0 : @owned $Klass):
+  %borrow = begin_borrow %0
+  %gkp = function_ref @get_klass_pointer : $@convention(thin) (@guaranteed Klass) -> Builtin.RawPointer
+  %raw = apply %gkp(%borrow) : $@convention(thin) (@guaranteed Klass) -> Builtin.RawPointer
+  end_borrow %borrow
+  %addr = pointer_to_address %raw to [strict] $*Int
+  %int = load [trivial] %addr
+  destroy_value %0
+  %stk = alloc_stack $Int
+  store %int to [trivial] %stk
+  %val = load [trivial] %stk
+  dealloc_stack %stk
+  return %val
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_custom_deinit :
+// CHECK: alloc_stack
+// CHECK-LABEL: } // end sil function 'destroy_custom_deinit'
+sil [ossa] @destroy_custom_deinit : $@convention(thin) (@owned PointerNCDeinit) -> Int {
+bb0(%0 : @owned $PointerNCDeinit):
+  %borrow = begin_borrow %0
+  %raw = struct_extract %borrow, #PointerNCDeinit.x
+  end_borrow %borrow
+  %addr = pointer_to_address %raw to [strict] $*Int
+  %int = load [trivial] %addr
+  destroy_value %0
+  %stk = alloc_stack $Int
+  store %int to [trivial] %stk
+  %val = load [trivial] %stk
+  dealloc_stack %stk
+  return %val
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_value_type_deinit :
+// CHECK: alloc_stack
+// CHECK-LABEL: } // end sil function 'destroy_value_type_deinit'
+sil [ossa] @destroy_value_type_deinit : $@convention(thin) (@owned PointerValueDeinit) -> Int {
+bb0(%0 : @owned $PointerValueDeinit):
+  %borrow = begin_borrow %0
+  %raw = struct_extract %borrow, #PointerValueDeinit.x
+  end_borrow %borrow
+  %addr = pointer_to_address %raw to [strict] $*Int
+  %int = load [trivial] %addr
+  destroy_value %0
+  %stk = alloc_stack $Int
+  store %int to [trivial] %stk
+  %val = load [trivial] %stk
+  dealloc_stack %stk
+  return %val
+}
+
+// CHECK-LABEL: sil [ossa] @end_borrow_trivial_except_non_escapable :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'end_borrow_trivial_except_non_escapable'
+sil [ossa] @end_borrow_trivial_except_non_escapable : $@convention(thin) (@guaranteed PointerNE) -> Int {
+bb0(%0 : @guaranteed $PointerNE):
+  %stk = alloc_stack $Int
+  %borrow = begin_borrow %0
+  %raw = struct_extract %borrow, #PointerNE.x
+  %addr = pointer_to_address %raw to [strict] $*Int
+  %int = load [trivial] %addr
+  end_borrow %borrow
+  store %int to [trivial] %stk
+  %val = load [trivial] %stk
+  dealloc_stack %stk
+  return %val
+}
+
+// CHECK-LABEL: sil [ossa] @end_borrow_non_trivial :
+// CHECK: alloc_stack
+// CHECK-LABEL: } // end sil function 'end_borrow_non_trivial'
+sil [ossa] @end_borrow_non_trivial : $@convention(thin) (@guaranteed PointerNonTrivial) -> Int {
+bb0(%0 : @guaranteed $PointerNonTrivial):
+  %stk = alloc_stack $Int
+  %borrow = begin_borrow %0
+  %raw = struct_extract %borrow, #PointerNonTrivial.x
+  %addr = pointer_to_address %raw to [strict] $*Int
+  %int = load [trivial] %addr
+  end_borrow %borrow
+  store %int to [trivial] %stk
+  %val = load [trivial] %stk
+  dealloc_stack %stk
+  return %val
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_value_and_end_borrow :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'destroy_value_and_end_borrow'
+sil [ossa] @destroy_value_and_end_borrow : $@convention(thin) (@owned Span<Int>) -> Int {
+bb0(%0 : @owned $Span<Int>):
+  %stk = alloc_stack $Int
+  %borrow = begin_borrow %0
+  %ptr = struct_extract %borrow, #Span._pointer
+  %data = unchecked_enum_data %ptr, #Optional.some!enumelt
+  %raw = struct_extract %data, #UnsafeRawPointer._rawValue
+  %addr = pointer_to_address %raw to [strict] $*Int
+  %int = load [trivial] %addr
+  end_borrow %borrow
+  destroy_value %0
+  store %int to [trivial] %stk
+  %val = load [trivial] %stk
+  dealloc_stack %stk
+  return %val
+}


### PR DESCRIPTION
This allows TempRValueElimination to eliminate temporary allocations in situations where these instructions would have previously blocked it.

Non-Escapable types are considered non-trivial. If being non-Escapable is the only reason the type is non-trivial (i.e. it is Copyable and has only trivial fields), then `end_borrow` does not need to do anything for it. An `end_borrow` of such a type can be considered to have no memory effects. The same applies to `destroy_value`.

To distinguish such types, introduce a new SILTypeProperties flag: NonEscapableFlag. A type is considered non-trivial if it or the NonTrivialFlag is set. Instead of setting NonTrivialFlag because a type is non-Escapable, set NonEscapableFlag. If NonEscapableFlag is set and NonTrivialFlag is not, then the type meets the condition for `end_borrow` & `destroy_value` to have no memory effects.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
