### PR TITLE
Windows: adjust the build layout to support shared builds

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -107,7 +107,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   %HostArchNameArg% ^
   -SourceCache %SourceRoot% ^
   -BinaryCache %BuildRoot% ^
-  -ImageRoot %BuildRoot% ^
+  -BuildRoot %BuildRoot% ^
   %WindowsSDKArgs% ^
   %PackagingArg% ^
   %TestArg% ^

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -107,6 +107,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   %HostArchNameArg% ^
   -SourceCache %SourceRoot% ^
   -BinaryCache %BuildRoot% ^
+  -ArtifactCache %BuildRoot%\ArtifactCache ^
   -BuildRoot %BuildRoot% ^
   -ObjectStore %BuildRoot%\ObjectStore ^
   %WindowsSDKArgs% ^

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -108,6 +108,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -SourceCache %SourceRoot% ^
   -BinaryCache %BuildRoot% ^
   -BuildRoot %BuildRoot% ^
+  -ObjectStore %BuildRoot%\ObjectStore ^
   %WindowsSDKArgs% ^
   %PackagingArg% ^
   %TestArg% ^

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1638,43 +1638,44 @@ function Get-Dependencies {
           [string]$ToolchainName
       )
 
-      $source = Join-Path -Path $BinaryCache -ChildPath $InstallerExeName
-      $destination = Join-Path -Path $BinaryCache -ChildPath toolchains\$ToolchainName
+      $source = Join-Path -Path $ArtifactCache -ChildPath $InstallerExeName
+      $ToolchainRoot = Join-Path -Path $ArtifactCache -ChildPath "toolchains"
+      $destination = Join-Path -Path $ToolchainRoot -ChildPath $ToolchainName
+      if (Test-Path $destination) { return }
 
-      # Check if the extracted directory already exists and is up to date.
-      if (Test-Path $destination) {
-          $installerWriteTime = (Get-Item $source).LastWriteTime
-          $extractedWriteTime = (Get-Item $destination).LastWriteTime
-          if ($installerWriteTime -le $extractedWriteTime) {
-              # Write-Output "'$InstallerExeName' is already extracted and up to date."
-              return
-          }
-      }
+      New-Item -ItemType Directory -Path $ToolchainRoot -ErrorAction Ignore | Out-Null
+      $TemporaryRoot = Join-Path -Path $ToolchainRoot -ChildPath ".$ToolchainName.$PID.$([Guid]::NewGuid()).tmp"
+      $BundleRoot = Join-Path -Path $TemporaryRoot -ChildPath "bundle"
+      $InstallRoot = Join-Path -Path $TemporaryRoot -ChildPath "root"
+      New-Item -ItemType Directory -Path $InstallRoot | Out-Null
 
-      # Write-Output "Extracting '$InstallerExeName' ..."
-
-      Invoke-WithDotNetRuntime {
-        Invoke-Program (Get-DotNet) "$($WiX.Path)\wix.dll" -- burn extract -acceptEula $WiX.EulaIdentifier $BinaryCache\$InstallerExeName -out $BinaryCache\toolchains\ -outba $BinaryCache\toolchains\
-      }
-      New-Item -ItemType Directory -Path $destination -Force | Out-Null
       $RuntimePath = "LocalApp\Programs\Swift\Runtimes\$PinnedVersion\usr\bin"
