### PR TITLE
(COM) Support Metatype Requirements

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6401,7 +6401,13 @@ GenericSignature::get(ArrayRef<GenericTypeParamType *> params,
 
 #ifndef NDEBUG
   for (auto req : requirements) {
-    assert(req.getFirstType()->isTypeParameter());
+    // The subject is normally a type parameter; a metatype subject
+    // (e.g.  'T.Type: P') is also permitted, in which case its instance type
+    // must be a type parameter.
+    auto subject = req.getFirstType();
+    if (auto *metatype = subject->getAs<AnyMetatypeType>())
+      subject = metatype->getInstanceType();
+    assert(subject->isTypeParameter());
     assert(!req.getFirstType()->hasTypeVariable());
     assert(req.getKind() == RequirementKind::Layout ||
            !req.getSecondType()->hasTypeVariable());

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6296,6 +6296,10 @@ ProtocolConformanceRef ProtocolConformanceRef::forAbstract(
   case TypeKind::OpaqueTypeArchetype:
   case TypeKind::ExistentialArchetype:
   case TypeKind::ElementArchetype:
+  case TypeKind::Metatype:
+  case TypeKind::ExistentialMetatype:
+    // The metatype of n abstract type can carry an abstract conformance its
+    // instance type is a type parameter, e.g. from 'T.Type: P'.
     break;
 
   default:

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3842,6 +3842,14 @@ ASTMangler::RequirementSubject ASTMangler::appendRequirementSubject(
     };
   }
 
+  // A metatype subject, e.g. 'T.Type: P'. Mangle the metatype as the subject
+  // type and use the substitution-style requirement operator, which references
+  // the preceding mangled type rather than a generic parameter index.
+  if (subjectType->is<AnyMetatypeType>()) {
+    appendType(subjectType, sig);
+    return RequirementSubject { RequirementSubject::Substitution };
+  }
+
   GenericTypeParamType *gpBase = subjectType->castTo<GenericTypeParamType>();
   return RequirementSubject { RequirementSubject::GenericParameter, gpBase };
 }

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -496,6 +496,34 @@ static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
     }
   }
 
+  Type instanceType = metatypeType->getInstanceType();
+
+  // Type parameters have abstract conformances. Preserve that behavior when
+  // the type parameter's metatype is the subject of the requirement.
+  if (instanceType->isTypeParameter())
+    return ProtocolConformanceRef::forAbstract(type, protocol);
+
+  // For a metatype of an archetype (e.g. 'T.Type' in a generic context), an
+  // abstract metatype conformance is provided by the generic environment's
+  // 'T.Type: P' requirement, which the RequirementMachine records with a
+  // metatype subject ('T.[metatype]').
+  if (auto *archetype = instanceType->getAs<ArchetypeType>()) {
+    if (auto *gamma = archetype->getGenericEnvironment()) {
+      for (const auto &requirement : gamma->getGenericSignature()
+                                        .getRequirements()) {
+        if (requirement.getKind() != RequirementKind::Conformance ||
+            !requirement.getFirstType()->is<AnyMetatypeType>())
+          continue;
+        if (!gamma->mapTypeIntoEnvironment(requirement.getFirstType())
+                  ->isEqual(type))
+          continue;
+        auto *refined = requirement.getProtocolDecl();
+        if (refined == protocol || refined->inheritsFrom(protocol))
+          return ProtocolConformanceRef::forAbstract(type, protocol);
+      }
+    }
+  }
+
   return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
 }
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -374,10 +374,21 @@ GenericEnvironment *GenericSignatureImpl::getGenericEnvironment() const {
   return GenericEnv;
 }
 
+/// Whether \p type is a valid subject for an abstract requirement query: a type
+/// parameter, or the metatype of one (e.g. the subject of `T.Type: P`). A
+/// metatype subject is threaded through the RequirementMachine tas the term
+/// `T.[metatype]`, so these queries answer correctly for it.
+namespace {
+bool isValidRequirementSubject(Type type) {
+  if (auto *metatype = type->getAs<AnyMetatypeType>())
+    type = metatype->getInstanceType();
+  return type->isTypeParameter();
+}
+}
+
 GenericSignature::LocalRequirements
 GenericSignatureImpl::getLocalRequirements(Type depType) const {
-  assert(depType->isTypeParameter() && "Expected a type parameter here");
-
+  assert(isValidRequirementSubject(depType) && "Expected a type parameter here");
   return getRequirementMachine()->getLocalRequirements(depType);
 }
 
