### PR TITLE
[ClangImporter] Don’t conflate cases with different underlying types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1631,7 +1631,7 @@ namespace {
       // again and thus may already have imported this typedef by this point.
       // If so, reuse the cached result rather than creating a duplicate.
       auto alreadyImported = Impl.ImportedDecls.find(
-          {Decl->getCanonicalDecl(), getVersion()});
+          Impl.getImportedDeclsKey(Decl, getVersion()));
       if (alreadyImported != Impl.ImportedDecls.end())
         return alreadyImported->second;
 
@@ -1724,7 +1724,7 @@ namespace {
       // importing its decl context. If we are able to find a cached result,
       // use it to avoid making a duplicate imported decl.
       auto alreadyImported =
-          Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
+          Impl.ImportedDecls.find(Impl.getImportedDeclsKey(decl, getVersion()));
       if (alreadyImported != Impl.ImportedDecls.end())
         return alreadyImported->second;
 
@@ -1987,8 +1987,10 @@ namespace {
       }
       }
 
-      const clang::EnumDecl *canonicalClangDecl = decl->getCanonicalDecl();
-      Impl.ImportedDecls[{canonicalClangDecl, getVersion()}] = result;
+      auto canonicalKey = Impl.getImportedDeclsKey(decl, getVersion());
+      const clang::EnumDecl *canonicalClangDecl =
+          cast<clang::EnumDecl>(canonicalKey.first);
+      Impl.ImportedDecls[canonicalKey] = result;
 
       // Import each of the enumerators.
 
@@ -2463,13 +2465,13 @@ namespace {
       // Create the struct declaration and record it.
       auto name = importedName.getBaseIdentifier(Impl.SwiftContext);
       NominalTypeDecl *result = nullptr;
+      auto canonicalKey = Impl.getImportedDeclsKey(decl, getVersion());
       // Try to find an already-imported struct. This case happens any time
       // there are nested structs. The "Parent" struct will import the "Child"
       // struct at which point it attempts to import its decl context which is
       // the "Parent" struct. Without trying to look up already-imported structs
       // this will cause an infinite loop.
-      auto alreadyImportedResult =
-          Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
+      auto alreadyImportedResult = Impl.ImportedDecls.find(canonicalKey);
       if (alreadyImportedResult != Impl.ImportedDecls.end())
         return alreadyImportedResult->second;
 
@@ -2512,14 +2514,14 @@ namespace {
             decl, importer::convertClangAccess(decl->getAccess()), loc, name,
             loc, ArrayRef<InheritedEntry>(), nullptr, dc);
       }
-      Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
+      Impl.ImportedDecls[canonicalKey] = result;
       // We've written a partial entry into ImportedDecls so that nested
       // member imports (especially those that recurse into us via
       // VisitRecordDecl) can find this StructDecl/ClassDecl instead of
       // looping. If we later decide to bail out and return nullptr, we need to
       // erase the partial entry.
       auto eraseCacheOnBailOut = [&] {
-        Impl.ImportedDecls.erase({decl->getCanonicalDecl(), getVersion()});
+        Impl.ImportedDecls.erase(canonicalKey);
       };
 
       if (getCxxValueSemanticsKind(decl->getTypeForDecl(), Impl) !=
@@ -3412,7 +3414,8 @@ namespace {
                                           : ConstantConvertKind::None,
             isStatic, decl,
             importer::convertClangAccess(clangEnum->getAccess()));
-        Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
+        Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] =
+            result;
 
         // If this is a compatibility stub, mark it as such.
         if (correctSwiftName)
