### PR TITLE
AST: Make `@_weakLinked import` respect underlying clang modules and `export_as`

### DIFF
--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Assertions.h"
+#include "clang/Basic/Module.h"
 
 using namespace swift;
 using namespace namelookup;
@@ -403,6 +404,85 @@ ArrayRef<ModuleDecl *> ImportCache::allocateArray(
     return ctx.AllocateCopy(results.getArrayRef());
 }
 
+/// Returns true if \p module wraps a Clang submodule of the Clang module that
+/// \p other is, or is an overlay of.
+static bool isClangSubmoduleOf(const ModuleDecl *module,
+                               const ModuleDecl *other) {
+  auto *clangModule = module->findUnderlyingClangModule();
+  if (!clangModule || !clangModule->isSubModule())
+    return false;
+
+  auto *otherClangModule = other->findUnderlyingClangModule();
+  if (!otherClangModule)
+    return false;
+
+  return clangModule->getTopLevelModule() ==
+         otherClangModule->getTopLevelModule();
+}
+
+/// Returns true if \p module declares that clients should see it as part of the
+/// module named \p name, by way of the Clang `export_as` declaration.
+static bool isExportedAs(const ModuleDecl *module, StringRef name) {
+  if (module->getExportAsName().str() == name)
+    return true;
+
+  // `export_as` is declared on a top-level Clang module, but a re-export can
+  // name one of its submodules.
+  if (auto *clangModule = module->findUnderlyingClangModule())
+    return clangModule->getTopLevelModule()->ExportAsModule == name;
+
+  return false;
+}
+
+/// Adds \p module to \p result, along with the Clang module that \p module is
+/// an overlay of, if there is one.
+static void
+addModuleAndUnderlyingClangModule(ModuleDecl *module,
+                                  llvm::SetVector<ModuleDecl *> &result) {
+  result.insert(module);
+  if (auto *underlyingModule = module->getUnderlyingModuleIfOverlay())
+    result.insert(underlyingModule);
+}
+
+/// Adds every module that makes up \p module to \p result: \p module itself,
+/// the Clang module that it overlays, and the modules that declare themselves
+/// to be part of it with `export_as`.
+static void addWeakImportModule(ModuleDecl *module,
+                                llvm::SetVector<ModuleDecl *> &result) {
+  addModuleAndUnderlyingClangModule(module, result);
+
+  auto name = module->getRealName().str();
+
+  auto *underlyingModule = module->getUnderlyingModuleIfOverlay();
+  if (!underlyingModule && module->isNonSwiftModule())
+    underlyingModule = module;
+
+  if (!underlyingModule)
+    return;
+
+  // A Clang submodule is part of the module that contains it, so walk the
+  // submodules to reach the modules that they re-export.
+  llvm::SetVector<ModuleDecl *> clangModules;
+  clangModules.insert(underlyingModule);
+
+  for (unsigned i = 0; i < clangModules.size(); ++i) {
+    auto *clangModule = clangModules[i];
+
+    SmallVector<ImportedModule, 4> reexportedModules;
+    clangModule->getImportedModules(reexportedModules,
+                                    ModuleDecl::ImportFilterKind::Exported);
+
+    for (auto reexported : reexportedModules) {
+      auto *reexportedModule = reexported.importedModule;
+
+      if (isClangSubmoduleOf(reexportedModule, clangModule))
+        clangModules.insert(reexportedModule);
+      else if (isExportedAs(reexportedModule, name))
+        addModuleAndUnderlyingClangModule(reexportedModule, result);
+    }
+  }
+}
+
 ArrayRef<ModuleDecl *>
 ImportCache::getWeakImports(const ModuleDecl *mod) {
   auto found = WeakCache.find(mod);
@@ -426,7 +506,7 @@ ImportCache::getWeakImports(const ModuleDecl *mod) {
         continue;
 
       ModuleDecl *importedModule = import.module.importedModule;
-      result.insert(importedModule);
+      addWeakImportModule(importedModule, result);
 
       // Only explicit re-exports of a weak-linked module are themselves
       // weak-linked.
@@ -440,7 +520,7 @@ ImportCache::getWeakImports(const ModuleDecl *mod) {
       importedModule->getImportedModules(
           reexportedModules, ModuleDecl::ImportFilterKind::Exported);
       for (auto reexportedModule : reexportedModules) {
-        result.insert(reexportedModule.importedModule);
+        addWeakImportModule(reexportedModule.importedModule, result);
       }
     }
   }

--- a/test/IRGen/weaklinked_import_overlay.swift
+++ b/test/IRGen/weaklinked_import_overlay.swift
@@ -1,0 +1,101 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+//
+// Build the Swift overlay for the Clang module 'Wrapper'.
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Wrapper.swiftmodule -module-name Wrapper -parse-as-library %t/Wrapper.swift -I %t/include -enable-library-evolution
+//
+// Build an intermediate module that re-exports the overlay.
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Intermediate.swiftmodule -module-name Intermediate -parse-as-library %t/Intermediate.swift -I %t -I %t/include -enable-library-evolution
+//
+// RUN: %target-swift-frontend -primary-file %t/DirectClient.swift -I %t -I %t/include -emit-ir | %FileCheck %s --check-prefix=DIRECT
+// RUN: %target-swift-frontend -primary-file %t/TransitiveClient.swift -I %t -I %t/include -emit-ir | %FileCheck %s --check-prefix=TRANSITIVE
+
+// UNSUPPORTED: OS=windows-msvc
+
+//--- include/module.modulemap
+
+module Wrapper {
+  header "Wrapper.h"
+  export *
+
+  module WrapperCore {
+    header "WrapperCore.h"
+    export *
+  }
+}
+
+module Core {
+  header "Core.h"
+  export *
+  export_as Wrapper
+}
+
+module Unrelated {
+  header "Unrelated.h"
+  export *
+}
+
+//--- include/Wrapper.h
+
+#include "WrapperCore.h"
+
+extern void wrapper_fn(void);
+
+//--- include/WrapperCore.h
+
+#include "Core.h"
+#include "Unrelated.h"
+
+//--- include/Core.h
+
+extern void core_fn(void);
+
+//--- include/Unrelated.h
+
+extern void unrelated_fn(void);
+
+//--- Wrapper.swift
+
+@_exported import Wrapper
+
+public func overlay_fn() { }
+
+//--- Intermediate.swift
+
+@_exported import Wrapper
+
+//--- DirectClient.swift
+
+@_weakLinked import Wrapper
+
+func testDirect() {
+  // DIRECT: declare extern_weak swiftcc void @"$s7Wrapper10overlay_fnyyF"()
+  overlay_fn()
+
+  // DIRECT: declare extern_weak void @wrapper_fn()
+  wrapper_fn()
+
+  // DIRECT: declare extern_weak void @core_fn()
+  core_fn()
+
+  // DIRECT: declare void @unrelated_fn()
+  unrelated_fn()
+}
+
+//--- TransitiveClient.swift
+
+@_weakLinked import Intermediate
+
+func testTransitive() {
+  // TRANSITIVE: declare extern_weak swiftcc void @"$s7Wrapper10overlay_fnyyF"()
+  overlay_fn()
+
+  // TRANSITIVE: declare extern_weak void @wrapper_fn()
+  wrapper_fn()
+
+  // TRANSITIVE: declare extern_weak void @core_fn()
+  core_fn()
+
+  // TRANSITIVE: declare void @unrelated_fn()
+  unrelated_fn()
+}

--- a/test/IRGen/weaklinked_import_peer_transitive_objc.swift
+++ b/test/IRGen/weaklinked_import_peer_transitive_objc.swift
@@ -13,8 +13,8 @@ import Foundation
 
 // ThisModule -weak imports-> intermediate_foundation -imports-> Foundation
 // Because Foundation is _not_ re-exported, make sure any symbols from it are strongly referenced.
-// CAUTION: Suppose you _want_ Foundation to be weak-linked. It's not enough to just `@_exported import Foundation`
-//          in the intermediate_foundation module. That only gets you the Swift half of the Foundation overlay.
+// If you _want_ Foundation to be weak-linked, write `@_exported import Foundation` in the
+// intermediate_foundation module. That covers both halves of the Foundation overlay.
 
 // CHECK-DAG: @"OBJC_CLASS_$_NSNotification" = external global %objc_class
 _ = NSNotification()

--- a/validation-test/IRGen/weaklinked_import_appkit.swift
+++ b/validation-test/IRGen/weaklinked_import_appkit.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+@_weakLinked import AppKit
+import Foundation
+
+public func test() {
+  // CHECK-DAG: @"OBJC_CLASS_$_NSView" = extern_weak global %objc_class
+  _ = NSView()
+
+  // CHECK-DAG: @"OBJC_CLASS_$_NSTextContainer" = extern_weak global %objc_class
+  _ = NSTextContainer()
+
+  // CHECK-DAG: declare extern_weak ptr @CGColorSpaceCreateDeviceRGB()
+  _ = CGColorSpaceCreateDeviceRGB()
+
+  // CHECK-DAG: @"OBJC_CLASS_$_NSNotification" = external global %objc_class
+  _ = NSNotification(name: .init(""), object: nil)
+}

--- a/validation-test/IRGen/weaklinked_import_uikit.swift
+++ b/validation-test/IRGen/weaklinked_import_uikit.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// REQUIRES: OS=ios
+
+@_weakLinked import UIKit
+import Foundation
+
+public func test() {
+  // CHECK-DAG: @"OBJC_CLASS_$_UIPasteboard" = extern_weak global %objc_class
+  _ = UIPasteboard.general
+
+  // CHECK-DAG: @"OBJC_CLASS_$_UIView" = extern_weak global %objc_class
+  _ = UIView()
+
+  // CHECK-DAG: @"OBJC_CLASS_$_NSNotification" = external global %objc_class
+  _ = NSNotification(name: .init(""), object: nil)
+}


### PR DESCRIPTION
`@_weakLinked import Foo` should cause symbols from all of the modules that can be considered part of `Foo` to be weakly linked. Previously, the compiler would only adjust the linkage for Foo and any module that Foo's Swift module re-exported. This failed to account for two categories of modules which should also get weakly linked:

- The underlying Clang modules of Swift modules that are re-exported by Foo.
- Any re-exported module in the graph with an `export_as` that matches another weakly-linked module in the graph.

The module graph traversal algorithm also needed to be updated to account for Clang submodules, which might be the source of re-exports that need to become weakly imported.

Update `ImportCache::getWeakImports()` to compute the set of weak imports correctly for these more complex import graphs.

Resolves rdar://176099495.
