### PR TITLE
Sema: Consider toll-free bridging in type join implementation

### DIFF
--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -710,6 +710,31 @@ static ClassDecl *getBridgedObjCClass(ClassDecl *classDecl) {
   return nullptr;
 }
 
+static void unwrapTollFreeBridging(Type &lhs, Type &rhs) {
+  auto *lhsDecl = lhs->getClassOrBoundGenericClass();
+  auto *rhsDecl = rhs->getClassOrBoundGenericClass();
+
+  if (lhsDecl == nullptr || rhsDecl == nullptr)
+    return;
+
+  // Toll-free bridging CF -> ObjC.
+  if (lhsDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
+      rhsDecl->getForeignClassKind() != ClassDecl::ForeignKind::CFType) {
+    if (auto *lhsBridged = getBridgedObjCClass(lhsDecl)) {
+      lhs = lhsBridged->getDeclaredInterfaceType();
+      ASSERT(!lhs->hasTypeParameter());
+    }
+
+  // Toll-free bridging ObjC -> CF.
+  } else if (lhsDecl->getForeignClassKind() != ClassDecl::ForeignKind::CFType &&
+             rhsDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
+    if (auto *rhsBridged = getBridgedObjCClass(rhsDecl)) {
+      rhs = rhsBridged->getDeclaredInterfaceType();
+      ASSERT(!rhs->hasTypeParameter());
+    }
+  }
+}
+
 static bool isCovariantInstanceType(Type t) {
   return t->getClassOrBoundGenericClass() ||
          t->is<ArchetypeType>();
@@ -743,48 +768,24 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
     }
 
     case ConversionBehavior::Class: {
+      unwrapTollFreeBridging(lhs, rhs);
+
       // Unwrap DynamicSelfType.
-      bool lhsWasSelf = false;
-      if (auto *lhsSelf = lhs->getAs<DynamicSelfType>()) {
-        lhsWasSelf = true;
-        lhs = lhsSelf->getSelfType();
+      Type lhsSelf;
+      if (auto *dynamicSelf = lhs->getAs<DynamicSelfType>()) {
+        lhsSelf = dynamicSelf->getSelfType();
       }
 
-      bool rhsWasSelf = false;
-      if (auto *rhsSelf = rhs->getAs<DynamicSelfType>()) {
-        rhsWasSelf = true;
-        rhs = rhsSelf->getSelfType();
+      Type rhsSelf;
+      if (auto *dynamicSelf = rhs->getAs<DynamicSelfType>()) {
+        rhsSelf = dynamicSelf->getSelfType();
       }
 
       // DynamicSelfType-to-DynamicSelfType conversions are exact.
-      if (lhsWasSelf && rhsWasSelf) {
-        auto result = isLikelyExactMatch(lhs, rhs);
+      if (lhsSelf && rhsSelf) {
+        auto result = isLikelyExactMatch(lhsSelf, rhsSelf);
         if (result.has_value() && !*result)
           return ConflictFlag::Class;
-      }
-
-      // No conversions to DynamicSelfType.
-      if (rhsWasSelf)
-        return ConflictFlag::Class;
-
-      auto *lhsDecl = lhs->getClassOrBoundGenericClass();
-      auto *rhsDecl = rhs->getClassOrBoundGenericClass();
-
-      // Toll-free bridging CF -> ObjC.
-      if (lhsDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
-          rhsDecl->getForeignClassKind() != ClassDecl::ForeignKind::CFType) {
-        if (auto *lhsBridged = getBridgedObjCClass(lhsDecl)) {
-          lhs = lhsBridged->getDeclaredInterfaceType();
-          ASSERT(!lhs->hasTypeParameter());
-        }
-
-      // Toll-free bridging ObjC -> CF.
-      } else if (lhsDecl->getForeignClassKind() != ClassDecl::ForeignKind::CFType &&
-                 rhsDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
-        if (auto *rhsBridged = getBridgedObjCClass(rhsDecl)) {
-          rhs = rhsBridged->getDeclaredInterfaceType();
-          ASSERT(!rhs->hasTypeParameter());
-        }
       }
 
       // Check for a subclassing relationship.
@@ -1404,7 +1405,7 @@ static Type subtypeJoinMeetImpl(Operation op, Type lhs, Type rhs,
     }
 
     case ConversionBehavior::Class: {
-      // FIXME: CF toll-free bridging
+      unwrapTollFreeBridging(lhs, rhs);
 
       auto result = superclassJoinMeetImpl(op, lhs, rhs);
       if (result)

--- a/test/Constraints/rdar181264379.swift
+++ b/test/Constraints/rdar181264379.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: objc_interop
+import Foundation
+import CoreFoundation
+
+let n: NSNumber = 1
+let d = [
+    "a": n,
+    "b": kCFBooleanTrue,
+]
+_ = d
+
+func f(_: [String: NSNumber?].Type) {}
+
+let t = type(of: d)
+f(t)

--- a/test/Sema/common_supertype_objc.swift
+++ b/test/Sema/common_supertype_objc.swift
@@ -1,0 +1,56 @@
+// RUN: %target-typecheck-verify-swift -solver-disable-enumerate-supertypes
+// REQUIRES: objc_interop
+
+import Foundation
+import CoreFoundation
+
+struct Exactly<T: ~Copyable> {}
+
+func test<T: ~Copyable>(_: consuming T, _: consuming T) -> Exactly<T> { fatalError() }
+
+func testTollFree1(x: CFString, y: NSString) -> Exactly<NSString> {
+  let result = test(x, y)
+  return result
+}
+
+func testTollFree2(x: NSString, y: CFString) -> Exactly<NSString> {
+  let result = test(x, y)
+  return result
+}
+
+func testTollFree3(x: CFNumber, y: NSNumber) -> Exactly<NSNumber> {
+  let result = test(x, y)
+  return result
+}
+
+func testTollFree4(x: NSNumber, y: CFNumber) -> Exactly<NSNumber> {
+  let result = test(x, y)
+  return result
+}
+
+func testTollFree3(x: CFBoolean, y: NSNumber) -> Exactly<NSNumber> {
+  let result = test(x, y)
+  return result
+}
+
+func testTollFree4(x: NSNumber, y: CFBoolean) -> Exactly<NSNumber> {
+  let result = test(x, y)
+  return result
+}
+
+func testTollFree5(x: CFNumber, y: CFBoolean) -> Exactly<CFNumber> {
+  let result = test(x, y)
+  // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('CFNumber' vs. 'CFBoolean')}}
+  return result
+}
+
+func testTollFree6(x: CFBoolean, y: CFNumber) -> Exactly<CFNumber> {
+  let result = test(x, y)
+  // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('CFBoolean' vs. 'CFNumber')}}
+  return result
+}
+
+func testTollFree7(x: CFBoolean, y: CFBoolean) -> Exactly<CFBoolean> {
+  let result = test(x, y)
+  return result
+}


### PR DESCRIPTION
In the below expression:

    import Foundation
    import CoreFoundation
    let n: NSNumber = 1
    let d = [
        "a": n,
        "b": kCFBooleanTrue,
    ]
    _ = d

We used to infer a type of [String: CFBoolean?], because we would attempt both potential bindings NSNumber and CFBoolean?; the first one would fail due to optional-to-non-optional conversion failing, while the second one would succeed. This was perhaps surprising, but it is valid because both CFNumber and CFBoolean are toll-free-bridged to NSNumber.

After some recent changes we would instead infer the type [String: Any] without attempting either NSNumber or CFBoolean?. This broke source compatibility by producing a diagnostic.

It was also not fully correct because Any is too general here; the two types are related via toll-free bridging. This commit teaches the new type join implementation about toll-free bridging. As a result, we now infer the type [String: NSNumber?] for the dictionary literal.

It is debatable if [String: Any], [String: Any?], or [String: NSNumber?] are the best type for this literal. Perhaps it should just be left alone or diagnosed.

However, fixing the missing case here is useful anyway.

Fixes rdar://181264379.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
