### PR TITLE
Diagnose 'async' before expression macro expansions

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -4452,11 +4452,22 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
 
   auto roles = cast<MacroDecl>(macro.getDecl())->getMacroRoles();
   // If it's not a declaration macro or a code item macro, it must have been
-  // parsed as an expression macro, and this decl is just its substitute decl.
-  // So there's no thing to be done here.
+  // parsed as an expression macro, and this decl is usually just its substitute
+  // decl. However, a modifier before a freestanding macro forces it to be
+  // parsed as a declaration. Diagnose `async` in that position when the macro
+  // actually resolves to an expression macro.
   if (!roles.contains(MacroRole::Declaration) &&
-      !roles.contains(MacroRole::CodeItem))
+      !roles.contains(MacroRole::CodeItem)) {
+    if (roles.contains(MacroRole::Expression)) {
+      if (auto *asyncAttr =
+              MED->getAttrs().getAttribute<AsyncAttr>(/*AllowInvalid=*/true)) {
+        MED->getASTContext().Diags
+            .diagnose(asyncAttr->getLocation(), diag::expected_await_not_async)
+            .fixItReplace(asyncAttr->getRange(), "await");
+      }
+    }
     return std::nullopt;
+  }
 
   return expandFreestandingMacro(MED);
 }

--- a/test/Macros/async_await_typo.swift
+++ b/test/Macros/async_await_typo.swift
@@ -1,0 +1,12 @@
+// REQUIRES: swift_swift_parser
+//
+// RUN: %target-typecheck-verify-swift %s
+
+@freestanding(expression)
+macro testMacro() -> Int = #externalMacro(module: "FakeMacros", type: "TestMacro")
+// expected-warning@-1 {{external macro implementation type}}
+
+func testAsyncInsteadOfAwait() async {
+  // expected-error@+1 {{found 'async' in expression; did you mean 'await'?}}{{3-8=await}}
+  async #testMacro()
+}


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/91574

**Explanation**

When async appears before a freestanding expression macro, for example:

async #someMacro()

the parser can interpret the macro expansion as a declaration because async is accepted as a declaration modifier.

If the macro later resolves to an expression macro, ExpandMacroExpansionDeclRequest previously returned without diagnosing the misplaced async. This could cause code that intended to use await to compile without executing the expression macro as expected.

This change detects that case after macro role resolution. When a macro expansion parsed as a declaration resolves to an expression macro and carries an async modifier, the compiler now emits the existing diagnostic:

found 'async' in expression; did you mean 'await'?

and provides a fix-it replacing async with await.

Declaration and code-item macros retain their existing behavior.

**Testing**

Added a regression test covering async before a freestanding expression macro.

Verified the original reproducer now produces:

error: found 'async' in expression; did you mean 'await'?

Also verified the regression test with:

swift-frontend -typecheck -verify test/Macros/async_await_typo.swift

<!-- Before merging this pull request, you must run the Swift continuous integration tests. For information about triggering CI builds via @swift-ci, see: https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci Thank you for your contribution to Swift! -->