### PR TITLE
Sema: Factor out ConformanceCache from ConstraintSystem

### DIFF
--- a/include/swift/Sema/ConformanceCache.h
+++ b/include/swift/Sema/ConformanceCache.h
@@ -1,0 +1,98 @@
+//===--- ConformanceCache.h - Caching conformance lookups -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This is a utility used for caching conformance lookups in the constraint
+// solver
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_SEMA_CONFORMANCE_CACHE_H
+#define SWIFT_SEMA_CONFORMANCE_CACHE_H
+
+#include "swift/Basic/OptionSet.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace swift {
+
+class ProtocolConformanceRef;
+class ProtocolDecl;
+class Type;
+class TypeBase;
+
+namespace constraints {
+
+// Subtyping.h
+enum class ConversionBehavior : unsigned;
+
+/// To avoid overhead from repeated conformance queries while exploring the
+/// disjunction search space, the code in Subtyping.cpp indirects global
+/// conformance lookups through this type. Other clients of Subtyping.cpp
+/// entry points can just create a ConformanceCache when needed to make a
+/// few calls, since there's probably no benefit to caching this information
+/// most of the time.
+struct ConformanceCache {
+  ConformanceCache() = default;
+
+  ConformanceCache(const ConformanceCache &) = delete;
+  ConformanceCache(ConformanceCache &&other);
+
+  ConformanceCache &operator=(const ConformanceCache &) = delete;
+  ConformanceCache &operator=(ConformanceCache &&) = delete;
+
+  /// A dictionary of all conformances that have been looked up by the solver.
+  llvm::DenseMap<std::pair<TypeBase *, ProtocolDecl *>, ProtocolConformanceRef>
+      Conformances;
+
+  /// We memoize the computation in the below.
+  llvm::DenseMap<std::pair<ConversionBehavior, ProtocolDecl *>, bool>
+      ConformanceTransitiveForSupertypeCache;
+
+  /// We memoize the computation in the below.
+  llvm::DenseMap<std::pair<ConversionBehavior, ProtocolDecl *>, bool>
+      ConformanceTransitiveForSubtypeCache;
+
+  /// Check whether the given type conforms to the given protocol and if
+  /// so return a valid conformance reference.
+  ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *P);
+
+  /// Suppose we are given a type T and a protocol P, and U conv T for
+  /// some type U; if U conforms to P, does it follow that T conforms to P?
+  bool checkTransitiveSubtypeConformance(Type type, ProtocolDecl *proto);
+
+  /// Suppose we are given a type T with the given conversion behavior,
+  /// and a protocol P, with the following setup:
+  /// - T conv $T0
+  /// - $T0 conforms P
+  /// The question is, does this imply that T must conform to P? This
+  /// returns true if so, false otherwise.
+  bool isConformanceTransitiveForSupertype(ConversionBehavior behavior,
+                                           ProtocolDecl *proto);
+
+  /// Suppose we are given a type T and a protocol P, and T conv U for
+  /// some type U; if U conforms to P, does it follow that T conforms to P?
+  bool checkTransitiveSupertypeConformance(Type type, ProtocolDecl *proto);
+
+  /// Suppose we are given a type T with the given conversion behavior,
+  /// and a protocol P, with the following setup:
+  /// - $T0 conv T
+  /// - $T0 conforms P
+  /// The question is, does this imply that T must conform to P? This
+  /// returns true if so, false otherwise.
+  bool isConformanceTransitiveForSubtype(ConversionBehavior behavior,
+                                         ProtocolDecl *proto);
+};
+
+}  // end namespace constraints
+
+}  // end namespace swift
+
+#endif  // SWIFT_SEMA_SUBTYPING_H

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -31,6 +31,7 @@
 #include "swift/Basic/OptionSet.h"
 #include "swift/Sema/CSFix.h"
 #include "swift/Sema/CSTrail.h"
+#include "swift/Sema/ConformanceCache.h"
 #include "swift/Sema/Constraint.h"
 #include "swift/Sema/ConstraintGraph.h"
 #include "swift/Sema/ConstraintLocator.h"
@@ -1031,10 +1032,6 @@ private:
   llvm::SmallDenseMap<ConstraintLocator *, ArrayRef<OpenedType>, 4>
       OpenedTypes;
 
-  /// A dictionary of all conformances that have been looked up by the solver.
-  llvm::DenseMap<std::pair<TypeBase *, ProtocolDecl *>, ProtocolConformanceRef>
-      Conformances;
-
   /// A cache for unavailability checks peformed by the solver.
   llvm::DenseMap<std::pair<const Decl *, ConstraintLocator *>, bool>
       UnavailableDecls;
@@ -1113,6 +1110,10 @@ public:
   /// ad-hoc distributed `SerializationRequirement` conformances).
   llvm::DenseMap<ConstraintLocator *, ProtocolDecl *>
       SynthesizedConformances;
+
+  /// This is not trail-protected state; it's just a cache for some
+  /// information about Decls.
+  ConformanceCache CC;
 
 private:
   /// Describes the current solver state.
