### PR TITLE
[Concurrency] Prevent isolation inference from implied global-actor isolated conformances.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5521,15 +5521,14 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
     case ActorIsolation::GlobalActor:
       // If we encountered an explicit globally isolated conformance, allow it
       // to override the _nonisolated_ isolation.
-      if (!foundIsolation ||
-          (foundIsolation->isolation.isNonisolatedOrConcurrent() &&
-           conformance->getSourceKind() == ConformanceEntryKind::Explicit)) {
+      if (conformance->getSourceKind() == ConformanceEntryKind::Explicit &&
+          (!foundIsolation || foundIsolation->isolation.isNonisolated())) {
         foundIsolation = {protoIsolation,
                           IsolationSource(proto, IsolationSource::Conformance)};
         continue;
       }
 
-      if (foundIsolation->isolation != protoIsolation)
+      if (foundIsolation && foundIsolation->isolation != protoIsolation)
         return std::nullopt;
 
       break;

--- a/test/Concurrency/nonisolated_protocol_global_actor_cutoff.swift
+++ b/test/Concurrency/nonisolated_protocol_global_actor_cutoff.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library %s -emit-sil -o /dev/null -verify -language-mode 6
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library %s -emit-sil -o /dev/null -verify -language-mode 6 -enable-experimental-feature NoExplicitNonIsolated
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_NoExplicitNonIsolated
+
+@MainActor
+func onMain() {}
+
+@MainActor
+protocol IsolatedBase {}
+
+nonisolated protocol NonisolatedRefinement: IsolatedBase {}
+
+protocol PlainBase {}
+nonisolated protocol PlainRefinement: PlainBase {}
+
+struct A: NonisolatedRefinement { func f() {} }
+
+struct B: PlainRefinement { func f() {} }
+
+struct C { func f() {} }
+extension C: NonisolatedRefinement {}
+
+protocol IndirectRefinement: NonisolatedRefinement {}
+
+struct D: IndirectRefinement { func f() {} }
+
+nonisolated func probe(a: A, b: B, c: C, d: D) {
+  a.f()
+  b.f()
+  c.f()
+  d.f()
+}
+
+@MainActor protocol IsolatedRefinement: NonisolatedRefinement {}
+
+struct E: IsolatedRefinement {
+  func h() { onMain() }
+}
+
+struct F: NonisolatedRefinement, IsolatedBase {
+  func k() { onMain() }
+}


### PR DESCRIPTION
For the following case, under `NoExplicitNonisolated` the compiler emits an error:

```swift
@MainActor
protocol IsolatedBase {}
nonisolated protocol NonisolatedRefinement: IsolatedBase {}

struct A: NonisolatedRefinement { func f() {} }

nonisolated func test() {
  A().f()   // error
}
```

In the above example, conformance to `IsolatedBase` is implied and under the `NoExplicitNonisolated`, the isolation wasn't found yet. The isolation should only be inferred from an explicit conformance (to `NonisolatedRefimenent`) and it can override nonisolated isolation, but the implementation didn't check whether conformance is explicit when there was no isolation set yet, which is wrong.

Resolves rdar://185522283.