### PR TITLE
utils: update to mimalloc 3.5.0

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3328,37 +3328,14 @@ function Build-mimalloc() {
     [hashtable]$Platform
   )
 
-  # TODO: migrate to the CMake build
-  $MSBuildArgs = @()
-  $MSBuildArgs += "-noLogo"
-  $MSBuildArgs += "-maxCpuCount"
-
-  $Properties = @{}
-  Add-KeyValueIfNew $Properties Configuration Release
-  Add-KeyValueIfNew $Properties OutDir "$BinaryCache\$($Platform.Triple)\mimalloc\bin\"
-  Add-KeyValueIfNew $Properties Platform "$($Platform.Architecture.ShortName)"
-
-  Invoke-IsolatingEnvVars {
-    Invoke-VsDevShell $Platform
-    # Avoid hard-coding the VC tools version number
-    $VCRedistDir = (Get-ChildItem "${env:VCToolsRedistDir}\$($HostPlatform.Architecture.ShortName)" -Filter "Microsoft.VC*.CRT").FullName
-    if ($VCRedistDir) {
-      Add-KeyValueIfNew $Properties VCRedistDir "$VCRedistDir\"
-    }
+  $MimallocBinaryCache = "$BinaryCache\$($Platform.Triple)\mimalloc"
+  # Match the architecture baselines in mimalloc's Visual Studio projects.
+  # MI_OPT_ARCH may select a newer ARM architecture as mimalloc evolves.
+  $MimallocArchitectureFlag = switch ($Platform.Architecture.ShortName) {
+    "x64" { "/arch:AVX2" }
+    "arm64" { "/arch:armv8.2" }
+    default { throw "Unsupported mimalloc architecture '$($Platform.Architecture.ShortName)'" }
   }
-
-  foreach ($Property in $Properties.GetEnumerator()) {
-    if ($Property.Value.Contains(" ")) {
-      $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value.Replace('\', '\\'))"
-    } else {
-      $MSBuildArgs += "-p:$($Property.Key)=$($Property.Value)"
-    }
-  }
-
-  Invoke-Program $msbuild "$SourceCache\mimalloc\ide\vs2022\mimalloc-lib.vcxproj" @MSBuildArgs "-p:IntDir=$BinaryCache\$($Platform.Triple)\mimalloc\mimalloc\"
-  Invoke-Program $msbuild "$SourceCache\mimalloc\ide\vs2022\mimalloc-override-dll.vcxproj" @MSBuildArgs "-p:IntDir=$BinaryCache\$($Platform.Triple)\mimalloc\mimalloc-override-dll\"
-
-  $HostSuffix = if ($Platform -eq $KnownPlatforms["WindowsX64"]) { "" } else { "-arm64" }
 
   $ToolchainRoots = @($Platform.ToolchainInstallRoot)
   if ($IncludeNoAsserts) {
@@ -3366,12 +3343,21 @@ function Build-mimalloc() {
   }
 
   foreach ($ToolchainRoot in $ToolchainRoots) {
-    New-Item -ItemType Directory -Force "$ToolchainRoot\usr\bin" | Out-Null
-    foreach ($item in "mimalloc.dll", "mimalloc-redirect$HostSuffix.dll") {
-      Copy-Item -Force `
-        -Path "$BinaryCache\$($Platform.Triple)\mimalloc\bin\$item" `
-        -Destination "$ToolchainRoot\usr\bin\"
-    }
+    Build-CMakeProject `
+      -Src "$SourceCache\mimalloc" `
+      -Bin $MimallocBinaryCache `
+      -InstallTo "$ToolchainRoot\usr" `
+      -Platform $Platform `
+      -CCompiler $Compilers.MSVC.C `
+      -CXXCompiler $Compilers.MSVC.CXX `
+      -Defines @{
+        CMAKE_CXX_FLAGS = @($MimallocArchitectureFlag);
+        MI_BUILD_OBJECT = "NO";
+        MI_BUILD_SHARED = "YES";
+        MI_BUILD_STATIC = "NO";
+        MI_BUILD_TESTS = "NO";
+        MI_NO_OPT_ARCH = "YES";
+      }
   }
 }
 

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -196,7 +196,7 @@
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
-                "mimalloc": "v3.0.3",
+                "mimalloc": "v3.5.0",
                 "swift-subprocess": "0.5",
                 "boringssl": "0226f30467f540a3f62ef48d453f93927da199b6"
             }
@@ -991,7 +991,7 @@
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
-                "mimalloc": "v3.0.3",
+                "mimalloc": "v3.5.0",
                 "swift-subprocess": "0.5",
                 "boringssl": "0226f30467f540a3f62ef48d453f93927da199b6"
             }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -929,7 +929,7 @@
                 "libxml2": "v2.11.5",
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
-                "mimalloc": "v3.0.3",
+                "mimalloc": "v3.5.0",
                 "swift-subprocess": "0.5",
                 "boringssl": "0226f30467f540a3f62ef48d453f93927da199b6"
             }


### PR DESCRIPTION
This updates us to the latest mimalloc release which has seem some more performance optimizations. Jump the minimum hardware requirement to ARM64 v8.2-a. This allows the previous generation of Surface laptops (8CX Gen 2) to continue to function. Apple M1 implements ARMv8.4-a, Snapdragon X implements ARMv8.7-a.

Switch to CMake to build mimalloc to avoid dealing with the MSVC toolset detection and selection. Updating from VS2022 VS2026 is currently prevented by this as the toolset has changed from v143 to v145 and the rules do not account for this (the vcxproj targets VS2022).

The migration also allows us to clean up some of the install rules.