@@ -2800,37 +2801,9 @@ public:
 
   /// Check whether the given type conforms to the given protocol and if
   /// so return a valid conformance reference.
-  ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *P);
-
-  /// We memoize the computation in the below.
-  llvm::DenseMap<std::pair<ConversionBehavior, ProtocolDecl *>, bool>
-      ConformanceTransitiveForSupertypeCache;
-
-  /// Suppose we are given a type T with the given conversion behavior,
-  /// and a protocol P, with the following setup:
-  /// - T conv $T0
-  /// - $T0 conforms P
-  /// The question is, does this imply that T must conform to P? This
-  /// returns true if so, false otherwise.
-  ///
-  /// Also see Subtyping.h, checkTranstiveSupertypeConformance().
-  bool isConformanceTransitiveForSupertype(ConversionBehavior behavior,
-                                           ProtocolDecl *proto);
-
-  /// We memoize the computation in the below.
-  llvm::DenseMap<std::pair<ConversionBehavior, ProtocolDecl *>, bool>
-      ConformanceTransitiveForSubtypeCache;
-
-  /// Suppose we are given a type T with the given conversion behavior,
-  /// and a protocol P, with the following setup:
-  /// - $T0 conv T
-  /// - $T0 conforms P
-  /// The question is, does this imply that T must conform to P? This
-  /// returns true if so, false otherwise.
-  ///
-  /// Also see Subtyping.h, checkTranstiveSubtypeConformance().
-  bool isConformanceTransitiveForSubtype(ConversionBehavior behavior,
-                                         ProtocolDecl *proto);
+  ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *P) {
+    return CC.lookupConformance(type, P);
+  }
 
   /// Wrapper over swift::adjustFunctionTypeForConcurrency that passes along
   /// the appropriate closure-type and opening extraction functions.

--- a/include/swift/Sema/Subtyping.h
+++ b/include/swift/Sema/Subtyping.h
@@ -18,6 +18,7 @@
 #define SWIFT_SEMA_SUBTYPING_H
 
 #include "swift/Basic/OptionSet.h"
