### PR TITLE
CopySinking: sink copies of a phi over that phi

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopySinking.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopySinking.swift
@@ -37,7 +37,30 @@ import SIL
 ///     // uses of %4
 /// ```
 ///
-/// 2. Sinks copies over terminator instructions (switch_enum, checked_cast_br):
+/// 2. Sinks copies of a phi over that phi:
+///
+/// ```
+///   bb1:
+///     %1 = copy_value %0
+///     br bb3(%0, %1)
+///   bb2:
+///     %3 = copy_value %2
+///     br bb3(%2, %3)
+///   bb3(%4 : @owned, %5 : @owned):
+///     // uses of %5
+/// ```
+/// ->
+/// ```
+///   bb1:
+///     br bb3(%0)
+///   bb2:
+///     br bb3(%2)
+///   bb3(%4 : @owned):
+///     %6 = copy_value %4
+///     // uses of %6
+/// ```
+///
+/// 3. Sinks copies over terminator instructions (switch_enum, checked_cast_br):
 ///
 /// ```
 ///   %1 = copy_value %0
@@ -58,7 +81,7 @@ import SIL
 ///     // uses of %5
 /// ```
 ///
-/// 3. Also handles `load [copy]` which is replaced by `load_borrow`:
+/// 4. Also handles `load [copy]` which is replaced by `load_borrow`:
 ///
 /// ```
 ///   %1 = load [copy] %addr
@@ -84,7 +107,9 @@ import SIL
 ///
 /// The optimization can be done if:
 /// * The `copy_value` or `load [copy]` has a single use.
-/// * The source operand has guaranteed ownership.
+/// * The source operand has guaranteed ownership. In case 2 the source is a phi of the same block
+///   which the copies are copies of - it can have any ownership, because the new copy is inserted
+///   at the begin of the block where that phi is definitely available.
 /// * The borrow scope can be extended or is already valid across the control flow.
 /// * For loads: no writes to the loaded address occur before the terminator.
 ///
