### PR TITLE
[Distributed] Don't crash when distributed actor "is" an actor system

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6075,6 +6075,10 @@ ERROR(actor_cannot_inherit_distributed_actor_protocol,none,
       "actor type %0 cannot conform to the 'DistributedActor' protocol. "
       "Isolation rules of these actor types are not interchangeable.",
       (DeclName))
+ERROR(distributed_actor_cannot_be_actor_system,none,
+      "distributed actor cannot conform to the "
+      "'DistributedActorSystem' protocol",
+      ())
 ERROR(broken_distributed_actor_requirement,none,
       "DistributedActor protocol is broken: unexpected requirement", ())
 ERROR(broken_distributed_actor_system_requirement,none,

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -1327,10 +1327,16 @@ bool CanSynthesizeDistributedActorCodableConformanceRequest::evaluate(
   if (!systemTy)
     return false;
 
-  if (!systemTy->getAnyNominal())
+  auto *systemNominal = systemTy->getAnyNominal();
+  if (!systemNominal)
     return false;
 
-  auto idTy = getDistributedActorSystemActorIDType(systemTy->getAnyNominal());
+  // A 'distributed actor' cannot be its own actor system; this is diagnosed
+  // elsewhere, don't attempt to synthesize the Codable conformance for it
+  if (systemNominal->isDistributedActor())
+    return false;
+
+  auto idTy = getDistributedActorSystemActorIDType(systemNominal);
   if (!idTy)
     return false;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -43,6 +43,10 @@ bool DerivedConformance::canDeriveDistributedActorSystem(
     NominalTypeDecl *nominal, DeclContext *dc) {
   auto &C = nominal->getASTContext();
 
+  // A 'distributed actor' cannot implement the actor system itself
+  if (nominal->isDistributedActor())
+    return false;
+
   // Make sure ad-hoc requirements that we'll use in synthesis are present, before we try to use them.
   // This leads to better error reporting because we already have errors happening (missing witnesses).
   if (auto handlerType = getDistributedActorSystemResultHandlerType(nominal)) {
@@ -467,8 +471,20 @@ deriveDistributedActorType_ActorSystem(
   if (!defaultDistributedActorSystemTypeDecl)
     return nullptr;
 
+  auto defaultSystemTy =
+      defaultDistributedActorSystemTypeDecl->getDeclaredInterfaceType();
+
+  // A 'distributed actor' cannot double as the actor system it is using,
+  // so don't adopt such module-wide default. Doing so would make the actor
+  // its own actor system, and we'd crash looking for the system's
+  // associated types on a distributed actor
+  if (auto systemNominal = defaultSystemTy->getAnyNominal()) {
+    if (systemNominal->isDistributedActor())
+      return nullptr;
+  }
+
   // Return the default system type.
-  return defaultDistributedActorSystemTypeDecl->getDeclaredInterfaceType();
+  return defaultSystemTy;
 }
 
 static Type
@@ -488,8 +504,14 @@ deriveDistributedActorType_SerializationRequirement(
   if (!DAS)
     return nullptr;
 
-  if (auto systemNominal = systemTy->getAnyNominal())
+  if (auto systemNominal = systemTy->getAnyNominal()) {
+    // A 'distributed actor' cannot be its own actor system; this is diagnosed
+    // elsewhere, so just fail to synthesize here
+    if (systemNominal->isDistributedActor())
+      return nullptr;
+
     return getDistributedActorSystemSerializationType(systemNominal);
+  }
 
   return nullptr;
 }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -716,6 +716,12 @@ bool swift::checkDistributedActorSystem(const NominalTypeDecl *system) {
   if (!swift::ensureDistributedModuleLoaded(nominal))
     return true;
 
+  // A 'distributed actor' cannot double as an actor system.
+  if (nominal->isDistributedActor()) {
+    nominal->diagnose(diag::distributed_actor_cannot_be_actor_system);
+    return true;
+  }
+
   // === AssociatedTypes
   // --- SerializationRequirement MUST be a protocol TODO(distributed): rdar://91663941
   // we may lift this in the future and allow classes but this requires more

--- a/test/Distributed/distributed_actor_basic.swift
+++ b/test/Distributed/distributed_actor_basic.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -22,4 +22,26 @@ distributed actor Second {
   distributed func two(first: First, second: Second) async {
     try! await first.one(second: self)
   }
+}
+
+// In order to avoid weird diagnostics and cycles in lookups, we just outright ban a distributed actor being an actor system.
+// This isn't something realistic code would attempt, but we should offer a nice diagnostic rather than crash.
+//
+// expected-error@+2{{distributed actor cannot conform to the 'DistributedActorSystem' protocol}}
+// expected-error@+1{{type 'NotAnActorSystem' does not conform to protocol 'DistributedActorSystem'}}
+distributed actor NotAnActorSystem: DistributedActorSystem {
+  // expected-note@-1{{add stubs for conformance}}
+}
+
+// The same goes for using a 'distributed actor' as some other distributed
+// actor's actor system, be it spelled explicitly like here, or picked up
+// as the module-wide 'DefaultDistributedActorSystem'
+distributed actor UsesActorAsItsSystem {
+  // expected-error@-1{{distributed actor 'UsesActorAsItsSystem' does not declare ActorSystem it can be used with}}
+  // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
+  // expected-error@-3{{type 'UsesActorAsItsSystem' does not conform to protocol 'DistributedActor'}}
+  // expected-error@-4{{type 'UsesActorAsItsSystem' does not conform to protocol 'Identifiable'}}
+  // expected-note@-5{{add stubs for conformance}}
+  typealias ActorSystem = First
+  // expected-note@-1{{possibly intended match 'UsesActorAsItsSystem.ActorSystem' (aka 'First') does not conform to 'DistributedActorSystem'}}
 }

--- a/validation-test/compiler_crashers/getDistributedActorSystemActorIDType-ed65c0.swift
+++ b/validation-test/compiler_crashers/getDistributedActorSystemActorIDType-ed65c0.swift
@@ -1,6 +1,0 @@
-// {"kind":"typecheck","original":"92c14a71","signature":"swift::getDistributedActorSystemActorIDType(swift::NominalTypeDecl*)","signatureAssert":"Assertion failed: (!system->isDistributedActor()), function getDistributedActorSystemActorIDType","signatureNext":"CanSynthesizeDistributedActorCodableConformanceRequest::evaluate"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-import Distributed
-distributed actor DefaultDistributedActorSystem: LocalTestingDistributedActorSystem {
-}

--- a/validation-test/compiler_crashers/getDistributedActorSystemResultHandlerType-b44285.swift
+++ b/validation-test/compiler_crashers/getDistributedActorSystemResultHandlerType-b44285.swift
@@ -1,6 +1,0 @@
-// {"kind":"emit-silgen","signature":"swift::getDistributedActorSystemResultHandlerType(swift::NominalTypeDecl*)","signatureAssert":"Assertion failed: (!system->isDistributedActor()), function getDistributedActorSystemResultHandlerType","signatureNext":"DerivedConformance::canDeriveDistributedActorSystem"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
-// REQUIRES: OS=macosx
-import Distributed
-distributed actor a: DistributedActorSystem {
-}

--- a/validation-test/compiler_crashers/getDistributedActorSystemSerializationType-a014ef.swift
+++ b/validation-test/compiler_crashers/getDistributedActorSystemSerializationType-a014ef.swift
@@ -1,4 +1,0 @@
-// {"kind":"typecheck","signature":"swift::getDistributedActorSystemSerializationType(swift::NominalTypeDecl*)","signatureAssert":"Assertion failed: (!system->isDistributedActor()), function getDistributedActorSystemSerializationType","signatureNext":"checkDistributedActorSystem"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-import Distributed typealias a = LocalTestingDistributedActorSystem protocol a{distributed actor b:a

--- a/validation-test/compiler_crashers_fixed/getDistributedActorSystemActorIDType-ed65c0.swift
+++ b/validation-test/compiler_crashers_fixed/getDistributedActorSystemActorIDType-ed65c0.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -typecheck %s
+// REQUIRES: OS=macosx
+import Distributed
+distributed actor DefaultDistributedActorSystem: LocalTestingDistributedActorSystem {
+}

--- a/validation-test/compiler_crashers_fixed/getDistributedActorSystemResultHandlerType-b44285.swift
+++ b/validation-test/compiler_crashers_fixed/getDistributedActorSystemResultHandlerType-b44285.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -emit-silgen %s
+// REQUIRES: OS=macosx
+import Distributed
+distributed actor a: DistributedActorSystem {
+}

--- a/validation-test/compiler_crashers_fixed/getDistributedActorSystemSerializationType-a014ef.swift
+++ b/validation-test/compiler_crashers_fixed/getDistributedActorSystemSerializationType-a014ef.swift
@@ -1,0 +1,3 @@
+// RUN: not %target-swift-frontend -typecheck %s
+// REQUIRES: OS=macosx
+import Distributed typealias a = LocalTestingDistributedActorSystem protocol a{distributed actor b:a


### PR DESCRIPTION
Instead, just outright ban this combination as it doesn't make much sense in real code and is likely an accident / typo. But we should diagnose it nicely rather than fail during type lookups.

Resolves a few more of the generated compiler crasher reproducers.
