### PR TITLE
Add uefi support

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -604,6 +604,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::Emscripten:
     addPlatformConditionValue(PlatformConditionKind::OS, "Emscripten");
     break;
+  case llvm::Triple::UEFI:
+    addPlatformConditionValue(PlatformConditionKind::OS, "UEFI");
+    break;
   case llvm::Triple::UnknownOS:
     if (Target.getOSName() == "none") {
       addPlatformConditionValue(PlatformConditionKind::OS, "none");

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -301,6 +301,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::UnknownOS:
     return "none";
   case llvm::Triple::UEFI:
+    return "uefi";
   case llvm::Triple::LiteOS:
   case llvm::Triple::Managarm:
     llvm_unreachable("unsupported OS");

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -10,6 +10,7 @@ set(swiftDriver_sources
   PrettyStackTrace.cpp
   ToolChain.cpp
   ToolChains.cpp
+  UEFIToolChains.cpp
   UnixToolChains.cpp
   WebAssemblyToolChains.cpp
   WindowsToolChains.cpp

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -457,6 +457,8 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
   case llvm::Triple::WASIp2:
   case llvm::Triple::WASIp3:
     return std::make_unique<toolchains::WebAssembly>(*this, target);
+  case llvm::Triple::UEFI:
+    return std::make_unique<toolchains::UEFI>(*this, target);
   case llvm::Triple::UnknownOS:
     return std::make_unique<toolchains::GenericUnix>(*this, target);
   default:

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -121,6 +121,21 @@ public:
                                       bool shared = true) const override;
 };
 
+class LLVM_LIBRARY_VISIBILITY UEFI : public ToolChain {
+protected:
+  InvocationInfo constructInvocation(const DynamicLinkJobAction &job,
+                                     const JobContext &context) const override;
+  InvocationInfo constructInvocation(const StaticLinkJobAction &job,
+                                     const JobContext &context) const override;
+
+public:
+  UEFI(const Driver &D, const llvm::Triple &Triple) : ToolChain(D, Triple) {}
+  ~UEFI() = default;
+
+  std::string sanitizerRuntimeLibName(StringRef Sanitizer,
+                                      bool shared = true) const override;
+};
+
 class LLVM_LIBRARY_VISIBILITY WebAssembly : public ToolChain {
 protected:
   InvocationInfo constructInvocation(const AutolinkExtractJobAction &job,

--- a/lib/Driver/UEFIToolChains.cpp
+++ b/lib/Driver/UEFIToolChains.cpp
@@ -1,0 +1,176 @@
+//===---- UEFIToolChains.cpp - Job invocations (UEFI-specific) ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// UEFI applications are PE/COFF executables targeting the UEFI firmware
+// environment. The target triple is of the form <arch>-unknown-uefi (e.g.
+// x86_64-unknown-uefi, aarch64-unknown-uefi). Clang understands these triples
+// natively and will produce PE/COFF objects; lld (lld-link) is used to link
+// them into a final .efi image with the EFI_APPLICATION subsystem.
+//
+// UEFI is a freestanding environment: there is no OS, no dynamic linker, and
+// no C or Swift standard library startup infrastructure. Only static linking
+// is supported. Sanitizers and profiling are not supported.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ToolChains.h"
+
+#include "swift/Basic/Assertions.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/Platform.h"
+#include "swift/Basic/Range.h"
+#include "swift/Config.h"
+#include "swift/Driver/Compilation.h"
+#include "swift/Driver/Driver.h"
+#include "swift/Driver/Job.h"
+#include "swift/Option/Options.h"
+#include "clang/Basic/Version.h"
+#include "clang/Driver/Util.h"
+#include "llvm/Option/Arg.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+
+using namespace swift;
+using namespace swift::driver;
+using namespace llvm::opt;
+using namespace swift::driver::toolchains;
+
+std::string toolchains::UEFI::sanitizerRuntimeLibName(StringRef Sanitizer,
+                                                       bool shared) const {
+  // Sanitizers are not supported in the UEFI freestanding environment.
+  llvm_unreachable("sanitizers are not supported for UEFI");
+}
+
+ToolChain::InvocationInfo
+toolchains::UEFI::constructInvocation(const DynamicLinkJobAction &job,
+                                      const JobContext &context) const {
+  assert(context.Output.getPrimaryOutputType() == file_types::TY_Image &&
+         "Invalid linker output type.");
+
+  // UEFI does not support dynamic libraries — only static executables.
+  if (job.getKind() == LinkKind::DynamicLibrary)
+    llvm_unreachable("UEFI does not support dynamic libraries");
+
+  ArgStringList Arguments;
+
+  // Pass the UEFI target triple so clang sets up the right PE/COFF defaults.
+  std::string Target = getTriple().str();
+  if (!Target.empty()) {
+    Arguments.push_back("-target");
+    Arguments.push_back(context.Args.MakeArgString(Target));
+  }
+
+  // Delegate to lld-link via clang for PE/COFF linking.
+  std::string Linker;
+  if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld))
+    Linker = A->getValue();
+  if (!Linker.empty())
+    Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
+
+  // UEFI subsystem: the linker needs /subsystem:efi_application (or
+  // efi_boot_service_driver, etc.). Default to efi_application; users can
+  // override via -Xlinker.
+  Arguments.push_back("-Xlinker");
+  Arguments.push_back("/subsystem:efi_application");
+
+  // No startup files in a freestanding UEFI environment.
+  Arguments.push_back("-nostartfiles");
+  // No standard libraries.
+  Arguments.push_back("-nostdlib");
+
+  SmallVector<std::string, 4> RuntimeLibPaths;
+  getRuntimeLibraryPaths(RuntimeLibPaths, context.Args, context.OI.SDKPath,
+                         /*Shared=*/false);
+
+  for (auto path : RuntimeLibPaths) {
+    Arguments.push_back("-L");
+    Arguments.push_back(context.Args.MakeArgString(path));
+  }
+
+  // Link swiftrt.obj if present (provides Swift runtime entry glue).
+  if (!context.Args.hasArg(options::OPT_nostartfiles)) {
+    SmallString<128> SharedResourceDirPath;
+    getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/false);
+
+    SmallString<128> swiftrtPath = SharedResourceDirPath;
+    llvm::sys::path::append(swiftrtPath,
+                            swift::getMajorArchitectureName(getTriple()));
+    llvm::sys::path::append(swiftrtPath, "swiftrt.obj");
+    if (llvm::sys::fs::exists(swiftrtPath))
+      Arguments.push_back(context.Args.MakeArgString(swiftrtPath));
+  }
+
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_Object);
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_LLVM_BC);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_LLVM_BC);
+
+  if (!context.OI.SDKPath.empty()) {
+    Arguments.push_back("-I");
+    Arguments.push_back(context.Args.MakeArgString(context.OI.SDKPath));
+  }
+
+  // Link the static Swift runtime if a .lnk response file is present.
+  SmallString<128> linkFilePath;
+  getResourceDirPath(linkFilePath, context.Args, /*Shared=*/false);
+  llvm::sys::path::append(linkFilePath, "static-executable-args.lnk");
+  if (llvm::sys::fs::is_regular_file(linkFilePath))
+    Arguments.push_back(context.Args.MakeArgString(Twine("@") + linkFilePath));
+
+  // Forward user-supplied linker and clang-linker flags.
+  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
+  context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
+
+  if (context.Args.hasArg(options::OPT_v))
+    Arguments.push_back("-v");
+
+  Arguments.push_back("-o");
+  Arguments.push_back(
+      context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
+
+  // Resolve the clang driver to use for linking.
+  const char *Clang = "clang";
+  if (const Arg *A = context.Args.getLastArg(options::OPT_tools_directory)) {
+    StringRef toolchainPath(A->getValue());
+    if (auto tool = llvm::sys::findProgramByName("clang", {toolchainPath}))
+      Clang = context.Args.MakeArgString(tool.get());
+  }
+
+  InvocationInfo II{Clang, Arguments};
+  II.allowsResponseFiles = true;
+  return II;
+}
+
+ToolChain::InvocationInfo
+toolchains::UEFI::constructInvocation(const StaticLinkJobAction &job,
+                                      const JobContext &context) const {
+  assert(context.Output.getPrimaryOutputType() == file_types::TY_Image &&
+         "Invalid linker output type.");
+
+  ArgStringList Arguments;
+  const char *AR = "llvm-ar";
+  Arguments.push_back("crs");
+  Arguments.push_back(
+      context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
+
+  addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
+                         file_types::TY_Object);
+  addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
+
+  InvocationInfo II{AR, Arguments};
+  return II;
+}

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -4027,7 +4027,7 @@ function(embedded_amend_archive_commands_on_darwin_host target triple)
   # is built by a separate CMake invocation, thus allowing to set the archiver
   # properly in the toolchain file.
   if(SWIFT_HOST_VARIANT STREQUAL "macosx" AND SWIFT_EMBEDDED_STDLIB_ARCHIVER_FOR_NON_DARWIN_PLATFORMS_UNDER_MACOS)
