### PR TITLE
[Sema] Use public module name in `appendMissingImportFixIt`

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -953,8 +953,11 @@ static void appendMissingImportFixIt(llvm::SmallString<64> &importText,
     importText += " ";
   }
 
+  // onlyIfImported below matches how modules are printed in
+  // `formatDiagnosticArgument`.
+  auto *mod = fixItInfo.moduleToImport;
   importText += "import ";
-  importText += fixItInfo.moduleToImport->getName().str();
+  importText += mod->getPublicModuleName(/*onlyIfImported*/ true).str();
   importText += "\n";
 }
 

--- a/test/NameLookup/member_import_visibility_public_module_name.swift
+++ b/test/NameLookup/member_import_visibility_public_module_name.swift
@@ -9,7 +9,7 @@
 //--- main.swift
 
 import Swift
-// expected-note {{add import of module 'Lib'}}
+// expected-note {{add import of module 'Lib'}} {{1-1=internal import Lib\n}}
 
 func foo(_ x: Int) -> Int {
   x.bar // expected-error {{property 'bar' is not available due to missing import of defining module 'Lib'}}


### PR DESCRIPTION
Make sure we match how we print modules in diagnostic arguments and respect their public module name.

rdar://186016923