### PR TITLE
[Embedded] Avoid <runtime/Private.h> when building for Embedded Swift

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -24,7 +24,11 @@
 #endif
 
 #include "../CompatibilityOverride/CompatibilityOverride.h"
+#if !SWIFT_CONCURRENCY_EMBEDDED
+// Private.h pulls in the demangler and other hosted C++ facilities, which are
+// unavailable when building for embedded (freestanding) targets.
 #include "../runtime/Private.h"
+#endif
 #include "Debug.h"
 #include "ExecutorBridge.h"
 #include "TaskPrivate.h"


### PR DESCRIPTION
Fixes rdar://185837523
