### PR TITLE
SwiftShims: expose shared COM ABI declarations

### DIFF
--- a/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
+++ b/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
@@ -9,6 +9,7 @@ install(FILES
   KeyPath.h
   LibcOverlayShims.h
   LibcShims.h
+  Metadata.h
   MetadataSections.h
   ObjCShims.h
   Random.h
@@ -23,6 +24,7 @@ install(FILES
   Target.h
   ThreadLocalStorage.h
   Visibility.h
+  _SwiftCOMShims.h
   _SwiftConcurrency.h
   _SwiftDistributed.h
   _SynchronizationShims.h

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -48,6 +48,7 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Basic/Unreachable.h"
+#include "swift/shims/Metadata.h"
 #include "swift/shims/HeapObject.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
@@ -3460,6 +3461,9 @@ public:
     return cd->getKind() == ContextDescriptorKind::Protocol;
   }
 };
+
+static_assert(sizeof(_SwiftProtocolDescriptorHeader) == sizeof(TargetProtocolDescriptor<InProcess>),
+              "_SwiftProtocolDescriptorHeader does not match TargetProtocolDescriptor");
 
 /// The descriptor for an opaque type.
 template <typename Runtime>

--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sources
   KeyPath.h
   LibcOverlayShims.h
   LibcShims.h
+  Metadata.h
   MetadataSections.h
   ObjCShims.h
   Random.h
