### PR TITLE
ClangImporter: only trust external_source_symbol when defined_in matches the owning module.

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -22,6 +22,7 @@
 #include "ImporterImpl.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/Basic/Module.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Sema.h"
 #include "llvm/ADT/STLExtras.h"
@@ -591,10 +592,17 @@ bool importer::isNSNotificationGlobal(const clang::NamedDecl *decl) {
 }
 
 bool importer::hasNativeSwiftDecl(const clang::Decl *decl) {
-  if (auto *attr = decl->getAttr<clang::ExternalSourceSymbolAttr>())
-    if (attr->getGeneratedDeclaration() && attr->getLanguage() == "Swift")
-      return true;
-  return false;
+  auto *attr = decl->getAttr<clang::ExternalSourceSymbolAttr>();
+  if (!attr || !attr->getGeneratedDeclaration() || attr->getLanguage() != "Swift")
+    return false;
+  // external_source_symbol is inheritable, so Clang can merge this marker from a
+  // -Swift.h forward-declaration onto a Clang module's real decl that has no Swift
+  // counterpart. Only trust it when defined_in names the decl's own module.
+  if (auto *owning = decl->getOwningModule())
+    if (!attr->getDefinedIn().empty() &&
+        attr->getDefinedIn() != owning->getTopLevelModuleName())
+      return false;
+  return true;
 }
 
 /// Translate the "nullability" notion from API notes into an optional type

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -133,6 +133,22 @@ SWIFT_CLASS("BOGUS")
 
 # pragma clang attribute pop
 
+// A generated_declaration marker whose defined_in names a module other than the one
+// that owns the decl models the marker leaking in via clang merging an unrelated
+// module's generated-header forward-declaration; the importer must not treat such a
+// decl as a missing native Swift type (see import-mixed-framework.swift).
+#pragma clang attribute push( \
+  __attribute__((external_source_symbol(language="Swift", \
+                 defined_in="NotMixed",generated_declaration))), \
+  apply_to=any(function,enum,objc_interface,objc_category,objc_protocol))
+
+SWIFT_CLASS("LeakedMarkerClass")
+__attribute__((objc_root_class))
+@interface LeakedMarkerClass
+@end
+
+# pragma clang attribute pop
+
 @interface SwiftClass (Category)
 - (void)categoryMethod:(struct PureClangType)arg;
 @end

--- a/test/ClangImporter/MixedSource/import-mixed-framework.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework.swift
@@ -19,6 +19,11 @@ instance.categoryMethod(clangStruct)
 
 let x: BogusClass? = nil // expected-error {{'BogusClass' is unavailable: cannot find Swift declaration for this class}}
 
+// A generated_declaration marker whose defined_in names a module other than the one
+// that owns the decl has leaked in (clang merges the attribute from another module's
+// forward-declaration); it must not make the type unavailable.
+let _: LeakedMarkerClass? = nil
+
 _ = PureSwiftClass.verify()
 _ = Mixed.PureSwiftClass.verify()
 


### PR DESCRIPTION
The Swift compatibility header prints forward declarations under an external_source_symbol(generated_declaration) attribute. Since that attribute is inheritable, Clang can merge it onto the real definition of those symbols from a Clang module, where no Swift half exists. The importer reads the marker, tries to find the corresponding Swift decl, fails, and marks the type unavailable. Only honor the marker when the module it names matches the owning module of the definition.

Resolves: rdar://185742408

