### PR TITLE
[IRGen] Fail the frontend command when the LLVM backend reports an error

### DIFF
--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -25,6 +25,11 @@ ERROR(no_llvm_target,none,
 ERROR(error_codegen_init_fail,none,
       "cannot initialize code generation passes for target", ())
 
+ERROR(error_generating_object_file,none,
+      "could not emit object file '%0': the LLVM backend reported an error; "
+      SWIFT_BUG_REPORT_MESSAGE,
+      (StringRef))
+
 ERROR(irgen_unimplemented,none,
       "unimplemented IR generation feature %0", (StringRef))
 ERROR(irgen_failure,none, "IR generation failure: %0", (StringRef))

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -641,6 +641,10 @@ public:
   /// Emit a .casid file next to the object file if CAS Backend is used.
   bool EmitCASIDFile = false;
 
+  /// Print error-severity LLVM backend diagnostics (e.g. object-file emission
+  /// errors) instead of swallowing them in IRGen's diagnostic handler.
+  bool PrintLLVMBackendDiagnostics = false;
+
   /// Paths to the pass plugins registered via -load-pass-plugin.
   std::vector<std::string> LLVMPassPlugins;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2467,6 +2467,13 @@ def cas_backend: Flag<["-"], "cas-backend">,
   Flags<[FrontendOption, NoDriverOption]>,
   HelpText<"Enable using CASBackend for object file output">;
 
+def print_llvm_backend_diagnostics
+    : Flag<["-"], "print-llvm-backend-diagnostics">,
+      Flags<[FrontendOption, NoDriverOption]>,
+      HelpText<
+          "Print error-severity LLVM backend diagnostics (e.g. object-file "
+          "emission errors) instead of swallowing them">;
+
 def debug_callsite_info: Flag<["-"], "debug-callsite-info">,
   Flags<[FrontendOption, NoDriverOption]>,
   HelpText<"Generate callsite information in debug info">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4356,6 +4356,8 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.UseCASBackend |= Args.hasArg(OPT_cas_backend);
   Opts.EmitCASIDFile |= Args.hasArg(OPT_cas_emit_casid_file);
+  Opts.PrintLLVMBackendDiagnostics |=
+      Args.hasArg(OPT_print_llvm_backend_diagnostics);
 
   if (CASOpts.WriteOutputHashXAttr && Opts.UseCASBackend) {
     Diags.diagnose(SourceLoc(), diag::error_option_incompatible,

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -736,6 +736,15 @@ namespace {
     SwiftDiagnosticHandler(const IRGenOptions &Opts) : IRGenOpts(Opts) {}
 
     bool handleDiagnostics(const llvm::DiagnosticInfo &DI) override {
+      // By default all backend diagnostics are swallowed here. When
+      // -print-llvm-backend-diagnostics is set, let LLVM's default handler
+      // print error-severity diagnostics (e.g. an unsupported relocation
+      // reported by MC object emission) so the underlying message is visible;
+      // performLLVM separately turns a recorded backend error into a frontend
+      // failure.
+      if (IRGenOpts.PrintLLVMBackendDiagnostics &&
+          DI.getSeverity() == llvm::DS_Error)
+        return false;
       return true;
     }
 
@@ -874,6 +883,18 @@ bool swift::performLLVM(const IRGenOptions &Opts, DiagnosticEngine &Diags,
   auto res = compileAndWriteLLVM(Module, TargetMachine, Opts, Stats, Diags,
                                  *OutputFile, DiagMutex,
                                  CASIDFile ? CASIDFile.get() : nullptr);
+
+  // The LLVM backend reports MC/codegen errors (e.g. an unsupported relocation)
+  // through the LLVMContext diagnostic handler, which records them but does not
+  // by itself fail this function. Without this check IRGen would keep the
+  // empty/partial object file and return success, turning a real compiler error
+  // into a confusing downstream link failure ("file is empty in '...'.o").
+  if (const auto *DiagHandler = Ctxt.getDiagHandlerPtr();
+      DiagHandler && DiagHandler->HasErrors) {
+    diagnoseSync(Diags, DiagMutex, SourceLoc(),
+                 diag::error_generating_object_file, OutputFilename);
+    res = true;
+  }
 
   Ctxt.setDiagnosticHandler(std::move(OldDiagnosticHandler));
 

--- a/test/IRGen/backend_error_diagnostic.ll
+++ b/test/IRGen/backend_error_diagnostic.ll
@@ -1,0 +1,30 @@
+; Verify that an error-severity LLVM backend diagnostic is turned into a
+; frontend failure instead of being silently swallowed while an empty/partial
+; object file is left behind (which previously surfaced only as a confusing
+; downstream "file is empty" link error).
+;
+; The backend error is triggered deterministically and target-independently by
+; an invalid instruction in module-level inline asm, which MC object emission
+; reports as an error-severity diagnostic through the LLVMContext handler.
+
+; This error is specific per backend, so we just check AArch64.
+
+; REQUIRES: CODEGENERATOR=AArch64
+
+; RUN: %empty-directory(%t)
+
+; By default the backend diagnostic message is swallowed, but the recorded
+; error now makes IRGen fail and emit its own diagnostic instead of reporting
+; success.
+; RUN: not %target-swift-frontend -target arm64-apple-ios7.0 -emit-object -o %t/out.o %s 2>&1 | %FileCheck %s
+
+; CHECK: error: could not emit object file '{{.*}}out.o': the LLVM backend reported an error; please submit a bug report
+; CHECK-NOT: {{invalid|unrecognized}} instruction mnemonic
+
+; With -print-llvm-backend-diagnostics, LLVM's underlying error message is
+; printed so the root cause is visible.
+; RUN: not %target-swift-frontend -target arm64-apple-ios7.0 -emit-object -print-llvm-backend-diagnostics -o %t/out2.o %s 2>&1 | %FileCheck -check-prefix=CHECK-VERBOSE %s
+
+; CHECK-VERBOSE: {{invalid|unrecognized}} instruction mnemonic
+
+module asm "this_is_not_a_valid_instruction"

--- a/test/IRGen/loadable_by_address.sil
+++ b/test/IRGen/loadable_by_address.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s  -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend %s  -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o
 
 sil_stage canonical
 
@@ -22,36 +22,6 @@ struct X {
   var x14: Int
   var x15: Int
   var x16: Int
-}
-
-sil @yield_nothing_take_x : $@convention(thin) @yield_once_2 (@owned X) -> (@yields @in_guaranteed ()) {
-entry(%x : $X):
-  %void_addr = alloc_stack $()
-  %void = tuple ()
-  store %void to %void_addr : $*()
-  yield %void_addr : $*(), resume bb1, unwind bb2
-
-bb1:
-  dealloc_stack %void_addr : $*()
-  return %void : $()
-
-bb2:
-  dealloc_stack %void_addr : $*()
-  unwind
-}
-
-// CHECK-LABEL: sil @begin_apply_x_yielder : {{.*}} {
-// CHECK:         ({{%[^,]+}}, {{%[^,]+}}, [[ALLOCATION:%[^,]+]]) = begin_apply
-// CHECK:         dealloc_stack [[ALLOCATION]]
-// CHECK-LABEL: } // end sil function 'begin_apply_x_yielder'
-sil @begin_apply_x_yielder : $@convention(thin) (@owned X) -> () {
-entry(%x : $X):
-  %fn = function_ref @yield_nothing_take_x : $@convention(thin) @yield_once_2 (@owned X) -> (@yields @in_guaranteed ())
-  (%void, %token, %allocation) = begin_apply %fn(%x) : $@convention(thin) @yield_once_2 (@owned X) -> (@yields @in_guaranteed ())
-  end_apply %token as $()
-  dealloc_stack %allocation : $*Builtin.SILToken
-  %retval = tuple ()
-  return %retval : $()
 }
 
 sil @branch_inst_f : $@convention(thin) (@owned X, UInt8) -> ()

--- a/test/IRGen/loadable_by_address_coro.sil
+++ b/test/IRGen/loadable_by_address_coro.sil
@@ -1,0 +1,60 @@
+// RUN: %target-swift-frontend %s  -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+// Wasm doesn't support swiftcoro arguments
+
+// UNSUPPORTED: CPU=wasm32
+
+import Builtin
+import Swift
+
+struct X {
+  var x1 : Int
+  var x2 : Int
+  var x3 : Int
+  var x4: Int
+  var x5: Int
+  var x6: Int
+  var x7: Int
+  var x8: Int
+  var x9: Int
+  var x10: Int
+  var x11: Int
+  var x12: Int
+  var x13: Int
+  var x14: Int
+  var x15: Int
+  var x16: Int
+}
+
+sil @yield_nothing_take_x : $@convention(thin) @yield_once_2 (@owned X) -> (@yields @in_guaranteed ()) {
+entry(%x : $X):
+  %void_addr = alloc_stack $()
+  %void = tuple ()
+  store %void to %void_addr : $*()
+  yield %void_addr : $*(), resume bb1, unwind bb2
+
+bb1:
+  dealloc_stack %void_addr : $*()
+  return %void : $()
+
+bb2:
+  dealloc_stack %void_addr : $*()
+  unwind
+}
+
+
+// CHECK-LABEL: sil @begin_apply_x_yielder : {{.*}} {
+// CHECK:         ({{%[^,]+}}, {{%[^,]+}}, [[ALLOCATION:%[^,]+]]) = begin_apply
+// CHECK:         dealloc_stack [[ALLOCATION]]
+// CHECK-LABEL: } // end sil function 'begin_apply_x_yielder'
+sil @begin_apply_x_yielder : $@convention(thin) (@owned X) -> () {
+entry(%x : $X):
+  %fn = function_ref @yield_nothing_take_x : $@convention(thin) @yield_once_2 (@owned X) -> (@yields @in_guaranteed ())
+  (%void, %token, %allocation) = begin_apply %fn(%x) : $@convention(thin) @yield_once_2 (@owned X) -> (@yields @in_guaranteed ())
+  end_apply %token as $()
+  dealloc_stack %allocation : $*Builtin.SILToken
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
IRGen installs an LLVMContext diagnostic handler
(SwiftDiagnosticHandler) whose handleDiagnostics() returned true unconditionally, telling LLVM the diagnostic was fully handled. That suppressed the default printer *and* dropped error-severity backend diagnostics on the floor. As a result an error raised during MC object emission -- e.g. an unsupported Mach-O subtraction relocation against an undefined symbol -- left performLLVM writing an empty/partial object file and returning success. swift-frontend then exited 0, and the failure only surfaced later as a confusing linker error ("file is empty in '...'.o").

Instead of doing this, Check the LLVMContext diagnostic handler's HasErrors after compileAndWriteLLVM and if it is set, emit a real diagnostic (error_generating_object_file) naming the output and fail. The handler still owns the flag, so this is race-free under parallel WMO codegen where each IRGenModule has its own LLVMContext.

I also added a frontend option, -print-llvm-backend-diagnostics, which lets error-severity backend diagnostics through to LLVM's default printer so the underlying message (the relocation error, etc.) is visible in addition to the frontend failing. The specific error is unlikely to be useful directly to users so it doesn't make sense to expose it.

rdar://186127685
