### PR TITLE
Adjust to some upstream llvm-project changes

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -225,8 +225,8 @@ getLibcFileMapping(const ASTContext &ctx, StringRef modulemapFileName,
       ctx.ClangImporterOpts, ctx.SearchPathOpts, clangDriver);
 
   llvm::opt::ArgStringList includeArgStrings;
-  const auto &clangToolchain =
-      clangDriver.getToolChain(clangDriverArgs, triple);
+  const auto &clangToolchain = clangDriver.getToolChain(
+      clangDriverArgs, llvm::Triple(triple.normalize()));
   clangToolchain.AddClangSystemIncludeArgs(clangDriverArgs, includeArgStrings);
   auto parsedIncludeArgs = parseClangDriverArgs(clangDriver, includeArgStrings);
 
@@ -305,8 +305,8 @@ static void getLibStdCxxFileMapping(
       ctx.ClangImporterOpts, ctx.SearchPathOpts, clangDriver);
 
   llvm::opt::ArgStringList stdlibArgStrings;
-  const auto &clangToolchain =
-      clangDriver.getToolChain(clangDriverArgs, triple);
+  const auto &clangToolchain = clangDriver.getToolChain(
+      clangDriverArgs, llvm::Triple(triple.normalize()));
   clangToolchain.AddClangCXXStdlibIncludeArgs(clangDriverArgs,
                                               stdlibArgStrings);
   auto parsedStdlibArgs = parseClangDriverArgs(clangDriver, stdlibArgStrings);
@@ -521,7 +521,8 @@ void GetWindowsFileMappings(
                                        Context.ClangImporterOpts, driverVFS);
   const llvm::opt::InputArgList Args = ClangImporter::createClangArgs(
       Context.ClangImporterOpts, Context.SearchPathOpts, Driver);
