### PR TITLE
RequirementMachine: synchronize symbol kind metadata

### DIFF
--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -32,10 +32,14 @@ const StringRef Symbol::Kinds[] = {
   "generic",
   "name",
   "shape",
+  "pack_element",
   "layout",
   "super",
   "concrete"
 };
+
+static_assert(static_cast<unsigned>(Symbol::Kind::ConcreteType) + 1 == Symbol::NumKinds);
+static_assert(sizeof(Symbol::Kinds) / sizeof(Symbol::Kinds[0]) == Symbol::NumKinds);
 
 /// Symbols are uniqued and immutable, stored as a single pointer;
 /// the Storage type is the allocated backing storage.

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -138,7 +138,7 @@ public:
     ConcreteType,
   };
 
-  static const unsigned NumKinds = 9;
+  static const unsigned NumKinds = 10;
 
   static const llvm::StringRef Kinds[];
 


### PR DESCRIPTION
`PackElement` was added to `Symbol::Kind` without updating `NumKinds` or the parallel debug-name table. This left the histogram undersized, shifted every debug name after `Shape`, and allowed `ConcreteType` to index beyond the table.

Add the missing name, update `NumKinds`, and assert that the enum, count, and name table remain synchronized.