### PR TITLE
SIL: Allow appending operands to debug_values (NFC)

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1807,20 +1807,6 @@ public:
     return sharedUInt32().InstructionBaseWithTrailingOperands.numOperands;
   }
 
-protected:
-  /// Removes the last operand, shrinking the tail allocated operand list.
-  /// The other, previous, operands, remain fully valid.
-  /// If there are any OtherTrailingTypes, they need to be moved separately by
-  /// the callee.
-  void eraseLastOperandInPlace() {
-    auto operands = getAllOperands();
-    ASSERT(!operands.empty() && "no operand to erase");
-
-    operands.back().~Operand();
-    sharedUInt32().InstructionBaseWithTrailingOperands.numOperands =
-        operands.size() - 1;
-  }
-
 public:
   ArrayRef<Operand> getAllOperands() const {
     return this->template getTrailingObjectsNonStrict<Operand>(
@@ -5765,19 +5751,38 @@ public:
 /// Define the start or update to a symbolic variable value (for loadable
 /// types).
 class DebugValueInst final
-    : public InstructionBaseWithTrailingOperands<
-          SILInstructionKind::DebugValueInst, DebugValueInst,
-          NonValueInstruction, SILType, SILLocation, const SILDebugScope *,
-          SILDIExprElement, char>,
-      private SILDebugVariableSupplement {
+    : public InstructionBase<SILInstructionKind::DebugValueInst,
+                             NonValueInstruction>,
+      private SILDebugVariableSupplement,
+      private llvm::TrailingObjects<DebugValueInst, SILType, SILLocation,
+                                    const SILDebugScope *, SILDIExprElement,
+                                    Operand, char> {
   friend TrailingObjects;
   friend SILBuilder;
 
   TailAllocatedDebugVariable VarInfo;
   USE_SHARED_UINT8;
+  USE_SHARED_UINT32;
 
   /// Optional debug basic block holding reconstruction instructions.
   SILBasicBlock *ReconstructionBlock = nullptr;
+
+  /// Unlike other instructions with trailing operands, a debug_value's operand
+  /// list can grow through salvageDebugInfo. Growing the tail allocation is impossible, and
+  /// so is recreating the instruction, as salvageDebugInfo can't invalidate
+  /// iterators or worklists.
+  /// Therefore, once the operand list outgrows the tail allocation, it moves to a
+  /// separately allocated array. This is stored in the first tail allocated
+  /// operand slot, which is unused from then on.
+  struct OutOfLineOperands {
+    Operand *operands;
+    /// The number of operand slots in \c operands, which can be larger than the
+    /// number of operands: shrinking the operand list cannot reallocate.
+    /// The actual number of operands is stored in the sharedUInt32.
+    unsigned capacity;
+  };
+  static_assert(sizeof(OutOfLineOperands) <= sizeof(Operand),
+                "out-of-line operands must fit in a tail allocated slot");
 
   DebugValueInst(SILDebugLocation DebugLoc, ArrayRef<SILValue> Operands,
                  SILModule &M, SILDebugVariable Var,
@@ -5789,15 +5794,47 @@ class DebugValueInst final
                                 UsesMoveableValueDebugInfo_t operandWasMoved,
                                 bool trace);
 
-  using InstructionBaseWithTrailingOperands::numTrailingObjects;
   SIL_DEBUG_VAR_SUPPLEMENT_TRAILING_OBJS_IMPL()
 
-  /// Removes the last operand, shrinking the tail allocated operand list.
+  size_t numTrailingObjects(OverloadToken<Operand>) const {
+    return sharedUInt32().DebugValueInst.tailCapacity;
+  }
+
+  OutOfLineOperands &getOutOfLineOperands() {
+    ASSERT(sharedUInt8().DebugValueInst.outOfLineOperands);
+    return *reinterpret_cast<OutOfLineOperands *>(
+        getTrailingObjectsNonStrict<Operand>());
+  }
+
+  /// Moves the operands to an array of \p capacity slots, which must be able
+  /// to hold all of them. Every operand is moved, so all `Operand` pointers of
+  /// this instruction are invalidated, as is any iterator over the use list
+  /// of an operand.
+  void reallocateOperands(unsigned capacity);
+
+public:
+  /// The maximum number of operands a debug value can have. Every operand has to
+  /// be kept available up to the debug value, so salvaging gives up rather than
+  /// growing the operand list beyond it.
+  static constexpr unsigned MaxOperands = 16;
+
+  ~DebugValueInst();
+
+  /// Removes the last operand, shrinking the operand list.
   /// Only the last operand can be removed, to avoid invalidating other
   /// existing Operand pointers. Pointers to this last operand are invalidated.
   void eraseLastOperand();
 
-public:
+  MutableArrayRef<Operand> getAllOperands() {
+    unsigned numOperands = sharedUInt32().DebugValueInst.numOperands;
+    if (sharedUInt8().DebugValueInst.outOfLineOperands)
+      return {getOutOfLineOperands().operands, numOperands};
+    return {getTrailingObjects<Operand>(), numOperands};
+  }
+  ArrayRef<Operand> getAllOperands() const {
+    return const_cast<DebugValueInst *>(this)->getAllOperands();
+  }
+
   /// Returns the single operand, asserting that there is exactly one.
   /// Should only be used in contexts where it is known that there is no
   /// debug reconstruction block.
@@ -5975,10 +6012,18 @@ public:
   /// value is no longer valid and cannot be salvaged.
   /// Uses inside a debug reconstruction block are replaced with undef. If this
   /// is the last operand, the operand list is shrunk.
-  /// Any pointers to the killed Operand are invalidated.
+  /// Any pointers to the killed Operand are invalidated. Other operands are
+  /// untouched.
   /// If \p operandType is specified, that undef will use that type (in the
   /// appropriate address/object form) instead of the current operand's type.
   void killOperand(unsigned operandIdx, SILType operandType = SILType());
+
+  /// Appends \p value to the operand list, growing it if needed.
+  /// The caller is responsible for the matching debug reconstruction block
+  /// argument. Growing moves every operand, so all `Operand` pointers of this
+  /// instruction may be invalidated, as is any iterator over the use list of
+  /// an operand.
+  void appendOperand(SILValue value);
 
   bool hasTrace() const { return sharedUInt8().DebugValueInst.trace; }
 

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -226,7 +226,8 @@ protected:
     SHARED_FIELD(DebugValueInst, uint8_t
                  usesMoveableValueDebugInfo : 1,
                  trace : 1,
-                 prependDeref : 1);
+                 prependDeref : 1,
+                 outOfLineOperands : 1);
 
     SHARED_FIELD(AllocStackInst, uint8_t
                  dynamicLifetime : 1,
@@ -316,6 +317,9 @@ protected:
     SHARED_TEMPLATE_FIELD(typename, FieldIndexCacheBase, uint32_t fieldIndex);
     SHARED_TEMPLATE_FIELD(typename, SwitchEnumInstBase, uint32_t numCases);
     SHARED_FIELD(AllocStackInst, uint32_t numOperands);
+    SHARED_FIELD(DebugValueInst, uint32_t
+                 numOperands : 16,
+                 tailCapacity : 16);
     SHARED_FIELD(EnumInst, uint32_t caseIndex);
     SHARED_FIELD(UncheckedEnumDataInst, uint32_t caseIndex);
     SHARED_FIELD(InjectEnumAddrInst, uint32_t caseIndex);

--- a/include/swift/SILOptimizer/Utils/DebugOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/DebugOptUtils.h
@@ -38,8 +38,14 @@ void deleteAllDebugUses(SILInstruction *inst, InstModCallbacks &callbacks,
 /// Pass \p salvage as false when the instruction already has been salvaged.
 void deleteAllDebugUses(SILInstruction *inst, bool salvage = true);
 
-/// Transfer debug info associated with (the result of) \p I to a
+/// Transfer debug info associated with (any result of) \p I to a
 /// new `debug_value` instruction before \p I is deleted.
+///
+/// This can update the operands of any debug user of \p I, which invalidates
+/// all `Operand` pointers and use list iterators.
+/// New instructions may be inserted in case a fragment is needed, or for
+/// store salvages. No instruction is deleted, so `debug_value` instructions
+/// and instruction iterators are safe to keep.
 void salvageDebugInfo(SILInstruction *I);
 
 /// Transfer debug info associated with the store-like instruction \p SI to a

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -452,14 +452,28 @@ DebugValueInst::DebugValueInst(
     SILDebugVariable Var,
     UsesMoveableValueDebugInfo_t usesMoveableValueDebugInfo, bool trace,
     bool prependDeref)
-    : InstructionBaseWithTrailingOperands(Operands, DebugLoc),
+    : InstructionBase(DebugLoc),
       SILDebugVariableSupplement(Var.DIExpr.getNumElements(),
                                  Var.Type.has_value(), Var.Loc.has_value(),
                                  Var.Scope),
-      VarInfo(Var, getTrailingObjects<char>(), getTrailingObjects<SILType>(),
-              getTrailingObjects<SILLocation>(),
-              getTrailingObjects<const SILDebugScope *>(),
-              getTrailingObjects<SILDIExprElement>()) {
+      // Initialize VarInfo with a temporary raw value of 0. The real
+      // initialization can only be done after the operand counts are set
+      // (see below).
+      VarInfo(0) {
+  ASSERT(Operands.size() <= MaxOperands &&
+         "too many operands for a debug value");
+  // The operands start out in the tail allocation, which is sized for them.
+  sharedUInt32().DebugValueInst.tailCapacity = Operands.size();
+  sharedUInt32().DebugValueInst.numOperands = Operands.size();
+
+  // VarInfo must be initialized after tailCapacity.
+  VarInfo = TailAllocatedDebugVariable(
+      Var, getTrailingObjects<char>(), getTrailingObjects<SILType>(),
+      getTrailingObjects<SILLocation>(),
+      getTrailingObjects<const SILDebugScope *>(),
+      getTrailingObjects<SILDIExprElement>());
+  TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                         Operands);
   if (usesMoveableValueDebugInfo ||
       llvm::any_of(Operands, [](SILValue op) {
         return op->getType().isMoveOnly();
@@ -641,18 +655,57 @@ void DebugValueInst::cloneReconstructionBlockFrom(DebugValueInst *src) {
     .cloneDebugReconstructionBlockContent(srcBB, newBB);
 }
 
-void DebugValueInst::eraseLastOperand() {
-  // The variable data is tail allocated after the operands, so shrinking the
-  // operand list moves it by one operand. It is all trivially copyable, so
-  // using memmove is safe. Nothing keeps pointers on the varinfo.
-  size_t varinfoSize = getDebugVarTrailingDataSize(
-      VarInfo.getName(getTrailingObjects<char>()).size(),
-      HasAuxDebugVariableType, hasAuxDebugLocation(), hasAuxDebugScope(),
-      NumDIExprOperands);
-  char *varinfoBegin = reinterpret_cast<char *>(getAllOperands().end());
+DebugValueInst::~DebugValueInst() {
+  for (Operand &operand : getAllOperands())
+    operand.~Operand();
+  if (sharedUInt8().DebugValueInst.outOfLineOperands)
+    AlignedFree(getOutOfLineOperands().operands);
+}
 
-  eraseLastOperandInPlace();
-  std::memmove(varinfoBegin - sizeof(Operand), varinfoBegin, varinfoSize);
+void DebugValueInst::reallocateOperands(unsigned capacity) {
+  auto operands = getAllOperands();
+  ASSERT(capacity >= operands.size() && "cannot lose operands");
+  ASSERT(sharedUInt32().DebugValueInst.tailCapacity > 0 &&
+         "a debug value with no tail capacity cannot grow");
+
+  auto *newOperands = static_cast<Operand *>(getModule().allocateInst(
+      sizeof(Operand) * capacity, alignof(Operand)));
+
+  // Operands are in a linked list, they cannot be moved trivially.
+  for (auto [idx, operand] : llvm::enumerate(operands)) {
+    SILValue value = operand.get();
+    operand.~Operand();
+    ::new (&newOperands[idx]) Operand(this, value);
+  }
+
+  if (sharedUInt8().DebugValueInst.outOfLineOperands)
+    AlignedFree(getOutOfLineOperands().operands);
+  sharedUInt8().DebugValueInst.outOfLineOperands = true;
+  getOutOfLineOperands() = {newOperands, capacity};
+}
+
+void DebugValueInst::appendOperand(SILValue value) {
+  unsigned numOperands = sharedUInt32().DebugValueInst.numOperands;
+  ASSERT(numOperands < MaxOperands && "too many operands for a debug value");
+  unsigned capacity = sharedUInt8().DebugValueInst.outOfLineOperands
+                          ? getOutOfLineOperands().capacity
+                          : sharedUInt32().DebugValueInst.tailCapacity;
+
+  // Grow to the next power of two: operands are appended one by one, and every
+  // reallocation has to move all of them.
+  if (numOperands == capacity)
+    reallocateOperands(
+        std::min<unsigned>(llvm::NextPowerOf2(capacity), MaxOperands));
+
+  sharedUInt32().DebugValueInst.numOperands = numOperands + 1;
+  ::new (&getAllOperands()[numOperands]) Operand(this, value);
+}
+
+void DebugValueInst::eraseLastOperand() {
+  auto operands = getAllOperands();
+  ASSERT(!operands.empty() && "no operand to erase");
+  operands.back().~Operand();
+  sharedUInt32().DebugValueInst.numOperands = operands.size() - 1;
 }
 
 void DebugValueInst::killOperand(unsigned operandIdx, SILType operandType) {


### PR DESCRIPTION
The salvageDebugInfo function is called at different moments in a lot of passes. It is not expected to delete instructions, as instructions might be in a worklist, and might double delete. It should also avoid creating new instructions.

Salvaging debug info should, as much as possible, rewrite existing debug_value instructions. Reallocating a new debug_value instruction to replace an existing one is not an option. To allow for operand lists to grow, the operand list can now be moved to a separately allocated operand list, whose memory is managed by the debug_value instruction.

This change is necessary before multi-operand salvage can be enabled.

Note: When operands are reallocated, `Operand *` are still invalidated. Some passes keep Operand pointers, and need to make sure `salvageDebugInfo()` isn't called on an instruction that will invalidate Operand pointers.