### PR TITLE
[Demangling] Mangle a generic node's constructor as a constructor.

### DIFF
--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -902,7 +902,16 @@ ManglingError Remangler::mangleBoundGenericFunction(Node *node,
   if (!unspec.isSuccess())
     return unspec.error();
   NodePointer unboundFunction = unspec.result();
-  RETURN_IF_ERROR(mangleFunction(unboundFunction, depth + 1));
+  switch (unboundFunction->getKind()) {
+  case Node::Kind::Function:
+    RETURN_IF_ERROR(mangleFunction(unboundFunction, depth + 1));
+    break;
+  case Node::Kind::Constructor:
+    RETURN_IF_ERROR(mangleConstructor(unboundFunction, depth + 1));
+    break;
+  default:
+    return MANGLING_ERROR(ManglingError::BadNodeKind, unboundFunction);
+  }
   char Separator = 'y';
   RETURN_IF_ERROR(mangleGenericArgs(node, Separator, depth + 1));
   Buffer << 'G';
@@ -1496,16 +1505,24 @@ ManglingError Remangler::mangleFullTypeMetadata(Node *node, unsigned depth) {
 }
 
 ManglingError Remangler::mangleFunction(Node *node, unsigned depth) {
+  // The node should have a context, a name, an optional list of parameter
+  // labels, and a type.
+  DEMANGLER_ASSERT(node->getNumChildren() >= 3, node);
+
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1)); // context
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1)); // name
 
   bool hasLabels = node->getChild(2)->getKind() == Node::Kind::LabelList;
+  if (hasLabels)
+    DEMANGLER_ASSERT(node->getNumChildren() >= 4, node);
   Node *FuncType = getSingleChild(node->getChild(hasLabels ? 3 : 2));
+  DEMANGLER_ASSERT(FuncType, node);
 
   if (hasLabels)
     RETURN_IF_ERROR(mangleChildNode(node, 2, depth + 1)); // parameter labels
 
   if (FuncType->getKind() == Node::Kind::DependentGenericType) {
+    DEMANGLER_ASSERT(FuncType->getNumChildren() >= 2, FuncType);
     RETURN_IF_ERROR(mangleFunctionSignature(
         getSingleChild(FuncType->getChild(1)), depth + 1));
     RETURN_IF_ERROR(

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -528,3 +528,4 @@ async_MainTY1_ ---> (2) suspend resume partial function for async main entry poi
 async_MainTQ0_ ---> (1) await resume partial function for async main entry point
 async_MainTu ---> async function pointer to async main entry point
 _async_MainTY1_ ---> (2) suspend resume partial function for async main entry point
+$s1AyycfcySiGfD1BV ---> $s1AyycfcySiGfD1BV


### PR DESCRIPTION
The node passed to mangleFunction can contain a Constructor instead of a Function. Constructor has no name child, and we'd read off the end of the child array. Handle this case, and add some checks of the child count before digging into the child array.

rdar://185733780