### PR TITLE
[test] Avoid an iOS 26 issue with no longer supporting 32-bit platforms for an availability check

### DIFF
--- a/test/Availability/availability_any_apple_os.swift
+++ b/test/Availability/availability_any_apple_os.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-macos26 -verify-additional-prefix apple- -verify-additional-prefix macos-
-// RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-ios26 -verify-additional-prefix apple- -verify-additional-prefix ios-
+// RUN: %target-typecheck-verify-swift -parse-stdlib -target arm64-apple-ios26 -verify-additional-prefix apple- -verify-additional-prefix ios-
 // RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-watchos26 -verify-additional-prefix apple- -verify-additional-prefix watchos-
 // RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-tvos26 -verify-additional-prefix apple- -verify-additional-prefix tvos-
 // RUN: %target-typecheck-verify-swift -parse-stdlib -target %target-cpu-apple-visionos26 -verify-additional-prefix apple- -verify-additional-prefix visionos-


### PR DESCRIPTION
This test started failing for 32-bit Android armv7 lately:
```
-parse-stdlib -target armv7-apple-ios26 -verify-additional-prefix apple- -verify-additional-prefix ios-
  # .---command stderr------------
  # | <unknown>:0: error: invalid iOS deployment version '-target armv7-apple-ios26', iOS 10 is the maximum deployment target for 32-bit targets
  # | <unknown>:0: error: unexpected error produced: invalid iOS deployment version '-target armv7-apple-ios26', iOS 10 is the maximum deployment target for 32-bit targets
  # | <unknown>:0: note: use '-verify-ignore-unknown' to ignore diagnostics at this location
```
Allan suggested this workaround instead.