### PR TITLE
CMake: Stop touching swiftmodule files on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,11 @@
-cmake_minimum_required(VERSION 3.24)
-
+cmake_minimum_required(VERSION 3.29)
 
 #  set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 1)
 
 # TODO: Fix RPATH usage to be CMP0068 compliant
 # Disable Policy CMP0068 for CMake 3.9
 # rdar://37725888
-if(POLICY CMP0068)
-  cmake_policy(SET CMP0068 OLD)
-endif()
-
-# Honour CMAKE_CXX_STANDARD in try_compile(), needed for check_cxx_native_regex.
-if(POLICY CMP0067)
-  cmake_policy(SET CMP0067 NEW)
-endif()
-
-# Convert relative paths to absolute for subdirectory `target_sources`
-if(POLICY CMP0076)
-  cmake_policy(SET CMP0076 NEW)
-endif()
-
-# Don't clobber existing variable values when evaluating `option()` declarations.
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
+cmake_policy(SET CMP0068 OLD)
 
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -371,15 +371,6 @@ function(add_pure_swift_host_library name)
     # NOTE: workaround for CMake not setting up include flags.
     INTERFACE_INCLUDE_DIRECTORIES ${module_dir})
 
-  # Workaround to touch the library and its objects so that we don't
-  # continually rebuild (again, see corresponding change in swift-syntax).
-  add_custom_command(
-      TARGET ${name}
-      POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> $<TARGET_OBJECTS:${name}> "${module_file}"
-      COMMAND_EXPAND_LISTS
-      COMMENT "Update mtime of library outputs workaround")
-
   # Downstream linking should include the swiftmodule in debug builds to allow lldb to
   # work correctly. Only do this on Darwin since neither gold (currently used by default
   # on Linux), nor the default Windows linker 'link' support '-add_ast_path'.
@@ -516,25 +507,6 @@ function(add_pure_swift_host_tool name)
     target_link_options(${name} PRIVATE
       "SHELL:-Xlinker --build-id=sha1")
   endif()
-
-  # Workaround to touch the library and its objects so that we don't
-  # continually rebuild (again, see corresponding change in swift-syntax).
-  add_custom_command(
-      TARGET ${name}
-      POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:${name}> $<TARGET_OBJECTS:${name}>
-      COMMAND_EXPAND_LISTS
-      COMMENT "Update mtime of executable outputs workaround")
-
-  # Even worse hack - ${name}.swiftmodule is added as an output, even though
-  # this is an executable target. Just touch it all the time to avoid having
-  # to rebuild it every time.
-  add_custom_command(
-      TARGET ${name}
-      POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/${name}.swiftmodule"
-      COMMAND_EXPAND_LISTS
-      COMMENT "Update mtime of executable outputs workaround")
 
   if(NOT APSHT_SWIFT_COMPONENT STREQUAL no_component)
     add_dependencies(${APSHT_SWIFT_COMPONENT} ${name})

--- a/lib/ASTGen/Sources/SwiftIDEUtilsBridging/CMakeLists.txt
+++ b/lib/ASTGen/Sources/SwiftIDEUtilsBridging/CMakeLists.txt
@@ -4,8 +4,11 @@ add_pure_swift_host_library(swiftIDEUtilsBridging CXX_INTEROP
   DEPENDENCIES
     swiftAST
   SWIFT_DEPENDENCIES
+    _CompilerSwiftBasicFormat
     _CompilerSwiftIDEUtils
     _CompilerSwiftSyntax
     _CompilerSwiftIDEUtils
+    _CompilerSwiftSyntaxMacroExpansion
+    _CompilerSwiftSyntaxMacros
     swiftASTGen
 )

--- a/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
@@ -19,4 +19,5 @@ add_swift_macro_library(ObservationMacros
     SwiftSyntaxBuilder
     SwiftSyntax
     SwiftSyntaxMacros
+    SwiftOperators
 )

--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -23,4 +23,5 @@ add_swift_macro_library(SwiftMacros
     SwiftSyntax
     SwiftSyntaxBuilder
     SwiftSyntaxMacros
+    SwiftOperators
 )

--- a/tools/swift-function-caller-generator/CMakeLists.txt
+++ b/tools/swift-function-caller-generator/CMakeLists.txt
@@ -7,6 +7,8 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
       SwiftSyntax
       SwiftSyntaxBuilder
       SwiftSyntaxMacros
+      SwiftDiagnostics
+      SwiftOperators
     PACKAGE_NAME Toolchain
   )
 

--- a/tools/swift-function-caller-generator/CMakeLists.txt
+++ b/tools/swift-function-caller-generator/CMakeLists.txt
@@ -9,4 +9,8 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
       SwiftSyntaxMacros
     PACKAGE_NAME Toolchain
   )
+
+  set_target_properties(swift-function-caller-generator PROPERTIES
+    Swift_MODULE_NAME SwiftFunctionCallerGenerator
+  )
 endif()

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -6,6 +6,7 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     SWIFT_DEPENDENCIES
       SwiftCompilerPluginMessageHandling
       SwiftLibraryPluginProvider
+      SwiftSyntaxBuilder
     PACKAGE_NAME Toolchain
   )
   set_target_properties(swift-plugin-server PROPERTIES
@@ -19,6 +20,7 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     SWIFT_DEPENDENCIES
       SwiftCompilerPluginMessageHandling
       SwiftLibraryPluginProvider
+      SwiftSyntaxBuilder
     PACKAGE_NAME Toolchain
   )
 

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -8,6 +8,9 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
       SwiftLibraryPluginProvider
     PACKAGE_NAME Toolchain
   )
+  set_target_properties(swift-plugin-server PROPERTIES
+    Swift_MODULE_NAME SwiftPluginServer
+  )
 
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${SWIFT_HOST_LIBRARIES_DEST_DIR}")
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${SWIFT_HOST_LIBRARIES_DEST_DIR}")


### PR DESCRIPTION
Swift-Syntax bumped minimum required CMake versions to 3.29. For whatever reason, that caused the code introduced in https://github.com/swiftlang/swift/pull/70859 to start working as designed and invalidate the build graph on every run. That was to work around a bug in versions of CMake prior to 3.26, but has since been fixed. The compiler depends on Swift-Syntax, which requires 3.29, so also bumping the compiler while we're at it to take advantage of the improved Swift handling. Since we're jumping to something newer that has the bug fixed, we can drop the code that forces a full rebuild of the universe.

With this change, I am able to get to a null-build:
```
 %  ninja swift-frontend -d explain
ninja: no work to do.
```

I will note that this isn't perfect and that more invasive changes are needed to fully clean things up, this is to alleviate the constant forced rebuild.

I've also taken the opportunity to remove some of the redundant policy settings.