### PR TITLE
[IRGen] Fix crash for type(of:) on a mutable existential variable

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3433,22 +3433,37 @@ void IRGenSILFunction::visitExistentialMetatypeInst(
   SILValue op = i->getOperand();
   SILType opType = op->getType();
 
+  // An existential_metatype does not consume its operand; it only inspects the
+  // dynamic type the operand designates. For a loadable existential SILGen may
+  // hand us either a loaded value or, when it borrows the operand's storage in
+  // place (e.g. `type(of:)` applied to a mutable variable), the address of one.
+  // Load the value from memory in the latter case; the load is non-consuming,
+  // so it introduces no reference-count operations.
+  auto getExistentialOperand = [&]() -> Explosion {
+    if (!opType.isAddress())
+      return getLoweredExplosion(op);
+    Explosion e;
+    Address addr = getLoweredAddress(op);
+    getTypeInfo(opType).as<LoadableTypeInfo>().loadAsTake(*this, addr, e);
+    return e;
+  };
+
   switch (opType.getPreferredExistentialRepresentation()) {
   case ExistentialRepresentation::COM:
     llvm_unreachable("COM existential metatype projection is not implemented");
   case ExistentialRepresentation::Metatype: {
-    Explosion existential = getLoweredExplosion(op);
+    Explosion existential = getExistentialOperand();
     emitMetatypeOfMetatype(*this, existential, opType, result);
     break;
   }
   case ExistentialRepresentation::Class: {
-    Explosion existential = getLoweredExplosion(op);
+    Explosion existential = getExistentialOperand();
     emitMetatypeOfClassExistential(*this, existential, i->getType(),
                                    opType, result);
     break;
   }
   case ExistentialRepresentation::Boxed: {
-    Explosion existential = getLoweredExplosion(op);
+    Explosion existential = getExistentialOperand();
     emitMetatypeOfBoxedExistential(*this, existential, opType, result);
     break;
   }

--- a/test/IRGen/existential_metatype_of_var.swift
+++ b/test/IRGen/existential_metatype_of_var.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-ir %s | %FileCheck %s
+
+// `type(of:)` does not consume its operand, so when it is applied to a mutable
+// variable of a loadable existential type SILGen borrows the variable's storage
+// in place and emits `existential_metatype` with an *address* operand. IRGen
+// used to assume that operand was always a loaded value and would over-claim
+// from the resulting explosion, tripping an assertion (Explosion::claim). It
+// must instead load the existential from the address.
+
+public protocol Widget: AnyObject { var owner: AnyObject? { get } }
+
+// A class holding an optional class-constrained existential, exercising the
+// pattern from the original report. This just needs to compile without
+// crashing.
+final class Container {
+  private var rootWidget: (any Widget)?
+  private var currentWidget: (any Widget)? {
+    guard let root = rootWidget else { return nil }
+    var best: any Widget = root
+    best = root
+    _ = "\(type(of: best))"
+    return root
+  }
+  func use() -> (any Widget)? { currentWidget }
+}
+
+// Minimal form: `type(of:)` on a mutable class-existential variable.
+// CHECK-LABEL: define {{.*}} @"$s27existential_metatype_of_var15widgetTypeOfVaryAA6Widget_pXpAaC_pF"
+// CHECK: call {{.*}}@swift_getObjectType
+public func widgetTypeOfVar(_ w: any Widget) -> any Widget.Type {
+  var best = w
+  best = w
+  return type(of: best)
+}
+
+// `type(of:)` on a mutable existential-metatype variable (Metatype
+// representation reached through an address).
+public func metatypeTypeOfVar(_ t: any Widget.Type) -> any Widget.Type.Type {
+  var best = t
+  best = t
+  return type(of: best)
+}
+
+// `type(of:)` on a mutable boxed (error) existential variable (Boxed
+// representation reached through an address).
+public func errorTypeOfVar(_ e: any Error) -> any Error.Type {
+  var best = e
+  best = e
+  return type(of: best)
+}


### PR DESCRIPTION
rdar://185642539

existential_metatype may be given the address of a loadable existential (e.g. when SILGen borrows a mutable variable's storage). Load the value from the address instead of treating the address as the exploded value.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
