### PR TITLE
[Distributed] Don't crash on 'distributed func' outside a type context

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8333,8 +8333,16 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
     }
 
     // distributed func must be declared inside an distributed actor
+    // A 'distributed func' at file scope, or in any other non-type context,
+    // has no 'Self' type to inspect, so reject it before asking for one
+    if (!dc->isTypeContext()) {
+      diagnoseAndRemoveAttr(
+          attr, diag::distributed_actor_func_not_in_distributed_actor);
+      return;
+    }
+
     auto selfTy = dc->getSelfTypeInContext();
-    if (!selfTy->isDistributedActor()) {
+    if (!selfTy || !selfTy->isDistributedActor()) {
       auto diagnostic = diagnoseAndRemoveAttr(
         attr, diag::distributed_actor_func_not_in_distributed_actor);
 

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -262,3 +262,16 @@ extension Greeting where SerializationRequirement == Codable {
 func isolated_generic_ok<T: DistributedActor>(_ t: isolated T) {}
 
 func isolated_existential_ok(_ t: isolated any DistributedActor) {}
+
+// ==== -----------------------------------------------------------------------
+// MARK: 'distributed' declarations outside of any type context
+
+// A 'distributed func' at file scope has no enclosing type at all, so there is
+// no 'Self' to check against; make sure we diagnose rather than crash
+distributed func topLevelDistributedFunc() {}
+// expected-error@-1{{'distributed' method can only be declared within 'distributed actor'}}
+
+func enclosingFunc() {
+  distributed func nestedDistributedFunc() {}
+  // expected-error@-1{{'distributed' method can only be declared within 'distributed actor'}}
+}

--- a/validation-test/compiler_crashers_fixed/DeclContext-getSelfInterfaceType-760438.swift
+++ b/validation-test/compiler_crashers_fixed/DeclContext-getSelfInterfaceType-760438.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::DeclContext::getSelfInterfaceType() const","signatureAssert":"Assertion failed: (isTypeContext()), function getSelfInterfaceType","signatureNext":"DeclContext::getSelfTypeInContext"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 distributed func a


### PR DESCRIPTION
These cases ended up crashing as we need to have a concrete serialization requirement to diagnose methods. Now it issues an error about this and offers a fixit (rather than crashing).

Resolves rdar://186154396
