### PR TITLE
[DeadObjectElimination] Treat `mark_dependence_addr` as a load-like use of its address operand

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadObjectElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadObjectElimination.swift
@@ -173,7 +173,7 @@ private struct UseCollector : AddressDefUseWalker {
   private enum Access {
     case destroy(Instruction)
     case store(StoreLikeInstruction)
-    case load(LoadLikeInstruction)
+    case load(LoadLikeInstruction, addressOperand: Operand)
     // A hybrid between "destroy" and "load"
     case loadTake(LoadInst)
 
@@ -182,7 +182,7 @@ private struct UseCollector : AddressDefUseWalker {
         case .destroy(let destroy): return destroy
         case .store(let store):     return store
         case .loadTake(let load):   return load
-        case .load(let load):       return load
+        case .load(let load, _):       return load
       }
     }
 
@@ -191,7 +191,7 @@ private struct UseCollector : AddressDefUseWalker {
       case .destroy(let destroy): return destroy.operands[0].value.type.objectType
       case .store(let store):     return store.valueType
       case .loadTake(let load):   return load.type
-      case .load(let load):       return load.valueType
+      case .load(_, let operand): return operand.value.type.objectType
       }
     }
 
@@ -212,7 +212,7 @@ private struct UseCollector : AddressDefUseWalker {
     var mutatingAccesses = [(subPath: SmallProjectionPath, access: Access, placeholder: PlaceholderInst)]()
 
     // Non-consuming reads processed after all mutations.
-    var loads = [(subPath: SmallProjectionPath, load: LoadLikeInstruction)]()
+    var loads = [(subPath: SmallProjectionPath, load: LoadLikeInstruction, operand: Operand)]()
 
     let valueType: Type
 
@@ -242,8 +242,8 @@ private struct UseCollector : AddressDefUseWalker {
       case .store(let store):
         context.salvageDebugInfo(of: store)
         addMutatingAccess(access, at: store, path: subPath, &ssaUpdater, context)
-      case .load(let load):
-        loads.append((subPath: subPath, load: load))
+      case .load(let load, let operand):
+        loads.append((subPath: subPath, load: load, operand: operand))
       case .loadTake(let load):
         addMutatingAccess(access, at: load, path: subPath, &ssaUpdater, context)
       }
@@ -381,7 +381,7 @@ private struct UseCollector : AddressDefUseWalker {
 
     case let fixLifetime as FixLifetimeInst:
       if fixLifetime.operand.value is AllocStackInst {
-        accessTree.append((SmallProjectionPath(), .load(fixLifetime)))
+        accessTree.append((SmallProjectionPath(), .load(fixLifetime, addressOperand: fixLifetime.operand)))
       }
       return .continueWalk
 
@@ -430,7 +430,7 @@ private struct UseCollector : AddressDefUseWalker {
       if load.loadOwnership == .take {
         accessTree.append((projectionPath, .loadTake(load)))
       } else {
-        accessTree.append((projectionPath, .load(load)))
+        accessTree.append((projectionPath, .load(load, addressOperand: load.operand)))
       }
       return .continueWalk
 
@@ -441,7 +441,7 @@ private struct UseCollector : AddressDefUseWalker {
       guard loadBorrow.uses.endingLifetime.users.allSatisfy({ $0 is EndBorrowInst}) else {
         return .abortWalk
       }
-      accessTree.append((projectionPath, .load(loadBorrow)))
+      accessTree.append((projectionPath, .load(loadBorrow, addressOperand: loadBorrow.operand)))
       return .continueWalk
 
     case let destroy as DestroyAddrInst:
@@ -479,6 +479,14 @@ private struct UseCollector : AddressDefUseWalker {
       }
       return .abortWalk
 
+    case let mda as MarkDependenceAddrInst:
+      assert(address == mda.addressOperand, "uses of `base` should not be handled by the walker")
+      guard address.value is AllocStackInst else {
+        return .abortWalk
+      }
+      accessTree.append((SmallProjectionPath(), .load(mda, addressOperand: address)))
+      return .continueWalk
+
     default:
       return .abortWalk
     }
@@ -491,7 +499,7 @@ private struct UseCollector : AddressDefUseWalker {
       guard address.value is AllocStackInst else {
         return .abortWalk
       }
-      accessTree.append((SmallProjectionPath(), .load(md as! LoadLikeInstruction)))
+      accessTree.append((SmallProjectionPath(), .load(md as! LoadLikeInstruction, addressOperand: address)))
       return .continueWalk
     default:
       return .abortWalk
@@ -551,7 +559,7 @@ private struct UseCollector : AddressDefUseWalker {
           if !subPath.isEmpty {
             projectedMutations.append(store)
           }
-        case .load(let load):
+        case .load(let load, _):
           hasLoad = true
           if let loadBorrow = load as? LoadBorrowInst {
             projectedLoadBorrows.append(loadBorrow)
@@ -850,15 +858,15 @@ private struct UseCollector : AddressDefUseWalker {
     }
   }
 
-  private func rewrite(loads: [(subPath: SmallProjectionPath, load: LoadLikeInstruction)],
+  private func rewrite(loads: [(subPath: SmallProjectionPath, load: LoadLikeInstruction, operand: Operand)],
                        _ ssaUpdater: inout SSAUpdater)
   {
-    for (subPath, load) in loads {
+    for (subPath, load, operand) in loads {
       let value = ssaUpdater.getValue(before: load)
       if let loadInst = load as? LoadInstruction {
         insertMarkDependencies(for: loadInst, context)
       }
-      load.rewrite(with: value, projection: subPath, context)
+      load.rewrite(operand: operand, with: value, projection: subPath, context)
     }
   }
 
@@ -1137,14 +1145,11 @@ extension InjectEnumAddrInst: StoreLikeInstruction {
 }
 
 private protocol LoadLikeInstruction: Instruction {
-  var valueType: Type { get }
-  func rewrite(with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext)
+  func rewrite(operand: Operand, with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext)
 }
 
 extension LoadInst : LoadLikeInstruction {
-  var valueType: Type { type }
-
-  func rewrite(with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
+  func rewrite(operand: Operand, with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
     let builder = Builder(before: self, context)
     switch loadOwnership {
     case .unqualified:
@@ -1159,9 +1164,7 @@ extension LoadInst : LoadLikeInstruction {
 }
 
 extension LoadBorrowInst: LoadLikeInstruction {
-  var valueType: Type { type }
-
-  func rewrite(with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
+  func rewrite(operand: Operand, with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
     let builder = Builder(before: self, context)
     let beginBorrow = builder.createBeginBorrow(of: value)
     let projectedValue = beginBorrow.createProjection(path: projection, builder: builder)
@@ -1172,20 +1175,43 @@ extension LoadBorrowInst: LoadLikeInstruction {
 
 // `mark_dependence/_addr` where the `base` uses the object/stack is treated as "load".
 private extension MarkDependenceInstruction {
-  var valueType: Type { base.type.objectType }
-
-  func rewrite(with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
+  func rewriteBase(with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
     baseOperand.set(to: value, context)
   }
 }
 
-extension MarkDependenceInst: LoadLikeInstruction {}
-extension MarkDependenceAddrInst: LoadLikeInstruction {}
+extension MarkDependenceInst: LoadLikeInstruction {
+  func rewrite(operand: Operand, with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
+    rewriteBase(with: value, projection: projection, context)
+  }
+}
+extension MarkDependenceAddrInst: LoadLikeInstruction {
+  func rewrite(operand: Operand, with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
+    switch operand {
+    case baseOperand:
+      rewriteBase(with: value, projection: projection, context)
+    case addressOperand:
+      // The value and base operands of a mark_dependence cannot be equal, and
+      // marking a value as depending on itself would be meaningless, so only
+      // create a mark_dependence if the two operands are different.
+      if value != base {
+        let builder = Builder(before: self, context)
+        let newMD = builder.createMarkDependence(value: value, base: base, kind: self.dependenceKind)
+        // Replace uses of the replacement value with newMD to forward the dependence.
+        // mark_dependence_addr produces no value so this is sufficient to replace it.
+        for use in value.uses where use.instruction != newMD {
+          use.set(to: newMD, context)
+        }
+      }
+      context.erase(instruction: self)
+    default:
+      fatalError("Attempted to rewrite non-operand of a mark_dependence_addr instruction: \(operand)")
+    }
+  }
+}
 
 extension FixLifetimeInst: LoadLikeInstruction {
-  var valueType: Type { operand.value.type.objectType }
-
-  func rewrite(with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
-    operand.set(to: value, context)
+  func rewrite(operand: Operand, with value: Value, projection: SmallProjectionPath, _ context: FunctionPassContext) {
+    self.operand.set(to: value, context)
   }
 }

--- a/test/IRGen/builtin_borrow_large.swift
+++ b/test/IRGen/builtin_borrow_large.swift
@@ -21,12 +21,14 @@ public func borrowBigPod(_ target: BigPod) -> Ref<BigPod> {
 	return Ref(target)
 }
 
+// TODO: Eliminate the remaining unused copy onto the stack.
+//
 // CHECK-LABEL: define {{.*}} @"$s{{.*}}12borrowBigArc
-// CHECK:         [[TMP:%.*]] = getelementptr inbounds nuw %T{{.*}}6BigArcVG, ptr [[BUF:%.*]], i32 0, i32 0
-// CHECK:         store ptr %0, ptr [[TMP:%.*]], align
-// CHECK:         [[TMP:%.*]] = getelementptr inbounds nuw %T{{.*}}6BigArcVG, ptr [[BUF]], i32 0, i32 0
-// CHECK:         [[RESULT:%.*]] = load ptr, ptr [[TMP]]
-// CHECK:         ret ptr [[RESULT]]
+// CHECK:         [[BUF:%[0-9]+]] = alloca
+// CHECK-NEXT:    @llvm.lifetime.start
+// CHECK-NEXT:    memcpy{{.*}} [[BUF]], {{.*}} %0
+// CHECK-NEXT:    @llvm.lifetime.end
+// CHECK-NEXT:    ret ptr %0
 @_lifetime(borrow target)
 public func borrowBigArc(_ target: BigArc) -> Ref<BigArc> {
 	return Ref(target)

--- a/test/SILOptimizer/addressable_dependency_optimization.swift
+++ b/test/SILOptimizer/addressable_dependency_optimization.swift
@@ -8,10 +8,11 @@
 
 // CHECK-LABEL: sil {{.*}}@$s4test0A10OneIntSpan1cs0D0VySiGs012CollectionOfB0VySiG_tF : $@convention(thin) (@in_guaranteed CollectionOfOne<Int>) -> @lifetime(borrow address_for_deps 0) @owned Span<Int> {
 // CHECK: bb0(%0 : $*CollectionOfOne<Int>):
-// CHECK:   [[RP:%.*]] = address_to_pointer {{.*}}%0 to $Builtin.RawPointer
-// CHECK:   [[UP:%.*]] = struct $UnsafeRawPointer ([[RP]])
-// CHECK:   [[OP:%.*]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, [[UP]]
-// CHECK:   [[SPAN:%.*]] = struct $Span<Int> ([[OP]]
+// CHECK-NOT: alloc_stack
+// CHECK:     [[RP:%.*]] = address_to_pointer {{.*}}%0 to $Builtin.RawPointer
+// CHECK:     [[UP:%.*]] = struct $UnsafeRawPointer ([[RP]])
+// CHECK:     [[OP:%.*]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, [[UP]]
+// CHECK:     [[SPAN:%.*]] = struct $Span<Int> ([[OP]]
 // CHECK-LABEL: } // end sil function '$s4test0A10OneIntSpan1cs0D0VySiGs012CollectionOfB0VySiG_tF'
 @available(SwiftStdlib 6.2, *)
 @lifetime(borrow c)

--- a/test/SILOptimizer/dead-object-elimination.sil
+++ b/test/SILOptimizer/dead-object-elimination.sil
@@ -5825,3 +5825,188 @@ bb9:
   %18 = tuple ()
   return %18
 }
+
+// CHECK-LABEL: sil [ossa] @mda_load_take :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         [[C:%.*]] = copy_value %0
+// CHECK:         mark_dependence [nonescaping] [[C]] on %0
+// CHECK-LABEL: } // end sil function 'mda_load_take'
+sil [ossa] @mda_load_take : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %3 = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mda_load_copy :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence [nonescaping]
+// CHECK-LABEL: } // end sil function 'mda_load_copy'
+sil [ossa] @mda_load_copy : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %3 = load [copy] %2 : $*Klass
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mda_multiple :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence [nonescaping]
+// CHECK:         mark_dependence [nonescaping]
+// CHECK-LABEL: } // end sil function 'mda_multiple'
+sil [ossa] @mda_multiple : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  %2 = copy_value %0 : $Klass
+  %3 = alloc_stack $Klass
+  store %2 to [init] %3 : $*Klass
+  mark_dependence_addr [nonescaping] %3 on %0
+  mark_dependence_addr [nonescaping] %3 on %1
+  %4 = load [take] %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  destroy_value %4 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mda_cross_bb :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence
+// CHECK-LABEL: } // end sil function 'mda_cross_bb'
+sil [ossa] @mda_cross_bb : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  br bb1
+bb1:
+  %3 = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mda_load_borrow :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence
+// CHECK-LABEL: } // end sil function 'mda_load_borrow'
+sil [ossa] @mda_load_borrow : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %3 = load_borrow %2 : $*Klass
+  end_borrow %3 : $Klass
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// A `mark_dependence_addr` combined with a value-form `mark_dependence` on the
+// load's address chain. Both dependences should lift to SSA-form
+// `mark_dependence`s on the forwarded value.
+//
+// TODO: Eliminate the dead alloc_stack here.
+//
+// CHECK-LABEL: sil [ossa] @mda_and_value_md :
+// CHECK:         alloc_stack
+// CHECK:         mark_dependence [nonescaping]
+// CHECK:         mark_dependence_addr [nonescaping]
+// CHECK-LABEL: } // end sil function 'mda_and_value_md'
+sil [ossa] @mda_and_value_md : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  %2 = copy_value %0 : $Klass
+  %3 = alloc_stack $Klass
+  store %2 to [init] %3 : $*Klass
+  %4 = mark_dependence [nonescaping] %3 on %1
+  mark_dependence_addr [nonescaping] %4 on %0
+  %5 = load [take] %4 : $*Klass
+  dealloc_stack %3 : $*Klass
+  destroy_value %5 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mda_after_load :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence
+// CHECK-LABEL: } // end sil function 'mda_after_load'
+sil [ossa] @mda_after_load : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  %3 = load [copy] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mda_partial_dominance :
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK:         mark_dependence
+// CHECK-LABEL: } // end sil function 'mda_partial_dominance'
+sil [ossa] @mda_partial_dominance : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  %3 = load [copy] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %0
+  %4 = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  destroy_value %4 : $Klass
+  %r = tuple ()
+  return %r : $()
+}
+
+// A mark_dependence_addr with identical address and base operands is
+// meaningless; a mark_dependence with identical address and base is invalid.
+// Drop the mark_dependence_addr without generating a mark_dependence.
+//
+// CHECK-LABEL: sil [ossa] @mda_depend_on_self :
+// CHECK:         [[VAL:%[0-9]+]] = copy_value %0
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     mark_dependence_addr
+// CHECK-NOT:     mark_dependence [nonescaping] [[VAL]] on [[VAL]]
+// CHECK:         destroy_value [[VAL]]
+// CHECK-LABEL: } // end sil function 'mda_depend_on_self'
+sil [ossa] @mda_depend_on_self : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2 : $*Klass
+  mark_dependence_addr [nonescaping] %2 on %2
+  %3 = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  destroy_value %3 : $Klass
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/inline_arrays.swift
+++ b/test/SILOptimizer/inline_arrays.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -primary-file %s -O -disable-availability-checking -module-name=test -emit-sil | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OPT
+// RUN: %target-swift-frontend  -primary-file %s -O -disable-availability-checking -module-name=test -emit-sil -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OPT
 
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
@@ -196,3 +196,52 @@ public func equal(_ lhs: borrowing [32 of Int], _ rhs: borrowing [32 of Int]) ->
     }
     return true
 }
+
+// MARK: rdar://183793878 (Reading an InlineArray field of struct in an Array causes a full copy of the struct)
+// Verify that we can use Array.span to avoid copying elements when subscripting.
+
+public struct E {
+    var tag: UInt8 = 0
+    var v: [16 of UInt8] = .init(repeating: 0)
+    var pad: [128 of UInt8] = .init(repeating: 0)
+}
+
+// CHECK-LABEL: sil @$s4test9s_dynamicys5UInt8VSayAA1EVG_S2itF
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function '$s4test9s_dynamicys5UInt8VSayAA1EVG_S2itF'
+public func s_dynamic(_ a: [E], _ i: Int, _ j: Int) -> UInt8 { a.span[i].v[j] }
+
+
+let gLet = [E](repeating: E(), count: 64)
+var gVar = [E](repeating: E(), count: 64)
+public final class Holder { var p = [E](repeating: E(), count: 64) }
+
+// CHECK-LABEL: sil @$s4test16a_borrowingParamys5UInt8VSayAA1EVG_S2itF
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function '$s4test16a_borrowingParamys5UInt8VSayAA1EVG_S2itF'
+public func a_borrowingParam(_ a: borrowing [E], _ i: Int, _ j: Int) -> UInt8 { a[i].v[j] }
+
+// CHECK-LABEL: sil {{.*}} @$s4test16a_consumingParamys5UInt8VSayAA1EVGn_S2itF
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function '$s4test16a_consumingParamys5UInt8VSayAA1EVGn_S2itF'
+public func a_consumingParam(_ a: consuming [E], _ i: Int, _ j: Int) -> UInt8 { a.span[i].v[j] }
+
+// CHECK-LABEL: sil @$s4test11a_globalLetys5UInt8VSi_SitF
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function '$s4test11a_globalLetys5UInt8VSi_SitF'
+public func a_globalLet(_ i: Int, _ j: Int) -> UInt8 { gLet.span[i].v[j] }
+
+// CHECK-LABEL: sil @$s4test11a_globalVarys5UInt8VSi_SitF
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function '$s4test11a_globalVarys5UInt8VSi_SitF'
+public func a_globalVar(_ i: Int, _ j: Int) -> UInt8 { gVar.span[i].v[j] }
+
+// CHECK-LABEL: sil @$s4test15a_classPropertyys5UInt8VAA6HolderC_S2itF
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function '$s4test15a_classPropertyys5UInt8VAA6HolderC_S2itF'
+public func a_classProperty(_ h: borrowing Holder, _ i: Int, _ j: Int) -> UInt8 { h.p.span[i].v[j] }
+
+// specialized a_consumingParam that does not consume the array, called from original a_consumingParam.
+// CHECK-LABEL: sil shared @$s4test16a_consumingParamys5UInt8VSayAA1EVGn_S2itFTf4gnn_n
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function '$s4test16a_consumingParamys5UInt8VSayAA1EVGn_S2itFTf4gnn_n'

--- a/test/SILOptimizer/static_inline_arrays.swift
+++ b/test/SILOptimizer/static_inline_arrays.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -disable-availability-checking -module-name=test -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -disable-availability-checking -module-name=test -emit-sil | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-BOTH
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Onone -disable-availability-checking -module-name=test -emit-sil | %FileCheck %s --check-prefix=CHECK-ONONE --check-prefix=CHECK-BOTH
 
 // Also do an end-to-end test to check all components, including IRGen.
 // RUN: %empty-directory(%t) 
@@ -36,23 +37,23 @@ struct IntByteAndByte {
 }
 
 struct S {
-  // CHECK-LABEL: sil_global hidden [let] @$s4test1SV6simples11InlineArrayVy$2_SiGvpZ : $InlineArray<3, Int> = {
-  // CHECK:         [[V:%.*]] = vector
-  // CHECK:         %initval = struct $InlineArray<3, Int> ([[V]])
-  // CHECK:       }
+  // CHECK-BOTH-LABEL: sil_global hidden [let] @$s4test1SV6simples11InlineArrayVy$2_SiGvpZ : $InlineArray<3, Int> = {
+  // CHECK-BOTH:         [[V:%.*]] = vector
+  // CHECK-BOTH:         %initval = struct $InlineArray<3, Int> ([[V]])
+  // CHECK-BOTH:       }
   static let simple: InlineArray = [1, 2, 3]
 
-  // CHECK-LABEL: sil_global hidden [let] @$s4test1SV12optionalIntss11InlineArrayVy$2_SiSgGvpZ : $InlineArray<3, Optional<Int>> = {
-  // CHECK:         [[V:%.*]] = vector
-  // CHECK:         %initval = struct $InlineArray<3, Optional<Int>> ([[V]])
-  // CHECK:       }
+  // CHECK-BOTH-LABEL: sil_global hidden [let] @$s4test1SV12optionalIntss11InlineArrayVy$2_SiSgGvpZ : $InlineArray<3, Optional<Int>> = {
+  // CHECK-BOTH:         [[V:%.*]] = vector
+  // CHECK-BOTH:         %initval = struct $InlineArray<3, Optional<Int>> ([[V]])
+  // CHECK-BOTH:       }
   static let optionalInts: InlineArray<_, Int?> = [10, 20, 30]
 
-  // CHECK-LABEL: sil_global hidden [let] @$s4test1SV13optionalArrays06InlineC0Vy$2_SiGSgvpZ : $Optional<InlineArray<3, Int>> = {
-  // CHECK:         [[V:%.*]] = vector
-  // CHECK:         [[A:%.*]] = struct $InlineArray<3, Int> ([[V]])
-  // CHECK:         %initval = enum $Optional<InlineArray<3, Int>>, #Optional.some!enumelt, [[A]]
-  // CHECK:       }
+  // CHECK-BOTH-LABEL: sil_global hidden [let] @$s4test1SV13optionalArrays06InlineC0Vy$2_SiGSgvpZ : $Optional<InlineArray<3, Int>> = {
+  // CHECK-BOTH:         [[V:%.*]] = vector
+  // CHECK-BOTH:         [[A:%.*]] = struct $InlineArray<3, Int> ([[V]])
+  // CHECK-BOTH:         %initval = enum $Optional<InlineArray<3, Int>>, #Optional.some!enumelt, [[A]]
+  // CHECK-BOTH:       }
   static let optionalArray: InlineArray? = [1, 2, 3]
 
   // CHECK-LABEL: sil_global hidden [let] @$s4test1SV12intBytePairss11InlineArrayVy$2_AA03IntC0VGvpZ : $InlineArray<3, IntByte> = {
@@ -71,25 +72,25 @@ struct S {
   // CHECK:       }
   static let optionalInlineArrayOfPairs: InlineArray<_, IntByte>? = [IntByte(i: 11, b: 12), IntByte(i: 13, b: 14), IntByte(i: 15, b: 16)]
 
-  // CHECK-LABEL: sil_global hidden [let] @$s4test1SV6tupless11InlineArrayVy$2_Si_SitGvpZ : $InlineArray<3, (Int, Int)> = {
-  // CHECK:         [[T0:%.*]] = tuple
-  // CHECK:         [[T1:%.*]] = tuple
-  // CHECK:         [[T2:%.*]] = tuple
-  // CHECK:         [[V:%.*]] = vector ([[T0]], [[T1]], [[T2]])
-  // CHECK:         %initval = struct $InlineArray<3, (Int, Int)> ([[V]])
-  // CHECK:       }
+  // CHECK-BOTH-LABEL: sil_global hidden [let] @$s4test1SV6tupless11InlineArrayVy$2_Si_SitGvpZ : $InlineArray<3, (Int, Int)> = {
+  // CHECK-BOTH:         [[T0:%.*]] = tuple
+  // CHECK-BOTH:         [[T1:%.*]] = tuple
+  // CHECK-BOTH:         [[T2:%.*]] = tuple
+  // CHECK-BOTH:         [[V:%.*]] = vector ([[T0]], [[T1]], [[T2]])
+  // CHECK-BOTH:         %initval = struct $InlineArray<3, (Int, Int)> ([[V]])
+  // CHECK-BOTH:       }
   static let tuples: InlineArray = [(10, 20), (30, 40), (50, 60)]
 
-  // CHECK-LABEL: sil_global hidden [let] @$s4test1SV6nesteds11InlineArrayVy$2_AFy$1_SiGGvpZ : $InlineArray<3, InlineArray<2, Int>> = {
-  // CHECK:         [[V0:%.*]] = vector
-  // CHECK:         [[A0:%.*]] = struct $InlineArray<2, Int> ([[V0]])
-  // CHECK:         [[V1:%.*]] = vector
-  // CHECK:         [[A1:%.*]] = struct $InlineArray<2, Int> ([[V1]])
-  // CHECK:         [[V2:%.*]] = vector
-  // CHECK:         [[A2:%.*]] = struct $InlineArray<2, Int> ([[V2]])
-  // CHECK:         [[V:%.*]] = vector ([[A0]], [[A1]], [[A2]])
-  // CHECK:         %initval = struct $InlineArray<3, InlineArray<2, Int>> ([[V]])
-  // CHECK:       }
+  // CHECK-BOTH-LABEL: sil_global hidden [let] @$s4test1SV6nesteds11InlineArrayVy$2_AFy$1_SiGGvpZ : $InlineArray<3, InlineArray<2, Int>> = {
+  // CHECK-BOTH:         [[V0:%.*]] = vector
+  // CHECK-BOTH:         [[A0:%.*]] = struct $InlineArray<2, Int> ([[V0]])
+  // CHECK-BOTH:         [[V1:%.*]] = vector
+  // CHECK-BOTH:         [[A1:%.*]] = struct $InlineArray<2, Int> ([[V1]])
+  // CHECK-BOTH:         [[V2:%.*]] = vector
+  // CHECK-BOTH:         [[A2:%.*]] = struct $InlineArray<2, Int> ([[V2]])
+  // CHECK-BOTH:         [[V:%.*]] = vector ([[A0]], [[A1]], [[A2]])
+  // CHECK-BOTH:         %initval = struct $InlineArray<3, InlineArray<2, Int>> ([[V]])
+  // CHECK-BOTH:       }
   static let nested: InlineArray<3, InlineArray<2, Int>> = [[100, 200], [300, 400], [500, 600]]
 
   // CHECK-LABEL: sil_global hidden [let] @$s4test1SV010intByteAndC0AA03IntcdC0VvpZ : $IntByteAndByte = {
@@ -158,6 +159,15 @@ struct S {
   // CHECK:       }
   static let optionalRepeatingLarge: InlineArray<64, Int>? = .init(repeating: 37)
 }
+
+// rdar://181752317 (Large constant lookup tables cause stack overflows in debug)
+// CHECK-BOTH-LABEL: sil_global hidden [let] @$s4test14topLevelSimples11InlineArrayVy$15_s6UInt16VGvp : $InlineArray<16, UInt16> = {
+// CHECK-BOTH:         [[V:%.*]] = vector
+// CHECK-BOTH:         [[A:%.*]] = struct $InlineArray<16, UInt16> ([[V]])
+// CHECK-BOTH:       }
+let topLevelSimple: [_ of UInt16] = [
+    0x0000, 0x0000, 0x07B5, 0x07B5, 0x0840, 0x0842, 0x0841, 0x083C, 0x0843, 0x083E, 0x083D, 0x0838, 0x083F, 0x083A, 0x0839, 0x0834,
+]
 
 @main
 struct Main {


### PR DESCRIPTION
When eliminating a dead object that is used as the address operand of `mark_dependence_addr`, we can rewrite the `mark_dependence_addr` to a `mark_dependence` using the value that was previously stored:

```
  %0 = ... : $Klass
  %1 = ... : $Klass
  %2 = alloc_stack $Klass
  store %1 to [init] %2 : $*Klass
  mark_dependence_addr [nonescaping] %2 on %0
  %3 = load [take] %2 : $*Klass
  dealloc_stack %2 : $*Klass
  destroy_value %3 : $Klass
```

->

```
  %0 = ... : $Klass
  %1 = ... : $Klass
  %2 = mark_dependence [nonescaping] %2 on %0
  destroy_value %2
```

Fixes: rdar://183793878
Fixes: rdar://182832029

Supersedes: https://github.com/swiftlang/swift/pull/91491
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
