### PR TITLE
[Distributed] Don't crash on 'distributed var' outside a distributed actor

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6568,8 +6568,9 @@ ERROR(distributed_actor_func_static,none,
       "'distributed' method cannot be 'static'",
       ())
 ERROR(distributed_actor_func_not_in_distributed_actor,none,
-      "'distributed' method can only be declared within 'distributed actor'",
-      ())
+      "distributed %select{method|computed property}0 can only be declared "
+      "in 'DistributedActor' type",
+      (bool))
 ERROR(distributed_actor_user_defined_special_property,none,
       "property %0 cannot be defined explicitly, as it conflicts with "
       "distributed actor synthesized stored property",

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -465,6 +465,9 @@ Type swift::getAssociatedTypeOfDistributedSystemOfActor(
   auto sig = actorOrExtension->getGenericSignatureOfContext();
 
   auto *actorType = actorOrExtension->getSelfNominalTypeDecl();
+  if (!actorType)
+    return ErrorType::get(ctx);
+
   if (isa<ProtocolDecl>(actorType))
     return memberTy->getReducedType(sig);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8289,13 +8289,27 @@ void AttributeChecker::visitActorAttr(ActorAttr *attr) {
 void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
   auto dc = D->getDeclContext();
 
-  // distributed can be applied to actor definitions and their methods
+  // distributed can be applied to actor definitions and their funcs or vars
   if (auto varDecl = dyn_cast<VarDecl>(D)) {
     if (varDecl->isDistributed()) {
+      // distributed var must be declared inside a distributed actor
+      auto selfTy = dc->isTypeContext() ? dc->getSelfTypeInContext() : Type();
+      if (!selfTy || !selfTy->isDistributedActor()) {
+        auto diagnostic = diagnoseAndRemoveAttr(
+            attr, diag::distributed_actor_func_not_in_distributed_actor,
+            /*isComputedProperty=*/true);
+
+        if (auto *protoDecl = dc->getSelfProtocolDecl()) {
+          diagnoseDistributedFunctionInNonDistributedActorProtocol(protoDecl,
+                                                                   diagnostic);
+        }
+        return;
+      }
+
       if (checkDistributedActorProperty(varDecl, /*diagnose=*/true))
         return;
     } else {
-      // distributed can not be applied to stored properties
+      // distributed can not be applied to local properties
       diagnoseAndRemoveAttr(attr, diag::distributed_actor_property);
       return;
     }
@@ -8310,9 +8324,10 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
       // good: `distributed actor`
       return;
     }
-  } else if (dyn_cast<StructDecl>(D) || dyn_cast<EnumDecl>(D)) {
+  } else if (isa<StructDecl>(D) || isa<EnumDecl>(D)) {
     diagnoseAndRemoveAttr(
-        attr, diag::distributed_actor_func_not_in_distributed_actor);
+        attr, diag::distributed_actor_func_not_in_distributed_actor,
+        /*isComputedProperty=*/false);
     return;
   }
 
@@ -8337,14 +8352,16 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
     // has no 'Self' type to inspect, so reject it before asking for one
     if (!dc->isTypeContext()) {
       diagnoseAndRemoveAttr(
-          attr, diag::distributed_actor_func_not_in_distributed_actor);
+          attr, diag::distributed_actor_func_not_in_distributed_actor,
+          /*isComputedProperty=*/false);
       return;
     }
 
     auto selfTy = dc->getSelfTypeInContext();
     if (!selfTy || !selfTy->isDistributedActor()) {
       auto diagnostic = diagnoseAndRemoveAttr(
-        attr, diag::distributed_actor_func_not_in_distributed_actor);
+        attr, diag::distributed_actor_func_not_in_distributed_actor,
+        /*isComputedProperty=*/false);
 
       if (auto *protoDecl = dc->getSelfProtocolDecl()) {
         diagnoseDistributedFunctionInNonDistributedActorProtocol(protoDecl,

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -26,19 +26,19 @@ distributed enum SomeDistributedActor_3 { } // expected-error{{'distributed' mod
 // NOTE: not distributed actor, so cannot have any distributed functions
 
 struct SomeNotActorStruct_2 {
-  distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
+  distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{distributed method can only be declared in 'DistributedActor' type}}
 }
 
 class SomeNotActorClass_3 {
-  distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
+  distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{distributed method can only be declared in 'DistributedActor' type}}
 }
 
 actor SomeNotDistributedActor_4 {
-  distributed func notInDistActorAsyncThrowing() async throws -> Int { 42 } // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
+  distributed func notInDistActorAsyncThrowing() async throws -> Int { 42 } // expected-error{{distributed method can only be declared in 'DistributedActor' type}}
 }
 
 protocol DP {
-  distributed func hello()  // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
+  distributed func hello()  // expected-error{{distributed method can only be declared in 'DistributedActor' type}}
 }
 
 protocol DPOK: DistributedActor {
@@ -50,7 +50,7 @@ protocol DPOK2: DPOK {
 }
 
 enum SomeNotActorEnum_5 {
-  distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
+  distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{distributed method can only be declared in 'DistributedActor' type}}
 }
 
 distributed actor SomeDistributedActor_6 {

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -20,7 +20,11 @@ actor LocalActor_1 {
   var mutable: String = ""
 
   distributed func nope() {
-    // expected-error@-1{{'distributed' method can only be declared within 'distributed actor'}}
+    // expected-error@-1{{distributed method can only be declared in 'DistributedActor' type}}
+  }
+
+  distributed var nein: Int {
+    12 // expected-error@-1{{distributed computed property can only be declared in 'DistributedActor' type}}
   }
 }
 
@@ -266,12 +270,20 @@ func isolated_existential_ok(_ t: isolated any DistributedActor) {}
 // ==== -----------------------------------------------------------------------
 // MARK: 'distributed' declarations outside of any type context
 
-// A 'distributed func' at file scope has no enclosing type at all, so there is
-// no 'Self' to check against; make sure we diagnose rather than crash
+// A 'distributed func' or 'distributed var' at file scope has no enclosing
+// type at all, so there is no 'Self' to check against; make sure we diagnose
+// rather than crash
 distributed func topLevelDistributedFunc() {}
-// expected-error@-1{{'distributed' method can only be declared within 'distributed actor'}}
+// expected-error@-1{{distributed method can only be declared in 'DistributedActor' type}}
+
+distributed var topLevelDistributedVar: Int { 0 }
+// expected-error@-1{{distributed computed property can only be declared in 'DistributedActor' type}}
 
 func enclosingFunc() {
   distributed func nestedDistributedFunc() {}
-  // expected-error@-1{{'distributed' method can only be declared within 'distributed actor'}}
+  // expected-error@-1{{distributed method can only be declared in 'DistributedActor' type}}
+
+  distributed var nestedDistributedVar: Int { 0 }
+  // expected-error@-1{{distributed computed property can only be declared in 'DistributedActor' type}}
+  _ = nestedDistributedVar
 }

--- a/test/Distributed/distributed_actor_missing_distributed_import.swift
+++ b/test/Distributed/distributed_actor_missing_distributed_import.swift
@@ -13,12 +13,12 @@ distributed actor class DAC {}
 
 actor A {
   func normal() async {}
-  distributed func dist() {} // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
-  distributed func distAsync() async {} // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
+  distributed func dist() {} // expected-error{{distributed method can only be declared in 'DistributedActor' type}}
+  distributed func distAsync() async {} // expected-error{{distributed method can only be declared in 'DistributedActor' type}}
 }
 
 actor B {
-  distributed var neverOk: String { // expected-error{{distributed property 'neverOk' declared without importing module 'Distributed'}}
+  distributed var neverOk: String { // expected-error{{distributed computed property can only be declared in 'DistributedActor' type}}
     ""
   }
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -14,7 +14,7 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 // MARK: Distributed actor protocols
 
 protocol WrongDistFuncs {
-    distributed func notDistActor() // expected-error{{'distributed' method can only be declared within 'distributed actor'}}{{5-17=}} {{-1:25-25=: DistributedActor}}
+    distributed func notDistActor() // expected-error{{distributed method can only be declared in 'DistributedActor' type}}{{5-17=}} {{-1:25-25=: DistributedActor}}
 }
 
 protocol DistProtocol: DistributedActor {
@@ -272,7 +272,7 @@ extension DistributedTacoMaker {
 
 extension TacoPreparation {
   distributed func makeSalsa() -> Salsa {}
-  // expected-error@-1{{'distributed' method can only be declared within 'distributed actor'}}
+  // expected-error@-1{{distributed method can only be declared in 'DistributedActor' type}}
 }
 
 distributed actor TacoWorker: DistributedTacoMaker {} // implemented in extensions

--- a/validation-test/compiler_crashers/getAssociatedTypeOfDistributedSystemOfActor-cec596.swift
+++ b/validation-test/compiler_crashers/getAssociatedTypeOfDistributedSystemOfActor-cec596.swift
@@ -1,4 +1,0 @@
-// {"kind":"typecheck","signature":"swift::getAssociatedTypeOfDistributedSystemOfActor(swift::DeclContext*, swift::Identifier)","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"getDistributedActorSerializationType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-import Distributed distributed var a{{

--- a/validation-test/compiler_crashers_fixed/getAssociatedTypeOfDistributedSystemOfActor-cec596.swift
+++ b/validation-test/compiler_crashers_fixed/getAssociatedTypeOfDistributedSystemOfActor-cec596.swift
@@ -1,0 +1,3 @@
+// RUN: not %target-swift-frontend -typecheck %s
+// REQUIRES: OS=macosx
+import Distributed distributed var a{{


### PR DESCRIPTION
Going through more of the compiler crashers...

A 'distributed var' outside a distributed actor asked for the enclosing type's ActorSystem and crashed dereferencing a null nominal when there was no such type. Reject it up front instead, and cleanup some of the diagnostics wording while at it.