@@ -22,6 +23,7 @@ set(sources
   Target.h
   ThreadLocalStorage.h
   Visibility.h
+  _SwiftCOMShims.h
   _SwiftConcurrency.h
   _SwiftDistributed.h
   _SynchronizationShims.h

--- a/stdlib/public/SwiftShims/swift/shims/Metadata.h
+++ b/stdlib/public/SwiftShims/swift/shims/Metadata.h
@@ -1,0 +1,56 @@
+//===--- Metadata.h - Swift metadata ABI structures -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// C-compatible declarations for Swift metadata ABI structures consumed by
+// Swift code.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_METADATA_H
+#define SWIFT_STDLIB_SHIMS_METADATA_H
+
+#include "SwiftStdint.h"
+
+#ifdef __cplusplus
+namespace swift {
+extern "C" {
+#endif
+
+/// The fixed portion of a Swift protocol descriptor.
+///
+/// Protocol-specific trailing objects immediately follow this header.
+typedef struct _SwiftProtocolDescriptorHeader {
+  /// Context descriptor flags.
+  __swift_uint32_t Flags;
+
+  /// Relative reference to the parent context descriptor.
+  __swift_int32_t Parent;
+
+  /// Relative reference to the protocol name.
+  __swift_int32_t Name;
+
+  /// Number of requirements in the protocol's requirement signature.
+  __swift_uint32_t NumRequirementsInSignature;
+
+  /// Number of protocol requirements.
+  __swift_uint32_t NumRequirements;
+
+  /// Nullable relative reference to the associated-type names.
+  __swift_int32_t AssociatedTypeNames;
+} _SwiftProtocolDescriptorHeader;
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace swift
+#endif
+
+#endif // SWIFT_STDLIB_SHIMS_METADATA_H

--- a/stdlib/public/SwiftShims/swift/shims/Target.h
+++ b/stdlib/public/SwiftShims/swift/shims/Target.h
@@ -21,6 +21,16 @@
 #define __has_builtin(x) 0
 #endif
 
+#if defined(_WIN32) && (defined(_M_IX86) || defined(__i386__))
+#if defined(_MSC_VER)
+#define __SWIFT_STDCALL __stdcall
+#else
+#define __SWIFT_STDCALL __attribute__((__stdcall__))
+#endif
+#else
+#define __SWIFT_STDCALL
+#endif
+
 // Is the target platform a simulator? We can't use TargetConditionals
 // when included from SwiftShims, so use the builtin.
 #if __has_builtin(__is_target_environment)

--- a/stdlib/public/SwiftShims/swift/shims/_SwiftCOMShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftCOMShims.h
@@ -1,0 +1,84 @@
+//===--- _SwiftCOMShims.h - Swift COM ABI structures ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// C-compatible declarations for compiler-emitted COM metadata and the common
+// COM entry points implemented by the supplemental runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_COM_SHIMS_H
+#define SWIFT_STDLIB_COM_SHIMS_H
+
+#include "SwiftStdint.h"
+#include "Target.h"
+
+#ifdef __cplusplus
+namespace swift {
+extern "C" {
+#endif
+
+/// The header of a compiler-emitted COM interface map.
+///
+/// The entries immediately follow this header.
+typedef struct _SwiftCOMInterfaceMapHeader {
+  __swift_uint32_t count;
+  __swift_uint32_t reserved;
+} _SwiftCOMInterfaceMapHeader;
+
+/// An entry in a compiler-emitted COM interface map.
+///
+/// `descriptor` is relative to the address of this field. Its low bit
+/// indicates that the resolved address contains an indirect reference to the
+/// protocol descriptor.
+///
+/// `index` identifies the physical interface address point in the native
+/// object's prefix. Projection zero is closest to the Swift object.
+typedef struct _SwiftCOMInterfaceMapEntry {
+  __swift_int32_t descriptor;
+  __swift_uint32_t index;
+} _SwiftCOMInterfaceMapEntry;
+
+#if defined(_WIN32)
+#define __SWIFT_COM_HRESULT long
+#else
+#define __SWIFT_COM_HRESULT __swift_int32_t
+#endif
+
+typedef __SWIFT_STDCALL __SWIFT_COM_HRESULT
+    (*_SwiftCOMQueryInterfaceFunction)(void * _Nonnull pUnk,
+                                       const void * _Nonnull riid,
+                                       void * _Nullable * _Nonnull ppvObject);
+typedef __SWIFT_STDCALL __swift_uint32_t
+    (*_SwiftCOMLifetimeFunction)(void * _Nonnull pUnk);
+
+__SWIFT_COM_HRESULT __SWIFT_STDCALL
+QueryInterface(void * _Nonnull pUnk, const void * _Nonnull riid,
+               void * _Nullable * _Nonnull ppvObject);
+
+__swift_uint32_t __SWIFT_STDCALL AddRef(void * _Nonnull pUnk);
+__swift_uint32_t __SWIFT_STDCALL Release(void * _Nonnull pUnk);
+
+__SWIFT_COM_HRESULT __SWIFT_STDCALL
+AggregatedQueryInterface(void * _Nonnull pUnk, const void * _Nonnull riid,
+                         void * _Nullable * _Nonnull ppvObject);
+
+__swift_uint32_t __SWIFT_STDCALL AggregatedAddRef(void * _Nonnull pUnk);
+__swift_uint32_t __SWIFT_STDCALL AggregatedRelease(void * _Nonnull pUnk);
+
+#undef __SWIFT_COM_HRESULT
+
+#ifdef __cplusplus
+} // extern "C"
+} // namespace swift
+#endif
+
+#endif // SWIFT_STDLIB_COM_SHIMS_H

--- a/stdlib/public/SwiftShims/swift/shims/module.modulemap
+++ b/stdlib/public/SwiftShims/swift/shims/module.modulemap
@@ -8,6 +8,7 @@ module SwiftShims {
   header "HeapObject.h"
   header "KeyPath.h"
   header "LibcShims.h"
+  header "Metadata.h"
   header "MetadataSections.h"
   header "Random.h"
   header "RefCount.h"
@@ -35,5 +36,10 @@ module SwiftOverlayShims {
 
 module _SynchronizationShims {
   header "_SynchronizationShims.h"
+  export *
+}
+
+module _SwiftCOMShims {
+  header "_SwiftCOMShims.h"
   export *
 }

--- a/test/IRGen/com-runtime-calling-convention.c
+++ b/test/IRGen/com-runtime-calling-convention.c
@@ -1,0 +1,52 @@
+// RUN: %clang -target i686-unknown-windows-msvc -I %swift_src_root/stdlib/public/SwiftShims -S -emit-llvm -x c %s -o - | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=X86
+
+#include "swift/shims/_SwiftCOMShims.h"
+
+#if defined(_WIN32)
+typedef __typeof__(QueryInterface(0, 0, 0)) _QIResult;
+typedef __typeof__(AggregatedQueryInterface(0, 0, 0)) _AggregatedQIResult;
+_Static_assert(__builtin_types_compatible_p(_QIResult, long),
+               "QueryInterface must return HRESULT's underlying C type");
+_Static_assert(__builtin_types_compatible_p(_AggregatedQIResult, long),
+               "AggregatedQueryInterface must return HRESULT's underlying C type");
+#endif
+
+__swift_int32_t callQueryInterface(void *pUnk, const void *riid,
+                                   void **ppvObject) {
+  return QueryInterface(pUnk, riid, ppvObject) +
+         AggregatedQueryInterface(pUnk, riid, ppvObject);
+}
+
+__swift_uint32_t callLifetime(void *pUnk) {
+  return AddRef(pUnk) + Release(pUnk) +
+         AggregatedAddRef(pUnk) + AggregatedRelease(pUnk);
+}
+
+__swift_int32_t callQueryInterfaceFunction(
+    _SwiftCOMQueryInterfaceFunction function, void *pUnk, const void *riid,
+    void **ppvObject) {
+  return function(pUnk, riid, ppvObject);
+}
+
+__swift_uint32_t callLifetimeFunction(_SwiftCOMLifetimeFunction function,
+                                      void *pUnk) {
+  return function(pUnk);
+}
+
+// CHECK-LABEL: define{{.*}} i32 @callQueryInterface
+// CHECK: call x86_stdcallcc i32 {{.*}}QueryInterface
+// CHECK: call x86_stdcallcc i32 {{.*}}AggregatedQueryInterface
+
+// CHECK-LABEL: define{{.*}} i32 @callLifetime
+// CHECK: call x86_stdcallcc i32 {{.*}}AddRef
+// CHECK: call x86_stdcallcc i32 {{.*}}Release
+// CHECK: call x86_stdcallcc i32 {{.*}}AggregatedAddRef
+// CHECK: call x86_stdcallcc i32 {{.*}}AggregatedRelease
+
+// CHECK-LABEL: define{{.*}} i32 @callQueryInterfaceFunction
+// CHECK: call x86_stdcallcc i32 %{{.*}}
+
+// CHECK-LABEL: define{{.*}} i32 @callLifetimeFunction
+// CHECK: call x86_stdcallcc i32 %{{.*}}


### PR DESCRIPTION
The compiler and supplemental COM module need common definitions of protocol descriptors, interface maps, and the C entry points installed in native interface vtables.

Expose those layouts and entry signatures through SwiftShims. Mark the entry points stdcall on Win32 x86 so their declarations match the COM ABI from the point where they are first consumed.