### PR TITLE
[RemoteInspection] Read types declared in a constrained extension of a generic type.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2718,6 +2718,29 @@ private:
     return buildContextDescriptorManglingForSymbol(descriptor.getSymbol(), dem);
   }
 
+  /// Given a demangled type, returns the unbound nominal a bound generic type
+  /// was formed from, or null if the type is not a bound generic type.
+  Demangle::NodePointer stripBoundGenericArgs(Demangle::NodePointer type) {
+    auto bound = type;
+    if (bound->getKind() == Node::Kind::Type && bound->getNumChildren() == 1)
+      bound = bound->getFirstChild();
+
+    switch (bound->getKind()) {
+    case Node::Kind::BoundGenericClass:
+    case Node::Kind::BoundGenericStructure:
+    case Node::Kind::BoundGenericEnum:
+    case Node::Kind::BoundGenericOtherNominalType:
+    case Node::Kind::BoundGenericTypeAlias:
+      break;
+    default:
+      return nullptr;
+    }
+
+    if (bound->getNumChildren() < 1)
+      return nullptr;
+    return bound->getFirstChild();
+  }
+
   Demangle::NodePointer
   buildContextDescriptorMangling(ContextDescriptorRef descriptor,
                                  Demangler &dem, int recursion_limit) {
@@ -2822,6 +2845,13 @@ private:
           readMangledName(extendedContextAddress, MangledNameKind::Type, dem);
       if (!demangledExtendedContext)
         return nullptr;
+
+      // An extension of a constrained generic type records its extended
+      // context as a bound generic type, but an Extension node's extended
+      // context has to be an unbound nominal, with the arguments described by
+      // the generic signature below. Strip the arguments off.
+      if (auto unbound = stripBoundGenericArgs(demangledExtendedContext))
+        demangledExtendedContext = unbound;
 
       auto demangling = dem.createNode(Node::Kind::Extension);
       demangling->addChild(parentDemangling, dem);
@@ -3215,8 +3245,90 @@ private:
 
     unsigned packIndex = 0;
 
+    // Parameters concretized by a same-type constraint carry no key argument,
+    // so their substitution has to come from the constraint instead. Map each
+    // parameter's position in the flattened parameter list to its depth and
+    // index the same way buildNominalTypeDecl counts levels, since that is how
+    // a constraint's subject names it.
+    std::vector<size_t> paramsPerLevel;
+    {
+      size_t runningCount = 0;
+      std::function<void(ContextDescriptorRef)> countLevels =
+          [&](ContextDescriptorRef current) {
+            if (auto parentContextRef = readParentContextDescriptor(current))
+              if (parentContextRef->isResolved())
+                if (auto parentContext = parentContextRef->getResolved())
+                  countLevels(parentContext);
+
+            auto genericContext = current->getGenericContext();
+            if (genericContext &&
+                (current->getKind() == ContextDescriptorKind::Class ||
+                 current->getKind() == ContextDescriptorKind::Enum ||
+                 current->getKind() == ContextDescriptorKind::Struct)) {
+              auto contextHeader = genericContext->getGenericContextHeader();
+              paramsPerLevel.emplace_back(contextHeader.NumParams -
+                                          runningCount);
+              runningCount += paramsPerLevel.back();
+            }
+          };
+      countLevels(descriptor);
+    }
+
+    // Returns the substitution a same-type constraint fixes the parameter at
+    // the given flattened position to, or a null type if no constraint does.
+    auto substFromSameTypeConstraint = [&](unsigned flatIndex) -> BuiltType {
+      // Find the depth and index this flattened position corresponds to.
+      unsigned depth = 0;
+      unsigned index = flatIndex;
+      for (auto count : paramsPerLevel) {
+        if (index < count)
+          break;
+        index -= count;
+        ++depth;
+      }
+
+      for (auto &req : generics->getGenericRequirements()) {
+        if (req.Flags.getKind() != GenericRequirementKind::SameType) {
+          continue;
+        }
+
+        Demangler dem;
+        auto subjectAddress = resolveRelativeField(descriptor, req.Param);
+        auto subject =
+            readMangledName(subjectAddress, MangledNameKind::Type, dem);
+        if (!subject)
+          continue;
+        if (subject->getKind() == Node::Kind::Type &&
+            subject->getNumChildren() == 1)
+          subject = subject->getFirstChild();
+        if (subject->getKind() != Node::Kind::DependentGenericParamType ||
+            subject->getNumChildren() != 2)
+          continue;
+        auto subjectDepth = subject->getChild(0);
+        auto subjectIndex = subject->getChild(1);
+        if (!subjectDepth->hasIndex() || !subjectIndex->hasIndex())
+          continue;
+        if (subjectDepth->getIndex() != depth ||
+            subjectIndex->getIndex() != index)
+          continue;
+
+        auto typeAddress = resolveRelativeField(descriptor, req.Type);
+        auto type = readMangledName(typeAddress, MangledNameKind::Type, dem);
+        if (!type)
+          continue;
+        auto result = decodeMangledType(type);
+        if (result.isError()) {
+          continue;
+        }
+        return result.getType();
+      }
+      return BuiltType();
+    };
+
+    unsigned flatParamIndex = 0;
     std::vector<BuiltType> builtSubsts;
     for (auto param : generics->getGenericParams()) {
+      unsigned thisParamIndex = flatParamIndex++;
       switch (param.getKind()) {
       case GenericParamKind::Type:
         // The type should have a key argument unless it's been same-typed
@@ -3238,10 +3350,13 @@ private:
             return {};
           builtSubsts.push_back(builtArg);
         } else {
-          // TODO: If the key argument has been concretized by a same-type
-          // constraint, that should be reflected in the built nominal type
-          // decl's generic constraints. This isn't handled correctly yet.
-          return {};
+          // The parameter has been concretized by a same-type constraint, so
+          // the constraint holds the substitution.
+          auto builtArg = substFromSameTypeConstraint(thisParamIndex);
+          if (!builtArg) {
+            return {};
+          }
+          builtSubsts.push_back(builtArg);
         }
         break;
 

--- a/validation-test/Reflection/reflect_type_in_constrained_extension.swift
+++ b/validation-test/Reflection/reflect_type_in_constrained_extension.swift
@@ -1,0 +1,73 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_type_in_constrained_extension
+// RUN: %target-codesign %t/reflect_type_in_constrained_extension
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_type_in_constrained_extension | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+
+struct S<T> {
+  let t: T
+}
+
+extension S<Int> {
+  struct Concretized {
+    let i = 42
+  }
+}
+
+extension S where T: Equatable {
+  struct Constrained {
+    let j = 7
+  }
+}
+
+reflect(any: S<Int>.Concretized())
+
+// CHECK-64: Reflecting an existential.
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_struct {{.*}}Concretized
+// CHECK-64:   (struct Swift.Int))
+// CHECK-64: Type info:
+// CHECK-64: (struct size=8 alignment=8 stride=8
+// CHECK-64:   (field name=i offset=0
+// CHECK-64:     (struct size=8
+
+// CHECK-32: Reflecting an existential.
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_struct {{.*}}Concretized
+// CHECK-32:   (struct Swift.Int))
+// CHECK-32: Type info:
+// CHECK-32: (struct size=4 alignment=4 stride=4
+// CHECK-32:   (field name=i offset=0
+// CHECK-32:     (struct size=4
+
+reflect(any: S<Int>.Constrained())
+
+// CHECK-64: Reflecting an existential.
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_struct {{.*}}Constrained
+// CHECK-64:   (struct Swift.Int))
+// CHECK-64: Type info:
+// CHECK-64: (struct size=8 alignment=8 stride=8
+// CHECK-64:   (field name=j offset=0
+// CHECK-64:     (struct size=8
+
+// CHECK-32: Reflecting an existential.
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_struct {{.*}}Constrained
+// CHECK-32:   (struct Swift.Int))
+// CHECK-32: Type info:
+// CHECK-32: (struct size=4 alignment=4 stride=4
+// CHECK-32:   (field name=j offset=0
+// CHECK-32:     (struct size=4
+
+doneReflecting()
+
+// CHECK-64: Done.
+// CHECK-32: Done.


### PR DESCRIPTION
Resolve a generic parameter that carries no key argument from the same-type constraint that concretized it, rather than giving up on the whole substitution. Strip the generic arguments off an extension's extended context as well, since an Extension node's extended context has to be an unbound nominal and the descriptor records a bound generic type, which produced a mangled name that would not demangle.

rdar://145092254