-      $RuntimeDestination = Join-Path -Path $destination -ChildPath $RuntimePath
+      $RuntimeDestination = Join-Path -Path $InstallRoot -ChildPath $RuntimePath
       $RuntimeTarget = [IO.Path]::Combine("X:\", $RuntimePath)
       New-Item -ItemType Directory -Path $RuntimeDestination -Force | Out-Null
       $DriveMapped = $false
       try {
-        Invoke-Program -OutNull subst.exe X: "$destination"
+        Invoke-WithDotNetRuntime {
+          Invoke-Program (Get-DotNet) "$($WiX.Path)\wix.dll" -- burn extract -acceptEula $WiX.EulaIdentifier $source -out $BundleRoot -outba $BundleRoot
+        }
+
+        Invoke-Program -OutNull subst.exe X: "$InstallRoot"
         $DriveMapped = $true
-        Get-ChildItem "$BinaryCache\toolchains\WixAttachedContainer" -Filter "*.msi" | ForEach-Object {
+        Get-ChildItem "$BundleRoot\WixAttachedContainer" -Filter "*.msi" | ForEach-Object {
           $LogFile = [System.IO.Path]::ChangeExtension($_.Name, "log")
           # Administrative installs do not run rtl.msi's SetDirectory actions.
           $TargetDirectory = if ($_.Name -eq "rtl.msi") { $RuntimeTarget } else { "X:\" }
-          Invoke-Program -OutNull msiexec.exe /lvx! $BinaryCache\toolchains\$LogFile /qn /a $BinaryCache\toolchains\WixAttachedContainer\$($_.Name) ALLUSERS=0 TARGETDIR=$TargetDirectory
+          Invoke-Program -OutNull msiexec.exe /lvx! $TemporaryRoot\$LogFile /qn /a $_.FullName ALLUSERS=0 TARGETDIR=$TargetDirectory
         }
+
+        subst.exe /d X: | Out-Null
+        $DriveMapped = $false
+        [IO.Directory]::Move($InstallRoot, $destination)
       } finally {
         if ($DriveMapped) {
           subst.exe /d X: | Out-Null
         }
+        Remove-Item -LiteralPath $TemporaryRoot -Recurse -Force -ErrorAction Ignore
       }
     }
 
@@ -1776,7 +1777,7 @@ function Get-Dependencies {
 
     if (-not $Toolchain) { return }
 
-    DownloadAndVerify $PinnedBuild "$BinaryCache\$PinnedToolchain.exe" $PinnedSHA256
+    DownloadAndVerify $PinnedBuild "$ArtifactCache\$PinnedToolchain.exe" $PinnedSHA256
 
     if ($Test -contains "lldb" -or $Test -contains "lldb-swift") {
       # The make tool isn't part of MSYS
@@ -1787,9 +1788,10 @@ function Get-Dependencies {
       Write-Success "GNUWin32 make 4.4.1"
     }
 
-    # TODO(compnerd) stamp/validate that we need to re-extract
-    New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\toolchains | Out-Null
-    Extract-Toolchain "$PinnedToolchain.exe" -ToolchainName $ToolchainVersionIdentifier
+    $ToolchainArtifact = "$ToolchainVersionIdentifier-$($BuildArchName.ToLowerInvariant())"
+    Invoke-WithArtifactLock "SwiftToolchainExtraction" {
+      Extract-Toolchain "$PinnedToolchain.exe" -ToolchainName $ToolchainArtifact
+    }
     Write-Success "Swift Toolchain $PinnedVersion"
 
     # Install CMake.
@@ -1842,13 +1844,15 @@ function Get-Dependencies {
 }
 
 function Get-PinnedToolchainToolsDir() {
-  return [IO.Path]::Combine("$BinaryCache\toolchains", "$ToolchainVersionIdentifier",
+  $ToolchainArtifact = "$ToolchainVersionIdentifier-$($BuildArchName.ToLowerInvariant())"
+  return [IO.Path]::Combine("$ArtifactCache\toolchains", $ToolchainArtifact,
     "LocalApp", "Programs", "Swift", "Toolchains", "$PinnedVersion+Asserts",
     "usr", "bin")
 }
 
 function Get-PinnedToolchainSDK([OS] $OS = $BuildPlatform.OS, [string] $Identifier = $OS.ToString()) {
-  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainVersionIdentifier,
+  $ToolchainArtifact = "$ToolchainVersionIdentifier-$($BuildArchName.ToLowerInvariant())"
+  return [IO.Path]::Combine("$ArtifactCache", "toolchains", $ToolchainArtifact,
     "LocalApp", "Programs", "Swift", "Platforms", $PinnedVersion,
     "$($OS.ToString()).platform", "Developer", "SDKs", "$Identifier.sdk")
 }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -510,6 +510,12 @@ $KnownNDKs = @{
   }
 }
 
+$WinFlexBison = @{
+  Version = "2.5.25"
+  URL = "https://github.com/lexxmark/winflexbison/releases/download/v2.5.25/win_flex_bison-2.5.25.zip"
+  SHA256 = "8D324B62BE33604B2C45AD1DD34AB93D722534448F55A16CA7292DE32B6AC135"
+}
+
 $KnownSyft = @{
   "1.29.1" = @{
     AMD64 = @{
@@ -765,11 +771,11 @@ function Get-AndroidNDKPath {
 }
 
 function Get-FlexExecutable {
-  return Join-Path -Path $BinaryCache -ChildPath "win_flex_bison\win_flex.exe"
+  return Join-Path -Path $ArtifactCache -ChildPath "win_flex_bison-$($WinFlexBison.Version)\win_flex.exe"
 }
 
 function Get-BisonExecutable {
-  return Join-Path -Path $BinaryCache -ChildPath "win_flex_bison\win_bison.exe"
+  return Join-Path -Path $ArtifactCache -ChildPath "win_flex_bison-$($WinFlexBison.Version)\win_bison.exe"
 }
 
 function Get-PythonPath([Hashtable] $Platform) {
@@ -1781,13 +1787,10 @@ function Get-Dependencies {
     }
 
     if ($IncludeDS2) {
-      $WinFlexBisonVersion = "2.5.25"
-      $WinFlexBisonURL = "https://github.com/lexxmark/winflexbison/releases/download/v$WinFlexBisonVersion/win_flex_bison-$WinFlexBisonVersion.zip"
-      $WinFlexBisonHash = "8D324B62BE33604B2C45AD1DD34AB93D722534448F55A16CA7292DE32B6AC135"
-      DownloadAndVerify $WinFlexBisonURL "$BinaryCache\win_flex_bison-$WinFlexBisonVersion.zip" $WinFlexBisonHash
-
-      Expand-ZipFile "win_flex_bison-$WinFlexBisonVersion.zip" -BinaryCache $BinaryCache -ExtractPath "win_flex_bison"
-      Write-Success "flex/bison $WinFlexBisonVersion"
+      $Artifact = "win_flex_bison-$($WinFlexBison.Version)"
+      DownloadAndVerify $WinFlexBison.URL "$ArtifactCache\$Artifact.zip" $WinFlexBison.SHA256
+      Expand-ArtifactZip "$Artifact.zip" $Artifact
+      Write-Success "flex/bison $($WinFlexBison.Version)"
     }
 
     if ($WinSDKVersion) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -23,6 +23,11 @@ Default: 'S:\SourceCache'
 The path to a directory where to write build system files and outputs.
 Default: 'S:\b'
 
+.PARAMETER ArtifactCache
+The path to a directory containing downloaded build artifacts that can be
+shared by multiple build trees.
+Default: 'S:\ArtifactCache'
+
 .PARAMETER BuildRoot
 The path to the merged file system image populated by the build. The
 "Program Files" subdirectories will be created beneath this directory.
@@ -140,6 +145,7 @@ param
   # Build Paths
   [System.IO.FileInfo] $SourceCache = "S:\SourceCache",
   [System.IO.FileInfo] $BinaryCache = "S:\BinaryCache",
+  [System.IO.FileInfo] $ArtifactCache = "S:\ArtifactCache",
   [Alias("ImageRoot")]
   [System.IO.FileInfo] $BuildRoot = "S:",
   [Alias("Cache")]
@@ -507,21 +513,24 @@ $KnownNDKs = @{
 $KnownSyft = @{
   "1.29.1" = @{
     AMD64 = @{
+      Artifact = "syft-1.29.1-windows-amd64"
       URL = "https://github.com/anchore/syft/releases/download/v1.29.1/syft_1.29.1_windows_amd64.zip"
       SHA256 = "3C67CD9AF40CDCC7FFCE041C8349B4A77F33810184820C05DF23440C8E0AA1D7"
-      Path = [IO.Path]::Combine("$BinaryCache\syft-1.29.1", "syft.exe")
+      Path = [IO.Path]::Combine("$ArtifactCache\syft-1.29.1-windows-amd64", "syft.exe")
     }
   };
   "1.40.0" = @{
     AMD64 = @{
+      Artifact = "syft-1.40.0-windows-amd64"
       URL = "https://github.com/anchore/syft/releases/download/v1.40.0/syft_1.40.0_windows_amd64.zip"
       SHA256 = "3F4021EC098B4BCBAF19BBA7028CF7704FEF12936970778CEC3C6D669B740E6D"
-      Path = [IO.Path]::Combine("$BinaryCache\syft-1.40.0", "syft.exe")
+      Path = [IO.Path]::Combine("$ArtifactCache\syft-1.40.0-windows-amd64", "syft.exe")
     };
     ARM64 = @{
+      Artifact = "syft-1.40.0-windows-arm64"
       URL = "https://github.com/anchore/syft/releases/download/v1.40.0/syft_1.40.0_windows_arm64.zip"
       SHA256 = "CE7129DBCC39809542C9BC5032B179131DFEE72C68C5B3741E3270A3D9ED46E4"
-      Path = [IO.Path]::Combine("$BinaryCache\syft-1.40.0", "syft.exe")
+      Path = [IO.Path]::Combine("$ArtifactCache\syft-1.40.0-windows-arm64", "syft.exe")
     };
   }
 }
@@ -1526,20 +1535,28 @@ function Get-Dependencies {
       New-Item -ItemType Directory (Split-Path -Path $Destination -Parent) -ErrorAction Ignore | Out-Null
 
       for ($Attempt = 1; $Attempt -le $DownloadRetryCount; $Attempt++) {
+        $TemporaryDestination = "$Destination.$PID.$([Guid]::NewGuid()).tmp"
         try {
-          $WebClient.DownloadFile($URL, $Destination)
-          $SHA256 = Get-FileHash -Path $Destination -Algorithm SHA256
+          $WebClient.DownloadFile($URL, $TemporaryDestination)
+          $SHA256 = Get-FileHash -Path $TemporaryDestination -Algorithm SHA256
           if ($SHA256.Hash -ne $Hash) {
             throw "SHA256 mismatch ($($SHA256.Hash) vs $Hash)"
           }
+
+          try {
+            [IO.File]::Move($TemporaryDestination, $Destination)
+          } catch {
+            if (-not (Test-Path $Destination)) { throw }
+          }
           return
         } catch {
-          Remove-Item -Path $Destination -ErrorAction Ignore
           if ($Attempt -eq $DownloadRetryCount) {
             throw
           }
           Write-Warning "Download of $URL failed (attempt $Attempt/$DownloadRetryCount): $_"
           Start-Sleep -Seconds ([Math]::Pow(2, $Attempt))
+        } finally {
+          Remove-Item -LiteralPath $TemporaryDestination -ErrorAction Ignore
         }
       }
     }
@@ -1555,22 +1572,31 @@ function Get-Dependencies {
       $Source = Join-Path -Path $BinaryCache -ChildPath $ZipFileName
       $Destination = Join-Path -Path $BinaryCache -ChildPath $ExtractPath
 
-      # Check if the extracted directory already exists and is up to date.
-      if (Test-Path $Destination) {
-          $ZipLastWriteTime = (Get-Item $Source).LastWriteTime
-          $ExtractedLastWriteTime = (Get-Item $Destination).LastWriteTime
-          # Compare the last write times
-          if ($ZipLastWriteTime -le $ExtractedLastWriteTime) {
-              # Write-Output "'$ZipFileName' is already extracted and up to date."
-              return
-          }
-      }
+      if (Test-Path $Destination) { return }
 
       $Destination = if ($CreateExtractPath) { $Destination } else { $BinaryCache }
 
       # Write-Output "Extracting '$ZipFileName' ..."
       New-Item -ItemType Directory -ErrorAction Ignore -Path $BinaryCache | Out-Null
       Expand-Archive -Path $Source -DestinationPath $Destination -Force
+    }
+
+    function Expand-ArtifactZip([string] $ZipFileName, [string] $ExtractPath) {
+      $Source = Join-Path -Path $ArtifactCache -ChildPath $ZipFileName
+      $Destination = Join-Path -Path $ArtifactCache -ChildPath $ExtractPath
+      if (Test-Path $Destination) { return }
+
+      $TemporaryDestination = Join-Path -Path $ArtifactCache -ChildPath ".$ExtractPath.$PID.$([Guid]::NewGuid()).tmp"
+      try {
+        Expand-Archive -LiteralPath $Source -DestinationPath $TemporaryDestination
+        try {
+          [IO.Directory]::Move($TemporaryDestination, $Destination)
+        } catch {
+          if (-not (Test-Path $Destination)) { throw }
+        }
+      } finally {
+        Remove-Item -LiteralPath $TemporaryDestination -Recurse -Force -ErrorAction Ignore
+      }
     }
 
     function Extract-Toolchain {
@@ -1622,8 +1648,8 @@ function Get-Dependencies {
 
     if ($IncludeSBoM) {
       $syft = Get-Syft
-      DownloadAndVerify $syft.URL "$BinaryCache\syft-$SyftVersion.zip" $syft.SHA256
-      Expand-ZipFile syft-$SyftVersion.zip -ExtractPath syft-$SyftVersion
+      DownloadAndVerify $syft.URL "$ArtifactCache\$($syft.Artifact).zip" $syft.SHA256
+      Expand-ArtifactZip "$($syft.Artifact).zip" $syft.Artifact
       Write-Success "syft $SyftVersion"
     }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -23,9 +23,10 @@ Default: 'S:\SourceCache'
 The path to a directory where to write build system files and outputs.
 Default: 'S:\b'
 
-.PARAMETER ImageRoot
-The path to a directory that mimics a file system image root, under which the
-"Program Files" subdirectories will be created with the files installed by CMake.
+.PARAMETER BuildRoot
+The path to the merged file system image populated by the build. The
+"Program Files" subdirectories will be created beneath this directory.
+ImageRoot is retained as a compatibility alias.
 Default: 'S:\'
 
 .PARAMETER Stage
@@ -134,7 +135,8 @@ param
   # Build Paths
   [System.IO.FileInfo] $SourceCache = "S:\SourceCache",
   [System.IO.FileInfo] $BinaryCache = "S:\BinaryCache",
-  [System.IO.FileInfo] $ImageRoot = "S:",
+  [Alias("ImageRoot")]
+  [System.IO.FileInfo] $BuildRoot = "S:",
   [System.IO.FileInfo] $Cache = "S:\CAS",
   [string] $Stage = "",
 
@@ -766,7 +768,7 @@ function Get-PythonExecutable {
 }
 
 function Get-EmbeddedPythonInstallDir() {
-  return [IO.Path]::Combine("$ImageRoot\", "Program Files", "Swift", "Python-$PythonVersion")
+  return [IO.Path]::Combine("$BuildRoot\", "Program Files", "Swift", "Python-$PythonVersion")
 }
 
 function Get-Syft {
@@ -779,16 +781,16 @@ function Get-CMake {
 
 function Get-InstallDir([Hashtable] $Platform) {
   if ($Platform -eq $HostPlatform) {
-    return [IO.Path]::Combine("$ImageRoot\", "Program Files", "Swift")
+    return [IO.Path]::Combine("$BuildRoot\", "Program Files", "Swift")
   }
   if ($Platform -eq $KnownPlatforms["WindowsARM64"]) {
-    return [IO.Path]::Combine("$ImageRoot\", "Program Files (Arm64)", "Swift")
+    return [IO.Path]::Combine("$BuildRoot\", "Program Files (Arm64)", "Swift")
   }
   if ($Platform -eq $KnownPlatforms["WindowsX64"]) {
-    return [IO.Path]::Combine("$ImageRoot\", "Program Files (Amd64)", "Swift")
+    return [IO.Path]::Combine("$BuildRoot\", "Program Files (Amd64)", "Swift")
   }
   if ($Platform -eq $KnownPlatforms["WindowsX86"]) {
-    return [IO.Path]::Combine("$ImageRoot\", "Program Files (x86)", "Swift")
+    return [IO.Path]::Combine("$BuildRoot\", "Program Files (x86)", "Swift")
   }
   throw "Unknown Platform"
 }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1881,22 +1881,31 @@ function Add-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
 function ConvertTo-CMakeArgument([string] $Argument) {
   # Backslashes in CMakeCache.txt are escape characters, but the synthetic CAS
   # roots deliberately use a UNC spelling. Preserve the complete synthetic
-  # path while normalizing ordinary Windows path separators.
+  # path while normalizing ordinary Windows path separators. A synthetic path
+  # may be the complete argument or the value of an option using `=`.
   $SyntheticPath = $Argument.IndexOf('\\swift\')
-  if ($SyntheticPath -ge 0) {
+  if ($SyntheticPath -eq 0 -or
+      ($SyntheticPath -gt 0 -and $Argument[$SyntheticPath - 1] -eq '=')) {
     $Prefix = $Argument.Substring(0, $SyntheticPath).Replace("\", "/")
-    return $Prefix + $Argument.Substring($SyntheticPath)
+    $Path = $Argument.Substring($SyntheticPath).Replace('$', '$$')
+    return $Prefix + $Path
   }
 
   # Preserve a leading double backslash for ordinary UNC paths, while using
-  # forward slashes for the remaining components as before.
-  $DoubleBackslash = $Argument.IndexOf("\\")
-  if ($DoubleBackslash -lt 0) {
+  # forward slashes for the remaining components as before. As above, the UNC
+  # path may be the value of an option using `=`.
+  $UNCPath = if ($Argument.StartsWith("\\")) {
+    0
+  } else {
+    $OptionValue = $Argument.IndexOf("=\\")
+    if ($OptionValue -ge 0) { $OptionValue + 1 } else { -1 }
+  }
+  if ($UNCPath -lt 0) {
     return $Argument.Replace("\", "/")
   }
 
-  $Prefix = $Argument.Substring(0, $DoubleBackslash).Replace("\", "/")
-  $Suffix = $Argument.Substring($DoubleBackslash + 2).Replace("\", "/")
+  $Prefix = $Argument.Substring(0, $UNCPath).Replace("\", "/")
+  $Suffix = $Argument.Substring($UNCPath + 2).Replace("\", "/")
   return "$Prefix\\$Suffix"
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -404,7 +404,7 @@ $WiX = @{
   EulaIdentifier = "wix7";
   URL = "https://www.nuget.org/api/v2/package/wix/7.0.0";
   SHA256 = "7f992e57c356dcbda2ea961bf3b348e1bd7d31d96795be4ac391e04cf140536d";
-  Path = [IO.Path]::Combine("$BinaryCache\WiX-7.0.0", "tools", "net8.0", "any");
+  Path = [IO.Path]::Combine("$ArtifactCache\WiX-7.0.0", "tools", "net8.0", "any");
 }
 
 $DotNetRuntime = @{
@@ -1440,7 +1440,7 @@ function Get-DotNetRuntime() {
 
 function Get-DotNetRuntimeRoot() {
   $Runtime = Get-DotNetRuntime
-  return [IO.Path]::Combine("$BinaryCache", "dotnet-runtime-$($DotNetRuntime.Version)-$($Runtime.RuntimeIdentifier)")
+  return [IO.Path]::Combine("$ArtifactCache", "dotnet-runtime-$($DotNetRuntime.Version)-$($Runtime.RuntimeIdentifier)")
 }
 
 function Get-DotNet() {
@@ -1733,12 +1733,12 @@ function Get-Dependencies {
     if ($Toolchain -or $Package) {
       $DotNetRuntimeInfo = Get-DotNetRuntime
       $DotNetArchive = "dotnet-runtime-$($DotNetRuntime.Version)-$($DotNetRuntimeInfo.RuntimeIdentifier).zip"
-      DownloadAndVerify $DotNetRuntimeInfo.URL "$BinaryCache\$DotNetArchive" $DotNetRuntimeInfo.SHA256
-      Expand-ZipFile $DotNetArchive -ExtractPath "dotnet-runtime-$($DotNetRuntime.Version)-$($DotNetRuntimeInfo.RuntimeIdentifier)"
+      DownloadAndVerify $DotNetRuntimeInfo.URL "$ArtifactCache\$DotNetArchive" $DotNetRuntimeInfo.SHA256
+      Expand-ArtifactZip $DotNetArchive "dotnet-runtime-$($DotNetRuntime.Version)-$($DotNetRuntimeInfo.RuntimeIdentifier)"
       Write-Success ".NET Runtime $($DotNetRuntime.Version) ($($DotNetRuntimeInfo.RuntimeIdentifier))"
 
-      DownloadAndVerify $WiX.URL "$BinaryCache\WiX-$($WiX.Version).zip" $WiX.SHA256
-      Expand-ZipFile WiX-$($WiX.Version).zip -ExtractPath WiX-$($WiX.Version)
+      DownloadAndVerify $WiX.URL "$ArtifactCache\WiX-$($WiX.Version).zip" $WiX.SHA256
+      Expand-ArtifactZip "WiX-$($WiX.Version).zip" "WiX-$($WiX.Version)"
       Write-Success "WiX $($WiX.Version)"
     }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -29,6 +29,11 @@ The path to the merged file system image populated by the build. The
 ImageRoot is retained as a compatibility alias.
 Default: 'S:\'
 
+.PARAMETER ObjectStore
+The path to the content-addressed object store used for build caching.
+Cache is retained as a compatibility alias.
+Default: 'S:\ObjectStore'
+
 .PARAMETER Stage
 The path to a directory where built msi's and the installer executable should be
 staged (for CI). Leave empty for local development builds.
@@ -137,7 +142,8 @@ param
   [System.IO.FileInfo] $BinaryCache = "S:\BinaryCache",
   [Alias("ImageRoot")]
   [System.IO.FileInfo] $BuildRoot = "S:",
-  [System.IO.FileInfo] $Cache = "S:\CAS",
+  [Alias("Cache")]
+  [System.IO.FileInfo] $ObjectStore = "S:\ObjectStore",
   [string] $Stage = "",
 
   # (Pinned) Bootstrap Toolchain
@@ -2314,7 +2320,7 @@ function Build-CMakeProject {
     }
 
     if ($EnableCaching) {
-      $env:LLVM_CACHE_CAS_PATH = "$Cache"
+      $env:LLVM_CACHE_CAS_PATH = "$ObjectStore"
       $SyntheticSourceCache = '\\swift\SourceCache$'
       $SyntheticBinaryCache = '\\swift\BinaryCache$'
       $CASPrefixMappings = [ordered]@{
@@ -2362,7 +2368,7 @@ function Build-CMakeProject {
         $SwiftCachingFlags = @(
           "-explicit-module-build",
           "-cache-compile-job",
-          "-cas-path", $Cache,
+          "-cas-path", $ObjectStore,
           "-incremental-dependency-scan",
           "-file-compilation-dir", $SyntheticBinaryCache,
           "-Xfrontend", "-prefix-map-sourceinfo"

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1750,8 +1750,8 @@ function Get-Dependencies {
       # The make tool isn't part of MSYS
       $GnuWin32MakeURL = "https://downloads.sourceforge.net/project/ezwinports/make-4.4.1-without-guile-w32-bin.zip"
       $GnuWin32MakeHash = "fb66a02b530f7466f6222ce53c0b602c5288e601547a034e4156a512dd895ee7"
-      DownloadAndVerify $GnuWin32MakeURL "$BinaryCache\GnuWin32Make-4.4.1.zip" $GnuWin32MakeHash
-      Expand-ZipFile GnuWin32Make-4.4.1.zip -ExtractPath GnuWin32Make-4.4.1
+      DownloadAndVerify $GnuWin32MakeURL "$ArtifactCache\GnuWin32Make-4.4.1.zip" $GnuWin32MakeHash
+      Expand-ArtifactZip GnuWin32Make-4.4.1.zip GnuWin32Make-4.4.1
       Write-Success "GNUWin32 make 4.4.1"
     }
 
@@ -2841,7 +2841,7 @@ function Get-CompilersDefines([Hashtable] $Platform,
     LLDB_PYTHON_RELATIVE_PATH = "lib/site-packages";
     LLDB_PYTHON_DLL_RELATIVE_PATH = "../../../../Python-$PythonVersion/usr/bin";
     LLDB_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "lldb-tblgen.exe");
-    LLDB_TEST_MAKE = "$BinaryCache\GnuWin32Make-4.4.1\bin\make.exe";
+    LLDB_TEST_MAKE = "$ArtifactCache\GnuWin32Make-4.4.1\bin\make.exe";
     LLVM_CONFIG_PATH = (Join-Path -Path $BuildTools -ChildPath "llvm-config.exe");
     LLVM_ENABLE_ASSERTIONS = $(if ($Variant -eq "Asserts") { "YES" } else { "NO" })
     LLVM_ENABLE_LTO = $(switch ($LTO) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -761,7 +761,7 @@ function Get-AndroidNDK {
 }
 
 function Get-AndroidNDKPath {
-  return Join-Path -Path $BinaryCache -ChildPath "android-ndk-$AndroidNDKVersion"
+  return Join-Path -Path $ArtifactCache -ChildPath "android-ndk-$AndroidNDKVersion"
 }
 
 function Get-FlexExecutable {
@@ -1583,7 +1583,9 @@ function Get-Dependencies {
       Expand-Archive -Path $Source -DestinationPath $Destination -Force
     }
 
-    function Expand-ArtifactZip([string] $ZipFileName, [string] $ExtractPath) {
+    function Expand-ArtifactZip([string] $ZipFileName,
+                                [string] $ExtractPath,
+                                [string] $ArchiveRoot = "") {
       $Source = Join-Path -Path $ArtifactCache -ChildPath $ZipFileName
       $Destination = Join-Path -Path $ArtifactCache -ChildPath $ExtractPath
       if (Test-Path $Destination) { return }
@@ -1591,8 +1593,13 @@ function Get-Dependencies {
       $TemporaryDestination = Join-Path -Path $ArtifactCache -ChildPath ".$ExtractPath.$PID.$([Guid]::NewGuid()).tmp"
       try {
         Expand-Archive -LiteralPath $Source -DestinationPath $TemporaryDestination
+        $PublishedSource = if ($ArchiveRoot) {
+          Join-Path -Path $TemporaryDestination -ChildPath $ArchiveRoot
+        } else {
+          $TemporaryDestination
+        }
         try {
-          [IO.Directory]::Move($TemporaryDestination, $Destination)
+          [IO.Directory]::Move($PublishedSource, $Destination)
         } catch {
           if (-not (Test-Path $Destination)) { throw }
         }
@@ -1768,8 +1775,8 @@ function Get-Dependencies {
 
     if ($Android) {
       $NDK = Get-AndroidNDK
-      DownloadAndVerify $NDK.URL "$BinaryCache\android-ndk-$AndroidNDKVersion-windows.zip" $NDK.SHA256
-      Expand-ZipFile "android-ndk-$AndroidNDKVersion-windows.zip" -ExtractPath "android-ndk-$AndroidNDKVersion" -CreateExtractPath $false
+      DownloadAndVerify $NDK.URL "$ArtifactCache\android-ndk-$AndroidNDKVersion-windows.zip" $NDK.SHA256
+      Expand-ArtifactZip "android-ndk-$AndroidNDKVersion-windows.zip" "android-ndk-$AndroidNDKVersion" "android-ndk-$AndroidNDKVersion"
       Write-Success "Android NDK $AndroidNDKVersion"
     }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -60,6 +60,10 @@ tracking.
 The number of attempts to make when downloading a dependency before giving up.
 Default: 3
 
+.PARAMETER ArtifactLockTimeoutSeconds
+The maximum time to wait for another process to release an artifact lock.
+Default: 1800
+
 .PARAMETER ProductVersion
 The product version to be used when building the installer. Supports semantic
 version strings (e.g., "1.0.0"). Default: "0.0.0"
@@ -171,6 +175,10 @@ param
   # Dependency Download Retries
   [ValidateRange(1, [int]::MaxValue)]
   [int] $DownloadRetryCount = 3,
+
+  # Artifact Lock Timeout
+  [ValidateRange(1, [int]::MaxValue)]
+  [int] $ArtifactLockTimeoutSeconds = 1800,
 
   # Dependencies
   [ValidatePattern('^\d+(\.\d+)*$')]
@@ -779,11 +787,11 @@ function Get-BisonExecutable {
 }
 
 function Get-PythonPath([Hashtable] $Platform) {
-  return [IO.Path]::Combine("$BinaryCache\", "Python$($Platform.Architecture.CMakeName)-$PythonVersion")
+  return [IO.Path]::Combine("$ArtifactCache\", "Python$($Platform.Architecture.CMakeName)-$PythonVersion")
 }
 
 function Get-EmbeddedPythonPath([Hashtable] $Platform) {
-  return [IO.Path]::Combine("$BinaryCache\", "EmbeddedPython$($Platform.Architecture.CMakeName)-$PythonVersion")
+  return [IO.Path]::Combine("$ArtifactCache\", "EmbeddedPython$($Platform.Architecture.CMakeName)-$PythonVersion")
 }
 
 function Get-PythonExecutable {
@@ -1569,26 +1577,6 @@ function Get-Dependencies {
       }
     }
 
-    function Expand-ZipFile {
-      param
-      (
-          [string]$ZipFileName,
-          [string]$ExtractPath,
-          [bool]$CreateExtractPath = $true
-      )
-
-      $Source = Join-Path -Path $BinaryCache -ChildPath $ZipFileName
-      $Destination = Join-Path -Path $BinaryCache -ChildPath $ExtractPath
-
-      if (Test-Path $Destination) { return }
-
-      $Destination = if ($CreateExtractPath) { $Destination } else { $BinaryCache }
-
-      # Write-Output "Extracting '$ZipFileName' ..."
-      New-Item -ItemType Directory -ErrorAction Ignore -Path $BinaryCache | Out-Null
-      Expand-Archive -Path $Source -DestinationPath $Destination -Force
-    }
-
     function Expand-ArtifactZip([string] $ZipFileName,
                                 [string] $ExtractPath,
                                 [string] $ArchiveRoot = "") {
@@ -1611,6 +1599,35 @@ function Get-Dependencies {
         }
       } finally {
         Remove-Item -LiteralPath $TemporaryDestination -Recurse -Force -ErrorAction Ignore
+      }
+    }
+
+    function Invoke-WithArtifactLock([string] $Name, [ScriptBlock] $ScriptBlock) {
+      $LockRoot = Join-Path -Path $ArtifactCache -ChildPath ".locks"
+      New-Item -ItemType Directory -Path $LockRoot -ErrorAction Ignore | Out-Null
+      $LockPath = Join-Path -Path $LockRoot -ChildPath "$Name.lock"
+
+      $Lock = $null
+      $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
+      while (-not $Lock) {
+        try {
+          $Lock = [IO.File]::Open($LockPath, [IO.FileMode]::OpenOrCreate,
+                                  [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+        } catch [IO.IOException] {
+          $ErrorCode = $_.Exception.HResult -band 0xffff
+          if ($ErrorCode -notin 32, 33) { throw }
+          if ($Stopwatch.Elapsed.TotalSeconds -ge $ArtifactLockTimeoutSeconds) {
+            throw "Timed out after $ArtifactLockTimeoutSeconds seconds waiting for artifact lock '$LockPath'"
+          }
+          Start-Sleep -Milliseconds 100
+        }
+      }
+      $Stopwatch.Stop()
+
+      try {
+        & $ScriptBlock
+      } finally {
+        $Lock.Dispose()
       }
     }
 
@@ -1679,8 +1696,8 @@ function Get-Dependencies {
     function Install-Python([string] $ArchName, [bool] $EmbeddedPython = $false) {
       $Python = Get-KnownPython $ArchName $EmbeddedPython
       $FileName = $(if ($EmbeddedPython) { "EmbeddedPython$ArchName-$PythonVersion" } else { "Python$ArchName-$PythonVersion" })
-      DownloadAndVerify $Python.URL "$BinaryCache\$FileName.zip" $Python.SHA256
-      Expand-ZipFile "$FileName.zip" -ExtractPath "$FileName"
+      DownloadAndVerify $Python.URL "$ArtifactCache\$FileName.zip" $Python.SHA256
+      Expand-ArtifactZip "$FileName.zip" $FileName
       Write-Success "$ArchName Python $PythonVersion"
     }
 
@@ -1739,7 +1756,9 @@ function Get-Dependencies {
       Install-Python $BuildArchName
       Install-Python $BuildArchName $true
     }
-    Install-PythonModules
+    Invoke-WithArtifactLock (Split-Path -Leaf (Get-PythonPath $BuildPlatform)) {
+      Install-PythonModules
+    }
 
     # WiX is needed both for packaging and for extracting the pinned toolchain
     # installer that bootstraps toolchain builds.

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -592,7 +592,7 @@ function Get-Ninja {
 
 $ninja = Get-Ninja
 
-$NugetRoot = "$BinaryCache\nuget"
+$NugetRoot = "$ArtifactCache\nuget"
 
 ## Select and prepare build tools, platforms, parameters, etc.
 
@@ -1820,20 +1820,22 @@ function Get-Dependencies {
         Invoke-IsolatingEnvVars { Invoke-VsDevShell $HostPlatform }
       } catch {
         Write-Output "Windows SDK $WinSDKVersion not found. Downloading from nuget.org ..."
-        Invoke-Program nuget install Microsoft.Windows.SDK.CPP -Version $WinSDKVersion -OutputDirectory $NugetRoot
+        Invoke-WithArtifactLock "WindowsSDK-$WinSDKVersion" {
+          Invoke-Program nuget install Microsoft.Windows.SDK.CPP -Version $WinSDKVersion -OutputDirectory $NugetRoot
 
-        # Set to script scope so Invoke-VsDevShell can read it.
-        $script:CustomWinSDKRoot = "$NugetRoot\Microsoft.Windows.SDK.CPP.$WinSDKVersion\c"
+          # Set to script scope so Invoke-VsDevShell can read it.
+          $script:CustomWinSDKRoot = "$NugetRoot\Microsoft.Windows.SDK.CPP.$WinSDKVersion\c"
 
-        # Install each required architecture package and move files under the base /lib directory.
-        $Builds = $WindowsSDKBuilds.Clone()
-        if (-not ($HostPlatform -in $Builds)) {
-          $Builds += $HostPlatform
-        }
+          # Install each required architecture package and move files under the base /lib directory.
+          $Builds = $WindowsSDKBuilds.Clone()
+          if (-not ($HostPlatform -in $Builds)) {
+            $Builds += $HostPlatform
+          }
 
-        foreach ($Build in $Builds) {
-          Invoke-Program nuget install Microsoft.Windows.SDK.CPP.$($Build.Architecture.ShortName) -Version $WinSDKVersion -OutputDirectory $NugetRoot
-          Copy-Directory "$NugetRoot\Microsoft.Windows.SDK.CPP.$($Build.Architecture.ShortName).$WinSDKVersion\c\*" "$CustomWinSDKRoot\lib\$WinSDKVersion"
+          foreach ($Build in $Builds) {
+            Invoke-Program nuget install Microsoft.Windows.SDK.CPP.$($Build.Architecture.ShortName) -Version $WinSDKVersion -OutputDirectory $NugetRoot
+            Copy-Directory "$NugetRoot\Microsoft.Windows.SDK.CPP.$($Build.Architecture.ShortName).$WinSDKVersion\c\*" "$CustomWinSDKRoot\lib\$WinSDKVersion"
+          }
         }
       }
     }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -538,18 +538,20 @@ $KnownSyft = @{
 $KnownCMakes = @{
   "4.4.1" = @{
     AMD64 = @{
+      Artifact = "cmake-4.4.1-windows-amd64"
       URL = "https://cmake.org/files/v4.4/cmake-4.4.1-windows-x86_64.zip"
       SHA256 = "091919E1CDE162B69D2D5E0F3B1F5670C973E72133F78126FBB18042947D6F19"
       FileName = "cmake-4.4.1-windows-x86_64.zip"
-      CMakeRoot = [IO.Path]::Combine("$BinaryCache", "cmake-4.4.1", "cmake-4.4.1-windows-x86_64", "share", "cmake-4.4")
-      Path = [IO.Path]::Combine("$BinaryCache", "cmake-4.4.1", "cmake-4.4.1-windows-x86_64", "bin", "cmake.exe")
+      CMakeRoot = [IO.Path]::Combine("$ArtifactCache", "cmake-4.4.1-windows-amd64", "cmake-4.4.1-windows-x86_64", "share", "cmake-4.4")
+      Path = [IO.Path]::Combine("$ArtifactCache", "cmake-4.4.1-windows-amd64", "cmake-4.4.1-windows-x86_64", "bin", "cmake.exe")
     };
     ARM64 = @{
+      Artifact = "cmake-4.4.1-windows-arm64"
       URL = "https://cmake.org/files/v4.4/cmake-4.4.1-windows-arm64.zip"
       SHA256 = "DC59D9F377F891B8DA42EDE22F53717034A9D093092FCEAF6297FEEEC6AFBA29"
       FileName = "cmake-4.4.1-windows-arm64.zip"
-      CMakeRoot = [IO.Path]::Combine("$BinaryCache", "cmake-4.4.1", "cmake-4.4.1-windows-arm64", "share", "cmake-4.4")
-      Path = [IO.Path]::Combine("$BinaryCache", "cmake-4.4.1", "cmake-4.4.1-windows-arm64", "bin", "cmake.exe")
+      CMakeRoot = [IO.Path]::Combine("$ArtifactCache", "cmake-4.4.1-windows-arm64", "cmake-4.4.1-windows-arm64", "share", "cmake-4.4")
+      Path = [IO.Path]::Combine("$ArtifactCache", "cmake-4.4.1-windows-arm64", "cmake-4.4.1-windows-arm64", "bin", "cmake.exe")
     };
   }
 }
@@ -1760,8 +1762,8 @@ function Get-Dependencies {
 
     # Install CMake.
     $CMake = Get-CMake
-    DownloadAndVerify $CMake.URL "$BinaryCache\cmake-$CMakeVersion.zip" $CMake.SHA256
-    Expand-ZipFile "cmake-$CMakeVersion.zip" -ExtractPath "cmake-$CMakeVersion"
+    DownloadAndVerify $CMake.URL "$ArtifactCache\$($CMake.FileName)" $CMake.SHA256
+    Expand-ArtifactZip $CMake.FileName $CMake.Artifact
     Write-Success "CMake $CMakeVersion"
 
     if ($Android) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1985,6 +1985,7 @@ $Compilers = @{
         @("-g", "-debug-info-format=${Format}")
       }
       AssumeFunctional  = $false
+      SourceInfoMapping = $false
     }
   }
 
@@ -2037,6 +2038,7 @@ $Compilers = @{
         @("-g", "-debug-info-format=${Format}")
       }
       AssumeFunctional  = $true
+      SourceInfoMapping = $true
     }
   }
 }
@@ -2433,9 +2435,12 @@ function Build-CMakeProject {
           "-cache-compile-job",
           "-cas-path", $ObjectStore,
           "-incremental-dependency-scan",
-          "-file-compilation-dir", $SyntheticBinaryCache,
-          "-Xfrontend", "-prefix-map-sourceinfo"
+          "-file-compilation-dir", $SyntheticBinaryCache
         )
+
+        if ($SwiftCompiler.SourceInfoMapping) {
+          $SwiftCachingFlags += @("-Xfrontend", "-prefix-map-sourceinfo")
+        }
 
         foreach ($Mapping in $CASPrefixMappings.GetEnumerator()) {
           $SwiftCachingFlags += @(


### PR DESCRIPTION
This pull request refactors the Windows build scripts to improve artifact management, caching, and concurrency safety. It introduces new parameters for more granular control of build directories, migrates artifact storage from `BinaryCache` to a new `ArtifactCache` location, and implements robust locking and extraction mechanisms to prevent race conditions during concurrent builds. Several helper functions and dependency paths have been updated accordingly.

**Artifact and Build Directory Refactoring:**

* Introduced new parameters in `build.ps1` for `ArtifactCache`, `BuildRoot`, and `ObjectStore`, replacing and aliasing previous parameters like `ImageRoot` and `Cache` for improved clarity and future compatibility. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L26-R41) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L137-R156)
* Updated all dependency, toolchain, and artifact paths in build logic and helper functions to use `ArtifactCache` instead of `BinaryCache`. This affects the download, extraction, and usage of tools like WiX, Syft, CMake, Python, Ninja, and Android NDK. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L393-R415) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R521-R568) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L562-R595) [[4]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L745-R802) [[5]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1424-R1457) [[6]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1633-R1701) [[7]](diffhunk://#diff-37b409724bd4ca4b5908ed77ebd6c6a39827fb0579bfaf53a44e448d4e4df28aL110-R112)

**Concurrency and Extraction Robustness:**

* Added `ArtifactLockTimeoutSeconds` parameter and implemented `Invoke-WithArtifactLock` to serialize artifact extraction and prevent race conditions when multiple processes access the same artifact. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R63-R66) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R179-R182) [[3]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1554-R1631)
* Improved extraction logic for zip files and toolchains by using temporary directories and atomic moves, ensuring consistency and avoiding partial extractions. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9R1554-R1631) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L1575-R1685)

**Toolchain and Dependency Management Enhancements:**

* Refactored toolchain extraction to use the new artifact cache and improved temp directory handling, including better cleanup and atomic directory moves.
* Added configuration for `winflexbison` as a known dependency, including version, URL, and hash.

**General Improvements:**

* Updated documentation and parameter help text to reflect new directory structure and usage.
* Ensured all helper functions and dependency installers use the new artifact cache locations for consistency. [[1]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L745-R802) [[2]](diffhunk://#diff-c861caa2fcc08744108e542ca836b07e342f537566e8c5f7a21a0e9125331ed9L782-R824)

These changes make the build process more reliable, modular, and suited for concurrent and distributed build environments.