@@ -3963,15 +3966,14 @@ namespace {
 
       // We may have already imported this function decl while importing its
       // decl context. Check decl cache to make sure we don't import twice.
-      const clang::Decl *cacheKey;
-      if (funcTemplate)
-        // Function templates are cached under the FunctionTemplateDecl
-        // so use funcTemplate as cache key if set.
-        cacheKey = funcTemplate->getCanonicalDecl();
-      else
-        // Otherwise use decl's canonical decl, matching importDeclAndCacheImpl
-        cacheKey = decl->getCanonicalDecl();
-      auto known = Impl.ImportedDecls.find({cacheKey, getVersion()});
+      //
+      // Function templates are cached under the FunctionTemplateDecl so use
+      // funcTemplate as cache key if set; otherwise use decl's canonical
+      // decl, matching importDeclAndCacheImpl.
+      auto cacheKey = funcTemplate
+                         ? Impl.getImportedDeclsKey(funcTemplate, getVersion())
+                         : Impl.getImportedDeclsKey(decl, getVersion());
+      auto known = Impl.ImportedDecls.find(cacheKey);
       if (known != Impl.ImportedDecls.end()) {
         return known->second;
       }
@@ -4127,7 +4129,7 @@ namespace {
 
       // We may have already imported this function decl while importing its
       // type signature. Check decl cache to make sure we don't import twice.
-      auto known2 = Impl.ImportedDecls.find({cacheKey, getVersion()});
+      auto known2 = Impl.ImportedDecls.find(cacheKey);
       if (known2 != Impl.ImportedDecls.end()) {
         return known2->second;
       }
@@ -4733,8 +4735,8 @@ namespace {
       // VisitFunctionDecl() might return a FuncDecl that was already
       // fully-imported from a CXXMethodDecl due to circular importing.
       // In that case, the fully-imported result should already be cached.
-      if (auto known =
-              Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
+      if (auto known = Impl.ImportedDecls.find(
+              Impl.getImportedDeclsKey(decl, getVersion()));
           known != Impl.ImportedDecls.end()) {
         ASSERT(known->second == method && "returning different");
         // Skip VisitCXXMethodDecl post-processing (which is not idempotent)
@@ -5534,8 +5536,8 @@ namespace {
           dc == Impl.importDeclContextOf(decl, decl->getDeclContext())) {
         // FIXME: Should also be able to do this for forced class
         // methods.
-        auto known = Impl.ImportedDecls.find({decl->getCanonicalDecl(),
-                                              getVersion()});
+        auto known = Impl.ImportedDecls.find(
+            Impl.getImportedDeclsKey(decl, getVersion()));
         if (known != Impl.ImportedDecls.end()) {
           auto decl = known->second;
           if (isAcceptableResultOrNull(decl, accessorInfo))
@@ -5685,8 +5687,8 @@ namespace {
           dc == Impl.importDeclContextOf(decl, decl->getDeclContext())) {
         // FIXME: Should also be able to do this for forced class
         // methods.
-        auto known = Impl.ImportedDecls.find({decl->getCanonicalDecl(),
-                                              getVersion()});
+        auto known = Impl.ImportedDecls.find(
+            Impl.getImportedDeclsKey(decl, getVersion()));
         if (known != Impl.ImportedDecls.end()) {
           auto decl = known->second;
           if (isAcceptableResultOrNull(decl, accessorInfo))
@@ -5802,7 +5804,7 @@ namespace {
         if (!isEffectfulPropAccessor &&
             dc == Impl.importDeclContextOf(decl, decl->getDeclContext()))
           Impl.ImportedDecls.try_emplace(
-              {decl->getCanonicalDecl(), getVersion()}, result);
+              Impl.getImportedDeclsKey(decl, getVersion()), result);
 
         if (importedName.isSubscriptAccessor()) {
           // If this was a subscript accessor, try to create a
@@ -6071,8 +6073,8 @@ namespace {
       }
 
       if (found && cacheResult)
-        Impl.ImportedDecls[{decl->getCanonicalDecl(),
-                            getActiveSwiftVersion()}] = found;
+        Impl.ImportedDecls[Impl.getImportedDeclsKey(
+            decl, getActiveSwiftVersion())] = found;
 
       return found;
     }
@@ -6217,7 +6219,7 @@ namespace {
                 ArrayRef<InheritedEntry>(),
                 /*TrailingWhere=*/nullptr);
 
-            Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
+            Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] = result;
             result->setAddedImplicitInitializers(); // suppress all initializers
             addObjCAttribute(result,
                             Impl.importIdentifier(decl->getIdentifier()));
@@ -6263,7 +6265,7 @@ namespace {
       if (declaredNative)
         markMissingSwiftDecl(result);
 
-      Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
+      Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] = result;
 
       // Import protocols this protocol conforms to.
       SmallVector<InheritedEntry, 4> inheritedTypes;
@@ -6301,7 +6303,8 @@ namespace {
             ArrayRef<InheritedEntry>(), nullptr, dc,
             /*isActor*/ false);
         if (cacheResult)
-          Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
+          Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] =
+              result;
 
         if (inheritFromNSObject)
           result->setSuperclass(Impl.getNSObjectType());
@@ -6431,7 +6434,7 @@ namespace {
         return nullptr;
       }
 
-      Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
+      Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] = result;
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
       if (declaredNative)
@@ -6645,8 +6648,8 @@ namespace {
 
       // Check whether the property already got imported.
       if (dc == Impl.importDeclContextOf(decl, decl->getDeclContext())) {
-        auto known = Impl.ImportedDecls.find({decl->getCanonicalDecl(),
-                                              getVersion()});
+        auto known = Impl.ImportedDecls.find(
+            Impl.getImportedDeclsKey(decl, getVersion()));
         if (known != Impl.ImportedDecls.end())
           return known->second;
       }
@@ -6979,7 +6982,7 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   alias->setUnderlyingType(typeDecl->getDeclaredInterfaceType());
 
   // Record that this is the official version of this declaration.
-  Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = alias;
+  Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] = alias;
   markAsVariant(alias, correctSwiftName);
   return alias;
 }
@@ -7222,7 +7225,7 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
         structDecl, ctx.Id_ObjectiveCType, storedUnderlyingType);
   }
 
-  Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = structDecl;
+  Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] = structDecl;
   return structDecl;
 }
 
@@ -7383,7 +7386,7 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
   auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
       decl, importer::convertClangAccess(decl->getAccess()), Loc, name, Loc,
       ArrayRef<InheritedEntry>(), nullptr, dc);
