### PR TITLE
[test] Allow libstdc++'s vector<unsigned long>::_M_assign_aux in swiftRemoteMirror

### DIFF
--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -275,6 +275,7 @@
 // RUN:             -e _ZNSt6vectorIjSaIjEE13_M_insert_auxIJjEEEvN9__gnu_cxx17__normal_iteratorIPjS1_EEDpOT_ \
 // RUN:             -e _ZNSt6vectorIjSaIjEE17_M_realloc_insertIJjEEEvN9__gnu_cxx17__normal_iteratorIPjS1_EEDpOT_ \
 // RUN:             -e _ZNSt6vectorImSaImEE17_M_realloc_insertIJRKmEEEvN9__gnu_cxx17__normal_iteratorIPmS1_EEDpOT_ \
+// RUN:             -e _ZNSt6vectorImSaImEE13_M_assign_auxIPKmEEvT_S5_St20forward_iterator_tag \
 // RUN:             -e _ZNSt6vectorISsSaISsEE17_M_realloc_insertIJSsEEEvN9__gnu_cxx17__normal_iteratorIPSsS1_EEDpOT_ \
 // RUN:             -e _ZNSt6vectorISt10unique_ptrIKvSt8functionIFvPS1_EEESaIS6_EE19_M_emplace_back_auxIJS6_EEEvDpOT_ \
 // RUN:             -e _ZNSt6vectorISt10unique_ptrIKvSt8functionIFvPS1_EEESaIS6_EE17_M_realloc_insertIJS6_EEEvN9__gnu_cxx17__normal_iteratorIPS6_S8_EEDpOT_ \


### PR DESCRIPTION
6d092d9c9a2 replaced a std::vector range construction with a call to std::vector::assign() in swift_reflection_iterateMetadataAllocationBacktraces. That instantiates libstdc++'s _M_assign_aux member template, which the GNU C++ headers force to public weak visibility, so libswiftRemoteMirror.so now exports

    std::vector<unsigned long>::_M_assign_aux<unsigned long const*>(
      unsigned long const*, unsigned long const*, std::forward_iterator_tag)

and symbol-visibility-linux.test-sh fails on every Linux build. Add the symbol to the swiftRemoteMirror filter list, alongside the other vector<unsigned long> helpers that libstdc++ leaks the same way.
