### PR TITLE
[Sema] Mark defer blocks as `@called(once)` when feature is enabled

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2611,9 +2611,18 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       infoBuilder = infoBuilder.withSendable(AFD->isSendable());
       // 'throws' only applies to the innermost function.
       infoBuilder = infoBuilder.withThrows(AFD->hasThrows(), thrownTy);
-      // Defer bodies must not escape.
       if (auto fd = dyn_cast<FuncDecl>(D)) {
-        infoBuilder = infoBuilder.withNoEscape(fd->isDeferBody());
+        if (fd->isDeferBody()) {
+          // Defer bodies must not escape.
+          infoBuilder = infoBuilder.withNoEscape(fd->isDeferBody());
+
+          // Defer is expected to be called only once, making it `@called(once)`
+          // allows it to consume non-Copyable values.
+          if (Context.LangOpts.hasFeature(Feature::CalledAttribute)) {
+            infoBuilder = infoBuilder.withCalledOnce();
+          }
+        }
+
         if (fd->hasSendingResult())
           infoBuilder = infoBuilder.withSendingResult();
       }

--- a/test/Interpreter/called_once.swift
+++ b/test/Interpreter/called_once.swift
@@ -315,3 +315,48 @@ func testNeverCalledThroughThunkReleasesCapture() {
 
 // CHECK-NEXT: Tracker(unused) deinit
 testNeverCalledThroughThunkReleasesCapture()
+
+func testDeferConsumesResource() {
+  let r = Resource("deferred")
+  defer {
+    r.use()
+  }
+  print("before defer")
+}
+
+// CHECK-NEXT: before defer
+// CHECK-NEXT: Resource(deferred) used
+// CHECK-NEXT: Resource(deferred) deinit
+testDeferConsumesResource()
+
+func testDeferMultipleCaptures() {
+  let a = Resource("a")
+  let b = Resource("b")
+  defer {
+    a.use()
+    b.use()
+  }
+  print("multi before")
+}
+
+// CHECK-NEXT: multi before
+// CHECK-NEXT: Resource(a) used
+// CHECK-NEXT: Resource(a) deinit
+// CHECK-NEXT: Resource(b) used
+// CHECK-NEXT: Resource(b) deinit
+testDeferMultipleCaptures()
+
+func testTwoDefersLIFO() {
+  let first = Resource("first-declared")
+  let second = Resource("second-declared")
+  defer { first.use() }
+  defer { second.use() }
+  print("two defers before")
+}
+
+// CHECK-NEXT: two defers before
+// CHECK-NEXT: Resource(second-declared) used
+// CHECK-NEXT: Resource(second-declared) deinit
+// CHECK-NEXT: Resource(first-declared) used
+// CHECK-NEXT: Resource(first-declared) deinit
+testTwoDefersLIFO()

--- a/test/SIL/called_once.swift
+++ b/test/SIL/called_once.swift
@@ -314,7 +314,7 @@ do {
 
   struct S2: ~Copyable {
     let operation: @called(once) () -> Void
-    
+
     init(operation: @escaping @called(once) () -> Void) {
       self.operation = operation
     }
@@ -326,4 +326,73 @@ do {
       operation() // expected-error {{cannot partially consume 'self' when it has a deinitializer}}
     }
   }
+}
+
+// A `defer` body is synthesized as a `@called(once)` function, so captures
+// it consumes are subject to the same "at most once" checking as any other
+// `@called(once)` closure.
+
+struct Resource: ~Copyable {
+  deinit {}
+  consuming func use() {}
+}
+
+func testDeferConsumesResource() {
+  let r = Resource()
+  defer {
+    r.use() // Ok
+  }
+
+  _ = 42
+}
+
+func testDeferDoubleConsume() {
+  let r = Resource() // expected-error 2 {{'r' consumed more than once}}
+  defer {
+    r.use() // expected-note 2 {{consumed here}}
+    r.use() // expected-note 2 {{consumed again here}}
+  }
+
+  _ = 42
+}
+
+func testDeferConsumesInLoop() {
+  let r = Resource() // expected-error 2 {{'r' consumed in a loop}}
+
+  defer {
+    for _ in 0..<3 {
+      r.use() // expected-note 2 {{consumed here}}
+    }
+  }
+
+  _ = 42
+}
+
+func testCallThenDeferCall(_ f: @escaping @called(once) () -> Void) { // expected-error {{'f' consumed more than once}}
+  defer { // expected-note {{consumed again here}}
+    f()
+  }
+  f() // expected-note {{consumed here}}
+}
+
+func testDeferMultipleIndependentCaptures(
+  _ f: @escaping @called(once) () -> Void,
+  _ g: @escaping @called(once) () -> Void
+) {
+  defer {
+    f()
+    g()
+  }
+
+  _ = 42
+}
+
+func testMultipleDefersIndependentCaptures(
+  _ f: @escaping @called(once) () -> Void,
+  _ g: @escaping @called(once) () -> Void
+) {
+  defer { f() }
+  defer { g() }
+
+  _ = 42
 }

--- a/test/SILGen/called_once.swift
+++ b/test/SILGen/called_once.swift
@@ -161,3 +161,39 @@ func testMixedCaptureKinds(_ f: @called(once) () -> Void) {
   g()
   _ = count
 }
+
+struct Resource: ~Copyable {
+  deinit {}
+  consuming func use() {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11called_once25testDeferConsumesResourceyyF : $@convention(thin) () -> () {
+// CHECK:  [[R_PROJ:%.*]] = project_box {{.*}} : ${ let Resource }, 0
+// CHECK:  [[R_TAKE_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_VALUE:%.*]] = load [take] [[R_TAKE_ADDR]] : $*Resource
+// CHECK:  // function_ref $defer #1 () in testDeferConsumesResource()
+// CHECK:  [[DEFER_REF:%.*]] = function_ref @$s11called_once25testDeferConsumesResourceyyF6$deferL_yyF : $@convention(thin) (@owned Resource) -> ()
+// CHECK:  apply [[DEFER_REF]]([[R_VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: } // end sil function '$s11called_once25testDeferConsumesResourceyyF'
+
+// CHECK-LABEL: sil private [ossa] @$s11called_once25testDeferConsumesResourceyyF6$deferL_yyF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: bb0([[R_CAPTURE:%.*]] : @closureCapture @owned $Resource):
+// CHECK:  [[R_STACK:%.*]] = alloc_stack $Resource, let, name "r"
+// CHECK:  [[R_INIT_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_STACK]] : $*Resource
+// CHECK:  store [[R_CAPTURE]] to [init] [[R_INIT_ADDR]] : $*Resource
+// CHECK:  [[R_ADDR:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[R_INIT_ADDR]] : $*Resource
+// CHECK:  [[R_FAKE_COPY:%.*]] = load [copy] [[R_ADDR]] : $*Resource
+// CHECK:  // function_ref Resource.use()
+// CHECK:  [[USE_REF:%.*]] = function_ref @$s11called_once8ResourceV3useyyF : $@convention(method) (@owned Resource) -> ()
+// CHECK:  apply [[USE_REF]]([[R_FAKE_COPY]]) : $@convention(method) (@owned Resource) -> ()
+// CHECK:  destroy_addr [[R_ADDR]] : $*Resource
+// CHECK: } // end sil function '$s11called_once25testDeferConsumesResourceyyF6$deferL_yyF'
+func testDeferConsumesResource() {
+  let r = Resource()
+
+  defer {
+    r.use()
+  }
+
+  _ = 42
+}


### PR DESCRIPTION
The body of a `defer` block is expected to be executed only once and annotating it as such enables breader use of non-Copyable values in them by allowing such values to be moved into them and consumed inside.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
