### PR TITLE
[ASTPrinter][LiteralExpressions] Print explicit enum raw values that were constant-folded

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4928,8 +4928,15 @@ void PrintAST::printEnumElement(EnumElementDecl *elt) {
     break;
   }
 
+  // Whether a raw value was written explicitly is determined from the original
+  // (pre-folded) expression: constant folding produces an implicit literal.
+  // The folded value is what gets printed (e.g. '2 + 3' prints as '5').
+  if (auto *original = elt->getOriginalRawValueExpr();
+      !original || original->isImplicit())
+    return;
+
   auto *raw = elt->getRawValueExpr();
-  if (!raw || raw->isImplicit())
+  if (!raw)
     return;
 
   // Print the explicit raw value expression.

--- a/test/LiteralExpressions/EnumRawValueObjCInterface.swift
+++ b/test/LiteralExpressions/EnumRawValueObjCInterface.swift
@@ -1,0 +1,26 @@
+// An '@objc' enum case's raw value is its Objective-C enumerator value, so a
+// textual interface prints it. Constant folding replaces the written expression
+// with an implicit literal, which is why explicitness comes from the original
+// expression rather than from the folded one.
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_LiteralExpressions
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name EnumRawValueObjCInterface -o %t/EnumRawValueObjCInterface.swiftmodule -emit-module-interface-path %t/EnumRawValueObjCInterface.swiftinterface -enable-library-evolution -swift-version 5 %s -enable-experimental-feature LiteralExpressions
+// RUN: %FileCheck %s < %t/EnumRawValueObjCInterface.swiftinterface
+
+import Foundation
+
+// CHECK-LABEL: @objc public enum E : Swift::Int {
+@objc public enum E: Int {
+  // CHECK-NEXT: case literal = 1
+  case literal = 1
+  // CHECK-NEXT: case sum = 5
+  case sum = 2 + 3
+  // An auto-incremented case has no written raw value and prints without one.
+  // CHECK-NEXT: case autoIncremented{{$}}
+  case autoIncremented
+  // CHECK-NEXT: case negative = -7
+  case negative = -7
+  // CHECK-NEXT: case product = 32
+  case product = 0x10 * 2
+}


### PR DESCRIPTION
With `LiteralExpressions` enabled, `getRawValueExpr()` constant-folds and returns a fresh literal, which is always implicit. printEnumElement used that value's implicit-ness to tell an explicit raw value from an auto-incremented one, so every explicit raw value was dropped wherever raw values print, such as an '@objc' enum's textual interface.

For an '@objc' enum the raw value is the Objective-C enumerator value, so a client rebuilt from the interface got 0, 1, 2 in place of the declared values.

Determine explicitness from `getOriginalRawValueExpr()`, the pre-folding expression whose implicit-ness still reflects whether a raw value was written, and print the folded value.
