### PR TITLE
[RemoteInspection] Fail the lowering when a Builtin.FixedArray count overflows its size fields.

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2882,6 +2882,13 @@ public:
     if (count < 0)
       count = 0;
 
+    // Size and Stride are 32 bits. Ensure we don't overflow them.
+    uint64_t totalSize = (uint64_t)elementTI->getStride() * (uint64_t)count;
+    if (totalSize > UINT32_MAX) {
+      TC.setError("FixedArray size overflows", BA);
+      return nullptr;
+    }
+
     return TC.makeTypeInfo<ArrayTypeInfo>(count, BA->getElementType(),
                                           elementTI);
   }

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1307,6 +1307,14 @@ $1_SiBV
 // CHECK-32-NEXT:     (field name=_value offset=0
 // CHECK-32-NEXT:       (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
 
+// A count that overflows the 32-bit size and stride fields is rejected rather
+// than silently wrapping. rdar://185733582
+$2147483646_SiBV
+// CHECK:      (builtin_fixed_array
+// CHECK-NEXT:   (integer value=2147483647)
+// CHECK-NEXT:   (struct Swift.Int))
+// CHECK-NEXT: Invalid lowering
+
 SiBW
 // CHECK-64:      (builtin_borrow
 // CHECK-64-NEXT:   (struct Swift.Int))


### PR DESCRIPTION
Bad data from the remote process can cause the element count times stride to overflow the 32-bit size/stride fields. Return an error instead.

rdar://185733582