### PR TITLE
MandatoryDestroyHoisting: model coroutine access scopes correctly

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MandatoryDestroyHoisting.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MandatoryDestroyHoisting.swift
@@ -44,20 +44,20 @@ let mandatoryDestroyHoisting = FunctionPass(name: "mandatory-destroy-hoisting") 
     return
   }
 
-  var endAccesses = Stack<EndAccessInst>(context)
-  defer { endAccesses.deinitialize() }
-  endAccesses.append(contentsOf: function.instructions.compactMap{ $0 as? EndAccessInst })
+  var accessScopeEnds = Stack<Instruction>(context)
+  defer { accessScopeEnds.deinitialize() }
+  accessScopeEnds.append(contentsOf: function.instructions.filter { $0.accessScopeBegin != nil })
 
   for block in function.blocks {
     for arg in block.arguments {
-      hoistDestroys(of: arg, endAccesses: endAccesses, context)
+      hoistDestroys(of: arg, accessScopeEnds: accessScopeEnds, context)
       if !context.continueWithNextSubpassRun() {
         return
       }
     }
     for inst in block.instructions {
       for result in inst.results {
-        hoistDestroys(of: result, endAccesses: endAccesses, context)
+        hoistDestroys(of: result, accessScopeEnds: accessScopeEnds, context)
         if !context.continueWithNextSubpassRun(for: inst) {
           return
         }
@@ -66,7 +66,7 @@ let mandatoryDestroyHoisting = FunctionPass(name: "mandatory-destroy-hoisting") 
   }
 }
 
-private func hoistDestroys(of value: Value, endAccesses: Stack<EndAccessInst>, _ context: FunctionPassContext) {
+private func hoistDestroys(of value: Value, accessScopeEnds: Stack<Instruction>, _ context: FunctionPassContext) {
   guard value.ownership == .owned,
 
         // We must not violate side-effect dependencies of non-copyable deinits.
@@ -93,7 +93,7 @@ private func hoistDestroys(of value: Value, endAccesses: Stack<EndAccessInst>, _
 
   // We must not move a destroy into an access scope, because the deinit can have an access scope as well.
   // And that would cause a false exclusivite error at runtime.
-  liverange.extendWithAccessScopes(of: endAccesses)
+  liverange.extendWithAccessScopes(of: accessScopeEnds)
 
   var aliveDestroys = insertNewDestroys(of: value, in: liverange)
   defer { aliveDestroys.deinitialize() }
@@ -234,7 +234,7 @@ private struct Liverange {
     fullLiverange.inclusiveRangeContains(instruction) && !prunedLiverange.inclusiveRangeContains(instruction)
   }
 
-  mutating func extendWithAccessScopes(of endAccesses: Stack<EndAccessInst>) {
+  mutating func extendWithAccessScopes(of accessScopeEnds: Stack<Instruction>) {
     var changed: Bool
     // We need to do this repeatedly because if access scopes are not nested properly, an overlapping scope
     // can make a non-overlapping scope also overlapping, e.g.
@@ -248,10 +248,10 @@ private struct Liverange {
     // ```
     repeat {
       changed = false
-      for endAccess in endAccesses {
-        if isOnlyInExtendedLiverange(endAccess), !isOnlyInExtendedLiverange(endAccess.beginAccess) {
-          prunedLiverange.insert(endAccess)
-          nonDestroyingUsers.append(endAccess)
+      for scopeEnd in accessScopeEnds {
+        if isOnlyInExtendedLiverange(scopeEnd), !isOnlyInExtendedLiverange(scopeEnd.accessScopeBegin!) {
+          prunedLiverange.insert(scopeEnd)
+          nonDestroyingUsers.append(scopeEnd)
           changed = true
         }
       }
@@ -262,6 +262,28 @@ private struct Liverange {
     fullLiverange.deinitialize()
     prunedLiverange.deinitialize()
     nonDestroyingUsers.deinitialize()
+  }
+}
+
+private extension Instruction {
+  /// If this instruction ends an access scope which is relevant for exclusivity checking, the instruction
+  /// which begins that scope. Otherwise nil.
+  ///
+  /// Beside `begin_access`/`end_access` this also covers yield-once coroutines: a coroutine callee - e.g. a
+  /// `modify` accessor of a class property - can begin a formal access before the yield and end it after the
+  /// resume. Such an access is not visible as `begin_access`/`end_access` in the caller, but bounded by
+  /// `begin_apply` and `end_apply`/`abort_apply`.
+  var accessScopeBegin: Instruction? {
+    switch self {
+    case let endAccess as EndAccessInst:
+      return endAccess.beginAccess
+    case let endApply as EndApplyInst:
+      return endApply.beginApply
+    case let abortApply as AbortApplyInst:
+      return abortApply.beginApply
+    default:
+      return nil
+    }
   }
 }
 

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -129,14 +129,6 @@ entry(%flag : $Builtin.Int1):
   // CHECK-NEXT:    [[R6:%.*]] = load ptr, ptr [[T0]], align
   // CHECK-NEXT:    [[T0:%.*]] = getelementptr inbounds{{.*}} [[BIGSUB]], ptr [[PTR]], i32 0, i32 7
   // CHECK-NEXT:    [[R7:%.*]] = load ptr, ptr [[T0]], align
-  // CHECK:         call void @swift_release(ptr [[R0]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R1]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R2]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R3]])
-  // CHECK:         call void @swift_release(ptr [[R4]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R5]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R6]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R7]])
 
   //   Branch.
   // CHECK-NEXT:    br i1 %0,
@@ -149,6 +141,17 @@ yes:
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
   end_apply %token as $()
 
+  //   The destroy of the yielded value must not be hoisted into the coroutine's
+  //   begin_apply/end_apply scope, so the releases happen here, after the resume.
+  // CHECK-NEXT:    call void @swift_release(ptr [[R0]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R1]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R2]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R3]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R4]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R5]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R6]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R7]])
+
   // CHECK-NEXT:    br label
   br cont
 
@@ -157,6 +160,8 @@ no:
   // CHECK-64-ptrauth-NEXT: ptrauth.blend
   // CHECK:    call swiftcc void [[CONTINUATION]](ptr noalias dereferenceable([[BUFFER_SIZE]]) [[BUFFER]], i1 true)
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R0]])
+  // CHECK:         call void @swift_release(ptr [[R7]])
   abort_apply %token
 
   // CHECK-NEXT:    br label

--- a/test/IRGen/yield_once_biggish.sil
+++ b/test/IRGen/yield_once_biggish.sil
@@ -122,10 +122,6 @@ entry(%flag : $Builtin.Int1):
   %0 = function_ref @test_simple : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @owned Biggish<T>)
   (%value, %token) = begin_apply %0<SomeSubclass>() : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @owned Biggish<T>)
 
-  // CHECK:         call void @swift_release(ptr [[R0_ORIG]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R1_ORIG]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R2_ORIG]])
-  // CHECK-NEXT:    call void @swift_release(ptr [[R3_ORIG]])
   //   Branch.
   // CHECK-NEXT:    br i1 %0,
   cond_br %flag, yes, no
@@ -137,6 +133,13 @@ yes:
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
   end_apply %token as $()
 
+  //   The destroy of the yielded value must not be hoisted into the coroutine's
+  //   begin_apply/end_apply scope, so the releases happen here, after the resume.
+  // CHECK-NEXT:    call void @swift_release(ptr [[R0_ORIG]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R1_ORIG]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R2_ORIG]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R3_ORIG]])
+
   // CHECK-NEXT:    br label
   br cont
 
@@ -145,6 +148,8 @@ no:
   // CHECK-64-ptrauth-NEXT: ptrauth.blend
   // CHECK:    call swiftcc void [[CONTINUATION]](ptr noalias dereferenceable([[BUFFER_SIZE]]) [[BUFFER]], i1 true)
   // CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 [[BUFFER_SIZE]], ptr [[BUFFER]])
+  // CHECK-NEXT:    call void @swift_release(ptr [[R0_ORIG]])
+  // CHECK:         call void @swift_release(ptr [[R3_ORIG]])
   abort_apply %token
 
   // CHECK-NEXT:    br label

--- a/test/Interpreter/mandatory_destroy_hoisting_exclusivity.swift
+++ b/test/Interpreter/mandatory_destroy_hoisting_exclusivity.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Onone %s -o %t/a.out.Onone
+// RUN: %target-codesign %t/a.out.Onone
+// RUN: %target-run %t/a.out.Onone | %FileCheck %s
+//
+// RUN: %target-build-swift -O %s -o %t/a.out.O
+// RUN: %target-codesign %t/a.out.O
+// RUN: %target-run %t/a.out.O | %FileCheck %s
+//
+// REQUIRES: executable_test
+
+// A `modify` accessor coroutine holds a dynamic access open across the yield. In the caller that
+// access is only bounded by begin_apply/end_apply, so MandatoryDestroyHoisting must not hoist the
+// destroy of `D` into that scope: `D.deinit` opens a second modify access on the same storage and
+// the runtime would trap with "Simultaneous accesses ... Fatal access conflict detected".
+//
+// rdar://185777259
+
+protocol P: AnyObject {
+  var p: Int { get set }
+}
+
+final class K: P {
+  var p: Int = 0
+}
+
+final class D {
+  let k: K
+  let v: Int
+  init(k: K, v: Int) { self.k = k; self.v = v }
+  deinit { k.p = 99 }
+}
+
+@inline(never)
+func combine(_ x: inout Int, _ d: D) {
+  x = d.v
+}
+
+@inline(never)
+func test(_ p: P, _ k: K) {
+  combine(&p.p, D(k: k, v: 7))
+}
+
+let k = K()
+test(k, k)
+
+// CHECK: k.p=99
+print("k.p=\(k.p)")

--- a/test/SILOptimizer/mandatory-destroy-hoisting.sil
+++ b/test/SILOptimizer/mandatory-destroy-hoisting.sil
@@ -233,6 +233,91 @@ bb2:
   br bb1
 }
 
+sil @coro : $@yield_once @convention(thin) () -> @yields @inout Int
+
+// CHECK-LABEL: sil [ossa] @non_overlapping_coroutine_scope :
+// CHECK:         fix_lifetime
+// CHECK-NEXT:    destroy_value %0
+// CHECK:         begin_apply
+// CHECK:       } // end sil function 'non_overlapping_coroutine_scope'
+sil [ossa] @non_overlapping_coroutine_scope : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  fix_lifetime %0
+  %1 = function_ref @coro : $@yield_once @convention(thin) () -> @yields @inout Int
+  (%2, %3) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @inout Int
+  end_apply %3 as $()
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// A `modify`/`read` accessor coroutine can hold a formal access open across the yield. That access is
+// not visible as begin_access/end_access in the caller, so the destroy must not be hoisted into the
+// begin_apply/end_apply scope.
+// CHECK-LABEL: sil [ossa] @overlapping_coroutine_scope :
+// CHECK:         end_apply
+// CHECK-NEXT:    destroy_value %4
+// CHECK:       } // end sil function 'overlapping_coroutine_scope'
+sil [ossa] @overlapping_coroutine_scope : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @coro : $@yield_once @convention(thin) () -> @yields @inout Int
+  (%2, %token) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @inout Int
+  %3 = move_value %0
+  fix_lifetime %3
+  end_apply %token as $()
+  destroy_value %3
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @overlapping_coroutine_scope_abort :
+// CHECK:       bb1:
+// CHECK-NEXT:    end_apply
+// CHECK-NEXT:    destroy_value %4
+// CHECK:       bb2:
+// CHECK-NEXT:    abort_apply
+// CHECK-NEXT:    destroy_value %4
+// CHECK:       } // end sil function 'overlapping_coroutine_scope_abort'
+sil [ossa] @overlapping_coroutine_scope_abort : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @coro : $@yield_once @convention(thin) () -> @yields @inout Int
+  (%2, %token) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @inout Int
+  %3 = move_value %0
+  fix_lifetime %3
+  cond_br undef, bb1, bb2
+bb1:
+  end_apply %token as $()
+  destroy_value %3
+  br bb3
+bb2:
+  abort_apply %token
+  destroy_value %3
+  br bb3
+bb3:
+  %r = tuple ()
+  return %r
+}
+
+// An access scope and a coroutine scope which make each other overlapping.
+// CHECK-LABEL: sil [ossa] @interleaved_coroutine_and_access_scope :
+// CHECK:         end_apply
+// CHECK-NEXT:    end_access %6
+// CHECK-NEXT:    destroy_value %4
+// CHECK:       } // end sil function 'interleaved_coroutine_and_access_scope'
+sil [ossa] @interleaved_coroutine_and_access_scope : $@convention(thin) (@owned String) -> () {
+bb0(%0 : @owned $String):
+  %1 = function_ref @coro : $@yield_once @convention(thin) () -> @yields @inout Int
+  (%2, %token) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @inout Int
+  %3 = move_value %0
+  fix_lifetime %3
+  %5 = begin_access [modify] [dynamic] undef : $*Int
+  end_apply %token as $()
+  end_access %5
+  destroy_value %3
+  %r = tuple ()
+  return %r
+}
+
 // CHECK-LABEL: sil [ossa] @dead_end_block :
 // CHECK:       bb0(%0 : @owned $String):
 // CHECK-NEXT:    destroy_value %0


### PR DESCRIPTION
`Liverange.extendWithAccessScopes` keeps a hoisted destroy out of open exclusivity scopes, because the deinit can open an access scope as well. It only collected `end_access`, so it modeled a single scope category: `begin_access`/`end_access` pairs visible in the current function.

A yield-once coroutine accessor - e.g. the protocol witness `modify` for a stored class property - opens `begin_access [dynamic]` inside the callee and holds it across the yield. In the caller that scope is bounded only by `begin_apply` and `end_apply`/`abort_apply`, so it was invisible to the pass, which then moved the destroy into it. The deinit opened a second modify access on the same storage and the runtime aborted with "Fatal access conflict detected" - a false positive introduced by the optimizer.

Generalize the scope-end set to any instruction with an `accessScopeBegin`, mapping `end_access` to `begin_access` and `end_apply`/`abort_apply` to `begin_apply`. This is conservative for coroutines that hold no access, which costs only a shorter hoist.

rdar://185777259