-  Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = structDecl;
+  Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] = structDecl;
 
   // Compute the underlying type.
   auto underlyingType = Impl.importTypeIgnoreIUO(
@@ -7686,7 +7689,8 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
     return nullptr;
 
   Impl.importAttributes(getter, swiftGetter);
-  Impl.ImportedDecls[{getter->getCanonicalDecl(), getVersion()}] = swiftGetter;
+  Impl.ImportedDecls[Impl.getImportedDeclsKey(getter, getVersion())] =
+      swiftGetter;
   if (swift3GetterName)
     markAsVariant(swiftGetter, *swift3GetterName);
 
@@ -7700,7 +7704,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
       return nullptr;
 
     Impl.importAttributes(setter, swiftSetter);
-    Impl.ImportedDecls[{setter->getCanonicalDecl(), getVersion()}] =
+    Impl.ImportedDecls[Impl.getImportedDeclsKey(setter, getVersion())] =
         swiftSetter;
     if (swift3SetterName)
       markAsVariant(swiftSetter, *swift3SetterName);
@@ -9083,11 +9087,23 @@ void SwiftDeclConverter::importInheritedConstructors(
   }
 }
 
+std::pair<const clang::Decl *, ImportNameVersion>
+ClangImporter::Implementation::getImportedDeclsKey(
+    const clang::NamedDecl *ClangDecl, ImportNameVersion version,
+    bool UseCanonicalDecl) {
+  // Some callers don't want to canonicalize.
+  if (!UseCanonicalDecl)
+    return {ClangDecl, version};
+
+  auto *Canon = cast<clang::NamedDecl>(ClangDecl->getCanonicalDecl());
+  return {Canon, version};
+}
+
 std::optional<Decl *> ClangImporter::Implementation::importDeclCached(
     const clang::NamedDecl *ClangDecl, ImportNameVersion version,
     bool UseCanonical) {
   auto Known = ImportedDecls.find(
-    { UseCanonical? ClangDecl->getCanonicalDecl(): ClangDecl, version });
+      getImportedDeclsKey(ClangDecl, version, UseCanonical));
   if (Known == ImportedDecls.end())
     return std::nullopt;
 
