### PR TITLE
[Distributed] Don't crash when the DistributedActor protocol fails to resolve

### DIFF
--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -805,7 +805,16 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
 
   auto &C = nominal->getASTContext();
   auto loc = nominal->getLoc();
-  recordRequiredImportAccessLevelForDecl(C.getDistributedActorDecl(), nominal,
+
+  // Fail gracefully if theDistributed module is imported, but 'DistributedActor'
+  // protocol fails to resolve for some reason.
+  auto *distributedActorProto = C.getDistributedActorDecl();
+  if (!distributedActorProto) {
+    C.Diags.diagnose(loc, diag::broken_stdlib_type, "DistributedActor");
+    return;
+  }
+
+  recordRequiredImportAccessLevelForDecl(distributedActorProto, nominal,
                                          nominal->getEffectiveAccess(), loc);
 
   // ==== Constructors

--- a/validation-test/compiler_crashers/recordRequiredImportAccessLevelForDecl-2c8d3a.swift
+++ b/validation-test/compiler_crashers/recordRequiredImportAccessLevelForDecl-2c8d3a.swift
@@ -1,7 +1,0 @@
-// {"kind":"typecheck","noSDK":true,"signature":"swift::recordRequiredImportAccessLevelForDecl(swift::Decl const*, swift::DeclContext const*, swift::AccessLevel, std::__1::function<void (swift::AttributedImport<swift::ImportedModule>)>)","signatureNext":"TypeChecker::checkDistributedActor"}
-// RUN: %empty-directory(%t)
-// RUN: not --crash %target-swift-frontend -typecheck -sdk %t %s
-// REQUIRES: OS=macosx
-import Distributed
-distributed actor a {
-}

--- a/validation-test/compiler_crashers_fixed/recordRequiredImportAccessLevelForDecl-2c8d3a.swift
+++ b/validation-test/compiler_crashers_fixed/recordRequiredImportAccessLevelForDecl-2c8d3a.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck -sdk %t %s
+// REQUIRES: OS=macosx
+import Distributed
+distributed actor a {
+}


### PR DESCRIPTION
Fixes another of the compiler crashers.

Prevent a crash in case of an empty SDK for some reason, and diagnose the issue properly.