### PR TITLE
utils: normalise paths for CAS builds

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1807,6 +1807,28 @@ function Add-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
   }
 }
 
+function ConvertTo-CMakeArgument([string] $Argument) {
+  # Backslashes in CMakeCache.txt are escape characters, but the synthetic CAS
+  # roots deliberately use a UNC spelling. Preserve the complete synthetic
+  # path while normalizing ordinary Windows path separators.
+  $SyntheticPath = $Argument.IndexOf('\\swift\')
+  if ($SyntheticPath -ge 0) {
+    $Prefix = $Argument.Substring(0, $SyntheticPath).Replace("\", "/")
+    return $Prefix + $Argument.Substring($SyntheticPath)
+  }
+
+  # Preserve a leading double backslash for ordinary UNC paths, while using
+  # forward slashes for the remaining components as before.
+  $DoubleBackslash = $Argument.IndexOf("\\")
+  if ($DoubleBackslash -lt 0) {
+    return $Argument.Replace("\", "/")
+  }
+
+  $Prefix = $Argument.Substring(0, $DoubleBackslash).Replace("\", "/")
+  $Suffix = $Argument.Substring($DoubleBackslash + 2).Replace("\", "/")
+  return "$Prefix\\$Suffix"
+}
+
 function Get-PlatformRoot([OS] $OS) {
   return ([IO.Path]::Combine((Get-InstallDir $HostPlatform), "Platforms", "$($OS.ToString()).platform"))
 }
@@ -2291,6 +2313,15 @@ function Build-CMakeProject {
 
     if ($EnableCaching) {
       $env:LLVM_CACHE_CAS_PATH = "$Cache"
+      $SyntheticSourceCache = '\\swift\SourceCache$'
+      $SyntheticBinaryCache = '\\swift\BinaryCache$'
+      $CASPrefixMappings = [ordered]@{
+        [IO.Path]::GetFullPath($SourceCache.FullName) = $SyntheticSourceCache;
+        [IO.Path]::GetFullPath($BinaryCache.FullName) = $SyntheticBinaryCache;
+      }
+      $env:LLVM_CACHE_PREFIX_MAPS = ($CASPrefixMappings.GetEnumerator() | ForEach-Object {
+        "$($_.Key)=$($_.Value)"
+      }) -join ";"
 
       # Skip the clang-cache launcher when targeting Android: cmake auto-detects
       # the NDK's clang (e.g. 19.x) as the actual compiler, but the launcher
@@ -2302,23 +2333,46 @@ function Build-CMakeProject {
       # the launcher.
       $LauncherSafe = ($Platform.OS -ne [OS]::Android)
 
+      # The dependency scanner presents source inputs to Clang using the
+      # synthetic paths from LLVM_CACHE_PREFIX_MAPS. This covers source paths
+      # in debug info, coverage, and macros without putting a host-specific
+      # `-ffile-prefix-map=<physical>=<synthetic>` in the cached command. Set
+      # the remaining compilation directory explicitly, and omit the CodeView
+      # command line because it contains the physical scanner replay mappings.
+      $ClangCachingFlags = @("-ffile-compilation-dir=$SyntheticBinaryCache")
+      if ($DebugInfo) {
+        $ClangCachingFlags += "-gno-codeview-command-line"
+      }
+
       if ($LauncherSafe -and $UseC -and $CCompiler.DriverStyle -ne [DriverStyle]::CL) {
+        Add-FlagsDefine $Defines CMAKE_C_FLAGS $ClangCachingFlags
         Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER `
             (Join-Path -Path (Split-Path $CCompiler.Executable) -ChildPath "clang-cache.exe")
       }
 
       if ($LauncherSafe -and $UseCXX -and $CXXCompiler.DriverStyle -ne [DriverStyle]::CL) {
+        Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $ClangCachingFlags
         Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER `
             (Join-Path -Path (Split-Path $CXXCompiler.Executable) -ChildPath "clang-cache.exe")
       }
 
       if ($UseSwift) {
-        Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @(
+        $SwiftCachingFlags = @(
           "-explicit-module-build",
           "-cache-compile-job",
           "-cas-path", $Cache,
-          "-incremental-dependency-scan"
+          "-incremental-dependency-scan",
+          "-file-compilation-dir", $SyntheticBinaryCache,
+          "-Xfrontend", "-prefix-map-sourceinfo"
         )
+
+        foreach ($Mapping in $CASPrefixMappings.GetEnumerator()) {
+          $SwiftCachingFlags += @(
+            "-scanner-prefix-map-paths", $Mapping.Key, $Mapping.Value
+          )
+        }
+
+        Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftCachingFlags
       }
     }
 
@@ -2340,7 +2394,7 @@ function Build-CMakeProject {
       # where they are interpreted as escapes.
       if ($Define.Value -is [string]) {
         # Single token value, no need to quote spaces, the splat operator does the right thing.
-        $Value = $Define.Value.Replace("\", "/")
+        $Value = ConvertTo-CMakeArgument $Define.Value
       } else {
         # Flags array, multiple tokens, quoting needed for tokens containing spaces
         $Value = ""
@@ -2349,7 +2403,7 @@ function Build-CMakeProject {
             $Value += " "
           }
 
-          $ArgWithForwardSlashes = $Arg.Replace("\", "/")
+          $ArgWithForwardSlashes = ConvertTo-CMakeArgument $Arg
           if ($ArgWithForwardSlashes.Contains(" ")) {
             # Escape the quote so it makes it through. PowerShell 5 and Core
             # handle quotes differently, so we need to check the version.


### PR DESCRIPTION
CAS artifacts are intended to be shared between builders, but compiler outputs currently retain the physical source, build, and CAS paths of the machine that populated the cache. This makes otherwise equivalent builds host-dependent and allows a cache hit to carry paths from another machine into debug information and serialized source information.

Give cached builds a stable UNC namespace for source and generated content. Map dependency scanner inputs into this namespace and use a stable compilation directory so that Swift and Clang describe the same logical build tree regardless of the physical checkout layout.

The CodeView command line contains the raw compiler invocation, including the physical CAS path and dependency scanner replay mappings. Clang's prefix mappings do not apply to this record, so omit it from cached debug builds until Clang can emit a normalised command line. The remaining CodeView file and line information is preserved.

Preserve the synthetic UNC spelling while passing these paths through CMake, where normal path conversion would otherwise change their meaning.