-    if(triple MATCHES "-elf$" OR triple MATCHES "-eabi$" OR triple MATCHES "-wasm$")
+    if(triple MATCHES "-elf$" OR triple MATCHES "-eabi$" OR triple MATCHES "-wasm$" OR triple MATCHES "-uefi$")
       # There is no way to change the archive commands only for a few targets, so
       # we resort going double work (and assume the previous commands exit successfully)
       add_custom_command(TARGET ${target}

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -293,6 +293,13 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
         "i686    i686-unknown-none-elf       i686-unknown-none-elf"
         "x86_64  x86_64-unknown-none-elf     x86_64-unknown-none-elf"
+        "x86_64  x86_64-unknown-uefi         x86_64-unknown-uefi"
+      )
+    endif()
+
+    if("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
+      list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+        "aarch64  aarch64-unknown-uefi       aarch64-unknown-uefi"
       )
     endif()
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -326,6 +326,14 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       continue()
     endif()
 
+    # Skip Concurrency for UEFI: it is a freestanding environment with no OS
+    # concurrency primitives, and the macOS SDK C++ headers used to build
+    # embedded Concurrency on Darwin hosts are not compatible with the UEFI
+    # target ABI.
+    if("${triple}" MATCHES "-uefi$")
+      continue()
+    endif()
+
     if (SWIFT_HOST_VARIANT STREQUAL "linux")
       if(NOT "${mod}" MATCHES "-linux-gnu$")
         continue()


### PR DESCRIPTION
This PR adds uefi support to the Swift compiler and the embedded Swift stdlib. This is not fully tested, so I've marked it as a draft for now. It depends on https://github.com/theoparis/swift-driver/commit/4f98fa8d40bfe7b9a0184a643beb326b19b5f6fb

To test it with both patches applied:
```
./utils/build-script --bootstrapping=hosttools --build-embedded-stdlib-cross-compiling \
  --extra-cmake-options="-DSWIFT_EMBEDDED_STDLIB_EXTRA_TARGET_TRIPLES=x86_64-unknown-uefi"
```
Building a minimal application currently requires libc stubs or llvm libc, as those would provide symbols like `memset` and `posix_memalign`.
```
swiftc -target x86_64-unknown-uefi \
       -enable-experimental-feature Embedded -wmo \
       hello.swift -o hello.efi
```

Assisted-By: Claude

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->