@@ -410,15 +421,13 @@ Type GenericSignatureImpl::getSuperclassBound(Type type) const {
 /// required to conform.
 GenericSignature::RequiredProtocols
 GenericSignatureImpl::getRequiredProtocols(Type type) const {
-  assert(type->isTypeParameter() && "Expected a type parameter");
-
+  assert(isValidRequirementSubject(type) && "Expected a type parameter");
   return getRequirementMachine()->getRequiredProtocols(type);
 }
 
 bool GenericSignatureImpl::requiresProtocol(Type type,
                                             ProtocolDecl *proto) const {
-  assert(type->isTypeParameter() && "Expected a type parameter");
-
+  assert(isValidRequirementSubject(type) && "Expected a type parameter");
   return getRequirementMachine()->requiresProtocol(type, proto);
 }
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -894,6 +894,22 @@ static int compareDependentTypesRec(Type type1, Type type2) {
   // Fast-path check for equality.
   if (type1->isEqual(type2)) return 0;
 
+  // Metatypes are ordered by their instance type, with a bare type parameter
+  // ordered before its metatype (so 'T' < 'T.Type'). This lets a metatype be
+  // the subject of a requirement, e.g. 'T.Type: P'.
+  auto meta1 = type1->getAs<AnyMetatypeType>();
+  auto meta2 = type2->getAs<AnyMetatypeType>();
+  if (meta1 || meta2) {
+    auto instance1 = meta1 ? meta1->getInstanceType() : type1;
+    auto instance2 = meta2 ? meta2->getInstanceType() : type2;
+    if (int comparison = compareDependentTypesRec(instance1, instance2))
+      return comparison;
+    // Equal instance types: the bare type parameter orders before the metatype.
+    if (static_cast<bool>(meta1) != static_cast<bool>(meta2))
+      return meta1 ? +1 : -1;
+    return 0;
+  }
+
   // Ordering is as follows:
   // - Generic params
   auto gp1 = type1->getAs<GenericTypeParamType>();
@@ -929,8 +945,16 @@ static int compareDependentTypesRec(Type type1, Type type2) {
 
 /// Canonical ordering for type parameters.
 int swift::compareDependentTypes(Type type1, Type type2) {
-  auto *root1 = type1->getRootGenericParam();
-  auto *root2 = type2->getRootGenericParam();
+  // Look through metatypes to the underlying type parameter when determining
+  // the generic-parameter weight; the metatype itself is ordered within
+  // `compareDependentTypesRec` (so 'T.Type: P' can be a requirement).
+  auto rootParamType = [](Type type) -> GenericTypeParamType * {
+    while (auto meta = type->getAs<AnyMetatypeType>())
+      type = meta->getInstanceType();
+    return type->getRootGenericParam();
+  };
+  auto *root1 = rootParamType(type1);
+  auto *root2 = rootParamType(type2);
   if (root1->getWeight() != root2->getWeight()) {
     return root2->getWeight() ? -1 : +1;
   }
@@ -974,7 +998,14 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
 
     // Left-hand side must be a canonical type parameter.
     if (reqt.getKind() != RequirementKind::SameType) {
-      if (!reqt.getFirstType()->isTypeParameter()) {
+      auto subjectType = reqt.getFirstType();
+
+      // A metatype subject (e.g. 'T.Type: P') is permitted; in that case its
+      // instance type must be the type parameter.
+      if (auto *metatype = subjectType->getAs<AnyMetatypeType>())
+        subjectType = metatype->getInstanceType();
+
+      if (!subjectType->isTypeParameter()) {
         dumpAndAbort([&](auto &out) {
           out << "Left-hand side must be a type parameter: ";
           reqt.dump(out);
@@ -1495,6 +1526,12 @@ void GenericSignatureImpl::getRequirementsWithInversesImpl(
 
     auto subject = req.getFirstType();
     auto *proto = req.getProtocolDecl();
+
+    // A metatype subject (e.g. 'T.Type: P') does not participate in primary
+    // associatedtype inverse defaulting and has no member types to suppress, so
+    // skip it.
+    if (subject->is<AnyMetatypeType>())
+      continue;
 
     // Only consider conformance requirements whose subject is rooted in
     // a generic parameter that is within this signature's depth.

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -388,8 +388,29 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
   }
 
   case RequirementKind::Conformance: {
-    auto substFirstType = substTypeParameter(
-        firstType, Position::ConformanceRequirement);
+    Type substFirstType;
+    Type conformanceKeyType = firstType;
+
+    if (auto *metatype = firstType->getAs<AnyMetatypeType>()) {
+      auto substInstanceType =
+          substTypeParameter(metatype->getInstanceType(),
+                             Position::ConformanceRequirement);
+
+      std::optional<MetatypeRepresentation> representation;
+      if (metatype->hasRepresentation())
+        representation = metatype->getRepresentation();
+
+      substFirstType =
+          isa<ExistentialMetatypeType>(metatype)
+              ? static_cast<Type>(ExistentialMetatypeType::get(substInstanceType,
+                                                               representation))
+              : static_cast<Type>(MetatypeType::get(substInstanceType,
+                                                    representation));
+      conformanceKeyType = metatype->getInstanceType();
+    } else {
+      substFirstType =
+          substTypeParameter(firstType, Position::ConformanceRequirement);
+    }
 
     auto *proto = req.getProtocolDecl();
 
@@ -402,7 +423,8 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
     // 'T : Sendable' would be incorrect; we want to ensure that we only admit
     // subclasses of 'C' which are 'Sendable'.
     bool allowMissing = false;
-    auto key = stripBoundDependentMemberTypes(firstType)->getCanonicalType();
+    auto key =
+        stripBoundDependentMemberTypes(conformanceKeyType)->getCanonicalType();
     if (ConcreteTypes.count(key) > 0)
       allowMissing = true;
 
@@ -420,8 +442,13 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
         // Handle the case of <T where T : P, T : C> where C is a class and
         // C does not conform to P and only substitute the parent type of T
         // by pretending we have a same-type requirement here.
-        substFirstType = substTypeParameter(
-            firstType, Position::SameTypeRequirement);
+        if (firstType->is<AnyMetatypeType>()) {
+          if (!allowMissing)
+            substFirstType = firstType;
+        } else {
+          substFirstType =
+              substTypeParameter(firstType, Position::SameTypeRequirement);
+        }
       }
     }
 
@@ -545,6 +572,18 @@ bool ConcreteContraction::performConcreteContraction(
   // subject type is a generic parameter.
   for (auto req : requirements) {
     auto subjectType = req.req.getFirstType();
+
+    // A metatype subject ('T.Type: P') is not a candidate for concrete
+    // contraction. We never fold the metatype itself to a concrete type, so
+    // skip it here and let it flow through to the rewrite system unchanged.
+    if (subjectType->is<AnyMetatypeType>()) {
+      ASSERT(subjectType->castTo<AnyMetatypeType>()
+                        ->getInstanceType()
+                        ->isTypeParameter() &&
+              "forgot to call desugarRequirement()");
+      continue;
+    }
+
     ASSERT(subjectType->isTypeParameter() &&
            "Forgot to call desugarRequirement()");
 

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -277,6 +277,10 @@ RequirementMachine::getLongestValidPrefix(const MutableTerm &term) const {
       ABORT([&](auto &out) {
         out << "Invalid symbol in a type term: " << term;
       });
+
+    case Symbol::Kind::Metatype:
+      // T.[metatype] is always a valid type term: any type has a metatype.
+      break;
     }
 
     // This symbol is valid, add it to the longest prefix.
@@ -830,6 +834,7 @@ void RequirementMachine::verify(const MutableTerm &term) const {
       case Symbol::Kind::ConcreteType:
       case Symbol::Kind::ConcreteConformance:
       case Symbol::Kind::Shape:
+      case Symbol::Kind::Metatype:
         ABORT([&](auto &out) {
           out << "Bad initial symbol in " << term;
         });
@@ -848,6 +853,7 @@ void RequirementMachine::verify(const MutableTerm &term) const {
       break;
 
     case Symbol::Kind::Shape:
+    case Symbol::Kind::Metatype:
       erased.add(symbol);
       break;
 

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -156,12 +156,20 @@ using namespace rewriting;
 ///
 MutableTerm RewriteContext::getMutableTermForType(CanType paramType,
                                                   const ProtocolDecl *proto) {
-  ASSERT(paramType->isTypeParameter());
-
   // Collect zero or more nested type names in reverse order.
   bool innermostAssocTypeWasResolved = false;
 
   SmallVector<Symbol, 3> symbols;
+
+  // Append one [metatype] symbol for each metatype layer, so 'T.Type' becomes
+  // 'T.[meatype]'. Reversing the collected symbols below preserves the order of
+  // nested metatypes such as 'T.Type.Type'.
+  while (auto metatypeType = dyn_cast<AnyMetatypeType>(paramType)) {
+    symbols.push_back(Symbol::forMetatype(*this));
+    paramType = metatypeType.getInstanceType();
+  }
+
+  ASSERT(paramType->isTypeParameter());
   while (auto memberType = dyn_cast<DependentMemberType>(paramType)) {
     paramType = memberType.getBase();
 
@@ -306,6 +314,13 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
           out << "Invalid root symbol: " << MutableTerm(begin, end);
         });
       }
+    }
+
+    // A [metatype] symbol turns the type accumulated into its metatype, so the
+    // term 'T.[metatype]' reconstructs as 'T.Type'.
+    if (symbol.getKind() == Symbol::Kind::Metatype) {
+      result = MetatypeType::get(result);
+      continue;
     }
 
     // An unresolved type can appear if we have invalid requirements.

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -299,6 +299,9 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
       case Symbol::Kind::ConcreteType:
       case Symbol::Kind::ConcreteConformance:
       case Symbol::Kind::Shape:
+        // A metatype symbol requires a type term before it, so it cannot appear
+        // first.
+      case Symbol::Kind::Metatype:
         ABORT([&](auto &out) {
           out << "Invalid root symbol: " << MutableTerm(begin, end);
         });

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -282,6 +282,9 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
     // 'Self' type).
     return nullptr;
 
+  case Symbol::Kind::Metatype:
+    return nullptr;
+
   case Symbol::Kind::Name:
   case Symbol::Kind::Layout:
   case Symbol::Kind::Superclass:
@@ -289,7 +292,6 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
   case Symbol::Kind::ConcreteConformance:
   case Symbol::Kind::Shape:
   case Symbol::Kind::PackElement:
-  case Symbol::Kind::Metatype:
     break;
   }
 

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -289,6 +289,7 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
   case Symbol::Kind::ConcreteConformance:
   case Symbol::Kind::Shape:
   case Symbol::Kind::PackElement:
+  case Symbol::Kind::Metatype:
     break;
   }
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -668,6 +668,7 @@ void PropertyMap::addProperty(
   case Symbol::Kind::AssociatedType:
   case Symbol::Kind::Shape:
   case Symbol::Kind::PackElement:
+  case Symbol::Kind::Metatype:
     break;
   }
 

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -230,6 +230,7 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
       case Symbol::Kind::GenericParam:
       case Symbol::Kind::Shape:
       case Symbol::Kind::PackElement:
+      case Symbol::Kind::Metatype:
         break;
       }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -389,7 +389,23 @@ static void desugarConformanceRequirement(
 
   // Fast path.
   if (constraintType->is<ProtocolType>()) {
-    if (req.getFirstType()->isTypeParameter()) {
+    // A type parameter or the metatype of one (e.g. 'T.Type: P', a metatype
+    // conformance) is a valid abstract subject.
+    auto subject = req.getFirstType();
+    bool subjectIsValid = subject->isTypeParameter();
+    if (auto *metatype = subject->getAs<AnyMetatypeType>()) {
+      // A metatype unconditionally conforms to the invertible protocols
+      // (Copyable, Escapable), so such a conformance requirement is vacuous.
+      // Drop it rather than recording a rewrite rule, matching how the
+      // always-satisfied default is elided for type parameters.
+      if (constraintType->castTo<ProtocolType>()
+                        ->getDecl()
+                        ->getInvertibleProtocolKind())
+        return;
+      subjectIsValid = metatype->getInstanceType()->isTypeParameter();
+    }
+
+    if (subjectIsValid) {
       result.push_back(req);
       return;
     }

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -201,6 +201,7 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
 RewriteContext::RewriteContext(ASTContext &ctx)
     : TheShapeSymbol(nullptr),
       ThePackElementSymbol(nullptr),
+      TheMetatypeSymbol(nullptr),
       Context(ctx),
       Stats(ctx.Stats),
       SymbolHistogram(Symbol::NumKinds),

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -51,6 +51,9 @@ class RewriteContext final {
   /// The singleton storage for pack element symbols.
   Symbol::Storage *ThePackElementSymbol;
 
+  /// The singleton storage for metatype symbols.
+  Symbol::Storage *TheMetatypeSymbol;
+
   /// Folding set for uniquing terms.
   llvm::FoldingSet<Term::Storage> Terms;
 

--- a/lib/AST/RequirementMachine/Rule.cpp
+++ b/lib/AST/RequirementMachine/Rule.cpp
@@ -75,6 +75,7 @@ const ProtocolDecl *Rule::isAnyConformanceRule() const {
     case Symbol::Kind::GenericParam:
     case Symbol::Kind::Shape:
     case Symbol::Kind::PackElement:
+    case Symbol::Kind::Metatype:
       break;
     }
 

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -33,6 +33,7 @@ const StringRef Symbol::Kinds[] = {
   "name",
   "shape",
   "pack_element",
+  "metatype",
   "layout",
   "super",
   "concrete"
@@ -92,6 +93,14 @@ struct Symbol::Storage final
 
   explicit Storage(ForPackElement shape) {
     Kind = Kind::PackElement;
+  }
+
+  /// A dummy type for overload resolution of the
+  /// `metatype` constructor for Storage.
+  struct ForMetatype {};
+
+  explicit Storage(ForMetatype shape) {
+    Kind = Kind::Metatype;
   }
 
   Storage(const ProtocolDecl *proto, Identifier name) {
@@ -340,6 +349,16 @@ Symbol Symbol::forPackElement(RewriteContext &ctx) {
   return (ctx.ThePackElementSymbol = symbol);
 }
 
+Symbol Symbol::forMetatype(RewriteContext &ctx) {
+  if (auto *symbol = ctx.TheMetatypeSymbol)
+    return symbol;
+
+  unsigned size = Storage::totalSizeToAlloc<unsigned, Term>(0, 0);
+  void *mem = ctx.Allocator.Allocate(size, alignof(Storage));
+  auto *symbol = new (mem) Storage(Storage::ForMetatype());
+  return (ctx.TheMetatypeSymbol = symbol);
+}
+
 /// Creates a layout symbol, representing a layout constraint.
 Symbol Symbol::forLayout(LayoutConstraint layout,
                          RewriteContext &ctx) {
@@ -490,6 +509,7 @@ const ProtocolDecl *Symbol::getRootProtocol() const {
   case Symbol::Kind::ConcreteType:
   case Symbol::Kind::ConcreteConformance:
   case Symbol::Kind::Shape:
+  case Symbol::Kind::Metatype:
     break;
   }
 
@@ -578,6 +598,12 @@ std::optional<int> Symbol::compare(Symbol other, RewriteContext &ctx) const {
     break;
   }
 
+  case Kind::Metatype:
+    // Payload-free singleton: two equal-kind metatype symbols are always
+    // pointer-identical, so this is caught before the switch; nothing to
+    // compare.
+    break;
+
   case Kind::Layout:
     result = getLayoutConstraint().compare(other.getLayoutConstraint());
     break;
@@ -650,6 +676,7 @@ Symbol Symbol::withConcreteSubstitutions(
   case Kind::Shape:
   case Kind::PackElement:
   case Kind::Layout:
+  case Kind::Metatype:
     break;
   }
 
@@ -780,6 +807,11 @@ void Symbol::dump(llvm::raw_ostream &out) const {
     out << "[element]";
     return;
   }
+
+  case Kind::Metatype: {
+    out << "[metatype]";
+    return;
+  }
   }
 
   llvm_unreachable("Bad symbol kind");
@@ -807,6 +839,7 @@ void Symbol::Storage::Profile(llvm::FoldingSetNodeID &id) const {
     return;
 
   case Symbol::Kind::Shape:
+  case Symbol::Kind::Metatype:
     // Nothing more to add.
     return;
 

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -32,10 +32,14 @@ const StringRef Symbol::Kinds[] = {
   "generic",
   "name",
   "shape",
+  "pack_element",
   "layout",
   "super",
   "concrete"
 };
+
+static_assert(static_cast<unsigned>(Symbol::Kind::ConcreteType) + 1 == Symbol::NumKinds);
+static_assert(sizeof(Symbol::Kinds) / sizeof(Symbol::Kinds[0]) == Symbol::NumKinds);
 
 /// Symbols are uniqued and immutable, stored as a single pointer;
 /// the Storage type is the allocated backing storage.

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -138,7 +138,7 @@ public:
     ConcreteType,
   };
 
-  static const unsigned NumKinds = 9;
+  static const unsigned NumKinds = 10;
 
   static const llvm::StringRef Kinds[];
 

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -121,6 +121,11 @@ public:
     /// parameter pack.
     PackElement,
 
+    /// Appending this symbol to the term for a type 'T' forms 'T.[metatype]',
+    /// which denotes 'T.Type'. The symbol carries no payload and is uniqued
+    /// once per rewrite context.
+    Metatype,
+
     //////
     ////// "Property-like" symbol kinds:
     //////
@@ -138,7 +143,7 @@ public:
     ConcreteType,
   };
 
-  static const unsigned NumKinds = 10;
+  static const unsigned NumKinds = 11;
 
   static const llvm::StringRef Kinds[];
 
@@ -211,6 +216,8 @@ public:
   static Symbol forShape(RewriteContext &ctx);
 
   static Symbol forPackElement(RewriteContext &Ctx);
+
+  static Symbol forMetatype(RewriteContext &Ctx);
 
   static Symbol forLayout(LayoutConstraint layout,
                           RewriteContext &ctx);

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -231,7 +231,15 @@ Type SubstitutionMap::lookupSubstitution(GenericTypeParamType *genericParam) con
 
 ProtocolConformanceRef
 SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
-  if (!type->isTypeParameter() || empty())
+  // The subject is normally a type parameter, but may be the metatype of one
+  // (e.g. 'T.Type: P'), whose instance is then the type parameter.
+  auto subjectIsAbstract = [](CanType type) {
+    if (auto *metatype = type->getAs<AnyMetatypeType>())
+      return metatype->getInstanceType()->isTypeParameter();
+    return type->isTypeParameter();
+  };
+
+  if (!subjectIsAbstract(type) || empty())
     return ProtocolConformanceRef::forInvalid();
 
   auto genericSig = getGenericSignature();

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -194,12 +194,13 @@ public:
     return new FixedSizeArchetypeTypeInfo(type, size, align, spareBits);
   }
 };
-} // end anonymous namespace
 
-/// Emit a single protocol witness table reference.
-llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
-                                                 CanArchetypeType archetype,
-                                                 ProtocolDecl *protocol) {
+/// Emit a single protocol witness table reference for an abstract type.
+llvm::Value *
+emitAbstractWitnessTableRef(IRGenFunction &IGF, CanType type,
+                            CanType dependentType,
+                            GenericEnvironment *environment,
+                            ProtocolDecl *protocol) {
   assert(Lowering::TypeConverter::protocolRequiresWitnessTable(protocol) &&
          "looking up witness table for protocol that doesn't have one");
 
@@ -210,14 +211,12 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
   // that protocol listed as a direct requirement.
 
   auto localDataKind =
-    LocalTypeDataKind::forAbstractProtocolWitnessTable(protocol);
+      LocalTypeDataKind::forAbstractProtocolWitnessTable(protocol);
 
   // Check immediately for an existing cache entry.
   // TODO: don't give this absolute precedence over other access paths.
-  auto wtable = IGF.tryGetLocalTypeData(archetype, localDataKind);
+  auto wtable = IGF.tryGetLocalTypeData(type, localDataKind);
   if (wtable) return wtable;
-
-  auto environment = archetype->getGenericEnvironment();
 
   // Otherwise, ask the generic signature for the best path to the conformance.
   // TODO: this isn't necessarily optimal if the direct conformance isn't
@@ -225,17 +224,16 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
   // to this conformance from concrete sources.
 
   auto signature = environment->getGenericSignature().getCanonicalSignature();
-  auto archetypeDepType = archetype->getInterfaceType();
 
-  auto astPath = signature->getConformancePath(archetypeDepType, protocol);
+  auto astPath = signature->getConformancePath(dependentType, protocol);
 
   auto i = astPath.begin(), e = astPath.end();
   assert(i != e && "empty path!");
 
   // The first entry in the path is a direct requirement of the signature,
   // for which we should always have local type data available.
-  CanType rootArchetype =
-    environment->mapTypeIntoEnvironment(i->first)->getCanonicalType();
+  CanType rootType =
+      environment->mapTypeIntoEnvironment(i->first)->getCanonicalType();
   ProtocolDecl *rootProtocol = i->second;
 
   // Turn the rest of the path into a MetadataPath.
@@ -268,14 +266,13 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
   }
   assert(lastProtocol == protocol);
 
-  auto rootWTable = IGF.tryGetLocalTypeData(rootArchetype,
-              LocalTypeDataKind::forAbstractProtocolWitnessTable(rootProtocol));
+  auto kind = LocalTypeDataKind::forAbstractProtocolWitnessTable(rootProtocol);
+  auto rootWTable = IGF.tryGetLocalTypeData(rootType, kind);
   // Fetch an opaque type's witness table if it wasn't cached yet.
   if (!rootWTable) {
-    if (auto opaqueRoot = dyn_cast<OpaqueTypeArchetypeType>(rootArchetype)) {
-      rootWTable = emitOpaqueTypeWitnessTableRef(IGF, opaqueRoot,
-                                                 rootProtocol);
-    }
+    if (auto opaqueRoot = dyn_cast<OpaqueTypeArchetypeType>(rootType))
+      rootWTable = emitOpaqueTypeWitnessTableRef(IGF, opaqueRoot, rootProtocol);
+
 #ifndef NDEBUG
     if (!rootWTable) {
       llvm::errs()
@@ -284,13 +281,12 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
              "to be passed to the function.\n"
           << "  Or the witness table is present and not bound in which case "
              "setScopedLocalTypeData or similar must be called.\n";
-      llvm::errs() << "Root archetype for conformance: " << rootArchetype
-                   << "\n";
-      rootArchetype->dump(llvm::errs());
+      llvm::errs() << "Root type for conformance: " << rootType << "\n";
+      rootType->dump(llvm::errs());
       llvm::errs() << "Root protocol without wtable: " << rootProtocol << "\n";
       rootProtocol->dump(llvm::errs());
-      llvm::errs() << "Archetype for conformance: " << archetype << "\n";
-      archetype->dump(llvm::errs());
+      llvm::errs() << "Abstract type for conformance: " << type << "\n";
+      type->dump(llvm::errs());
       llvm::errs() << "Protocol for conformance: " << protocol << "\n";
       protocol->dump(llvm::errs());
       llvm::errs() << "Function:\n";
@@ -306,16 +302,41 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
     assert(rootWTable && "root witness table not bound in local context!");
   }
 
-  auto conformance = ProtocolConformanceRef::forAbstract(
-      rootArchetype, rootProtocol);
-  wtable = path.followFromWitnessTable(IGF, rootArchetype,
-                                       conformance,
+  auto conformance =
+      ProtocolConformanceRef::forAbstract(rootType, rootProtocol);
+  wtable = path.followFromWitnessTable(IGF, rootType, conformance,
                                        MetadataResponse::forComplete(rootWTable),
                                        /*request*/ MetadataState::Complete,
                                        nullptr).getMetadata();
 
-  IGF.setScopedLocalTypeData(archetype, localDataKind, wtable);
+  IGF.setScopedLocalTypeData(type, localDataKind, wtable);
   return wtable;
+}
+
+} // end anonymous namespace
+
+/// Emit a single protocol witness table reference.
+llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
+                                                 CanArchetypeType archetype,
+                                                 ProtocolDecl *protocol) {
+  CanType dependentType = archetype->getInterfaceType()->getCanonicalType();
+  return emitAbstractWitnessTableRef(IGF, archetype, dependentType,
+                                     archetype->getGenericEnvironment(),
+                                     protocol);
+}
+
+llvm::Value *
+irgen::emitArchetypeMetatypeWitnessTableRef(IRGenFunction &IGF,
+                                            CanType metatype,
+                                            ProtocolDecl *protocol) {
+  CanType instanceType =
+      cast<AnyMetatypeType>(metatype)->getInstanceType()->getCanonicalType();
+  CanArchetypeType archetype = cast<ArchetypeType>(instanceType);
+  CanType dependentType =
+      MetatypeType::get(archetype->getInterfaceType())->getCanonicalType();
+  return emitAbstractWitnessTableRef(IGF, metatype, dependentType,
+                                     archetype->getGenericEnvironment(),
+                                     protocol);
 }
 
 MetadataResponse

--- a/lib/IRGen/GenArchetype.h
+++ b/lib/IRGen/GenArchetype.h
@@ -48,6 +48,11 @@ namespace irgen {
                                             CanArchetypeType archetype,
                                             ProtocolDecl *protocol);
 
+  /// Emit a witness table reference for a metatype of an archetype.
+  llvm::Value *
+  emitArchetypeMetatypeWitnessTableRef(IRGenFunction &IGF, CanType metatype,
+                                       ProtocolDecl *protocol);
+
   /// Emit a metadata reference for an associated type of an archetype.
   MetadataResponse emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                                  CanArchetypeType origin,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3904,6 +3904,16 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
   // requirements of the archetype. Look at what's locally bound.
   ProtocolConformance *concreteConformance;
   if (conformance.isAbstract()) {
+    // An abstract conformance whose conforming type is a metatype rather than
+    // an archetype arises from a `where T.Type: P` requirement. Its root
+    // witness table is supplied as a generic argument and bound against the
+    // metatype itself. Derive inherited protocol tables through the signature's
+    // conformance access path.
+    if (!isa<ArchetypeType>(srcType)) {
+      assert(srcType->is<AnyMetatypeType>());
+      return emitArchetypeMetatypeWitnessTableRef(IGF, srcType, proto);
+    }
+
     auto archetype = cast<ArchetypeType>(srcType);
     return emitArchetypeWitnessTableRef(IGF, archetype, proto);
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3564,6 +3564,12 @@ emitWitnessTableForLoweredCallee(IRGenSILFunction &IGF,
   auto substConformance =
       substCalleeType->getWitnessMethodConformanceOrInvalid();
 
+  // For a conformance of a protocol metatype itself (e.g. from `T.Type: P`)
+  // the conforming type is the metatype, not its instance.
+  if (substConformance && substConformance.getType() &&
+      substConformance.getType()->is<AnyMetatypeType>())
+    substSelfType = substConformance.getType()->getCanonicalType();
+
   llvm::Value *argMetadata = IGF.emitTypeMetadataRef(substSelfType);
   llvm::Value *wtable =
     emitWitnessTableRef(IGF, substSelfType, &argMetadata, substConformance);

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4551,7 +4551,13 @@ public:
       require(AMI->getTypeDependentOperands().empty() || lookupType->hasLocalArchetype(),
               "Should not have an operand for the opened existential");
     }
-    if (!isa<ArchetypeType>(lookupType) && !isa<DynamicSelfType>(lookupType)) {
+    bool isArchetypeMetatype = false;
+    // The metatype of an archetype (e.g. 'T.Type' for a 'T.Type: P'
+    // requirement) uses an abstract metatype conformance, like an archetype.
+    if (auto metatype = dyn_cast<AnyMetatypeType>(lookupType))
+      isArchetypeMetatype = isa<ArchetypeType>(metatype.getInstanceType());
+    if (!isa<ArchetypeType>(lookupType) && !isa<DynamicSelfType>(lookupType) &&
+        !isArchetypeMetatype) {
       require(AMI->getConformance().isConcrete(),
               "concrete type lookup requires concrete conformance");
       auto conformance = AMI->getConformance().getConcrete();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1873,11 +1873,27 @@ namespace {
         return forceUnwrapIfExpected(ref, memberLocator);
       }
 
+      // `T.x`, where `T.Type: P` and `x` is a requirement of `P`, applies `x`
+      // to the metatype value. Do not treat it as an unbound instance reference
+      // such as `P.x`.
+      bool isMetatypeConformanceMember = false;
+      if (!baseIsInstance && member->isInstanceMember()) {
+        if (auto *PD = dyn_cast<ProtocolDecl>(member->getDeclContext())) {
+          auto conformance =
+              cs.lookupConformance(cs.getType(base)->getRValueType(), PD);
+
+          // A missing conformance represents the ordinary unbound-reference
+          // case.
+          isMetatypeConformanceMember =
+              conformance && !conformance.hasMissingConformance();
+        }
+      }
+
       const bool isMetatypeExtMember =
           member->getDeclContext()->isMetatypeExtension();
       const bool isUnboundInstanceMember =
           (!baseIsInstance && member->isInstanceMember() &&
-           !isMetatypeExtMember);
+           !isMetatypeExtMember && !isMetatypeConformanceMember);
       const bool needsCurryThunk =
           shouldBuildCurryThunk(choice, baseIsInstance);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -193,6 +193,14 @@ bool constraints::doesMemberRefApplyCurriedSelf(Type baseTy,
         baseTy->getRValueType()->is<AnyMetatypeType>()) {
       if (decl->getDeclContext()->isMetatypeExtension())
         return true;
+      // `T.f()` where `T.Type: P` applies the metatype as `self`. A missing
+      // conformacne denotes an unbound reference such as `Q.f`.
+      if (auto *PD = dyn_cast<ProtocolDecl>(decl->getDeclContext())) {
+        auto conformance = lookupConformance(baseTy->getRValueType(), PD,
+                                             /*allowMissing=*/true);
+        if (conformance && !conformance.hasMissingConformance())
+          return true;
+      }
       return false;
     }
   }
@@ -9050,6 +9058,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   if (type->isTypeVariableOrMember())
     return formUnsolved();
 
+  // Wai tuntil the instance type of an unresolved metatype is known.
+  if (auto *metatype = type->getAs<AnyMetatypeType>())
+    if (metatype->getInstanceType()->isTypeVariableOrMember())
+      return formUnsolved();
+
   // If we have a function type and are checking for Sendable conformance we
   // need to delay if we have Sendable dependence.
   if (auto *fnTy = type->getAs<FunctionType>()) {
@@ -10678,6 +10691,10 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // have already been excluded.
   llvm::SmallPtrSet<ValueDecl *, 2> excludedDynamicMembers;
 
+  // Protocol requirements found through a metatype conformance are viable
+  // directly on the metatype base.
+  llvm::SmallPtrSet<ValueDecl *, 2> metatypeConformanceMembers;
+
   // Local function that adds the given declaration if it is a
   // reasonable choice.
   auto addChoice = [&](OverloadChoice candidate) {
@@ -10802,6 +10819,13 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         // metatype type itself.  They are accessed directly on the protocol
         // metatype value (e.g. P.value), not on an instance of the protocol.
         if (decl->getDeclContext()->isMetatypeExtension()) {
+          result.addViable(candidate);
+          return;
+        }
+
+        // This requirement was found through a conformance of the metatype, so
+        // do not perform the usual adjustment to the instance type.
+        if (metatypeConformanceMembers.count(decl)) {
           result.addViable(candidate);
           return;
         }
@@ -11066,6 +11090,32 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     addChoice(getOverloadChoice(result.getValueDecl(),
                                 /*isBridged=*/false,
                                 /*isUnwrappedOptional=*/false));
+
+  // Include requirements of protocols to which the metatype conforms.
+  if (baseObjTy->is<AnyMetatypeType>()) {
+    if (auto signature = DC->getGenericSignatureOfContext()) {
+      for (const auto &requirement : signature.getRequirements()) {
+        if (requirement.getKind() != RequirementKind::Conformance ||
+            !requirement.getFirstType()->is<AnyMetatypeType>())
+          continue;
+        if (!DC->mapTypeIntoEnvironment(requirement.getFirstType())
+               ->isEqual(baseObjTy))
+          continue;
+
+        SmallVector<ValueDecl *, 4> members;
+        DC->lookupQualified(requirement.getProtocolDecl(),
+                            DeclNameRef(lookupName.getFullName()), SourceLoc(),
+                            NLFlags::QualifiedDefault, members);
+        for (auto *member : members) {
+          if (auto *VD = dyn_cast<ValueDecl>(member)) {
+            metatypeConformanceMembers.insert(VD);
+            addChoice(getOverloadChoice(VD, /*isBridged=*/false,
+                                        /*isUnwrappedOptional=*/false));
+          }
+        }
+      }
+    }
+  }
 
   // Backward compatibility hack. In Swift 4, `init` and init were
   // the same name, so you could write "foo.init" to look up a

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2050,7 +2050,19 @@ ConstraintSystem::getTypeOfMemberReferencePre(
     // For a protocol, substitute the base object directly. We don't need a
     // conformance constraint because we wouldn't have found the declaration
     // if it didn't conform.
-    addConstraint(ConstraintKind::Bind, baseOpenedTy, selfObjTy,
+
+    // A requirement found through 'T.Type: P' binds 'Self' to 'T.Type' rather
+    // than to 'T'.
+    Type selfBase = baseOpenedTy;
+    if (value->isInstanceMember() && baseRValueTy->is<AnyMetatypeType>()) {
+      if (auto *PD = dyn_cast<ProtocolDecl>(value->getDeclContext())) {
+        auto conformance = lookupConformance(baseRValueTy, PD);
+        if (conformance && !conformance.hasMissingConformance())
+          selfBase = baseRValueTy;
+      }
+    }
+
+    addConstraint(ConstraintKind::Bind, selfBase, selfObjTy,
                   getConstraintLocator(locator), /*isFavored=*/false,
                   preparedOverload);
   } else if (!isDynamicLookup && !isInvalidMetatypeExtensionMemberRef) {

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -522,3 +522,4 @@ $sIeg_BAIegHgIL_TR ---> {T:} reabstraction thunk helper from @escaping @callee_g
 $sSiBW ---> Builtin.Borrow<Swift.Int>
 $sBAIeNghHgIL_BAytIeNghHgILr_TR ---> {T:} reabstraction thunk helper from @escaping @caller_isolated @callee_guaranteed @Sendable @async (@guaranteed Builtin.ImplicitActor) -> () to @escaping @caller_isolated @callee_guaranteed @Sendable @async (@guaranteed Builtin.ImplicitActor) -> (@out ())
 $s4main12testCallOnceyyyyXOnF ---> main.testCallOnce(__owned @called(once) () -> ()) -> ()
+$s1M1fyyxmAA1PxmRQlF ---> M.f<A where A.Type: M.P>(A.Type) -> ()

--- a/test/Generics/metatype_conformance_contraction.swift
+++ b/test/Generics/metatype_conformance_contraction.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P { }
+struct S { }
+
+// Concrete contraction must substitute through the metatype subject rather than
+// leaving `T.Type : P` unreduced and aborting signature verification.
+func f<T>(_: T.Type) where T == S, T.Type: P { }
+// expected-warning@-1 {{same-type requirement makes generic parameter 'T' non-generic; this is an error in the Swift 6 language mode}}
+// expected-error@-2 {{type 'S.Type' in conformance requirement does not refer to a generic parameter or associated type}}

--- a/test/Generics/metatype_conformance_requirement.swift
+++ b/test/Generics/metatype_conformance_requirement.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+protocol P { }
+struct S<T> { }
+
+// CHECK-LABEL: .f@
+// CHECK-NEXT:  Generic signature: <T where T.Type : P>
+func f<T>(_: T.Type) where T.Type: P { }
+
+// CHECK-LABEL: .g@
+// CHECK-NEXT:  Generic signature: <T where T.Type : P>
+func g<T>(_: T) where T.Type: P { }
+
+// CHECK-LABEL: .h@
+// CHECK-NEXT:  Generic signature: <T>
+func h<T>(_: S<T.Type>) { }

--- a/test/IRGen/metatype_conformance_requirement.swift
+++ b/test/IRGen/metatype_conformance_requirement.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -module-name Test -parse-as-library -emit-ir %s -o - | %FileCheck %s
+
+protocol P {
+  func method()
+}
+
+protocol Q: P {
+}
+
+func f<T>(_: T.Type) where T.Type: Q {
+  T.method()
+}
+
+// CHECK-LABEL: define {{.*}}f
+
+// Obtain the inherited T.Type: P witness table from the directly available
+// T.Type: Q witness table.
+
+// CHECK: [[P_SLOT:%.*]] = getelementptr inbounds ptr, ptr %T.Type.Q, i32 1
+// CHECK: [[P_WTABLE:%.*]] = load ptr, ptr [[P_SLOT]]
+
+// Load P.method from the inherited witness table.
+// CHECK: [[METHOD_SLOT:%.*]] = getelementptr inbounds ptr, ptr [[P_WTABLE]], i32 1
+// CHECK: [[METHOD:%.*]] = load ptr, ptr [[METHOD_SLOT]]
+
+// Dispatch using the T.Type: P witness table.
+// CHECK: call swiftcc void [[METHOD]]({{.*}}ptr [[P_WTABLE]])

--- a/test/SILGen/metatype_conformance_requirement.swift
+++ b/test/SILGen/metatype_conformance_requirement.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -verify -sil-verify-all %s | %FileCheck %s
+
+protocol P {
+  func method()
+}
+
+struct Storage<Value> {
+  var value: Value
+}
+
+struct Outer<T> where T.Type: P {
+  struct Nested {
+    var value: T?
+  }
+
+  // Forming Nested's context substitution map must preserve the abstract
+  // T.Type: P conformance inherited from Outer.
+  var storage: Storage<Nested>
+}
+
+// CHECK-LABEL: sil {{.*}}invoke
+// CHECK: witness_method $T.Type, #P.method
+func invoke<T>(_: T.Type) where T.Type: P {
+  T.method()
+}

--- a/test/Sema/metatype_conformance_requirement.swift
+++ b/test/Sema/metatype_conformance_requirement.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+protocol P {
+  var identifier: Int { get }
+  func describe() -> String
+}
+
+protocol Q: P {
+}
+
+// expected-note@+1{{required by global function 'property' where 'T.Type' = 'S.Type'}}
+func property<T>(_: T.Type) -> Int where T.Type: P {
+  T.identifier
+}
+
+func method<T>(_: T.Type) -> String where T.Type: P {
+  T.describe()
+}
+
+func forward<T>(_ t: T.Type) -> Int where T.Type: P {
+  property(t)
+}
+
+func refined<T>(_: T.Type) -> String where T.Type: Q {
+  T.describe()
+}
+
+func unknown<T>(_: T.Type) where T.Type: P {
+  // expected-error@+1{{type 'T' has no member 'nonexistent'}}
+  _ = T.nonexistent
+}
+
+func unrequired<T>(_: T.Type) {
+  // expected-error@+1{{type 'T' has no member 'identifier'}}
+  _ = T.identifier
+}
+
+struct S {
+}
+
+func f() {
+  // expected-error@+2{{type 'S.Type' cannot conform to 'P'}}
+  // expected-note@+1{{only concrete types such as structs, enums and classes can conform to protocols}}
+  _ = property(S.self)
+}

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -4,12 +4,13 @@ add_swift_unittest(SwiftASTTests
   ASTWalkerTests.cpp
   AvailabilityContextTests.cpp
   AvailabilityDomainTests.cpp
-  IndexSubsetTests.cpp
   DiagnosticBehaviorTests.cpp
   DiagnosticConsumerTests.cpp
   DiagnosticGroupsTests.cpp
   DiagnosticFormattingTests.cpp
   DiagnosticInfoTests.cpp
+  GenericSignatureTests.cpp
+  IndexSubsetTests.cpp
   SourceLocTests.cpp
   TestContext.cpp
   TypeMatchTests.cpp

--- a/unittests/AST/GenericSignatureTests.cpp
+++ b/unittests/AST/GenericSignatureTests.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Requirement.h"
+#include "swift/AST/Types.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::unittest;
+
+TEST(GenericSignature, MetatypeRequirementQueries) {
+  TestContext C;
+  ASTContext &Context = C.Ctx;
+
+  ProtocolDecl *protocol = C.makeProtocol("P");
+  GenericTypeParamType *T = GenericTypeParamType::getType(0, 0, Context);
+  Type metatype = MetatypeType::get(T);
+
+  auto signature =
+      buildGenericSignature(Context, nullptr, {T},
+                            {Requirement(RequirementKind::Conformance, metatype,
+                                         protocol->getDeclaredInterfaceType())},
+                            DefaultRequirementOptions());
+
+  EXPECT_TRUE(signature->requiresProtocol(metatype, protocol));
+
+  auto protocols = signature->getRequiredProtocols(metatype);
+  ASSERT_EQ(protocols.size(), 1u);
+  ASSERT_EQ(protocols.front(), protocol);
+
+  auto requirements = signature->getLocalRequirements(metatype);
+  ASSERT_EQ(requirements.protos.size(), 1u);
+  EXPECT_EQ(requirements.protos.front(), protocol);
+  EXPECT_FALSE(requirements.superclass);
+  EXPECT_FALSE(requirements.layout);
+  EXPECT_FALSE(requirements.packShape);
+}

--- a/unittests/AST/GenericSignatureTests.cpp
+++ b/unittests/AST/GenericSignatureTests.cpp
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "TestContext.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Requirement.h"
 #include "swift/AST/Types.h"
@@ -46,4 +48,52 @@ TEST(GenericSignature, MetatypeRequirementQueries) {
   EXPECT_FALSE(requirements.superclass);
   EXPECT_FALSE(requirements.layout);
   EXPECT_FALSE(requirements.packShape);
+}
+
+TEST(GenericSignature, AbstractMetatypeConformance) {
+  TestContext C;
+  ASTContext &Context = C.Ctx;
+
+  ProtocolDecl *protocol = C.makeProtocol("P");
+  GenericTypeParamType *T = GenericTypeParamType::getType(0, 0, Context);
+  Type metatype = MetatypeType::get(T);
+
+  auto signature =
+      buildGenericSignature(Context, nullptr, {T},
+                            {Requirement(RequirementKind::Conformance, metatype,
+                                         protocol->getDeclaredInterfaceType())},
+                            DefaultRequirementOptions());
+
+  // A metatype requirement can be represented by an abstract conformance.
+  auto conformance = ProtocolConformanceRef::forAbstract(metatype, protocol);
+
+  ASSERT_TRUE(conformance);
+  EXPECT_TRUE(conformance.isAbstract());
+
+  // Looking up the requirement before mapping it into an environment must
+  // preserve the abstract metatype conformance.
+  auto interfaceConformance = lookupConformance(metatype, protocol);
+  ASSERT_TRUE(interfaceConformance);
+  EXPECT_TRUE(interfaceConformance.isAbstract());
+
+  // A substitution map can retrieve the conformance for a metatype subject.
+  llvm::SmallVector<Type, 1> replacements{T};
+  llvm::SmallVector<ProtocolConformanceRef, 1> conformances{conformance};
+
+  auto substitutions =
+      SubstitutionMap::get(signature, replacements, conformances);
+
+  auto substituted =
+      substitutions.lookupConformance(metatype->getCanonicalType(), protocol);
+  ASSERT_TRUE(substituted);
+  EXPECT_TRUE(substituted.isAbstract());
+
+  auto *environment = signature.getGenericEnvironment();
+  ASSERT_NE(environment, nullptr);
+
+  Type archetype = environment->mapTypeIntoEnvironment(T);
+
+  auto lookup = lookupConformance(MetatypeType::get(archetype), protocol);
+  ASSERT_TRUE(lookup);
+  EXPECT_TRUE(lookup.isAbstract());
 }

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -13,6 +13,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/RequirementSignature.h"
 #include "swift/AST/SILOptions.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/SourceFile.h"
@@ -91,6 +92,17 @@ public:
     return result;
   }
 
+  ProtocolDecl *makeProtocol(StringRef name) {
+    ProtocolDecl *result =
+        new (Ctx) ProtocolDecl(FileForLookups, SourceLoc(), SourceLoc(),
+                               Ctx.getIdentifier(name),
+                               /*primaryAssociatedTypeNames=*/{},
+                               /*inherited=*/{}, /*trailingWhere=*/nullptr);
+    result->setImplicit();
+    result->setAccess(AccessLevel::Internal);
+    result->setRequirementSignature(RequirementSignature());
+    return result;
+  }
 };
 
 } // end namespace unittest


### PR DESCRIPTION
This pull request extends Swift's generic signature and requirement machinery to support requirements where the subject is a metatype of a type parameter (e.g., `T.Type: P`). This enables more expressive generic constraints and ensures correct conformance checking and canonicalization for metatype subjects. The changes are carefully integrated across the AST, requirement machine, and related infrastructure to handle metatypes as first-class requirement subjects.

Key changes include:

**Generic Signature and Requirement Handling Enhancements:**

* Updated `GenericSignature` and related assertion logic to recognize and validate metatypes of type parameters as valid requirement subjects, ensuring that requirements like `T.Type: P` are properly supported. [[1]](diffhunk://#diff-b447c8aaea41999882aae22a7d3230dd6d55d0a9e65d38f8f67f998570cf7fdcR377-R391) [[2]](diffhunk://#diff-b447c8aaea41999882aae22a7d3230dd6d55d0a9e65d38f8f67f998570cf7fdcL413-R430) [[3]](diffhunk://#diff-b447c8aaea41999882aae22a7d3230dd6d55d0a9e65d38f8f67f998570cf7fdcR906-R921) [[4]](diffhunk://#diff-b447c8aaea41999882aae22a7d3230dd6d55d0a9e65d38f8f67f998570cf7fdcL932-R966) [[5]](diffhunk://#diff-b447c8aaea41999882aae22a7d3230dd6d55d0a9e65d38f8f67f998570cf7fdcL977-R1017) [[6]](diffhunk://#diff-e72124ba4cb2914331ccb632f0fb6e8ed4bcd0adbd08bd866e937d9e6eca3d15L6404-R6414)
* Improved canonical ordering and comparison of dependent types to account for metatypes, ensuring that a bare type parameter orders before its metatype (so `'T' < 'T.Type'`). [[1]](diffhunk://#diff-b447c8aaea41999882aae22a7d3230dd6d55d0a9e65d38f8f67f998570cf7fdcR906-R921) [[2]](diffhunk://#diff-b447c8aaea41999882aae22a7d3230dd6d55d0a9e65d38f8f67f998570cf7fdcL932-R966)

**Protocol Conformance and Lookup:**

* Modified protocol conformance lookup to handle metatypes of type parameters, preserving abstract conformance behavior and ensuring correct handling in generic environments. [[1]](diffhunk://#diff-5e3c624d440ee19cdc8e908dddd0fc64abd4732f295238ca5450ddbe232f70d5R499-R526) [[2]](diffhunk://#diff-e72124ba4cb2914331ccb632f0fb6e8ed4bcd0adbd08bd866e937d9e6eca3d15R6299-R6302)

**Requirement Machine and Rewrite System:**

* Extended the requirement machine and rewrite system to support metatype symbols, allowing metatypes to be represented in rewrite terms (e.g., `'T.[metatype]'`), and updated related logic for term construction, verification, and property mapping. [[1]](diffhunk://#diff-9c3230947fb1a64b084e85793c155193d84caf2c753bf9cb011c1e0a95cf911dL159-R172) [[2]](diffhunk://#diff-9c3230947fb1a64b084e85793c155193d84caf2c753bf9cb011c1e0a95cf911dR310-R325) [[3]](diffhunk://#diff-3a15a72873d47975e984f5d44e40b1d354f690a87059514adb296068095c8feaR280-R283) [[4]](diffhunk://#diff-3a15a72873d47975e984f5d44e40b1d354f690a87059514adb296068095c8feaR837) [[5]](diffhunk://#diff-3a15a72873d47975e984f5d44e40b1d354f690a87059514adb296068095c8feaR856) [[6]](diffhunk://#diff-66fa844c5b20e5434f50d2286adb62dc5dacfa12bec1ace30a95c4253186668aR285-R287) [[7]](diffhunk://#diff-9a0d6ff7d015c89eb99a60790d70f38cf1a0165896a7fff689fbfae9e907b965R671) [[8]](diffhunk://#diff-47f45c3f4fb767946e90e9c2d17f359464b7dc4f12d5e58206795f422ff8e6dfR233) [[9]](diffhunk://#diff-2243bec19cfd3ac7199f9358fc434d8babd49f301a1c90e5fa0693891354fab0R204) [[10]](diffhunk://#diff-960f97bd6d7dba623e7a690d4e2ccb21b6bd1a79e6ff60754c57e2b1130d4af4R54-R56)

**Requirement Substitution and Lowering:**

* Updated requirement substitution and lowering logic to correctly substitute and handle metatype subjects in conformance requirements, ensuring that metatype requirements are properly propagated and not erroneously contracted or rewritten. [[1]](diffhunk://#diff-b1be1b1042e10d27536ce83da25002785b59d6785a808950e2c14c0471bdf4ffL391-R413) [[2]](diffhunk://#diff-b1be1b1042e10d27536ce83da25002785b59d6785a808950e2c14c0471bdf4ffL405-R427) [[3]](diffhunk://#diff-b1be1b1042e10d27536ce83da25002785b59d6785a808950e2c14c0471bdf4ffL423-R451) [[4]](diffhunk://#diff-b1be1b1042e10d27536ce83da25002785b59d6785a808950e2c14c0471bdf4ffR575-R586) [[5]](diffhunk://#diff-a9ca34d37cc71819dc3388f0d58248d1c8d4d78597584e7585323501bde83620L392-R408)

**AST Mangling:**

* Enhanced AST mangling to correctly mangle metatype requirement subjects, using the substitution-style requirement operator for metatypes.

These changes collectively make metatypes of type parameters first-class citizens in Swift's generic signature system, enabling more powerful and expressive generic programming patterns.