### PR TITLE
[Lifetimes] Form a lifetime dependency on the guaranteed base of a borrow accessor call

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -329,6 +329,12 @@ extension LifetimeDependence.Scope {
         // intermediate reference in a chain like `a.b.c` is destroyed as soon as the next one has been loaded, which
         // would give a scope too narrow to contain the dependent value.
         self.init(base: parentStorage, context)
+      } else if refElementAddr.instance.referenceRoot.ownership == .guaranteed {
+        // The reference was forwarded from a guaranteed value rather than
+        // loaded out of memory. Nothing may overwrite the storage that value
+        // was borrowed from while the borrow is live, so the referent stays
+        // alive for the whole borrow scope.
+        self.init(base: refElementAddr.instance.referenceRoot, context)
       } else {
         self.init(base: refElementAddr.instance, context)
       }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -262,6 +262,26 @@ private func loadedAddress(of reference: Value) -> Value? {
   }
 }
 
+/// The guaranteed value that `reference` was forwarded from, if it has one.
+private func guaranteedReferenceRoot(of reference: Value) -> Value? {
+  let root = reference.referenceRoot
+  return root.ownership == .guaranteed ? root : nil
+}
+
+/// If `value` is the result of a call that returns `@guaranteed`, the argument
+/// that the result is a borrow of.
+private func guaranteedResultBase(of value: Value) -> Value? {
+  guard value.isGuaranteedApplyResult,
+        let apply = value.definingInstruction as? ApplyInst,
+        // A borrow accessor for a global has no `self`; its result borrows
+        // immortal storage. Let the caller handle that.
+        apply.functionConvention.hasSelfParameter,
+        let selfArgument = apply.arguments.last else {
+    return nil
+  }
+  return guaranteedReferenceRoot(of: selfArgument) ?? selfArgument
+}
+
 // Scope initialization.
 extension LifetimeDependence.Scope {
   /// Construct a lifetime dependence scope from the base value that other values depend on. This derives the kind of
@@ -329,12 +349,12 @@ extension LifetimeDependence.Scope {
         // intermediate reference in a chain like `a.b.c` is destroyed as soon as the next one has been loaded, which
         // would give a scope too narrow to contain the dependent value.
         self.init(base: parentStorage, context)
-      } else if refElementAddr.instance.referenceRoot.ownership == .guaranteed {
+      } else if let guaranteedRoot =
+                    guaranteedReferenceRoot(of: refElementAddr.instance) {
         // The reference was forwarded from a guaranteed value rather than
-        // loaded out of memory. Nothing may overwrite the storage that value
-        // was borrowed from while the borrow is live, so the referent stays
-        // alive for the whole borrow scope.
-        self.init(base: refElementAddr.instance.referenceRoot, context)
+        // loaded out of memory, as happens for a `struct_extract` of a
+        // borrowed struct.
+        self.init(base: guaranteedRoot, context)
       } else {
         self.init(base: refElementAddr.instance, context)
       }
@@ -393,6 +413,11 @@ extension LifetimeDependence.Scope {
   // LifetimeDependenceself.init(markDep) with a gatherDependenceScopes() utility used by both
   // LifetimeDependenceInsertion and LifetimeDependenceScopeFixup.
   private init(guaranteed base: Value, _ context: some Context) {
+    // Introduce a dependency on the base of a borrow accessor call.
+    if let accessorBase = guaranteedResultBase(of: base) {
+      self.init(base: accessorBase, context)
+      return
+    }
     var iter = base.getBorrowIntroducers(context).makeIterator()
     // If no borrow introducer was found, then this is a borrow of a trivial value. Since we can assume a single
     // introducer here, then this is the only condition under which we have a trivial introducer.
@@ -426,6 +451,9 @@ extension LifetimeDependence.Scope {
       self = .local(varScope)
     } else if let ga = GlobalAccessBase(address: value) {
       self = .global(ga)
+    } else if let accessorBase = guaranteedResultBase(of: value) {
+      // A trivial `borrow` accessor result, rooted on the base of the accessor.
+      self.init(base: accessorBase, context)
     } else {
       self = .unknown(value)
     }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_accessor.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow_accessor.swift
@@ -1,0 +1,135 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -disable-availability-checking \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   -enable-experimental-feature BorrowAndMutateAccessors
+
+// Check which value each dependence is rooted at.
+//
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -module-name test \
+// RUN:   -disable-availability-checking \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   -enable-experimental-feature BorrowAndMutateAccessors \
+// RUN:   -Xllvm -sil-print-after=lifetime-dependence-insertion 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+
+struct Wrapped {
+  var span: Span<Int> {
+    @_lifetime(borrow self)
+    get { fatalError() }
+  }
+}
+
+final class Holder {
+  let _wrapped: Wrapped
+
+  init(wrapped: Wrapped) { self._wrapped = wrapped }
+
+  var wrapped: Wrapped {
+    borrow { return _wrapped }
+  }
+}
+
+// `Wrapped` above is empty, so the accessor's result is trivial and has no
+// borrow introducers at all. A non-trivial result takes a different path -- the
+// introducer walk reaches the accessor's `self` argument on its own -- so both
+// have to be covered.
+final class RichHolder {
+  let _data = [1, 2, 3]
+
+  var data: [Int] {
+    borrow { return _data }
+  }
+}
+
+// MARK: - Accepted
+
+// The base is a guaranteed argument, so the accessor's result is valid for the
+// whole function and the dependence roots at the argument.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s4test12fromArgumentys4SpanVySiGAA6HolderCF : $@convention(thin) (@guaranteed Holder) -> @lifetime(borrow 0) @owned Span<Int> {
+// CHECK: bb0(%0 : @guaranteed $Holder):
+// CHECK: [[WRAPPED:%.*]] = apply %{{.*}}(%0) : $@convention(method) (@guaranteed Holder) -> @guaranteed Wrapped
+// CHECK: [[SPAN:%.*]] = apply %{{.*}}([[WRAPPED]]) : $@convention(method) (Wrapped) -> @lifetime(borrow 0) @owned Span<Int>
+// CHECK: mark_dependence [unresolved] [[SPAN]] on %0
+// CHECK-LABEL: } // end sil function '$s4test12fromArgumentys4SpanVySiGAA6HolderCF'
+@_lifetime(borrow h)
+func fromArgument(_ h: Holder) -> Span<Int> {
+  return h.wrapped.span
+}
+
+// The reference reaches the accessor through a `struct_extract` of a borrowed
+// struct. SILGen copies and borrows that reference just for the accessor call,
+// so the dependence must root at the borrowed struct instead.
+struct Outer {
+  let holder: Holder
+
+  // CHECK-LABEL: sil hidden [ossa] @$s4test5OuterV4spans4SpanVySiGvg : $@convention(method) (@guaranteed Outer) -> @lifetime(borrow 0) @owned Span<Int> {
+  // CHECK: bb0(%0 : @guaranteed $Outer):
+  // CHECK: struct_extract %0, #Outer.holder
+  // CHECK: [[SPAN:%.*]] = apply %{{.*}} : $@convention(method) (Wrapped) -> @lifetime(borrow 0) @owned Span<Int>
+  // CHECK: mark_dependence [unresolved] [[SPAN]] on %0
+  // CHECK-LABEL: } // end sil function '$s4test5OuterV4spans4SpanVySiGvg'
+  var span: Span<Int> {
+    @_lifetime(borrow self)
+    get {
+      holder.wrapped.span
+    }
+  }
+}
+
+// A dependent value used within the function, rather than returned.
+func localUse(_ h: Holder) -> Int {
+  let span = h.wrapped.span
+  return span.count
+}
+
+// The same two shapes with a non-trivial accessor result. These reach the
+// accessor's `self` argument through the borrow introducer walk rather than
+// through the trivial path, so they must root at the same place.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s4test8richFromys4SpanVySiGAA10RichHolderCF : $@convention(thin) (@guaranteed RichHolder) -> @lifetime(borrow 0) @owned Span<Int> {
+// CHECK: bb0(%0 : @guaranteed $RichHolder):
+// CHECK: mark_dependence [unresolved] %{{.*}} on %0
+// CHECK-LABEL: } // end sil function '$s4test8richFromys4SpanVySiGAA10RichHolderCF'
+@_lifetime(borrow h)
+func richFrom(_ h: RichHolder) -> Span<Int> {
+  return h.data.span
+}
+
+struct RichOuter {
+  let holder: RichHolder
+
+  // CHECK-LABEL: sil hidden [ossa] @$s4test9RichOuterV4spans4SpanVySiGvg : $@convention(method) (@guaranteed RichOuter) -> @lifetime(borrow 0) @owned Span<Int> {
+  // CHECK: bb0(%0 : @guaranteed $RichOuter):
+  // CHECK: struct_extract %0, #RichOuter.holder
+  // CHECK: mark_dependence [unresolved] %{{.*}} on %0
+  // CHECK-LABEL: } // end sil function '$s4test9RichOuterV4spans4SpanVySiGvg'
+  var span: Span<Int> {
+    @_lifetime(borrow self)
+    get {
+      holder.data.span
+    }
+  }
+}
+
+// MARK: - Rejected
+
+// The base is a local: the accessor's result is only valid while that local is,
+// so the dependent value cannot outlive the function. `other` gives the result
+// something to depend on, so the only error is the escape itself.
+@_lifetime(borrow other)
+func escapingLocal(_ other: Holder) -> Span<Int> {
+  let local = Holder(wrapped: Wrapped())
+  return local.wrapped.span // expected-error {{lifetime-dependent value escapes its scope}}
+  // expected-note @-2 {{it depends on the lifetime of variable 'local'}}
+  // expected-note @-2 {{this use causes the lifetime-dependent value to escape}}
+}

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_class_storage.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_class_storage.swift
@@ -154,6 +154,26 @@ func localUse() -> Int {
   return span.count
 }
 
+// A class reference reached by `struct_extract` from a borrowed struct rather
+// than loaded out of memory. Nothing may overwrite the struct's storage while
+// it is borrowed, so the referent stays alive for the whole borrow. The
+// dependence roots at the borrowed struct, not at the copy of the reference
+// that SILGen makes, which is destroyed as soon as the next link is loaded.
+struct StructThenClass {
+  let mid: Mid
+
+  // CHECK-LABEL: sil hidden [ossa] @$s4test15StructThenClassV7getDatas4SpanVySiGyF : $@convention(method) (@guaranteed StructThenClass) -> @lifetime(borrow 0) @owned Span<Int> {
+  // CHECK: bb0(%0 : @guaranteed $StructThenClass):
+  // CHECK: struct_extract %0, #StructThenClass.mid
+  // CHECK: [[SPAN:%.*]] = apply %{{.*}} : $@convention(method) <τ_0_0> (@guaranteed Array<τ_0_0>) -> @lifetime(borrow 0) @owned Span<τ_0_0>
+  // CHECK: mark_dependence [unresolved] [[SPAN]] on %0
+  // CHECK-LABEL: } // end sil function '$s4test15StructThenClassV7getDatas4SpanVySiGyF'
+  @_lifetime(borrow self)
+  func getData() -> Span<Int> {
+    return mid.c.d.span
+  }
+}
+
 // MARK: - Rejected
 
 final class MutableField {


### PR DESCRIPTION
When a borrow accessor is called on a guaranteed 'self', form a lifetime dependency on the borrowed root. This lets us deal with borrowing from, for example, structs that contain class instances that themselves contain 'let' values, generalizing the previous work in this area for rdar://185905526.