-  const clang::driver::ToolChain &ToolChain = Driver.getToolChain(Args, Triple);
+  const clang::driver::ToolChain &ToolChain =
+      Driver.getToolChain(Args, llvm::Triple(Triple.normalize()));
   llvm::vfs::FileSystem &VFS = ToolChain.getVFS();
 
   struct {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -413,8 +413,8 @@ void CompilerInvocation::computeCXXStdlibOptions() {
         ClangImporter::createClangDriver(LangOpts, ClangImporterOpts);
     auto clangDriverArgs = ClangImporter::createClangArgs(
         ClangImporterOpts, SearchPathOpts, clangDriver);
-    auto &clangToolchain =
-        clangDriver.getToolChain(clangDriverArgs, LangOpts.Target);
+    auto &clangToolchain = clangDriver.getToolChain(
+        clangDriverArgs, llvm::Triple(LangOpts.Target.normalize()));
     auto cxxStdlibKind = clangToolchain.GetCXXStdlibType(clangDriverArgs);
     auto cxxDefaultStdlibKind = clangToolchain.GetDefaultCXXStdlibType();
 

--- a/test/IRGen/inout_noalias.swift
+++ b/test/IRGen/inout_noalias.swift
@@ -6,7 +6,7 @@
 @_silgen_name("swapPointers")
 public func swapPointers<T>(_ lhs: inout UnsafePointer<T>, _ rhs: inout UnsafePointer<T>) {}
 
-// CHECK-OPT-LABEL: define{{.*}}swiftcc void @"$s13inout_noalias6rotateyys11InlineArrayVy$63_SdGz_AEzS2dtF"(ptr noalias captures(none) dereferenceable(512) %0, ptr noalias captures(none) dereferenceable(512) %1, double %2, double %3) {{.*}} {
+// CHECK-OPT-LABEL: define{{.*}}swiftcc void @"$s13inout_noalias6rotateyys11InlineArrayVy$63_SdGz_AEzS2dtF"(ptr noalias {{(nofree )?}}captures(none) dereferenceable(512) %0, ptr noalias {{(nofree )?}}captures(none) dereferenceable(512) %1, double %2, double %3) {{.*}} {
 // CHECK-OPT-NOT:     %found.conflict
 // CHECK-OPT-NOT:     scalar.ph
 // CHECK-OPT:         vector.body

--- a/test/IRGen/objc_globals.swift
+++ b/test/IRGen/objc_globals.swift
@@ -10,9 +10,11 @@ import Foundation
 @inline(never)
 func blackHole<T>(_ t: T) { }
 
-// CHECK-DAG: @"OBJC_CLASS_$_NSNumber" = external global %struct._class_t
+// The `@42` literal in `giveMeANumber` is emitted as a constant NSNumber
+// object rather than a `+[NSNumber numberWithInt:]` message send.
+// CHECK-DAG: @"OBJC_CLASS_$_NSConstantIntegerNumber" = external global %struct._class_t
+// CHECK-DAG: @_unnamed_nsconstantintegernumber_ = private constant %struct.__builtin_NSConstantIntegerNumber { ptr @"OBJC_CLASS_$_NSConstantIntegerNumber", ptr @{{.*}}, i64 42 }, section "__DATA,__objc_intobj,regular,no_dead_strip"
 // CHECK-DAG: @"OBJC_CLASS_$_NSString" = external global %struct._class_t
-// CHECK-DAG: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = internal global ptr @"OBJC_CLASS_$_NSNumber", section "__DATA,__objc_classrefs,regular,no_dead_strip"
 // CHECK-DAG: @"OBJC_CLASSLIST_REFERENCES_$_{{.*}}" = internal global ptr @"OBJC_CLASS_$_NSString", section "__DATA,__objc_classrefs,regular,no_dead_strip"
 
 public func testLiterals() {
@@ -34,9 +36,7 @@ public func fooLazy() {
 // CHECK:         ret
 
 // CHECK-LABEL: define internal ptr @giveMeANumber()
-// CHECK:         [[CLASS:%.*]] = load ptr, ptr
-// CHECK-DAG:         [[SELECTOR:%.*]] = load ptr, ptr @OBJC_SELECTOR_REFERENCES_.{{.*}}
-// CHECK:         call {{.*}} @objc_msgSend
+// CHECK:         call ptr @llvm.objc.retainAutoreleaseReturnValue(ptr @_unnamed_nsconstantintegernumber_)
 // CHECK:         ret
 
 // CHECK-LABEL: define internal ptr @giveMeAMetaclass()

--- a/test/IRGen/pre_specialize.swift
+++ b/test/IRGen/pre_specialize.swift
@@ -75,13 +75,13 @@
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingV9computedXxvg1B07AnotherB0C_Ts5"(ptr{{( returned)?}} %0)
 
 // specialized InternalThing.computedX.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr noalias swiftself captures(none) dereferenceable({{(4|8)}}) %1)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingV9computedXxvs1B07AnotherB0C_Ts5"(ptr %0, ptr noalias {{(nofree )?}}swiftself captures(none) dereferenceable({{(4|8)}}) %1)
 
 // specialized InternalThing.subscript.getter
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A13InternalThingVyxSicig1B07AnotherB0C_Ts5"([[INT:(i64|i32)]] %0, ptr{{( returned)?}} %1)
 
 // specialized InternalThing.subscript.setter
-// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr noalias swiftself captures(none) dereferenceable({{(4|8)}}) %2)
+// CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s1A13InternalThingVyxSicis1B07AnotherB0C_Ts5"(ptr %0, [[INT]] %1, ptr noalias {{(nofree )?}}swiftself captures(none) dereferenceable({{(4|8)}}) %2)
 
 // specialized InternalRef.compute()
 // CHECK-B-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc ptr @"$s1A11InternalRefC7computexyF1B12AnotherThingC_Ts5

--- a/test/Interop/C/bounds-safety/import-bounds-attributed-nullability-typedef.swift
+++ b/test/Interop/C/bounds-safety/import-bounds-attributed-nullability-typedef.swift
@@ -7,11 +7,10 @@
 // Regression test for nullability being dropped when a __counted_by/__sized_by/
 // __ended_by (clang BoundsAttributedType) is applied to a pointer whose nullability attribute is inside a typedef.
 //
-// In the default -fexperimental-bounds-safety-attributes mode clang rebuilds the
-// pointer to its canonical type when forming the BoundsAttributedType, discarding
-// the typedef sugar and with it the _Nonnull, so the pointer is imported as
-// optional. Under -fbounds-safety the nullability is carried on the pointer type
-// itself and is preserved. Tracked as https://github.com/swiftlang/llvm-project/issues/13277
+// Clang preserves the nullability in both modes, so these pointers are imported
+// as non-optional. The modes still differ in whether the typedef sugar itself
+// survives: in -fexperimental-bounds-safety-attributes mode a pointer without a
+// bounds attribute keeps its typedef, whereas -fbounds-safety desugars it.
 
 //--- Inputs/nullable-typedef.h
 #pragma once
@@ -22,16 +21,13 @@
 // CHECK: typealias nonnull_int_ptr_t = UnsafeMutablePointer<CInt>
 typedef int * _Nonnull nonnull_int_ptr_t;
 
-// FIXME: pointer parameters and return types should be nonnull in both modes
-// ATTR:   func cb(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>!
-// BOUNDS: func cb(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt>
+// CHECK: func cb(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt>
 nonnull_int_ptr_t __counted_by(len) cb(int len, nonnull_int_ptr_t __counted_by(len) p);
-// FIXME: ditto 
-// ATTR:   func sb(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) -> UnsafeMutablePointer<CInt>!
-// BOUNDS: func sb(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt>
+// CHECK: func sb(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt>
 nonnull_int_ptr_t __sized_by(len) sb(int len, nonnull_int_ptr_t __sized_by(len) p);
-// FIXME: ditto
-// ATTR:   func eb(_ p: UnsafeMutablePointer<CInt>!, _ end: nonnull_int_ptr_t) -> UnsafeMutablePointer<CInt>!
+// The `end` parameter carries no bounds attribute, so it keeps its typedef in
+// attribute-only mode.
+// ATTR:   func eb(_ p: UnsafeMutablePointer<CInt>, _ end: nonnull_int_ptr_t) -> UnsafeMutablePointer<CInt>
 // BOUNDS: func eb(_ p: UnsafeMutablePointer<CInt>, _ end: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt>
 nonnull_int_ptr_t __ended_by(end) eb(nonnull_int_ptr_t __ended_by(end) p, nonnull_int_ptr_t end);
 

--- a/test/Interop/C/swiftify-import/typedef-bounds-attr.swift
+++ b/test/Interop/C/swiftify-import/typedef-bounds-attr.swift
@@ -57,13 +57,11 @@ fooptr_t __sized_by(4) test_fooptr3(int len, fooptr_t __sized_by(len) p);
 // }}
 fooptr_t __single _Nonnull test_fooptr4(int len, fooptr_t __sized_by(len) p);
 
-// expected-expansion@+9:67{{
+// expected-expansion@+7:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func test_fooptr5(_ p: UnsafeRawBufferPointer) -> OpaquePointer {|}}
 //   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
-//   Diverges due to https://github.com/swiftlang/llvm-project/issues/13277
-//   expected-attr-remark@4{{macro content: |    return unsafe test_fooptr5(len, OpaquePointer(p.baseAddress))|}}
-//   expected-bounds-remark@4{{macro content: |    return unsafe test_fooptr5(len, OpaquePointer(p.baseAddress!))|}}
+//   expected-remark@4{{macro content: |    return unsafe test_fooptr5(len, OpaquePointer(p.baseAddress!))|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 layer2_t __single test_fooptr5(int len, layer2_t __sized_by(len) p);

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -111,7 +111,7 @@ struct SWIFT_NONESCAPABLE CaptureView {
     CaptureView() : view(nullptr) {}
     CaptureView(View p [[clang::lifetimebound]]) : view(p) {}
 
-    void captureView(View v [[clang::lifetime_capture_by(this)]]) {
+    void captureView(View v [[clang::lifetime_capture_by_this]]) {
         view = v;
     }
 

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -80,7 +80,7 @@ struct DependsOnSelf {
 inline struct SpanBox getStructSpanBox() { return {iarray, iarray, sarray, sarray}; }
 
 struct CaptureByReference {
-    void set(const std::vector<int>& x [[clang::lifetime_capture_by(this)]]) { 
+    void set(const std::vector<int>& x [[clang::lifetime_capture_by_this]]) {
         this->x = ConstSpanOfInt(x.data(), x.size());
     };
     ConstSpanOfInt x;


### PR DESCRIPTION
Targeting main to minimise the difference between `main` and `rebranch`.

Paired with https://github.com/swiftlang/llvm-project/pull/14052.