@@ -108,9 +133,12 @@ let copySinking = FunctionPass(name: "copy-sinking") {
     if !context.continueWithNextSubpassRun(for: block.terminator) {
       return
     }
-    for arg in block.arguments {
+
+    for arg in block.arguments.reversed() {
       if let phi = Phi(arg) {
         if trySinkCopiesOverPhi(phi: phi, context) {
+          changed = true
+        } else if trySinkCopiesOfPhiOverPhi(phi: phi, context) {
           changed = true
         }
       }
@@ -158,6 +186,55 @@ private func trySinkCopiesOverPhi(phi: Phi, _ context: FunctionPassContext) -> B
   phi.value.uses.ignore(user: newCopy).replaceAll(with: newCopy, context)
 
   return true
+}
+
+private func trySinkCopiesOfPhiOverPhi(phi: Phi, _ context: FunctionPassContext) -> Bool {
+  let block = phi.value.parentBlock
+  var copiedFrom: Phi? = nil
+
+  for incomingOp in phi.incomingOperands {
+    guard let copy = incomingOp.value as? CopyValueInst,
+          copy.uses.isSingleUse,
+          let fromPhi = copy.fromValue.passedToPhi(via: incomingOp.instruction as! BranchInst)
+    else {
+      return false
+    }
+    if let copiedFrom {
+      if fromPhi.value != copiedFrom.value {
+        return false
+      }
+    } else {
+      copiedFrom = fromPhi
+    }
+  }
+  guard let copiedFrom else {
+    return false
+  }
+
+  // Create a single copy of the copied-from phi in the phi's block and replace the phi with it.
+  let newCopy: Value
+  if let borrowedFrom = copiedFrom.borrowedFrom {
+    newCopy = Builder(after: borrowedFrom, context).createCopyValue(operand: borrowedFrom)
+  } else {
+    newCopy = Builder(atBeginOf: block, context).createCopyValue(operand: copiedFrom.value)
+  }
+  phi.value.uses.replaceAll(with: newCopy, context)
+
+  // Remove the phi operand from all predecessor branches and erase the now-dead incoming copies.
+  erasePhiArgument(phi: phi, erasingIncomingInstructions: true, context)
+
+  return true
+}
+
+private extension Value {
+  func passedToPhi(via branch: BranchInst) -> Phi? {
+    for use in uses {
+      if use.instruction == branch {
+        return branch.getPhi(for: use)
+      }
+    }
+    return nil
+  }
 }
 
 private func trySinkCopiesOver(terminator: ForwardingInstruction & UnaryInstruction & TermInst,

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestroyValue.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyDestroyValue.swift
@@ -73,17 +73,13 @@ extension DestroyValueInst : OnoneSimplifiable, SILCombineSimplifiable {
     }
 
     for incomingOp in phi.incomingOperands {
-      let oldBranch = incomingOp.instruction as! BranchInst
-      let builder = Builder(before: oldBranch, context)
-      builder.createDestroyValue(operand: incomingOp.value)
-      builder.createBranch(to: phiBlock, arguments: oldBranch.arguments(excluding: incomingOp))
-      context.erase(instruction: oldBranch)
+      Builder(before: incomingOp.instruction, context).createDestroyValue(operand: incomingOp.value)
     }
 
     // Users of `phi` include `debug_value` instructions and this `destroy_value`
     context.erase(instructions: phi.value.users)
 
-    phiBlock.eraseArgument(at: phi.value.index, context)
+    erasePhiArgument(phi: phi, context)
   }
 }
 
@@ -202,10 +198,4 @@ private func isDeinitBarrierInBlock(before instruction: Instruction, _ context: 
   return ReverseInstructionList(first: instruction.previous).contains(where: {
     $0.isDeinitBarrier(context.calleeAnalysis)
   })
-}
-
-private extension BranchInst {
-  func arguments(excluding excludeOp: Operand) -> [Value] {
-    return Array(operands.filter{ $0 != excludeOp }.values)
-  }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPhiArgument.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPhiArgument.swift
@@ -70,15 +70,7 @@ extension Phi {
 
     // Remove the phi operand from all predecessor branches and erase the now-dead incoming
     // `begin_borrow`s.
-    for incomingOp in incomingOperands {
-      let beginBorrow = incomingOp.value as! BeginBorrowInst
-      let existingBranch = incomingOp.instruction as! BranchInst
-      let argsWithRemovedPhiOp = existingBranch.operands.filter{ $0 != incomingOp }.map{ $0.value }
-      Builder(before: existingBranch, context).createBranch(to: block, arguments: argsWithRemovedPhiOp)
-      context.erase(instruction: existingBranch)
-      context.erase(instruction: beginBorrow)
-    }
-    block.eraseArgument(at: value.index, context)
+    erasePhiArgument(phi: self, erasingIncomingInstructions: true, context)
     return true
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -2321,6 +2321,10 @@ final public class BranchInst : TermInst {
   public func getArgument(for operand: Operand) -> Argument {
     return targetBlock.arguments[operand.index]
   }
+
+  public func getPhi(for operand: Operand) -> Phi {
+    return Phi(getArgument(for: operand))!
+  }
 }
 
 final public class CondBranchInst : TermInst {

--- a/SwiftCompilerSources/Sources/SIL/Utilities/PhiUpdater.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/PhiUpdater.swift
@@ -176,15 +176,55 @@ public func replacePhiWithIncomingValue(phi: Phi, _ context: some MutatingContex
     phi.value.uses.replaceAll(with: uniqueIncomingValue, context)
   }
 
+  erasePhiArgument(phi: phi, context)
+  return true
+}
+
+/// Removes the `phi` argument from its block and from the branches of all predecessors:
+///
+/// ```
+///   bb1:
+///     br bb3(%1, %2)
+///   bb2:
+///     br bb3(%3, %4)
+///   bb3(%5 : $T, %6 : $T):   // Predecessors: bb1, bb2
+/// ```
+/// ->
+/// ```
+///   bb1:
+///     br bb3(%1)
+///   bb2:
+///     br bb3(%3)
+///   bb3(%5 : $T):
+/// ```
+///
+/// The phi must not have any uses.
+/// If `erasingIncomingInstructions` is true, the instructions which define the incoming values
+/// are erased, too. Those instructions must not have any uses beside the branch operands.
+///
+public func erasePhiArgument(phi: Phi, erasingIncomingInstructions: Bool = false,
+                             _ context: some MutatingContext) {
   let block = phi.value.parentBlock
   for incomingOp in phi.incomingOperands {
+    let incomingInst = erasingIncomingInstructions ? incomingOp.value.definingInstruction : nil
     let existingBranch = incomingOp.instruction as! BranchInst
-    let argsWithRemovedPhiOp = existingBranch.operands.filter{ $0 != incomingOp }.map{ $0.value }
-    Builder(before: existingBranch, context).createBranch(to: block, arguments: argsWithRemovedPhiOp)
+    Builder(before: existingBranch, context).createBranch(to: block,
+                                                          arguments: existingBranch.arguments(excluding: incomingOp))
     context.erase(instruction: existingBranch)
+    if let incomingInst {
+      context.erase(instruction: incomingInst)
+    }
   }
   block.eraseArgument(at: phi.value.index, context)
-  return true
+}
+
+private extension BranchInst {
+  /// Returns the branch arguments without the argument for `excludedOperand`.
+  ///
+  /// Used to re-create the branch when a phi argument of the target block is removed.
+  func arguments(excluding excludedOperand: Operand) -> [Value] {
+    return Array(operands.filter{ $0 != excludedOperand }.values)
+  }
 }
 
 private func getUniqueIncomingValue(of phi: Phi, _ context: some MutatingContext) -> Value? {

--- a/test/SILOptimizer/copy-sinking.sil
+++ b/test/SILOptimizer/copy-sinking.sil
@@ -85,6 +85,175 @@ bb3(%6 : @owned $C):
   return %6
 }
 
+// CHECK-LABEL: sil [ossa] @sink_copies_of_owned_phi :
+// CHECK:       bb1:
+// CHECK-NEXT:    destroy_value %1
+// CHECK-NEXT:    br bb3(%0)
+// CHECK:       bb2:
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    br bb3(%1)
+// CHECK:       bb3([[P:%.*]] : @owned $C):
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[P]]
+// CHECK-NEXT:    destroy_value [[P]]
+// CHECK-NEXT:    return [[C]]
+// CHECK:       } // end sil function 'sink_copies_of_owned_phi'
+sil [ossa] @sink_copies_of_owned_phi : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%0 : @owned $C, %1 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1
+  %3 = copy_value %0
+  br bb3(%0, %3)
+
+bb2:
+  destroy_value %0
+  %6 = copy_value %1
+  br bb3(%1, %6)
+
+bb3(%8 : @owned $C, %9 : @owned $C):
+  destroy_value %8
+  return %9
+}
+
+// The copied-from values are guaranteed, therefore the copies are already sunk by
+// `trySinkCopiesOverPhi` and the phi becomes guaranteed.
+//
+// CHECK-LABEL: sil [ossa] @sink_copies_of_guaranteed_phi :
+// CHECK:       bb1:
+// CHECK-NEXT:    br bb3(%0, %0)
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb3(%1, %1)
+// CHECK:       bb3({{%.*}} : @guaranteed $C, [[P:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    [[BF:%.*]] = borrowed [[P]] from (%1, %0)
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[BF]]
+// CHECK:         return [[C]]
+// CHECK:       } // end sil function 'sink_copies_of_guaranteed_phi'
+sil [ossa] @sink_copies_of_guaranteed_phi : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = copy_value %0
+  br bb3(%0, %2)
+
+bb2:
+  %4 = copy_value %1
+  br bb3(%1, %4)
+
+bb3(%6 : @guaranteed $C, %7 : @owned $C):
+  %8 = borrowed %6 from ()
+  fix_lifetime %8
+  return %7
+}
+
+// Same as above, but the copied-from phi is a re-borrow. The sunk copy must be inserted
+// after the `borrowed` instruction of the new guaranteed phi.
+//
+// CHECK-LABEL: sil [ossa] @sink_copies_of_reborrow_phi :
+// CHECK:       bb1:
+// CHECK-NEXT:    [[B1:%.*]] = begin_borrow %0
+// CHECK-NEXT:    br bb3([[B1]], [[B1]])
+// CHECK:       bb2:
+// CHECK-NEXT:    [[B2:%.*]] = begin_borrow %0
+// CHECK-NEXT:    br bb3([[B2]], [[B2]])
+// CHECK:       bb3([[RB:%.*]] : @reborrow $C, [[P:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    [[BF:%.*]] = borrowed [[P]] from ([[RB]])
+// CHECK-NEXT:    [[BFRB:%.*]] = borrowed [[RB]] from (%0)
+// CHECK-NEXT:    [[C:%.*]] = copy_value [[BF]]
+// CHECK-NEXT:    end_borrow [[BFRB]]
+// CHECK:         return [[C]]
+// CHECK:       } // end sil function 'sink_copies_of_reborrow_phi'
+sil [ossa] @sink_copies_of_reborrow_phi : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = begin_borrow %0
+  %3 = copy_value %2
+  br bb3(%2, %3)
+
+bb2:
+  %5 = begin_borrow %0
+  %6 = copy_value %5
+  br bb3(%5, %6)
+
+bb3(%8 : @reborrow $C, %9 : @owned $C):
+  %10 = borrowed %8 from (%0)
+  end_borrow %10
+  destroy_value %0
+  return %9
+}
+
+// In bb2 the copy is not a copy of the value which is passed to the other phi on _that_ edge.
+//
+// CHECK-LABEL: sil [ossa] @dont_sink_copies_of_phi_wrong_source :
+// CHECK:       bb3({{%.*}} : @owned $C, {{%.*}} : @owned $C):
+// CHECK:       } // end sil function 'dont_sink_copies_of_phi_wrong_source'
+sil [ossa] @dont_sink_copies_of_phi_wrong_source : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%0 : @owned $C, %1 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1
+  %3 = copy_value %0
+  br bb3(%0, %3)
+
+bb2:
+  %5 = copy_value %0
+  destroy_value %0
+  br bb3(%1, %5)
+
+bb3(%8 : @owned $C, %9 : @owned $C):
+  destroy_value %8
+  return %9
+}
+
+// CHECK-LABEL: sil [ossa] @dont_sink_copies_of_phi_no_single_copy_use :
+// CHECK:       bb3({{%.*}} : @owned $C, {{%.*}} : @owned $C):
+// CHECK:       } // end sil function 'dont_sink_copies_of_phi_no_single_copy_use'
+sil [ossa] @dont_sink_copies_of_phi_no_single_copy_use : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%0 : @owned $C, %1 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1
+  %3 = copy_value %0
+  fix_lifetime %3
+  br bb3(%0, %3)
+
+bb2:
+  destroy_value %0
+  %6 = copy_value %1
+  br bb3(%1, %6)
+
+bb3(%8 : @owned $C, %9 : @owned $C):
+  destroy_value %8
+  return %9
+}
+
+// In bb2 the incoming value is not a copy at all.
+//
+// CHECK-LABEL: sil [ossa] @dont_sink_copies_of_phi_not_a_copy :
+// CHECK:       bb3({{%.*}} : @owned $C, {{%.*}} : @owned $C):
+// CHECK:       } // end sil function 'dont_sink_copies_of_phi_not_a_copy'
+sil [ossa] @dont_sink_copies_of_phi_not_a_copy : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%0 : @owned $C, %1 : @owned $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %1
+  %3 = copy_value %0
+  br bb3(%0, %3)
+
+bb2:
+  br bb3(%0, %1)
+
+bb3(%8 : @owned $C, %9 : @owned $C):
+  destroy_value %8
+  return %9
+}
+
 // CHECK-LABEL: sil [ossa] @sink_load_over_enum :
 // CHECK:         %1 = load_borrow %0
 // CHECK-NEXT:    switch_enum %1


### PR DESCRIPTION
If all incoming values of a phi are copies of a value which is passed to another phi
of the same block, the copies can be replaced by a single copy of that phi:

```
  bb1:
    %1 = copy_value %0
    br bb3(%0, %1)
  bb2:
    %3 = copy_value %2
    br bb3(%2, %3)
  bb3(%4 : @owned, %5 : @owned):
```
->
```
  bb1:
    br bb3(%0)
  bb2:
    br bb3(%2)
  bb3(%4 : @owned):
    %6 = copy_value %4
```

Unlike the existing phi case, the copied-from value doesn't need to be guaranteed,
because the new copy is inserted at the begin of the block where the copied-from phi
is definitely available.

The copy must be a copy of the value which is passed to the other phi on _that_
incoming edge. Otherwise the wrong value would be copied in the phi's block.