### PR TITLE
[Distributed] Don't crash reading ActorSystem off an invalid conformance

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -203,6 +203,10 @@ Type swift::getDistributedActorSystemType(NominalTypeDecl *actor) {
   // Dig out the actor system type.
   Type selfType = actor->getSelfInterfaceType();
   auto conformance = lookupConformance(selfType, DA);
+
+  if (!conformance || conformance.isInvalid())
+    return ErrorType::get(C);
+
   return conformance.getTypeWitnessByName(C.Id_ActorSystem);
 }
 

--- a/validation-test/compiler_crashers/getDistributedActorSystemType-9fbe2e.swift
+++ b/validation-test/compiler_crashers/getDistributedActorSystemType-9fbe2e.swift
@@ -1,8 +1,0 @@
-// {"kind":"typecheck","original":"4ddade84","signature":"swift::getDistributedActorSystemType(swift::NominalTypeDecl*)","signatureAssert":"Assertion failed: (!isInvalid()), function getTypeWitnessByName","signatureNext":"TypeChecker::checkDistributedActor"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-import Distributed
-@attached(extension conformances: DistributedActor) macro a()
-@a distributed actor b {
-  distributed init()
-}

--- a/validation-test/compiler_crashers/getDistributedActorSystemType-c0196c.swift
+++ b/validation-test/compiler_crashers/getDistributedActorSystemType-c0196c.swift
@@ -1,7 +1,0 @@
-// {"kind":"typecheck","original":"4d88b138","signature":"swift::getDistributedActorSystemType(swift::NominalTypeDecl*)","signatureAssert":"Assertion failed: (!isInvalid()), function getTypeWitnessByName","signatureNext":"createImplicitConstructor"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-import Distributed
-@attached(extension conformances: DistributedActor) macro a()
-@a distributed actor b {
-}

--- a/validation-test/compiler_crashers_fixed/getDistributedActorSystemType-9fbe2e.swift
+++ b/validation-test/compiler_crashers_fixed/getDistributedActorSystemType-9fbe2e.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-swift-frontend -typecheck %s
+// REQUIRES: OS=macosx
+import Distributed
+@attached(extension conformances: DistributedActor) macro a()
+@a distributed actor b {
+  distributed init()
+}

--- a/validation-test/compiler_crashers_fixed/getDistributedActorSystemType-c0196c.swift
+++ b/validation-test/compiler_crashers_fixed/getDistributedActorSystemType-c0196c.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend -typecheck %s
+// REQUIRES: OS=macosx
+import Distributed
+@attached(extension conformances: DistributedActor) macro a()
+@a distributed actor b {
+}


### PR DESCRIPTION
Fixing more compiler crashers...

Two crashers hit this through different callers, one via default initializer synthesis and one via checkDistributedActor.
