### PR TITLE
[PassManager] Fix inverted condition for -sil-verify-without-invalidation

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1030,7 +1030,7 @@ void SILPassManager::runModulePass(unsigned TransIdx) {
   updateSILModuleStatsAfterTransform(*Mod, SMT, *this, NumPassesRun, duration.count());
 
   if (Options.VerifyAll &&
-      (CurrentPassHasInvalidated || !SILVerifyWithoutInvalidation)) {
+      (CurrentPassHasInvalidated || SILVerifyWithoutInvalidation)) {
     Mod->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
     verifyAnalyses();
     runSwiftModuleVerification();


### PR DESCRIPTION
The -sil-verify-without-invalidation option is supposed to force verifying modules after all passes when -sil-verify-all is enabled, even if they were unchanged.

Instead, verification happened on unchanged modules by default, and was disabled with this option. Function passes have the correct condition, where this option would enable more verifications.

Module passes that don't invalidate anything are probably rare, but this inverted condition has been in the code ever since the option was added, 11 years ago, in 6300f26