@@ -10410,7 +10426,8 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   clang::PrettyStackTraceDecl trace(ClangDecl, clang::SourceLocation(),
                                     Instance->getSourceManager(), "importing");
 
-  auto Canon = cast<clang::NamedDecl>(UseCanonicalDecl? ClangDecl->getCanonicalDecl(): ClangDecl);
+  auto Key = getImportedDeclsKey(ClangDecl, version, UseCanonicalDecl);
+  auto *Canon = cast<clang::NamedDecl>(Key.first);
 
   auto Known = importDeclCached(Canon, version, UseCanonicalDecl);
   if (Known.has_value()) {
@@ -10434,7 +10451,7 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   }
 
   if (!HadForwardDeclaration) {
-    auto it = ImportedDecls.try_emplace({Canon, version}, Result);
+    auto it = ImportedDecls.try_emplace(Key, Result);
     if (CONDITIONAL_ASSERT_enabled() && !it.second &&
         Result != it.first->second) {
       ABORT([&](auto &out) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9089,14 +9089,38 @@ void SwiftDeclConverter::importInheritedConstructors(
 
 std::pair<const clang::Decl *, ImportNameVersion>
 ClangImporter::Implementation::getImportedDeclsKey(
-    const clang::NamedDecl *ClangDecl, ImportNameVersion version,
-    bool UseCanonicalDecl) {
+    const clang::NamedDecl *clangDecl, ImportNameVersion version,
+    bool useCanonicalDecl) {
   // Some callers don't want to canonicalize.
-  if (!UseCanonicalDecl)
-    return {ClangDecl, version};
+  if (!useCanonicalDecl)
+    return {clangDecl, version};
 
-  auto *Canon = cast<clang::NamedDecl>(ClangDecl->getCanonicalDecl());
-  return {Canon, version};
+  auto *canonDecl = cast<clang::NamedDecl>(clangDecl->getCanonicalDecl());
+
+  // Sometimes two enum constants with different underlying types can end up in
+  // the same redeclaration chain even though they aren't interchangeable. When
+  // that happens, we instead "canonicalize" to the first decl we encountered
+  // that has the same integer type as this one.
+  if (clangDecl != canonDecl) {
+    auto getCaseIntegerType =
+          [](const clang::Decl *clangDecl) -> clang::QualType {
+      if (auto caseDecl = dyn_cast<clang::EnumConstantDecl>(clangDecl))
+        return cast<clang::EnumDecl>(caseDecl->getDeclContext())
+                    ->getIntegerType();
+      return clang::QualType();
+    };
+
+    auto caseType = getCaseIntegerType(clangDecl);
+    auto canonCaseType = getCaseIntegerType(canonDecl);
+    if (!caseType.isNull() && !canonCaseType.isNull()
+          && !getClangASTContext().hasSameType(caseType, canonCaseType)) {
+      auto altCanonKey = std::make_pair(canonDecl, caseType.getCanonicalType());
+      auto altCanonEntry = AltCanonDecls.try_emplace(altCanonKey, clangDecl);
+      canonDecl = altCanonEntry.first->second;
+    }
+  }
+
+  return {canonDecl, version};
 }
 
 std::optional<Decl *> ClangImporter::Implementation::importDeclCached(
@@ -10429,7 +10453,7 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   auto Key = getImportedDeclsKey(ClangDecl, version, UseCanonicalDecl);
   auto *Canon = cast<clang::NamedDecl>(Key.first);
 
-  auto Known = importDeclCached(Canon, version, UseCanonicalDecl);
+  auto Known = importDeclCached(ClangDecl, version, UseCanonicalDecl);
   if (Known.has_value()) {
     if (!SuperfluousTypedefsAreTransparent &&
         SuperfluousTypedefs.count(Canon))
@@ -10459,11 +10483,13 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
         ClangDecl->getNameForDiagnostic(out, {{}}, true);
         out << "' ";
         ClangDecl->getSourceRange().print(out, Instance->getSourceManager());
-        if (ClangDecl != Canon) {
-          out << "\nCanonical clang::Decl: '";
+        if (ClangDecl != Key.first) {
+          out << "\nImportedDecls key decl: '";
           Canon->getNameForDiagnostic(out, {{}}, true);
           out << "' ";
           Canon->getSourceRange().print(out, Instance->getSourceManager());
+          out << " version: ";
+          Key.second.dump(out);
         }
         out << "\nImported as Swift Decl:\n";
         if (Result)

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -61,6 +61,20 @@ STATISTIC(ImportNameNumCacheMisses, "# of times the import name cache was missed
 using namespace swift;
 using namespace importer;
 
+void ImportNameVersion::dump(llvm::raw_ostream &out) const {
+  if (*this == raw())
+    out << "raw";
+  else
+    out << asClangVersionTuple().getAsString();
+  if (supportsConcurrency())
+    out << " (concurrency)";
+}
+
+void ImportNameVersion::dump() const {
+  dump(llvm::errs());
+  llvm::errs() << "\n";
+}
+
 Identifier importer::getOperatorName(ASTContext &ctx,
                                      clang::OverloadedOperatorKind op) {
   switch (op) {

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -173,6 +174,9 @@ public:
   static constexpr inline ImportNameVersion forTypes() {
     return ImportNameVersion::maxVersion();
   }
+
+  void dump(llvm::raw_ostream &out) const;
+  SWIFT_DEBUG_DUMP;
 };
 
 /// Describes a name that was imported from Clang.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1256,6 +1256,13 @@ public:
   /// \param decl The Clang record or function declaration to validate.
   void validateSwiftAttributes(const clang::NamedDecl *decl);
 
+  /// Determines the key that should be used to store or look up \p ClangDecl
+  /// in \c ImportedDecls . This will usually canonicalize the decl, although
+  /// there are rare exceptions.
+  std::pair<const clang::Decl *, Version>
+  getImportedDeclsKey(const clang::NamedDecl *ClangDecl, Version version,
+                      bool UseCanonicalDecl = true);
+
   /// If we already imported a given decl, return the corresponding Swift decl.
   /// Otherwise, return nullptr.
   std::optional<Decl *> importDeclCached(const clang::NamedDecl *ClangDecl,
@@ -1284,8 +1291,7 @@ public:
   }
 
   Decl *lookupImportedDecl(const clang::NamedDecl *decl) {
-    auto Known = importDeclCached(
-        cast<clang::NamedDecl>(decl->getCanonicalDecl()), CurrentVersion, true);
+    auto Known = importDeclCached(decl, CurrentVersion, true);
     if (Known.has_value())
       return Known.value();
     return nullptr;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -41,6 +41,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Type.h"
+#include "clang/AST/TypeOrdering.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetInfo.h"
@@ -582,6 +583,13 @@ public:
 
   /// Mapping of already-imported declarations.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;
+
+  /// Maps a canonical declaration and a type that only appears \em elsewhere
+  /// in its redeclaration chain to the declaration that should be used as part
+  /// of its \c ImportedDecls cache key. See \c getImportedDeclsKey()
+  /// for details.
+  llvm::DenseMap<std::pair<const clang::Decl *, clang::QualType>,
+                 const clang::NamedDecl *> AltCanonDecls;
 
   /// Per-module count of Clang decls actually deserialized (materialized) into
   /// the shared ASTContext, keyed by the owning serialized module. Populated by

--- a/test/ClangImporter/enum-cross-module-inconsistent-redeclaration.swift
+++ b/test/ClangImporter/enum-cross-module-inconsistent-redeclaration.swift
@@ -1,0 +1,121 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify %t/typed-then-untyped.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/untyped-then-typed.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/transitivetyped-then-transitiveuntyped.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/typed-then-untyped-then-untypedduplicate.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/untyped-then-untypedduplicate-then-typed.swift -I %t
+
+// Check that, when two unrelated C modules declare enum constants with the same
+// name but different underlying types, ClangImporter does not conflate them
+// despite both being in the same redeclaration chain. Since this behavior can
+// depend on the order modules are imported in, we test several different
+// combinations of `import` statements.
+//
+// We also check the three-way case: when three unrelated C modules declare
+// enum constants with the same name, where two (Untyped and UntypedDuplicate)
+// share an underlying type and the third (Typed) does not, ClangImporter
+// imports Untyped and UntypedDuplicate (but not Typed) as a single Swift
+// declaration, regardless of which import order makes which enum canonical.
+
+//--- Typed.h
+#ifndef TYPED_H
+#define TYPED_H
+
+enum : unsigned short {
+    SHARED_CONSTANT_NAME = 0x00A8,
+};
+
+#endif
+
+//--- Untyped.h
+#ifndef UNTYPED_H
+#define UNTYPED_H
+
+enum {
+    SHARED_CONSTANT_NAME = 0x00A8,
+};
+
+#endif
+
+//--- TransitiveTyped.h
+#include "Typed.h"
+
+//--- TransitiveUntyped.h
+#include "Untyped.h"
+
+//--- UntypedDuplicate.h
+#ifndef UNTYPED_DUPLICATE_H
+#define UNTYPED_DUPLICATE_H
+
+enum {
+    SHARED_CONSTANT_NAME = 5,
+};
+
+#endif
+
+//--- module.modulemap
+module Typed {
+    header "Typed.h"
+    export *
+}
+module Untyped {
+    header "Untyped.h"
+    export *
+}
+module TransitiveTyped {
+    header "TransitiveTyped.h"
+    export *
+}
+module TransitiveUntyped {
+    header "TransitiveUntyped.h"
+    export *
+}
+module UntypedDuplicate {
+    header "UntypedDuplicate.h"
+    export *
+}
+
+//--- typed-then-untyped.swift
+import Typed
+import Untyped
+
+let z: UInt16 = SHARED_CONSTANT_NAME
+
+//--- untyped-then-typed.swift
+import Untyped
+import Typed
+
+let z: UInt16 = SHARED_CONSTANT_NAME
+
+//--- transitivetyped-then-transitiveuntyped.swift
+// This transitive case is interesting because the order that the compiler
+// processes transitive imports may depend on clang implementation details.
+
+import TransitiveTyped
+import TransitiveUntyped
+
+let z: UInt16 = SHARED_CONSTANT_NAME
+
+//--- typed-then-untyped-then-untypedduplicate.swift
+// Typed, whose type doesn't match Untyped/UntypedDuplicate, is imported first
+// and becomes canonical. Untyped and UntypedDuplicate still merge into a
+// single declaration.
+import Typed
+import Untyped
+import UntypedDuplicate
+
+let a: UInt16 = SHARED_CONSTANT_NAME
+let b: Int = SHARED_CONSTANT_NAME
+
+//--- untyped-then-untypedduplicate-then-typed.swift
+// Untyped or UntypedDuplicate is imported first and becomes canonical, so the
+// other one matches it by type directly and merges without needing the
+// shared-representative bookkeeping that the other ordering relies on.
+import Untyped
+import UntypedDuplicate
+import Typed
+
+let a: UInt16 = SHARED_CONSTANT_NAME
+let b: Int = SHARED_CONSTANT_NAME


### PR DESCRIPTION
Suppose two unrelated C headers declare an anonymous enum with the same constant names, but different underlying types. clang will include them in the same redeclaration chain, so they will share a canonical decl and Swift will only import one of them. However, *which* one gets imported may depend on the ordering of `import` statements and even on the order that transitive imports are processed by clang. This caused regressions in rebranch because clang-23 started processing submodules more lazily, perturbing the order of transitive imports and changing which declaration would be imported.

Introduce logic to use an *un*-canonicalized EnumConstantDecl as the key to the ImportedDecls cache if it has a different type from the canonical one; that way, we will import both versions of the constant instead of conflating them.

Fixes rdar://185736988.