### PR TITLE
(COM) preserve calling convention

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1547,6 +1547,41 @@ static bool doesClangExpansionMatchSchema(IRGenModule &IGM,
   return true;
 }
 
+static std::optional<clang::CallingConv>
+getNonDefaultClangCallingConvention(IRGenModule &IGM,
+                                    CanSILFunctionType fnType) {
+  auto representation = fnType->getRepresentation();
+  if (representation != SILFunctionTypeRepresentation::CFunctionPointer &&
+      representation != SILFunctionTypeRepresentation::CXXMethod)
+    return std::nullopt;
+
+  auto *clangType = fnType->getClangTypeInfo().getType();
+  if (!clangType)
+    return std::nullopt;
+
+  const clang::FunctionType *functionType = nullptr;
+  if (auto *pointer = clangType->getAs<clang::PointerType>())
+    functionType = pointer->getPointeeType()->getAs<clang::FunctionType>();
+  else if (auto *reference = clangType->getAs<clang::ReferenceType>())
+    functionType =
+        reference->getPointeeType()->getAs<clang::FunctionType>();
+  else
+    functionType = clangType->getAs<clang::FunctionType>();
+
+  ASSERT(functionType && "unexpected Clang function type");
+  auto callingConv = functionType->getCallConv();
+  // Both representations otherwise use the platform C convention. Compare
+  // against the free-function default so that a method's default thiscall
+  // convention is still preserved on 32-bit Windows.
+  auto defaultCallingConv =
+      IGM.getClangASTContext().getDefaultCallingConvention(
+          /*IsVariadic=*/false, /*IsCXXMethod=*/false);
+  if (callingConv == defaultCallingConv)
+    return std::nullopt;
+
+  return callingConv;
+}
+
 /// Expand the result and parameter types to the appropriate LLVM IR
 /// types for C, C++ and Objective-C signatures.
 void SignatureExpansion::expandExternalSignatureTypes() {
@@ -1637,8 +1672,12 @@ void SignatureExpansion::expandExternalSignatureTypes() {
     paramTys.push_back(clangTy);
   }
 
-  // Generate function info for this signature.
+  // Generate function info for this signature. Preserve the calling
+  // convention carried by an imported C or C++ function type rather than
+  // rebuilding every function as the platform-default C convention.
   auto extInfo = clang::FunctionType::ExtInfo();
+  if (auto callingConv = getNonDefaultClangCallingConvention(IGM, FnType))
+    extInfo = extInfo.withCallingConv(*callingConv);
 
   bool isCXXMethod =
       FnType->getRepresentation() == SILFunctionTypeRepresentation::CXXMethod;
@@ -2470,6 +2509,9 @@ Signature SignatureExpansion::getSignature() {
   auto callingConv =
       expandCallingConv(IGM, FnType->getRepresentation(), FnType->isAsync(),
                         FnType->isCalleeAllocatedCoroutine());
+  if (getNonDefaultClangCallingConvention(IGM, FnType))
+    callingConv = static_cast<llvm::CallingConv::ID>(
+        ForeignInfo.ClangInfo->getEffectiveCallingConvention());
 
   Signature result;
   result.Type = llvmType;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4423,12 +4423,18 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
   }
 
   if (auto func = dyn_cast<clang::FunctionDecl>(clangDecl)) {
-    auto clangType = func->getType().getTypePtr();
+    auto clangType = func->getType();
     AbstractionPattern origPattern =
         foreignInfo.self.isImportAsMember()
-            ? AbstractionPattern::getCFunctionAsMethod(origType, clangType,
+            ? AbstractionPattern::getCFunctionAsMethod(origType,
+                                                       clangType.getTypePtr(),
                                                        foreignInfo.self)
-            : AbstractionPattern(origType, clangType);
+            : AbstractionPattern(origType, clangType.getTypePtr());
+    if (shouldStoreClangType(extInfoBuilder.getRepresentation())) {
+      auto clangPointerType =
+          func->getASTContext().getPointerType(clangType).getTypePtr();
+      extInfoBuilder = extInfoBuilder.withClangFunctionType(clangPointerType);
+    }
     return getSILFunctionType(
         TC, TypeExpansionContext::minimal(), origPattern, substInterfaceType,
         extInfoBuilder, CFunctionConventions(func, TC.Context), foreignInfo,

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4704,6 +4704,8 @@ static CanSILFunctionType getUncachedSILFunctionTypeForConstant(
     const clang::Type *clangType = nullptr;
     if (bridgedTypes.Pattern.isClangType()) {
       clangType = bridgedTypes.Pattern.getClangType();
+    } else if (bridgedTypes.Pattern.isCXXMethod()) {
+      clangType = bridgedTypes.Pattern.getCXXMethod()->getType().getTypePtr();
     }
     if (clangType) {
       // According to [NOTE: ClangTypeInfo-contents], we need to wrap a function

--- a/test/IRGen/Inputs/objc_implementation.h
+++ b/test/IRGen/Inputs/objc_implementation.h
@@ -37,6 +37,7 @@
 extern void implFunc(int param);
 extern void implFuncCName(int param) __asm__("_implFuncAsmName");
 extern void implFuncRenamed_C(int param) __attribute__((swift_name("implFuncRenamed_Swift(param:)")));
+extern int implFuncSwiftCall(int param) __attribute__((swiftcall));
 
 #if __OBJC__
 @interface NoImplClass

--- a/test/IRGen/c-function-calling-convention.sil
+++ b/test/IRGen/c-function-calling-convention.sil
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -parse-stdlib -use-clang-function-types -target i686-unknown-windows-msvc -module-name M -emit-ir %s | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=X86
+
+sil_stage canonical
+
+import Builtin
+
+// CHECK-LABEL: define{{.*}} x86_stdcallcc i32 @stdcall_function(i32 {{%.*}})
+sil @stdcall_function : $@convention(c, cType: "int (__attribute__((stdcall)) *)(int)") (Builtin.Int32) -> Builtin.Int32 {
+bb0(%value : $Builtin.Int32):
+  return %value : $Builtin.Int32
+}
+
+// CHECK-LABEL: define{{.*}} swiftcc i32 @call_stdcall_function
+// CHECK: call x86_stdcallcc i32 %{{.*}}(i32 {{%.*}})
+sil @call_stdcall_function : $@convention(thin) (@convention(c, cType: "int (__attribute__((stdcall)) *)(int)") (Builtin.Int32) -> Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
+bb0(%function : $@convention(c, cType: "int (__attribute__((stdcall)) *)(int)") (Builtin.Int32) -> Builtin.Int32, %value : $Builtin.Int32):
+  %result = apply %function(%value) : $@convention(c, cType: "int (__attribute__((stdcall)) *)(int)") (Builtin.Int32) -> Builtin.Int32
+  return %result : $Builtin.Int32
+}

--- a/test/IRGen/c_implementation.swift
+++ b/test/IRGen/c_implementation.swift
@@ -2,8 +2,16 @@
 // RUN:   -disable-objc-interop \
 // RUN:   -F %clang-importer-sdk-path/frameworks %s \
 // RUN:   -import-objc-header %S/Inputs/objc_implementation.h -emit-ir \
+// RUN:   -use-clang-function-types \
 // RUN:   -target %target-future-triple > %t.ir
 // RUN: %FileCheck --input-file %t.ir %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   -disable-objc-interop \
+// RUN:   -F %clang-importer-sdk-path/frameworks %s \
+// RUN:   -import-objc-header %S/Inputs/objc_implementation.h -emit-sil \
+// RUN:   -use-clang-function-types \
+// RUN:   -experimental-print-full-convention \
+// RUN:   -target %target-future-triple | %FileCheck %s --check-prefix=SIL
 
 @implementation @c
 public func implFunc(_ param: Int32) {}
@@ -14,10 +22,16 @@ public func implFuncCName(_ param: Int32) {}
 @implementation @c(implFuncRenamed_C)
 public func implFuncRenamed_Swift(param: Int32) {}
 
+@implementation @c
+public func implFuncSwiftCall(_ param: Int32) -> Int32 {
+  return param
+}
+
 public func fn() {
   implFunc(2)
   implFuncCName(3)
   implFuncRenamed_Swift(param: 4)
+  _ = implFuncSwiftCall(5)
 }
 
 /// implFunc(_:)
@@ -30,6 +44,11 @@ public func fn() {
 
 // CHECK-NOT: define{{.*}} swiftcc void @"$s16c_implementation13implFuncCNameyys5Int32VF"
 
+/// implFuncSwiftCall(_:)
+// SIL-LABEL: sil [asmname "implFuncSwiftCall"]
+// SIL-SAME: @convention(c, cType:
+// SIL-SAME: swiftcall
+
 /// fn()
 // CHECK-LABEL: define{{.*}} swiftcc void @"$s16c_implementation2fnyyF"
 // CHECK:   call void @implFunc
@@ -37,4 +56,3 @@ public func fn() {
 // CHECK:   call void @implFuncRenamed_C
 // CHECK:   ret void
 // CHECK: }
-

--- a/test/IRGen/c_implementation.swift
+++ b/test/IRGen/c_implementation.swift
@@ -48,11 +48,13 @@ public func fn() {
 // SIL-LABEL: sil [asmname "implFuncSwiftCall"]
 // SIL-SAME: @convention(c, cType:
 // SIL-SAME: swiftcall
+// CHECK-LABEL: define{{.*}} swiftcc i32 @implFuncSwiftCall
 
 /// fn()
 // CHECK-LABEL: define{{.*}} swiftcc void @"$s16c_implementation2fnyyF"
 // CHECK:   call void @implFunc
 // CHECK:   call void @"\01_implFuncAsmName"
 // CHECK:   call void @implFuncRenamed_C
+// CHECK:   call swiftcc i32 @implFuncSwiftCall
 // CHECK:   ret void
 // CHECK: }

--- a/test/Interop/Cxx/class/method/Inputs/calling-convention.h
+++ b/test/Interop/Cxx/class/method/Inputs/calling-convention.h
@@ -1,0 +1,5 @@
+struct CallingConvention {
+  void defaultMethod();
+  void __stdcall stdcallMethod();
+  void __cdecl cdeclMethod();
+};

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -8,6 +8,11 @@ module Methods {
   requires cplusplus
 }
 
+module CallingConvention {
+  header "calling-convention.h"
+  requires cplusplus
+}
+
 module AmbiguousMethods {
   header "ambiguous_methods.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/method/calling-convention-irgen.swift
+++ b/test/Interop/Cxx/class/method/calling-convention-irgen.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-ir -parse-stdlib -module-name Swift -cxx-interoperability-mode=default -use-clang-function-types -target i686-unknown-windows-msvc -resource-dir %t -I %S/Inputs %s | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=X86
+
+// Use an empty resource directory so implicit Cxx and CxxStdlib lookups do not
+// require runtime modules built for i686.
+// Supply Void without requiring a standard library for the target.
+public typealias Void = ()
+
+import CallingConvention
+
+// The default instance-method convention is thiscall, while an explicit
+// cdecl method uses the platform C convention.
+// CHECK-LABEL: define{{.*}} swiftcc void @"$ss7callAllyySo17CallingConventionVzF"
+// CHECK: call x86_thiscallcc void @"?defaultMethod@CallingConvention@@QAEXXZ"(ptr {{%.*}})
+// CHECK: call x86_stdcallcc void @"?stdcallMethod@CallingConvention@@QAGXXZ"(ptr {{%.*}})
+// CHECK: call void @"?cdeclMethod@CallingConvention@@QAAXXZ"(ptr {{%.*}})
+// CHECK: ret void
+public func callAll(_ value: inout CallingConvention) {
+  value.defaultMethod()
+  value.stdcallMethod()
+  value.cdeclMethod()
+}


### PR DESCRIPTION
This pull request improves Swift's interoperability with C by ensuring that non-default calling conventions from imported C function types are preserved in the generated IR, rather than always using the platform default. This is particularly important for functions using conventions like `stdcall` or `preserve_most`, which can affect ABI compatibility. The changes also add new test cases to verify correct handling of these conventions.

**Preservation of C Calling Conventions:**

* Added a helper function `getNonDefaultClangCallingConvention` in `GenCall.cpp` to detect and extract non-default calling conventions from imported C function types, ensuring that Swift-generated functions use the correct convention when interoperating with C.
* Modified `SignatureExpansion::expandExternalSignatureTypes` and `SignatureExpansion::getSignature` to use the extracted calling convention when present, instead of always defaulting to the platform convention. [[1]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4L1633-R1669) [[2]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R2496-R2498)

**SIL Function Type Construction:**

* Updated `getSILFunctionTypeForClangDecl` in `SILFunctionType.cpp` to properly store the Clang function type pointer when needed, which is required for tracking and preserving calling conventions through the type system.

**Test Coverage:**

* Added a new C header and Swift test (`objc_implementation.h`, `c_implementation.swift`) to verify that a function with the `preserve_most` calling convention is correctly imported and invoked from Swift, including checks in both IR and SIL output. [[1]](diffhunk://#diff-fdcaf6d0a5020a9bb219ae1da5f9d953c9cb6769fdc039c737054f9d1a5a8f3eR40) [[2]](diffhunk://#diff-8e82e2ee288f04d94a15dcc80330eb4ec917c37defcdbec12a415334d828b1c1R5-R14) [[3]](diffhunk://#diff-8e82e2ee288f04d94a15dcc80330eb4ec917c37defcdbec12a415334d828b1c1R25-R34) [[4]](diffhunk://#diff-8e82e2ee288f04d94a15dcc80330eb4ec917c37defcdbec12a415334d828b1c1R47-L40)
* Introduced a new SIL test (`c-function-calling-convention.sil`) to check that the `stdcall` calling convention is correctly preserved for C function pointers on Windows.