### PR TITLE
[Sema] Anchor derivation macro expansions inside the conformance context's braces

### DIFF
--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -998,15 +998,14 @@ bool swift::memberwiseAccessorsRequireActorIsolation(NominalTypeDecl *nominal) {
 /// with its parent context for name lookup.
 static SourceLoc getValidParentLocForDerivation(DerivedConformance &derived,
                                                 ValueDecl *requirement) {
+  auto braces = cast<IterableDeclContext>(derived.ConformanceDecl)->getBraces();
+  if (braces.Start.isValid())
+    return braces.Start;
+
+  if (braces.End.isValid())
+    return braces.End;
+
   auto atLoc = derived.Conformance->getLoc();
-  if (atLoc.isValid())
-    return atLoc;
-
-  atLoc = derived.Nominal->getBraces().Start;
-  if (atLoc.isValid())
-    return atLoc;
-
-  atLoc = derived.Nominal->getBraces().End;
   if (atLoc.isValid())
     return atLoc;
 

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1002,9 +1002,6 @@ static SourceLoc getValidParentLocForDerivation(DerivedConformance &derived,
   if (braces.Start.isValid())
     return braces.Start;
 
-  if (braces.End.isValid())
-    return braces.End;
-
   auto atLoc = derived.Conformance->getLoc();
   if (atLoc.isValid())
     return atLoc;

--- a/test/Sema/derived_conformance_macro_scopes.swift
+++ b/test/Sema/derived_conformance_macro_scopes.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-silgen -compiler-assertions -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -enable-library-evolution -compiler-assertions -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) %s | %FileCheck %s
+
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+// CHECK-LABEL: struct InInheritanceClause : Equatable {
+struct InInheritanceClause: Equatable {
+  var hasSeen = false
+}
+
+// CHECK-LABEL: struct InExtension {
+struct InExtension {
+  var hasSeen = false
+}
+
+extension InExtension: Equatable {}
+
+// CHECK-LABEL: enum EnumInInheritanceClause : Equatable {
+enum EnumInInheritanceClause: Equatable {
+  case a
+  case b(Int)
+}
+
+// CHECK-LABEL: struct EmptyBraces : Equatable {
+struct EmptyBraces: Equatable {}


### PR DESCRIPTION
This PR fixes stdlib build crashing when enabling the `deriveRequirementViaMacro` experimental feature flag.
It also adds a regression test guarding against that same crash with a small reproducer.