### PR TITLE
[Test] rdar165231596.swift: mark OS stdlib & back deployment unsupported

### DIFF
--- a/validation-test/stdlib/rdar165231596.swift
+++ b/validation-test/stdlib/rdar165231596.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: executable_test
+// UNSUPPORTED: back_deployment_runtime || use_os_stdlib
 
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values
 


### PR DESCRIPTION
This test relates to the change to Span subscripting introduced in #91536 so it will fail when using an older stdlib.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