+#include "swift/Sema/ConformanceCache.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace swift {
@@ -25,9 +26,12 @@ namespace swift {
 class GenericSignature;
 class ProtocolDecl;
 class Type;
+class TypeVariableType;
+struct TypePosition;
 
 namespace constraints {
 
+class ConstraintLocator;
 class ConstraintSystem;
 
 /// Checks if two types can unify if we record a bind constraint between them.
@@ -130,16 +134,6 @@ void getTypeVariablesWithVariance(
     Type type, TypePosition pos,
     bool funcResultIsInvariant=false);
 
-/// Suppose we are given a type T and a protocol P, and T conv U for
-/// some type U; if U conforms to P, does it follow that T conforms to P?
-bool checkTransitiveSupertypeConformance(ConstraintSystem &cs,
-                                         Type type, ProtocolDecl *proto);
-
-/// Suppose we are given a type T and a protocol P, and U conv T for
-/// some type U; if U conforms to P, does it follow that T conforms to P?
-bool checkTransitiveSubtypeConformance(ConstraintSystem &cs,
-                                       Type type, ProtocolDecl *proto);
-
 /// Check if there exist any subtypes of the given type, other than
 /// the type itself. If the type contains type variables, this will
 /// give a conservative approximation.
@@ -193,12 +187,12 @@ void simple_display(llvm::raw_ostream &out, ConflictReason reason);
 ///
 /// Even if the types do not contain type variables or type parameters,
 /// this does not give a completely accurate answer, yet.
-ConflictReason checkConversion(ConstraintSystem &cs,
+ConflictReason checkConversion(ConformanceCache &cache,
                                Type lhs, Type rhs,
                                GenericSignature sig);
 
 /// More meaningful overload for when you want a boolean result.
-bool canConvertTo(ConstraintSystem &cs,
+bool canConvertTo(ConformanceCache &cache,
                   Type lhs, Type rhs,
                   GenericSignature sig);
 

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_host_library(swiftSema STATIC
   BindingProducer.cpp
   BuilderTransform.cpp
   Comment.cpp
+  ConformanceCache.cpp
   CSApply.cpp
   CSBindings.cpp
   CSDisjunction.cpp

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1539,7 +1539,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // Existing exact binding must be a supertype of the new lower bound.
-      if (!canConvertTo(CS, binding.BindingType, existing.BindingType,
+      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType,
                         GenericSignature())) {
         SUBSUME_DEBUG("Exact vs supertype conflict");
         return SubsumeBindingResult::Conflict;
@@ -1560,7 +1560,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // Existing exact binding must be a subtype of the new upper bound.
-      if (!canConvertTo(CS, existing.BindingType, binding.BindingType,
+      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType,
                         GenericSignature())) {
         SUBSUME_DEBUG("Exact vs subtype conflict");
         return SubsumeBindingResult::Conflict;
@@ -1588,7 +1588,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // Exact binding must be a supertype of the existing lower bound.
-      if (!canConvertTo(CS, existing.BindingType, binding.BindingType,
+      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType,
                         GenericSignature())) {
         SUBSUME_DEBUG("Supertype vs exact conflict");
         return SubsumeBindingResult::Conflict;
@@ -1641,7 +1641,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // The existing lower bound should be a subtype of the new upper bound.
-      if (!canConvertTo(CS, existing.BindingType, binding.BindingType,
+      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType,
                         GenericSignature())) {
         SUBSUME_DEBUG("Supertype vs subtype conflict");
         return SubsumeBindingResult::Conflict;
@@ -1688,7 +1688,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // The new exact binding should be a subtype of the existing upper bound.
-      if (!canConvertTo(CS, binding.BindingType, existing.BindingType,
+      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType,
                         GenericSignature())) {
         SUBSUME_DEBUG("Subtype vs exact conflict");
         return SubsumeBindingResult::Conflict;
@@ -1716,7 +1716,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // The new lower bound should be a subtype of the existing upper bound.
-      if (!canConvertTo(CS, binding.BindingType, existing.BindingType,
+      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType,
                         GenericSignature())) {
         SUBSUME_DEBUG("Subtype vs supertype conflict");
         return SubsumeBindingResult::Conflict;
@@ -1892,8 +1892,8 @@ void BindingSet::reduceBinding(PotentialBinding &binding) {
     if (checkConformanceConstraints) {
       bool conforms = llvm::all_of(Protocols,
           [&](ProtocolDecl *proto) -> bool {
-            return checkTransitiveSubtypeConformance(
-                  CS, binding.BindingType, proto);
+            return CS.CC.checkTransitiveSubtypeConformance(
+                  binding.BindingType, proto);
           });
 
       if (!conforms) {
@@ -1952,8 +1952,8 @@ void BindingSet::reduceBinding(PotentialBinding &binding) {
     if (checkConformanceConstraints) {
       bool conforms = llvm::all_of(Protocols,
           [&](ProtocolDecl *proto) -> bool {
-            return checkTransitiveSupertypeConformance(
-                  CS, binding.BindingType, proto);
+            return CS.CC.checkTransitiveSupertypeConformance(
+                  binding.BindingType, proto);
           });
 
       if (!conforms) {
@@ -1974,7 +1974,7 @@ void BindingSet::reduceBinding(PotentialBinding &binding) {
       bool condition = llvm::any_of(Protocols,
           [&](ProtocolDecl *proto) {
         return (!proto->existentialConformsToSelf() &&
-                CS.isConformanceTransitiveForSupertype(
+                CS.CC.isConformanceTransitiveForSupertype(
                   ConversionBehavior::None, proto));
       });
 
@@ -2521,12 +2521,12 @@ bool LiteralRequirement::isCoveredBy(AllowedBindingKind kind, Type type,
     case AllowedBindingKind::Supertypes:
       if (!type->getAnyNominal() && !type->isExistentialType())
         return false;
-      return canConvertTo(CS, defaultType, type, GenericSignature());
+      return canConvertTo(CS.CC, defaultType, type, GenericSignature());
 
     case AllowedBindingKind::Subtypes:
       if (!type->getAnyNominal() && !type->isExistentialType())
         return false;
-      return canConvertTo(CS, type, defaultType, GenericSignature());
+      return canConvertTo(CS.CC, type, defaultType, GenericSignature());
     }
   }
 }

--- a/lib/Sema/CSDisjunction.cpp
+++ b/lib/Sema/CSDisjunction.cpp
@@ -875,12 +875,12 @@ void SolverDisjunction::pruneDisjunction(ConstraintSystem &cs,
         if (paramFlags.isAutoClosure())
           paramType = paramType->castTo<FunctionType>()->getResult();
 
-        reason |= checkConversion(cs, argType, paramType, genericSig);
+        reason |= checkConversion(cs.CC, argType, paramType, genericSig);
       }
 
       auto overloadResultType = overloadType->getResult();
       auto applyResultType = argFuncType->getResult();
-      reason |= checkConversion(cs, overloadResultType,
+      reason |= checkConversion(cs.CC, overloadResultType,
                                 applyResultType, genericSig);
 
       if (reason) {

--- a/lib/Sema/ConformanceCache.cpp
+++ b/lib/Sema/ConformanceCache.cpp
@@ -1,0 +1,291 @@
+//===--- ConformanceCache.cpp - Caching conformance lookups ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements various utilities for caching conformance lookups, and
+// performing transitive conformance lookups, where we reason about whether
+// the subtypes or supertypes of a known type can possibly conform to some
+// protocol.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Sema/ConformanceCache.h"
+#include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Types.h"
+#include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/Subtyping.h"
+
+#define DEBUG_TYPE "Subtyping"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+using namespace constraints;
+
+ProtocolConformanceRef
+ConformanceCache::lookupConformance(Type type, ProtocolDecl *protocol) {
+  auto cacheKey = std::make_pair(type.getPointer(), protocol);
+
+  auto cachedConformance = Conformances.find(cacheKey);
+  if (cachedConformance != Conformances.end())
+    return cachedConformance->second;
+
+  auto conformance =
+      swift::lookupConformance(type, protocol, /*allowMissing=*/true);
+  Conformances[cacheKey] = conformance;
+  return conformance;
+}
+
+/// T conv $T0
+/// $T0 conforms P
+bool ConformanceCache::isConformanceTransitiveForSupertype(
+    ConversionBehavior behavior, ProtocolDecl *proto) {
+  // Sendable conformance is too loose to conclude anything.
+  if (proto->isSpecificProtocol(KnownProtocolKind::Sendable))
+    return false;
+
+  auto key = std::make_pair(behavior, proto);
+  auto found = ConformanceTransitiveForSupertypeCache.find(key);
+  if (found != ConformanceTransitiveForSupertypeCache.end())
+    return found->second;
+
+  auto &ctx = proto->getASTContext();
+
+  // Enumerate possible nominal supertypes of a type having the
+  // given conversion behavior.
+  SmallVector<NominalTypeDecl *, 4> declsToCheck;
+
+  if (behavior != ConversionBehavior::Optional) {
+    // Every T converts to Optional<T>.
+    if (auto *optionalDecl = ctx.getOptionalDecl())
+      declsToCheck.push_back(optionalDecl);
+  }
+
+  // Every hashable T converts to AnyHashable.
+  // FIXME: Actually check if the type is hashable.
+  if (auto *anyHashableDecl = ctx.getAnyHashableDecl())
+    declsToCheck.push_back(anyHashableDecl);
+
+  auto addPointers = [&]() {
+    declsToCheck.push_back(ctx.getUnsafePointerDecl());
+    declsToCheck.push_back(ctx.getUnsafeRawPointerDecl());
+  };
+
+  auto addMutablePointers = [&]() {
+    addPointers();
+    declsToCheck.push_back(ctx.getUnsafeMutablePointerDecl());
+    declsToCheck.push_back(ctx.getUnsafeMutableRawPointerDecl());
+  };
+
+  bool result = true;
+
+  switch (behavior) {
+  case ConversionBehavior::None:
+  case ConversionBehavior::Class:
+  case ConversionBehavior::Dictionary:
+  case ConversionBehavior::Set:
+  case ConversionBehavior::Optional:
+  case ConversionBehavior::AnyHashable:
+  case ConversionBehavior::Tuple:
+    break;
+
+  case ConversionBehavior::String:
+    // Strings convert to UnsafePointer.
+    addPointers();
+    break;
+
+  case ConversionBehavior::Array:
+    addPointers();
+    break;
+
+  case ConversionBehavior::Pointer:
+    addMutablePointers();
+    break;
+
+  case ConversionBehavior::Double:
+    // Note this is funny, but valid. We return false if
+    // either Double or CGFloat conform to the protocol,
+    // so the only "transitive" protocols in this case
+    // are those that neither CGFloat nor Double conform
+    // to.
+    if (auto *doubleDecl = ctx.getDoubleDecl())
+      declsToCheck.push_back(doubleDecl);
+    if (auto *cgFloatDecl = ctx.getCGFloatDecl())
+      declsToCheck.push_back(cgFloatDecl);
+    break;
+
+  case ConversionBehavior::Function:
+  case ConversionBehavior::Metatype:
+  case ConversionBehavior::ExistentialMetatype:
+    // FIXME: Metatypes and functions.
+    result = false;
+    break;
+
+  case ConversionBehavior::LValue:
+    ASSERT(false && "Must unwrap lvalue type first!");
+    break;
+
+  case ConversionBehavior::InOut:
+    // InOut types convert to mutable pointers.
+    addMutablePointers();
+    break;
+
+  case ConversionBehavior::Existential:
+    // FIXME: Implement this.
+    result = false;
+    break;
+
+  case ConversionBehavior::Unknown:
+    // Can't say anything in this case.
+    result = false;
+    break;
+  }
+
+  if (result) {
+    // Check if any of our nominal types conform.
+    // If they do, then conformance is not transitive.
+    for (auto *decl : declsToCheck) {
+      SmallVector<ProtocolConformance *, 1> results;
+      decl->lookupConformance(proto, results);
+      if (!results.empty()) {
+        result = false;
+        break;
+      }
+    }
+  }
+
+  // Cache the result.
+  bool inserted =
+    ConformanceTransitiveForSupertypeCache.insert(
+      std::make_pair(key, result)).second;
+  ASSERT(inserted);
+
+  return result;
+}
+
+bool ConformanceCache::checkTransitiveSupertypeConformance(
+    Type type, ProtocolDecl *proto) {
+  // Every lvalue type can be converted to its object type, so
+  // we must consider conversions of the object type in this case.
+  if (auto *lvalueType = type->getAs<LValueType>())
+    type = lvalueType->getObjectType();
+  auto behavior = getConversionBehavior(type);
+  if (isConformanceTransitiveForSupertype(behavior, proto)) {
+    // Unwrap InOut and LValue type.
+    return !lookupConformance(type->getWithoutSpecifierType(), proto)
+        .isInvalid();
+  }
+  return true;
+}
+
+/// $T0 conv T
+/// $T0 conforms P
+bool ConformanceCache::isConformanceTransitiveForSubtype(
+    ConversionBehavior behavior, ProtocolDecl *proto) {
+  // Sendable conformance is too loose to conclude anything.
+  if (proto->isSpecificProtocol(KnownProtocolKind::Sendable))
+    return false;
+
+  switch (behavior) {
+  case ConversionBehavior::None:
+  case ConversionBehavior::String:
+  case ConversionBehavior::Array:
+  case ConversionBehavior::Dictionary:
+  case ConversionBehavior::Set:
+    // All subtypes of these have the same nominal type,
+    // and conform to the same protocols.
+    return true;
+
+  case ConversionBehavior::Tuple:
+    // All subtypes of a tuple remain a tuple, and conform
+    // to the same protocols.
+    return true;
+
+  case ConversionBehavior::Class:
+    // A subclass might conform to more protocols than a
+    // superclass.
+    return false;
+
+  case ConversionBehavior::Double: {
+    auto key = std::make_pair(behavior, proto);
+    auto found = ConformanceTransitiveForSubtypeCache.find(key);
+    if (found != ConformanceTransitiveForSubtypeCache.end())
+      return found->second;
+
+    SmallVector<NominalTypeDecl *, 4> declsToCheck;
+
+    auto &ctx = proto->getASTContext();
+    if (auto *cgFloatDecl = ctx.getCGFloatDecl())
+      declsToCheck.push_back(cgFloatDecl);
+    if (auto *doubleDecl = ctx.getDoubleDecl())
+      declsToCheck.push_back(doubleDecl);
+
+    bool result = false;
+    for (auto *decl : declsToCheck) {
+      SmallVector<ProtocolConformance *, 1> results;
+      decl->lookupConformance(proto, results);
+      if (!results.empty()) {
+        result = true;
+        break;
+      }
+    }
+
+    // Cache the result.
+    bool inserted =
+      ConformanceTransitiveForSubtypeCache.insert(
+        std::make_pair(key, result)).second;
+    ASSERT(inserted);
+
+    return result;
+  }
+
+  case ConversionBehavior::InOut:
+  case ConversionBehavior::LValue:
+    // InOutType and LValueType have no proper subtypes.
+    return true;
+
+  case ConversionBehavior::Optional:
+    // FIXME: Check payload type.
+    return false;
+
+  case ConversionBehavior::AnyHashable:
+    // All Hashable types are subtypes of AnyHashable, so
+    // we cannot conclude anything about protocol conformance
+    // in this case.
+    return false;
+
+  case ConversionBehavior::Pointer:
+    // FIXME: Check pointer types.
+    return false;
+
+  case ConversionBehavior::Function:
+  case ConversionBehavior::Metatype:
+  case ConversionBehavior::ExistentialMetatype:
+    // FIXME: Metatypes and functions.
+    return false;
+
+  case ConversionBehavior::Existential:
+  case ConversionBehavior::Unknown:
+    // Can't say anything in this case.
+    return false;
+  }
+}
+
+bool ConformanceCache::checkTransitiveSubtypeConformance(
+    Type type, ProtocolDecl *proto) {
+  auto behavior = getConversionBehavior(type);
+  if (isConformanceTransitiveForSubtype(behavior, proto)) {
+    // Unwrap InOut and LValue type.
+    return !lookupConformance(type->getWithoutSpecifierType(), proto)
+        .isInvalid();
+  }
+  return true;
+}

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5080,20 +5080,6 @@ bool ConstraintSystem::isArgumentGenericFunction(Type argType, Expr *argExpr) {
   return false;
 }
 
-ProtocolConformanceRef
-ConstraintSystem::lookupConformance(Type type, ProtocolDecl *protocol) {
-  auto cacheKey = std::make_pair(type.getPointer(), protocol);
-
-  auto cachedConformance = Conformances.find(cacheKey);
-  if (cachedConformance != Conformances.end())
-    return cachedConformance->second;
-
-  auto conformance =
-      swift::lookupConformance(type, protocol, /*allowMissing=*/true);
-  Conformances[cacheKey] = conformance;
-  return conformance;
-}
-
 std::pair<bool, std::optional<KeyPathCapability>>
 ConstraintSystem::inferKeyPathLiteralCapability(TypeVariableType *keyPathType) {
   auto *typeLocator = keyPathType->getImpl().getLocator();

--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -1,4 +1,4 @@
-//===--- Subtyping.cpp - Swift subtyping and conversion rules 00-----------===//
+//===--- Subtyping.cpp - Swift subtyping and conversion rules -------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -201,252 +201,6 @@ bool swift::constraints::isSubtypeOfExistentialType(Type candidateType,
                                                 /*allowMissing=*/false);
     return result.first || result.second;
   });
-}
-
-/// T conv $T0
-/// $T0 conforms P
-bool ConstraintSystem::isConformanceTransitiveForSupertype(
-    ConversionBehavior behavior, ProtocolDecl *proto) {
-  // Sendable conformance is too loose to conclude anything.
-  if (proto->isSpecificProtocol(KnownProtocolKind::Sendable))
-    return false;
-
-  auto key = std::make_pair(behavior, proto);
-  auto found = ConformanceTransitiveForSupertypeCache.find(key);
-  if (found != ConformanceTransitiveForSupertypeCache.end())
-    return found->second;
-
-  auto &ctx = getASTContext();
-
-  // Enumerate possible nominal supertypes of a type having the
-  // given conversion behavior.
-  SmallVector<NominalTypeDecl *, 4> declsToCheck;
-
-  if (behavior != ConversionBehavior::Optional) {
-    // Every T converts to Optional<T>.
-    if (auto *optionalDecl = ctx.getOptionalDecl())
-      declsToCheck.push_back(optionalDecl);
-  }
-
-  // Every hashable T converts to AnyHashable.
-  // FIXME: Actually check if the type is hashable.
-  if (auto *anyHashableDecl = ctx.getAnyHashableDecl())
-    declsToCheck.push_back(anyHashableDecl);
-
-  auto addPointers = [&]() {
-    declsToCheck.push_back(ctx.getUnsafePointerDecl());
-    declsToCheck.push_back(ctx.getUnsafeRawPointerDecl());
-  };
-
-  auto addMutablePointers = [&]() {
-    addPointers();
-    declsToCheck.push_back(ctx.getUnsafeMutablePointerDecl());
-    declsToCheck.push_back(ctx.getUnsafeMutableRawPointerDecl());
-  };
-
-  bool result = true;
-
-  switch (behavior) {
-  case ConversionBehavior::None:
-  case ConversionBehavior::Class:
-  case ConversionBehavior::Dictionary:
-  case ConversionBehavior::Set:
-  case ConversionBehavior::Optional:
-  case ConversionBehavior::AnyHashable:
-  case ConversionBehavior::Tuple:
-    break;
-
-  case ConversionBehavior::String:
-    // Strings convert to UnsafePointer.
-    addPointers();
-    break;
-
-  case ConversionBehavior::Array:
-    addPointers();
-    break;
-
-  case ConversionBehavior::Pointer:
-    addMutablePointers();
-    break;
-
-  case ConversionBehavior::Double:
-    // Note this is funny, but valid. We return false if
-    // either Double or CGFloat conform to the protocol,
-    // so the only "transitive" protocols in this case
-    // are those that neither CGFloat nor Double conform
-    // to.
-    if (auto *doubleDecl = ctx.getDoubleDecl())
-      declsToCheck.push_back(doubleDecl);
-    if (auto *cgFloatDecl = ctx.getCGFloatDecl())
-      declsToCheck.push_back(cgFloatDecl);
-    break;
-
-  case ConversionBehavior::Function:
-  case ConversionBehavior::Metatype:
-  case ConversionBehavior::ExistentialMetatype:
-    // FIXME: Metatypes and functions.
-    result = false;
-    break;
-
-  case ConversionBehavior::LValue:
-    ASSERT(false && "Must unwrap lvalue type first!");
-    break;
-
-  case ConversionBehavior::InOut:
-    // InOut types convert to mutable pointers.
-    addMutablePointers();
-    break;
-
-  case ConversionBehavior::Existential:
-    // FIXME: Implement this.
-    result = false;
-    break;
-
-  case ConversionBehavior::Unknown:
-    // Can't say anything in this case.
-    result = false;
-    break;
-  }
-
-  if (result) {
-    // Check if any of our nominal types conform.
-    // If they do, then conformance is not transitive.
-    for (auto *decl : declsToCheck) {
-      SmallVector<ProtocolConformance *, 1> results;
-      decl->lookupConformance(proto, results);
-      if (!results.empty()) {
-        result = false;
-        break;
-      }
-    }
-  }
-
-  // Cache the result.
-  bool inserted =
-    ConformanceTransitiveForSupertypeCache.insert(
-      std::make_pair(key, result)).second;
-  ASSERT(inserted);
-
-  return result;
-}
-
-bool swift::constraints::checkTransitiveSupertypeConformance(
-    ConstraintSystem &cs, Type type, ProtocolDecl *proto) {
-  // Every lvalue type can be converted to its object type, so
-  // we must consider conversions of the object type in this case.
-  if (auto *lvalueType = type->getAs<LValueType>())
-    type = lvalueType->getObjectType();
-  auto behavior = getConversionBehavior(type);
-  if (cs.isConformanceTransitiveForSupertype(behavior, proto)) {
-    // Unwrap InOut and LValue type.
-    return !cs.lookupConformance(type->getWithoutSpecifierType(), proto)
-        .isInvalid();
-  }
-  return true;
-}
-
-/// $T0 conv T
-/// $T0 conforms P
-bool ConstraintSystem::isConformanceTransitiveForSubtype(
-    ConversionBehavior behavior, ProtocolDecl *proto) {
-  // Sendable conformance is too loose to conclude anything.
-  if (proto->isSpecificProtocol(KnownProtocolKind::Sendable))
-    return false;
-
-  switch (behavior) {
-  case ConversionBehavior::None:
-  case ConversionBehavior::String:
-  case ConversionBehavior::Array:
-  case ConversionBehavior::Dictionary:
-  case ConversionBehavior::Set:
-    // All subtypes of these have the same nominal type,
-    // and conform to the same protocols.
-    return true;
-
-  case ConversionBehavior::Tuple:
-    // All subtypes of a tuple remain a tuple, and conform
-    // to the same protocols.
-    return true;
-
-  case ConversionBehavior::Class:
-    // A subclass might conform to more protocols than a
-    // superclass.
-    return false;
-
-  case ConversionBehavior::Double: {
-    auto key = std::make_pair(behavior, proto);
-    auto found = ConformanceTransitiveForSubtypeCache.find(key);
-    if (found != ConformanceTransitiveForSubtypeCache.end())
-      return found->second;
-
-    SmallVector<NominalTypeDecl *, 4> declsToCheck;
-
-    auto &ctx = getASTContext();
-    if (auto *cgFloatDecl = ctx.getCGFloatDecl())
-      declsToCheck.push_back(cgFloatDecl);
-    if (auto *doubleDecl = ctx.getDoubleDecl())
-      declsToCheck.push_back(doubleDecl);
-
-    bool result = false;
-    for (auto *decl : declsToCheck) {
-      SmallVector<ProtocolConformance *, 1> results;
-      decl->lookupConformance(proto, results);
-      if (!results.empty()) {
-        result = true;
-        break;
-      }
-    }
-
-    // Cache the result.
-    bool inserted =
-      ConformanceTransitiveForSubtypeCache.insert(
-        std::make_pair(key, result)).second;
-    ASSERT(inserted);
-
-    return result;
-  }
-
-  case ConversionBehavior::InOut:
-  case ConversionBehavior::LValue:
-    // InOutType and LValueType have no proper subtypes.
-    return true;
-
-  case ConversionBehavior::Optional:
-    // FIXME: Check payload type.
-    return false;
-
-  case ConversionBehavior::AnyHashable:
-    // All Hashable types are subtypes of AnyHashable, so
-    // we cannot conclude anything about protocol conformance
-    // in this case.
-    return false;
-
-  case ConversionBehavior::Pointer:
-    // FIXME: Check pointer types.
-    return false;
-
-  case ConversionBehavior::Function:
-  case ConversionBehavior::Metatype:
-  case ConversionBehavior::ExistentialMetatype:
-    // FIXME: Metatypes and functions.
-    return false;
-
-  case ConversionBehavior::Existential:
-  case ConversionBehavior::Unknown:
-    // Can't say anything in this case.
-    return false;
-  }
-}
-
-bool swift::constraints::checkTransitiveSubtypeConformance(
-    ConstraintSystem &cs, Type type, ProtocolDecl *proto) {
-  auto behavior = getConversionBehavior(type);
-  if (cs.isConformanceTransitiveForSubtype(behavior, proto)) {
-    // Unwrap InOut and LValue type.
-    return !cs.lookupConformance(type->getWithoutSpecifierType(), proto)
-        .isInvalid();
-  }
-  return true;
 }
 
 std::optional<bool>
@@ -741,13 +495,13 @@ static bool isCovariantInstanceType(Type t) {
 }
 
 /// More meaningful overload for when you want a boolean result.
-bool swift::constraints::canConvertTo(ConstraintSystem &cs,
+bool swift::constraints::canConvertTo(ConformanceCache &cache,
                                       Type lhs, Type rhs,
                                       GenericSignature sig) {
-  return !checkConversion(cs, lhs, rhs, sig);
+  return !checkConversion(cache, lhs, rhs, sig);
 }
 
-ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
+ConflictReason swift::constraints::checkConversion(ConformanceCache &cache,
                                                    Type lhs, Type rhs,
                                                    GenericSignature sig) {
   if (lhs->isEqual(rhs))
@@ -817,7 +571,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
 
     case ConversionBehavior::Array: {
       // Array-to-Array conversions.
-      auto result = checkConversion(cs,
+      auto result = checkConversion(cache,
                                     lhs->getArrayElementType(),
                                     rhs->getArrayElementType(), sig);
       if (result)
@@ -829,12 +583,12 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
       // Dictionary-to-Dictionary conversions.
       auto lhsPair = *ConstraintSystem::isDictionaryType(lhs);
       auto rhsPair = *ConstraintSystem::isDictionaryType(rhs);
-      auto keyResult = checkConversion(cs,
+      auto keyResult = checkConversion(cache,
                                        lhsPair.first,
                                        rhsPair.first, sig);
       if (keyResult)
         return keyResult | ConflictFlag::DictionaryKey;
-      auto valueResult = checkConversion(cs,
+      auto valueResult = checkConversion(cache,
                                          lhsPair.second,
                                          rhsPair.second, sig);
       if (valueResult)
@@ -846,7 +600,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
       auto lhsElt = *ConstraintSystem::isSetType(lhs);
       auto rhsElt = *ConstraintSystem::isSetType(rhs);
 
-      auto result = checkConversion(cs, lhsElt, rhsElt, sig);
+      auto result = checkConversion(cache, lhsElt, rhsElt, sig);
       if (result)
         return result | ConflictFlag::Set;
       break;
@@ -856,7 +610,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
       auto argObjectType = lhs->getOptionalObjectType();
       auto objectType = rhs->getOptionalObjectType();
 
-      auto result = checkConversion(cs, argObjectType, objectType, sig);
+      auto result = checkConversion(cache, argObjectType, objectType, sig);
       if (result)
         return result | ConflictFlag::Optional;
       break;
@@ -873,7 +627,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
         break;
       }
 
-      auto result = checkConversion(cs, argInstanceType, instanceType, sig);
+      auto result = checkConversion(cache, argInstanceType, instanceType, sig);
       if (result)
         return result | ConflictFlag::Metatype;
       break;
@@ -902,7 +656,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
       for (unsigned i : indices(lhsTuple->getElements())) {
         auto lhsElt = lhsTuple->getElementType(i);
         auto rhsElt = rhsTuple->getElementType(i);
-        auto result = checkConversion(cs, lhsElt, rhsElt, sig);
+        auto result = checkConversion(cache, lhsElt, rhsElt, sig);
         if (result)
           return result | ConflictFlag::TupleElement;
       }
@@ -939,7 +693,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
 
     } else {
       // Attempt LValue-to-RValue conversion.
-      return checkConversion(cs, lhs->getWithoutSpecifierType(), rhs, sig);
+      return checkConversion(cache, lhs->getWithoutSpecifierType(), rhs, sig);
     }
 
   // Handle case where the kinds don't match, and we're not converting
@@ -984,7 +738,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
     case ConversionBehavior::Optional: {
       // We have a non-optional on the left. Try value-to-optional.
       auto objectType = rhs->getOptionalObjectType();
-      auto result = checkConversion(cs, lhs, objectType, sig);
+      auto result = checkConversion(cache, lhs, objectType, sig);
       if (result)
         return result | ConflictFlag::Optional;
 
@@ -1037,7 +791,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
       bool failed = llvm::any_of(
           sig->getRequiredProtocols(rhs),
           [&](ProtocolDecl *proto) {
-            return !checkTransitiveSupertypeConformance(cs, lhs, proto);
+            return !cache.checkTransitiveSupertypeConformance(lhs, proto);
           });
       if (failed)
         return ConflictFlag::Conformance;
@@ -1047,7 +801,7 @@ ConflictReason swift::constraints::checkConversion(ConstraintSystem &cs,
       bool failed = llvm::any_of(
           sig->getRequiredProtocols(lhs),
           [&](ProtocolDecl *proto) {
-            return !checkTransitiveSubtypeConformance(cs, rhs, proto);
+            return !cache.checkTransitiveSubtypeConformance(rhs, proto);
           });
       if (failed)
         return ConflictFlag::Conformance;

--- a/test/Sema/common_supertype_objc.swift
+++ b/test/Sema/common_supertype_objc.swift
@@ -54,3 +54,23 @@ func testTollFree7(x: CFBoolean, y: CFBoolean) -> Exactly<CFBoolean> {
   let result = test(x, y)
   return result
 }
+
+// This used to produce a bogus diagnostic.
+func testArrayLiteral(x: CFString, y: NSString) -> [NSString] {
+  let a = [y, x]
+  return a
+}
+
+// More silly test cases for toll-free bridging, since we don't have enough
+// of them in the test suite.
+
+extension NSString {
+  func noTollFreeBridgeDynamicSelf() -> Self {
+    let x: CFString = self  // expected-error {{cannot convert value of type 'Self' to specified type 'CFString'}}
+    return self
+  }
+}
+
+func noTollFreeBridgeArchetype<T: NSString>(_ t: T) -> CFString {
+  return t  // expected-error {{cannot convert return expression of type 'T' to return type 'CFString'}}
+}


### PR DESCRIPTION
The `ConstraintSystem` caches conformance lookups to reduce overhead when exploring disjunctions. For this reason, the Subtyping.cpp operations, which are used by disjunction and binding optimizations in the solver, would take a `ConstraintSystem &` so they could use this cache.

Since this was the only part of the constraint system that those operations actually looked at, split the conformance cache off into its own type, to allow these functions to be used elsewhere without a constraint system instance around.

The idea is that since most clients like IDE tooling are not doing millions of lookups in one shot, caching the lookups is irrelevant, so they can create and pass in an empty `ConformanceCache` when needed. Today they're spinning up a whole new `ConstraintSystem` and solving a constraint, so of course they're already paying the same cost anyway.