### PR TITLE
[Refactoring] Add an "Expand Derived Conformance" refactoring

### DIFF
--- a/include/swift/Refactoring/RefactoringKinds.def
+++ b/include/swift/Refactoring/RefactoringKinds.def
@@ -66,6 +66,8 @@ CURSOR_REFACTORING(AddAsyncWrapper, "Add Async Wrapper", add.async-wrapper)
 
 CURSOR_REFACTORING(ExpandMacro, "Expand Macro", expand.macro)
 
+CURSOR_REFACTORING(ExpandDerivedConformance, "Expand Derived Conformance", expand.derived_conformance)
+
 CURSOR_REFACTORING(InlineMacro, "Inline Macro", inline.macro)
 
 RANGE_REFACTORING(ExtractExpr, "Extract Expression", extract.expr)

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/IDE/Utils.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Edit.h"
@@ -627,10 +628,10 @@ remove(SourceManager &SM, CharSourceRange Range) {
 
 /// Given the expanded code for a particular macro, perform whitespace
 /// adjustments to make the refactoring more suitable for inline insertion.
-static StringRef
-adjustMacroExpansionWhitespace(GeneratedSourceInfo::Kind kind,
-                               StringRef expandedCode,
-                               llvm::SmallString<64> &scratch) {
+static StringRef adjustMacroExpansionWhitespace(GeneratedSourceInfo::Kind kind,
+                                                StringRef expandedCode,
+                                                llvm::SmallString<64> &scratch,
+                                                SourceFile *originalFile) {
   scratch.clear();
 
   switch (kind) {
@@ -663,6 +664,15 @@ adjustMacroExpansionWhitespace(GeneratedSourceInfo::Kind kind,
   case GeneratedSourceInfo::DefaultArgument:
   case GeneratedSourceInfo::AttributeFromClang:
   case GeneratedSourceInfo::SyntheticMacro:
+    // If inside a macro expansion from a synthetic macro, add a leading
+    // new line so that consecutive buffers do not end/start on the same line,
+    // and the first buffer is not on the same line as the conformance context's
+    // braces.
+    if (originalFile && originalFile->Kind == SourceFileKind::SyntheticMacro) {
+      scratch += "\n";
+      scratch += expandedCode;
+      return scratch;
+    }
     return expandedCode;
   }
 }
@@ -682,11 +692,6 @@ void swift::ide::SourceEditConsumer::acceptMacroExpansionBuffer(
       rewrittenBuffer.empty())
     return;
 
-  SmallString<64> scratchBuffer;
-  if (adjustExpansion) {
-    rewrittenBuffer = adjustMacroExpansionWhitespace(
-        generatedInfo->kind, rewrittenBuffer, scratchBuffer);
-  }
 
   // `containingFile` is the file of the actual expansion site, where as
   // `originalFile` is the possibly enclosing buffer. Concretely:
@@ -710,6 +715,12 @@ void swift::ide::SourceEditConsumer::acceptMacroExpansionBuffer(
   SourceFile *originalFile =
       containingSF->getParentModule()->getSourceFileContainingLocation(
           originalSourceRange.getStart());
+
+  SmallString<64> scratchBuffer;
+  if (adjustExpansion) {
+    rewrittenBuffer = adjustMacroExpansionWhitespace(
+        generatedInfo->kind, rewrittenBuffer, scratchBuffer, originalFile);
+  }
 
   if (originalFile && originalFile->Kind == SourceFileKind::SyntheticMacro) {
     auto derivationInfo =

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -710,6 +710,18 @@ void swift::ide::SourceEditConsumer::acceptMacroExpansionBuffer(
   SourceFile *originalFile =
       containingSF->getParentModule()->getSourceFileContainingLocation(
           originalSourceRange.getStart());
+
+  if (originalFile && originalFile->Kind == SourceFileKind::SyntheticMacro) {
+    auto derivationInfo =
+        SM.getGeneratedSourceInfo(originalFile->getBufferID());
+    // The derivation buffer is anchored at the conformance context's opening
+    // brace.
+    auto memberListStart = Lexer::getLocForEndOfToken(
+        SM, derivationInfo->originalSourceRange.getStart());
+    originalSourceRange = CharSourceRange(memberListStart, 0);
+    originalFile = originalFile->getEnclosingSourceFile();
+  }
+
   StringRef originalPath;
   if (containingSF->getBufferID() != originalFile->getBufferID()) {
     originalPath = SM.getIdentifierForBuffer(originalFile->getBufferID());

--- a/lib/Refactoring/ExpandMacro.cpp
+++ b/lib/Refactoring/ExpandMacro.cpp
@@ -12,7 +12,9 @@
 
 #include "ContextFinder.h"
 #include "RefactoringActions.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/TypeRepr.h"
 
 using namespace swift::refactoring;
 
@@ -170,6 +172,155 @@ getMacroExpansionBuffers(SourceManager &sourceMgr, ResolvedCursorInfoPtr Info) {
   return {};
 }
 
+static NominalTypeDecl *findProtocolsAndNominal(
+    SourceManager &SM, ResolvedCursorInfoPtr cursorInfo,
+    llvm::SmallSetVector<ProtocolDecl *, 4> &derivedProtocols) {
+
+  // We should be somewhere here:
+  // extension T : SomeProtocol, ... { ... }
+  //                   ^
+  // or
+  // (struct|enum|class) T: SomeProtocol, ... { ... }
+  //                          ^
+  // Where `SomeProtocol` can be a regular protocol or a typealias.
+
+  SourceFile *containingSF = cursorInfo->getSourceFile();
+  if (!containingSF)
+    return nullptr;
+
+  SourceLoc loc = cursorInfo->getLoc();
+
+  auto entryContainingLoc =
+      [&](InheritedTypes inherited) -> std::optional<unsigned> {
+    for (auto i : inherited.getIndices()) {
+      auto *repr = inherited.getTypeRepr(i);
+      if (repr && SM.rangeContainsTokenLoc(repr->getSourceRange(), loc))
+        return i;
+    }
+    return std::nullopt;
+  };
+
+  auto collectProtocols = [&](InheritedTypes inherited) {
+    auto index = entryContainingLoc(inherited);
+    if (!index)
+      return false;
+
+    Type entryTy = inherited.getResolvedType(*index);
+    if (!entryTy || !entryTy->isExistentialType())
+      return false;
+
+    auto layout = entryTy->getExistentialLayout();
+    for (auto *protocol : layout.getProtocols()) {
+      // Only collect protocols that can be derived, so we don't have to resolve
+      // unnecessary conformances
+      if (!protocol->getKnownDerivableProtocolKind())
+        continue;
+      derivedProtocols.insert(protocol);
+    }
+    return !derivedProtocols.empty();
+  };
+
+  ContextFinder Finder(*containingSF, loc, [&](ASTNode N) {
+    auto *D = N.dyn_cast<Decl *>();
+    if (!D)
+      return false;
+    if (auto *ext = dyn_cast<ExtensionDecl>(D))
+      return entryContainingLoc(InheritedTypes(ext)).has_value();
+    if (auto *nominal = dyn_cast<NominalTypeDecl>(D))
+      return entryContainingLoc(InheritedTypes(nominal)).has_value();
+    return false;
+  });
+
+  Finder.resolve();
+
+  // Get innermost context using reverse
+  for (auto ctx : llvm::reverse(Finder.getContexts())) {
+    auto *D = ctx.dyn_cast<Decl *>();
+    if (auto *ext = dyn_cast_or_null<ExtensionDecl>(D)) {
+      if (collectProtocols(InheritedTypes(ext)))
+        return ext->getExtendedNominal();
+      break;
+    }
+    if (auto *nominal = dyn_cast_or_null<NominalTypeDecl>(D)) {
+      if (!isa<StructDecl>(D) && !isa<ClassDecl>(D) && !isa<EnumDecl>(D))
+        continue;
+      if (collectProtocols(InheritedTypes(nominal)))
+        return nominal;
+      break;
+    }
+  }
+  return nullptr;
+}
+
+static llvm::SmallSetVector<unsigned, 2>
+getDerivedConformancesExpansionBuffers(SourceManager &SM,
+                                       ResolvedCursorInfoPtr cursorInfo) {
+  // Make sure we only do the work if the `DeriveConformancesViaMacros`
+  // experimental feature is enabled. If not, then no conformance is derived
+  // using macros, so this is pointless.
+  auto *sf = cursorInfo->getSourceFile();
+  if (!sf)
+    return {};
+  if (!sf->getASTContext().LangOpts.hasFeature(
+          Feature::DeriveConformancesViaMacros))
+    return {};
+
+  llvm::SmallSetVector<ProtocolDecl *, 4> derivedProtocols;
+
+  auto ty = findProtocolsAndNominal(SM, cursorInfo, derivedProtocols);
+  if (!ty)
+    return {};
+
+  llvm::SmallSetVector<unsigned, 2> bufferIDs;
+
+  auto registerProtocol = [&](ProtocolDecl *protocol) {
+    llvm::SmallVector<ProtocolConformance *, 2> conformances;
+    ty->lookupConformance(protocol, conformances);
+    for (auto *conformance : conformances) {
+      for (auto *requirement : protocol->getProtocolRequirements()) {
+        if (isa<AssociatedTypeDecl>(requirement))
+          continue;
+        auto *witness = conformance->getWitnessDecl(requirement);
+        if (!witness || !witness->isFromSyntheticMacroExpansion())
+          continue;
+        auto loc = witness->getStartLoc();
+        if (loc.isInvalid())
+          continue;
+        bufferIDs.insert(SM.findBufferContainingLoc(loc));
+      }
+    }
+  };
+
+  for (auto *derived : derivedProtocols) {
+    registerProtocol(derived);
+    for (auto *inherited : derived->getAllInheritedProtocols()) {
+      registerProtocol(inherited);
+    }
+  }
+  return bufferIDs;
+}
+
+static bool
+expandDerivedConformanceWitnesses(SourceManager &SM,
+                                  ResolvedCursorInfoPtr cursorInfo,
+                                  SourceEditConsumer &editConsumer) {
+  auto bufferIDs = getDerivedConformancesExpansionBuffers(SM, cursorInfo);
+  if (bufferIDs.empty())
+    return true;
+
+  SourceFile *containingSF = cursorInfo->getSourceFile();
+  if (!containingSF)
+    return true;
+
+  // Send all of the rewritten buffer snippets.
+  for (auto bufferID : bufferIDs) {
+    editConsumer.acceptMacroExpansionBuffer(SM, bufferID, containingSF,
+                                            /*adjustExpansion=*/false,
+                                            /*includeBufferName=*/true);
+  }
+  return false;
+}
+
 static bool expandMacro(SourceManager &SM, ResolvedCursorInfoPtr cursorInfo,
                         SourceEditConsumer &editConsumer,
                         bool adjustExpansion) {
@@ -210,6 +361,17 @@ bool RefactoringActionExpandMacro::isApplicable(ResolvedCursorInfoPtr Info,
 bool RefactoringActionExpandMacro::performChange() {
   return expandMacro(SM, CursorInfo, EditConsumer, /*adjustExpansion=*/false);
 }
+
+bool RefactoringActionExpandDerivedConformance::isApplicable(ResolvedCursorInfoPtr Info,
+                                                DiagnosticEngine &Diag) {
+  // Mirrors `RefactoringActionInlineMacro::isApplicable`
+  return !getDerivedConformancesExpansionBuffers(Diag.SourceMgr, Info).empty();
+}
+
+bool RefactoringActionExpandDerivedConformance::performChange() {
+  return expandDerivedConformanceWitnesses(SM, CursorInfo, EditConsumer);
+}
+
 
 bool RefactoringActionInlineMacro::isApplicable(ResolvedCursorInfoPtr Info,
                                                 DiagnosticEngine &Diag) {

--- a/lib/Refactoring/ExpandMacro.cpp
+++ b/lib/Refactoring/ExpandMacro.cpp
@@ -315,7 +315,7 @@ expandDerivedConformanceWitnesses(SourceManager &SM,
   // Send all of the rewritten buffer snippets.
   for (auto bufferID : bufferIDs) {
     editConsumer.acceptMacroExpansionBuffer(SM, bufferID, containingSF,
-                                            /*adjustExpansion=*/false,
+                                            /*adjustExpansion=*/true,
                                             /*includeBufferName=*/true);
   }
   return false;

--- a/test/SourceKit/Macros/expand_derived_conformance.swift
+++ b/test/SourceKit/Macros/expand_derived_conformance.swift
@@ -34,26 +34,26 @@ struct Suppressed: ~Copyable {
 //##-- Conformance stated in the inheritance clause.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=1:16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=DIRECT %s
 // DIRECT: source.edit.kind.active:
-// DIRECT-NEXT: __derivation_macro__Direct@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// DIRECT-NEXT: {{^}}{{ +}}1:27-1:27 ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
 // DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
 //##-- Conformance stated in an extension.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=9:24 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=IN_EXTENSION %s
 // IN_EXTENSION: source.edit.kind.active:
-// IN_EXTENSION-NEXT: __derivation_macro__InExtension@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// IN_EXTENSION-NEXT: {{^}}{{ +}}9:35-9:35 ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
 // IN_EXTENSION-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
 //##-- A typealias naming a protocol composition resolves to the same buffer for both protocols, so only one edit is expected.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=13:22 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=VIA_TYPEALIAS %s
 // VIA_TYPEALIAS: source.edit.kind.active:
-// VIA_TYPEALIAS-NEXT: __derivation_macro__ViaTypealias@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}13:44-13:44 ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
 // VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-// VIA_TYPEALIAS-NOT: __derivation_macro__
+// VIA_TYPEALIAS-NOT: 13:44-13:44
 
 //##-- Hashable has no macro-derived witnesses of its own, so this walks its inherited protocols down to Equatable.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=17:12 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=ENUM %s
 // ENUM: source.edit.kind.active:
-// ENUM-NEXT: __derivation_macro__Enum@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_semantics("derived_enum_equals")
+// ENUM-NEXT: {{^}}{{ +}}17:22-17:22 ({{.*}}_deriveEquatablefMf_.swift) "@_semantics("derived_enum_equals")
 // ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // ENUM-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 

--- a/test/SourceKit/Macros/expand_derived_conformance.swift
+++ b/test/SourceKit/Macros/expand_derived_conformance.swift
@@ -34,26 +34,30 @@ struct Suppressed: ~Copyable {
 //##-- Conformance stated in the inheritance clause.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=1:16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=DIRECT %s
 // DIRECT: source.edit.kind.active:
-// DIRECT-NEXT: {{^}}{{ +}}1:27-1:27 ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// DIRECT-NEXT: {{^}}{{ +}}1:27-1:27 ({{.*}}_deriveEquatablefMf_.swift) "
+// DIRECT-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
 //##-- Conformance stated in an extension.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=9:24 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=IN_EXTENSION %s
 // IN_EXTENSION: source.edit.kind.active:
-// IN_EXTENSION-NEXT: {{^}}{{ +}}9:35-9:35 ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// IN_EXTENSION-NEXT: {{^}}{{ +}}9:35-9:35 ({{.*}}_deriveEquatablefMf_.swift) "
+// IN_EXTENSION-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // IN_EXTENSION-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
 //##-- A typealias naming a protocol composition resolves to the same buffer for both protocols, so only one edit is expected.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=13:22 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=VIA_TYPEALIAS %s
 // VIA_TYPEALIAS: source.edit.kind.active:
-// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}13:44-13:44 ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}13:44-13:44 ({{.*}}_deriveEquatablefMf_.swift) "
+// VIA_TYPEALIAS-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 // VIA_TYPEALIAS-NOT: 13:44-13:44
 
 //##-- Hashable has no macro-derived witnesses of its own, so this walks its inherited protocols down to Equatable.
 // RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=17:12 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=ENUM %s
 // ENUM: source.edit.kind.active:
-// ENUM-NEXT: {{^}}{{ +}}17:22-17:22 ({{.*}}_deriveEquatablefMf_.swift) "@_semantics("derived_enum_equals")
+// ENUM-NEXT: {{^}}{{ +}}17:22-17:22 ({{.*}}_deriveEquatablefMf_.swift) "
+// ENUM-NEXT: @_semantics("derived_enum_equals")
 // ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // ENUM-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 

--- a/test/SourceKit/Macros/expand_derived_conformance.swift
+++ b/test/SourceKit/Macros/expand_derived_conformance.swift
@@ -1,70 +1,55 @@
+// REQUIRES: swift_swift_parser, asserts
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+1):16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=DIRECT %s
 struct Direct: Equatable {
   var x: Int = 0
 }
+// DIRECT: source.edit.kind.active:
+// DIRECT-NEXT: {{^}}{{ +}}[[@LINE-4]]:27-[[@LINE-4]]:27 ({{.*}}_deriveEquatablefMf_.swift) "
+// DIRECT-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+4):24 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=IN_EXTENSION %s
 struct InExtension {
   var x: Int = 0
 }
-
 extension InExtension: Equatable {}
+// IN_EXTENSION: source.edit.kind.active:
+// IN_EXTENSION-NEXT: {{^}}{{ +}}[[@LINE-2]]:35-[[@LINE-2]]:35 ({{.*}}_deriveEquatablefMf_.swift) "
+// IN_EXTENSION-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// IN_EXTENSION-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
 typealias EquatableAndHashable = Equatable & Hashable
 
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+1):22 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=VIA_TYPEALIAS %s
 struct ViaTypealias: EquatableAndHashable {
   var x: Int = 0
 }
+// VIA_TYPEALIAS: source.edit.kind.active:
+// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}[[@LINE-4]]:44-[[@LINE-4]]:44 ({{.*}}_deriveEquatablefMf_.swift) "
+// VIA_TYPEALIAS-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+// VIA_TYPEALIAS-NOT: [[@LINE-7]]:44-[[@LINE-7]]:44
 
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+1):12 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=ENUM %s
 enum Enum: Hashable {
   case a
   case b(Int)
 }
-
-// Not a protocol entry: nothing to expand.
-class Base {}
-class Derived: Base {}
-
-// A suppressed entry is not a derived conformance either.
-struct Suppressed: ~Copyable {
-  var x: Int = 0
-}
-
-// REQUIRES: swift_swift_parser, asserts
-// REQUIRES: swift_feature_DeriveConformancesViaMacros
-
-//##-- Conformance stated in the inheritance clause.
-// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=1:16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=DIRECT %s
-// DIRECT: source.edit.kind.active:
-// DIRECT-NEXT: {{^}}{{ +}}1:27-1:27 ({{.*}}_deriveEquatablefMf_.swift) "
-// DIRECT-NEXT: @_implements(Swift::Equatable, ==(_:_:))
-// DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-
-//##-- Conformance stated in an extension.
-// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=9:24 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=IN_EXTENSION %s
-// IN_EXTENSION: source.edit.kind.active:
-// IN_EXTENSION-NEXT: {{^}}{{ +}}9:35-9:35 ({{.*}}_deriveEquatablefMf_.swift) "
-// IN_EXTENSION-NEXT: @_implements(Swift::Equatable, ==(_:_:))
-// IN_EXTENSION-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-
-//##-- A typealias naming a protocol composition resolves to the same buffer for both protocols, so only one edit is expected.
-// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=13:22 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=VIA_TYPEALIAS %s
-// VIA_TYPEALIAS: source.edit.kind.active:
-// VIA_TYPEALIAS-NEXT: {{^}}{{ +}}13:44-13:44 ({{.*}}_deriveEquatablefMf_.swift) "
-// VIA_TYPEALIAS-NEXT: @_implements(Swift::Equatable, ==(_:_:))
-// VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-// VIA_TYPEALIAS-NOT: 13:44-13:44
-
-//##-- Hashable has no macro-derived witnesses of its own, so this walks its inherited protocols down to Equatable.
-// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=17:12 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=ENUM %s
 // ENUM: source.edit.kind.active:
-// ENUM-NEXT: {{^}}{{ +}}17:22-17:22 ({{.*}}_deriveEquatablefMf_.swift) "
+// ENUM-NEXT: {{^}}{{ +}}[[@LINE-5]]:22-[[@LINE-5]]:22 ({{.*}}_deriveEquatablefMf_.swift) "
 // ENUM-NEXT: @_semantics("derived_enum_equals")
 // ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // ENUM-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
-//##-- A superclass entry denotes no protocol so do nothing.
-// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=24:16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck --allow-empty -check-prefix=NO_EXPANSION %s
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+2):16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck --allow-empty -check-prefix=NO_EXPANSION %s
+class Base {}
+class Derived: Base {}
 
-//##-- A suppressed entry is not a derived conformance so do nothing.
-// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=27:21 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck --allow-empty -check-prefix=NO_EXPANSION %s
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=%(line+1):21 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck --allow-empty -check-prefix=NO_EXPANSION %s
+struct Suppressed: ~Copyable {
+  var x: Int = 0
+}
 
 // NO_EXPANSION-NOT: source.edit.kind.active

--- a/test/SourceKit/Macros/expand_derived_conformance.swift
+++ b/test/SourceKit/Macros/expand_derived_conformance.swift
@@ -1,0 +1,66 @@
+struct Direct: Equatable {
+  var x: Int = 0
+}
+
+struct InExtension {
+  var x: Int = 0
+}
+
+extension InExtension: Equatable {}
+
+typealias EquatableAndHashable = Equatable & Hashable
+
+struct ViaTypealias: EquatableAndHashable {
+  var x: Int = 0
+}
+
+enum Enum: Hashable {
+  case a
+  case b(Int)
+}
+
+// Not a protocol entry: nothing to expand.
+class Base {}
+class Derived: Base {}
+
+// A suppressed entry is not a derived conformance either.
+struct Suppressed: ~Copyable {
+  var x: Int = 0
+}
+
+// REQUIRES: swift_swift_parser, asserts
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+//##-- Conformance stated in the inheritance clause.
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=1:16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=DIRECT %s
+// DIRECT: source.edit.kind.active:
+// DIRECT-NEXT: __derivation_macro__Direct@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+
+//##-- Conformance stated in an extension.
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=9:24 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=IN_EXTENSION %s
+// IN_EXTENSION: source.edit.kind.active:
+// IN_EXTENSION-NEXT: __derivation_macro__InExtension@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// IN_EXTENSION-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+
+//##-- A typealias naming a protocol composition resolves to the same buffer for both protocols, so only one edit is expected.
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=13:22 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=VIA_TYPEALIAS %s
+// VIA_TYPEALIAS: source.edit.kind.active:
+// VIA_TYPEALIAS-NEXT: __derivation_macro__ViaTypealias@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_implements(Swift::Equatable, ==(_:_:))
+// VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+// VIA_TYPEALIAS-NOT: __derivation_macro__
+
+//##-- Hashable has no macro-derived witnesses of its own, so this walks its inherited protocols down to Equatable.
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=17:12 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck -check-prefix=ENUM %s
+// ENUM: source.edit.kind.active:
+// ENUM-NEXT: __derivation_macro__Enum@==__buffer 1:1-1:{{[0-9]+}} ({{.*}}_deriveEquatablefMf_.swift) "@_semantics("derived_enum_equals")
+// ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// ENUM-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+
+//##-- A superclass entry denotes no protocol so do nothing.
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=24:16 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck --allow-empty -check-prefix=NO_EXPANSION %s
+
+//##-- A suppressed entry is not a derived conformance so do nothing.
+// RUN: %sourcekitd-test -req=refactoring.expand.derived_conformance -pos=27:21 %s -- -enable-experimental-feature DeriveConformancesViaMacros -module-name DerivedConformanceUser %s | %FileCheck --allow-empty -check-prefix=NO_EXPANSION %s
+
+// NO_EXPANSION-NOT: source.edit.kind.active

--- a/test/refactoring/Macros/expand_derived_conformance.swift
+++ b/test/refactoring/Macros/expand_derived_conformance.swift
@@ -1,0 +1,50 @@
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+struct Direct: Equatable {
+  var x: Int = 0
+}
+
+struct InExtension {
+  var x: Int = 0
+}
+
+extension InExtension: Equatable {}
+
+typealias EquatableAndHashable = Equatable & Hashable
+
+struct ViaTypealias: EquatableAndHashable {
+  var x: Int = 0
+}
+
+enum Enum: Hashable {
+  case a
+  case b(Int)
+}
+
+// RUN: %empty-directory(%t)
+
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) --dump-text -source-filename %s -pos=3:21 | %FileCheck -check-prefix=DIRECT %s
+// DIRECT: {{.*}}.swift 3:27 -> 3:27
+// DIRECT-EMPTY:
+// DIRECT-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=11:28 | %FileCheck -check-prefix=IN_EXTENSION %s
+// IN_EXTENSION: {{.*}}.swift 11:35 -> 11:35
+// IN_EXTENSION-EMPTY:
+// IN_EXTENSION-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// IN_EXTENSION-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=15:31 | %FileCheck -check-prefix=VIA_TYPEALIAS %s
+// VIA_TYPEALIAS: {{.*}}.swift 15:44 -> 15:44
+// VIA_TYPEALIAS-EMPTY:
+// VIA_TYPEALIAS-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
+// VIA_TYPEALIAS-NOT: {{.*}}.swift 15:44 -> 15:44
+
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=19:17 | %FileCheck -check-prefix=ENUM %s
+// ENUM: {{.*}}.swift 19:22 -> 19:22
+// ENUM-EMPTY:
+// ENUM-NEXT: @_semantics("derived_enum_equals")
+// ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// ENUM-NEXT: static func __derived_enum_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {

--- a/test/refactoring/Macros/expand_derived_conformance.swift
+++ b/test/refactoring/Macros/expand_derived_conformance.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) --dump-text -source-filename %s -pos=%(line+1):21 | %FileCheck -check-prefix=DIRECT %s
+// RUN: %refactor-check-compiles -expand-derived-conformance -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) --dump-text -source-filename %s -pos=%(line+1):21 | %FileCheck -check-prefix=DIRECT %s
 struct Direct: Equatable {
   var x: Int = 0
 }
@@ -11,7 +11,7 @@ struct Direct: Equatable {
 // DIRECT-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+5):28 | %FileCheck -check-prefix=IN_EXTENSION %s
+// RUN: %refactor-check-compiles -expand-derived-conformance -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+5):28 | %FileCheck -check-prefix=IN_EXTENSION %s
 struct InExtension {
   var x: Int = 0
 }
@@ -24,7 +24,7 @@ extension InExtension: Equatable {}
 
 typealias EquatableAndHashable = Equatable & Hashable
 
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+1):31 | %FileCheck -check-prefix=VIA_TYPEALIAS %s
+// RUN: %refactor-check-compiles -expand-derived-conformance -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+1):31 | %FileCheck -check-prefix=VIA_TYPEALIAS %s
 struct ViaTypealias: EquatableAndHashable {
   var x: Int = 0
 }
@@ -34,7 +34,7 @@ struct ViaTypealias: EquatableAndHashable {
 // VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 // VIA_TYPEALIAS-NOT: {{.*}}.swift [[@LINE-7]]:44 -> [[@LINE-7]]:44
 
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+1):17 | %FileCheck -check-prefix=ENUM %s
+// RUN: %refactor-check-compiles -expand-derived-conformance -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+1):17 | %FileCheck -check-prefix=ENUM %s
 enum Enum: Hashable {
   case a
   case b(Int)

--- a/test/refactoring/Macros/expand_derived_conformance.swift
+++ b/test/refactoring/Macros/expand_derived_conformance.swift
@@ -1,49 +1,45 @@
 // REQUIRES: swift_feature_DeriveConformancesViaMacros
 
+// RUN: %empty-directory(%t)
+
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) --dump-text -source-filename %s -pos=%(line+1):21 | %FileCheck -check-prefix=DIRECT %s
 struct Direct: Equatable {
   var x: Int = 0
 }
+// DIRECT: {{.*}}.swift [[@LINE-3]]:27 -> [[@LINE-3]]:27
+// DIRECT-EMPTY:
+// DIRECT-NEXT: @_implements(Swift::Equatable, ==(_:_:))
+// DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+5):28 | %FileCheck -check-prefix=IN_EXTENSION %s
 struct InExtension {
   var x: Int = 0
 }
 
 extension InExtension: Equatable {}
-
-typealias EquatableAndHashable = Equatable & Hashable
-
-struct ViaTypealias: EquatableAndHashable {
-  var x: Int = 0
-}
-
-enum Enum: Hashable {
-  case a
-  case b(Int)
-}
-
-// RUN: %empty-directory(%t)
-
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) --dump-text -source-filename %s -pos=3:21 | %FileCheck -check-prefix=DIRECT %s
-// DIRECT: {{.*}}.swift 3:27 -> 3:27
-// DIRECT-EMPTY:
-// DIRECT-NEXT: @_implements(Swift::Equatable, ==(_:_:))
-// DIRECT-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=11:28 | %FileCheck -check-prefix=IN_EXTENSION %s
-// IN_EXTENSION: {{.*}}.swift 11:35 -> 11:35
+// IN_EXTENSION: {{.*}}.swift [[@LINE-1]]:35 -> [[@LINE-1]]:35
 // IN_EXTENSION-EMPTY:
 // IN_EXTENSION-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // IN_EXTENSION-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
 
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=15:31 | %FileCheck -check-prefix=VIA_TYPEALIAS %s
-// VIA_TYPEALIAS: {{.*}}.swift 15:44 -> 15:44
+typealias EquatableAndHashable = Equatable & Hashable
+
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+1):31 | %FileCheck -check-prefix=VIA_TYPEALIAS %s
+struct ViaTypealias: EquatableAndHashable {
+  var x: Int = 0
+}
+// VIA_TYPEALIAS: {{.*}}.swift [[@LINE-3]]:44 -> [[@LINE-3]]:44
 // VIA_TYPEALIAS-EMPTY:
 // VIA_TYPEALIAS-NEXT: @_implements(Swift::Equatable, ==(_:_:))
 // VIA_TYPEALIAS-NEXT: static func __derived_struct_equals(_ lhs: Self, _ rhs: Self) -> Swift::Bool {
-// VIA_TYPEALIAS-NOT: {{.*}}.swift 15:44 -> 15:44
+// VIA_TYPEALIAS-NOT: {{.*}}.swift [[@LINE-7]]:44 -> [[@LINE-7]]:44
 
-// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=19:17 | %FileCheck -check-prefix=ENUM %s
-// ENUM: {{.*}}.swift 19:22 -> 19:22
+// RUN: %refactor-check-compiles -expand-derived-conformance -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -source-filename %s -pos=%(line+1):17 | %FileCheck -check-prefix=ENUM %s
+enum Enum: Hashable {
+  case a
+  case b(Int)
+}
+// ENUM: {{.*}}.swift [[@LINE-4]]:22 -> [[@LINE-4]]:22
 // ENUM-EMPTY:
 // ENUM-NEXT: @_semantics("derived_enum_equals")
 // ENUM-NEXT: @_implements(Swift::Equatable, ==(_:_:))

--- a/test/refactoring/Macros/expand_derived_conformance.swift
+++ b/test/refactoring/Macros/expand_derived_conformance.swift
@@ -1,5 +1,8 @@
 // REQUIRES: swift_feature_DeriveConformancesViaMacros
 
+// https://github.com/swiftlang/swift/issues/91958
+// UNSUPPORTED: OS=windows-msvc
+
 // RUN: %empty-directory(%t)
 
 // RUN: %refactor-check-compiles -expand-derived-conformance -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) --dump-text -source-filename %s -pos=%(line+1):21 | %FileCheck -check-prefix=DIRECT %s

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -150,6 +150,11 @@ static llvm::cl::list<std::string> LoadPluginLibrary(
     "load-plugin-library",
     llvm::cl::desc("Path to a compiler plugin library"));
 
+static llvm::cl::list<std::string> EnableExperimentalFeature(
+    "enable-experimental-feature",
+    llvm::cl::desc("Enable an experimental feature"));
+
+
 enum class DumpType {
   REWRITTEN,
   JSON,
@@ -373,6 +378,12 @@ int main(int argc, char *argv[]) {
         PluginSearchOption::LoadPluginLibrary{path});
   Invocation.setDefaultInProcessPluginServerPathIfNecessary();
 
+  for (const auto &featureName : options::EnableExperimentalFeature) {
+    auto feature = Feature::getExperimentalFeature(featureName);
+    if (feature)
+      Invocation.getLangOptions().enableFeature(*feature);
+  }
+
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
       options::SourceFilename);
   Invocation.getFrontendOptions().RequestedAction = FrontendOptions::ActionType::Typecheck;
@@ -382,11 +393,6 @@ int main(int argc, char *argv[]) {
 
   if (options::EnableExperimentalConcurrency)
     Invocation.getLangOptions().EnableExperimentalConcurrency = true;
-
-  // Make sure the `DeriveConformancesViaMacros` experimental feature is enabled
-  // if we want to expand derived conformances.
-  if (options::Action == RefactoringKind::ExpandDerivedConformance)
-    Invocation.getLangOptions().enableFeature(Feature::DeriveConformancesViaMacros);
 
   for (auto FileName : options::InputFilenames)
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -85,7 +85,10 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
            clEnumValN(RefactoringKind::AddAsyncAlternative,
                       "add-async-alternative", "Add an async alternative of a function taking a callback"),
            clEnumValN(RefactoringKind::AddAsyncWrapper,
-                      "add-async-wrapper", "Add an async alternative that forwards onto the function taking a callback")));
+                      "add-async-wrapper", "Add an async alternative that forwards onto the function taking a callback"),
+           clEnumValN(RefactoringKind::ExpandDerivedConformance,
+                      "expand-derived-conformance", "Expands the conformance derived using macros")));
+
 
 
 static llvm::cl::opt<std::string>
@@ -142,6 +145,10 @@ Triple("target", llvm::cl::desc("target triple"));
 static llvm::cl::opt<std::string> ResourceDir(
     "resource-dir",
     llvm::cl::desc("The directory that holds the compiler resource files"));
+
+static llvm::cl::list<std::string> LoadPluginLibrary(
+    "load-plugin-library",
+    llvm::cl::desc("Path to a compiler plugin library"));
 
 enum class DumpType {
   REWRITTEN,
@@ -361,6 +368,11 @@ int main(int argc, char *argv[]) {
   if (!options::ResourceDir.empty())
     Invocation.setRuntimeResourcePath(options::ResourceDir);
 
+  for (const auto &path : options::LoadPluginLibrary)
+    Invocation.getSearchPathOptions().PluginSearchOpts.emplace_back(
+        PluginSearchOption::LoadPluginLibrary{path});
+  Invocation.setDefaultInProcessPluginServerPathIfNecessary();
+
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
       options::SourceFilename);
   Invocation.getFrontendOptions().RequestedAction = FrontendOptions::ActionType::Typecheck;
@@ -370,6 +382,11 @@ int main(int argc, char *argv[]) {
 
   if (options::EnableExperimentalConcurrency)
     Invocation.getLangOptions().EnableExperimentalConcurrency = true;
+
+  // Make sure the `DeriveConformancesViaMacros` experimental feature is enabled
+  // if we want to expand derived conformances.
+  if (options::Action == RefactoringKind::ExpandDerivedConformance)
+    Invocation.getLangOptions().enableFeature(Feature::DeriveConformancesViaMacros);
 
   for (auto FileName : options::InputFilenames)
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);


### PR DESCRIPTION
Following the merge of the `Equatable` derivation using macro behind the `deriveRequirementViaMacro` feature flag, this PR adds a refactor to expand these derived conformances. 

For a cursor on a protocol in a type's conformance list, this returns the code the compiler generated to satisfy it, the way "Expand Macro" shows what a macro produced. 

It is not listed in the list of available actions, mirroring what the "Expand Macro" action does.

Conformances written in an extension or through a typealias for several protocols are handled, and asking about a protocol also shows the code generated for the protocols it inherits.

This PR also adds a test that shows the refactoring behaves as expected.