### PR TITLE
Adopt -_fastUTF8StringContents:utf8Length:

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -478,6 +478,22 @@ private func _NSStringUTF8Pointer(
   return unsafe (contents: result, utf8Length: utf8Length)
 }
 
+@_silgen_name("swift_stdlib_installNSStringCompatibilityMethods")
+internal func _installNSStringCompatibilityMethods() -> Bool
+
+private let _nsStringCompatibilityMethodsInstalled =
+  _installNSStringCompatibilityMethods()
+
+/*
+ Adds methods we need onto NSString, IFF it doesn't already have them.
+
+ Must run before any foreign `_CocoaString` reaches `_withCocoaUTF8Pointer`.
+ */
+internal func _installNSStringCompatibilityMethodsIfNeeded() -> Void {
+  let installed = _nsStringCompatibilityMethodsInstalled
+  _debugPrecondition(installed)
+}
+
 @_effects(readonly)
 internal func _getNSCFConstantStringContentsPointer(
   _ cocoa: AnyObject
@@ -575,6 +591,8 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
     return _StringGuts(_SmallString(taggedCocoa: cocoaString)!)
 #endif
   case .cocoa:
+    _installNSStringCompatibilityMethodsIfNeeded()
+
     // "Copy" it into a value to be sure nobody will modify behind
     // our backs. In practice, when value is already immutable, this
     // just does a retain.

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -36,10 +36,11 @@ internal typealias _CocoaString = AnyObject
    _ buffer: UnsafeMutablePointer<UInt16>, range aRange: _SwiftNSRange
   )
 
-  @objc(_fastCStringContents:)
-  func _fastCStringContents(
-    _ requiresNulTermination: Int8
-  ) -> UnsafePointer<CChar>?
+  @objc(_fastUTF8StringContents:utf8Length:)
+  func _fastUTF8StringContents(
+    _ requiresNulTermination: Int8,
+    _ outUTF8Length: UnsafeMutablePointer<UInt>
+  ) -> UnsafePointer<UInt8>?
 
   @objc(_fastCharacterContents)
   func _fastCharacterContents() -> UnsafePointer<UInt16>?
@@ -465,16 +466,16 @@ internal func _bridgeTaggedASCII(
 #endif
 
 @_effects(readonly)
-private func _NSStringASCIIPointer(_ str: _StringSelectorHolder) -> UnsafePointer<UInt8>? {
+private func _NSStringUTF8Pointer(
+  _ str: _StringSelectorHolder,
+) -> (contents: UnsafePointer<UInt8>?, utf8Length: UInt) {
   //TODO(String bridging): Unconditionally asking for nul-terminated contents is
   // overly conservative and hurts perf with some NSStrings
-  return unsafe str._fastCStringContents(1)?._asUInt8
-}
-
-@_effects(readonly)
-private func _NSStringUTF8Pointer(_ str: _StringSelectorHolder) -> UnsafePointer<UInt8>? {
-  //We don't have a way to ask for UTF8 here currently
-  return unsafe _NSStringASCIIPointer(str)
+  var utf8Length:UInt = 0
+  let result = withUnsafeMutablePointer(to: &utf8Length) {
+    unsafe str._fastUTF8StringContents(1, $0)
+  }
+  return unsafe (contents: result, utf8Length: utf8Length)
 }
 
 @_effects(readonly)
@@ -487,99 +488,67 @@ internal func _getNSCFConstantStringContentsPointer(
   ).pointee.str
 }
 
-@_effects(readonly) // @opaque
-private func _withCocoaASCIIPointer<R>(
-  _ str: _CocoaString,
-  requireStableAddress: Bool,
-  work: (UnsafePointer<UInt8>) -> R?
-) -> R? {
-  #if _pointerBitWidth(_64)
-  if _isObjCTaggedPointer(str) {
-    if requireStableAddress {
-      return nil // tagged pointer strings don't support _fastCStringContents
-    }
-    if let smol = _SmallString(taggedASCIICocoa: str) {
-      return _StringGuts(smol).withFastUTF8 {
-        unsafe work($0.baseAddress._unsafelyUnwrappedUnchecked)
-      }
-    }
-  }
-  #endif
-  defer { _fixLifetime(str) }
-  if let ptr = unsafe _NSStringASCIIPointer(_objc(str)) {
-    return unsafe work(ptr)
-  }
-  return nil
-}
-
 // Inline to make sure the optimizer can see through the closure
 @_effects(readonly) @inline(__always)
 private func _withCocoaUTF8Pointer<R>(
   _ str: _CocoaString,
   requireStableAddress: Bool,
-  work: (UnsafePointer<UInt8>) -> R?
+  work: (UnsafePointer<UInt8>, Int) -> R?
 ) -> R? {
   #if _pointerBitWidth(_64)
   if _isObjCTaggedPointer(str) {
     if requireStableAddress {
-      return nil // tagged pointer strings don't support _fastCStringContents
+      return nil // tagged pointer strings don't support _fastUTF8StringContents
     }
     if let smol = _SmallString(taggedCocoa: str) {
       return _StringGuts(smol).withFastUTF8 {
-        unsafe work($0.baseAddress._unsafelyUnwrappedUnchecked)
+        unsafe work($0.baseAddress._unsafelyUnwrappedUnchecked, $0.count)
       }
     }
   }
   #endif
   defer { _fixLifetime(str) }
-  if let ptr = unsafe _NSStringUTF8Pointer(_objc(str)) {
-    return unsafe work(ptr)
-  }
-  return nil
-}
-
-@_effects(readonly)
-internal func withCocoaASCIIPointer<R>(
-  _ str: _CocoaString,
-  work: (UnsafePointer<UInt8>) -> R?
-) -> R? {
-  return unsafe _withCocoaASCIIPointer(str, requireStableAddress: false, work: work)
+  let (ptr, utf8Length) = unsafe _NSStringUTF8Pointer(_objc(str))
+  guard let ptr = unsafe ptr else { return nil }
+  return unsafe work(ptr, Int(utf8Length))
 }
 
 @_effects(readonly)
 internal func withCocoaUTF8Pointer<R>(
   _ str: _CocoaString,
-  work: (UnsafePointer<UInt8>) -> R?
+  work: (UnsafePointer<UInt8>, Int) -> R?
 ) -> R? {
   return unsafe _withCocoaUTF8Pointer(str, requireStableAddress: false, work: work)
 }
 
 @_effects(readonly)
-internal func stableCocoaASCIIPointer(_ str: _CocoaString)
-  -> UnsafePointer<UInt8>? {
-  return unsafe _withCocoaASCIIPointer(str, requireStableAddress: true, work: { unsafe $0 })
-}
-
-@_effects(readonly)
 internal func stableCocoaUTF8Pointer(_ str: _CocoaString)
-  -> UnsafePointer<UInt8>? {
-  return unsafe _withCocoaUTF8Pointer(str, requireStableAddress: true, work: { unsafe $0 })
+  -> (UnsafePointer<UInt8>, Int)? {
+  return unsafe _withCocoaUTF8Pointer(
+    str,
+    requireStableAddress: true,
+    work: { (unsafe $0, $1) }
+  )
 }
 
 @unsafe
 private enum CocoaStringPointer {
-  case ascii(UnsafePointer<UInt8>)
-  case utf8(UnsafePointer<UInt8>)
+  case ascii(UnsafePointer<UInt8>, Int)
+  case utf8(UnsafePointer<UInt8>, Int)
   case utf16(UnsafePointer<UInt16>)
   case none
 }
 
 @_effects(readonly)
 private func _getCocoaStringPointer(
-  _ cfImmutableValue: _CocoaString
+  _ cfImmutableValue: _CocoaString,
+  utf16Length: Int
 ) -> CocoaStringPointer {
-  if let ascii = unsafe stableCocoaASCIIPointer(cfImmutableValue) {
-    return unsafe .ascii(ascii)
+  if let (ptr, utf8Count) = unsafe stableCocoaUTF8Pointer(cfImmutableValue) {
+    if utf8Count == utf16Length { //this only holds for ASCII contents
+      return unsafe .ascii(ptr, utf8Count)
+    }
+    return unsafe .utf8(ptr, utf8Count)
   }
   // We could ask for UTF16 here via _stdlib_binary_CFStringGetCharactersPtr,
   // but we currently have no use for it
@@ -628,19 +597,22 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
     }
 #endif
 
-    let (fastUTF8, isASCII): (Bool, Bool)
-    switch unsafe _getCocoaStringPointer(immutableCopy) {
-    case .ascii(_): (fastUTF8, isASCII) = (true, true)
-    case .utf8(_): (fastUTF8, isASCII) = (true, false)
-    default:  (fastUTF8, isASCII) = (false, false)
+    let utf16Len = _stdlib_binary_CFStringGetLength(immutableCopy)
+
+    // `count` is the UTF-8 byte count when we have fast UTF-8 contents, and the
+    // UTF-16 length otherwise, see _StringObject's `sharedCount`
+    let (fastUTF8, isASCII, count): (Bool, Bool, Int)
+    switch unsafe _getCocoaStringPointer(immutableCopy, utf16Length: utf16Len) {
+    case .ascii(_, let utf8Count): (fastUTF8, isASCII, count) = (true, true, utf8Count)
+    case .utf8(_, let utf8Count): (fastUTF8, isASCII, count) = (true, false, utf8Count)
+    default:  (fastUTF8, isASCII, count) = (false, false, utf16Len)
     }
-    let length = _stdlib_binary_CFStringGetLength(immutableCopy)
 
     return _StringGuts(
       cocoa: immutableCopy,
       providesFastUTF8: fastUTF8,
       isASCII: isASCII,
-      length: length)
+      length: count)
   }
 }
 

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -978,7 +978,7 @@ extension _StringObject {
     }
     if largeIsCocoa {
       return unsafe withCocoaObject {
-        unsafe stableCocoaUTF8Pointer($0)._unsafelyUnwrappedUnchecked
+        unsafe stableCocoaUTF8Pointer($0)._unsafelyUnwrappedUnchecked.0
       }
     }
 #endif

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -275,7 +275,7 @@ extension __StringStorage {
   }
   
   @objc(_fastUTF8StringContents:utf8Length:)
-  @_effects(readonly)
+  @_effects(releasenone) // writes through outUTF8Length; not readonly
   final internal func _fastUTF8StringContents(
     _ requiresNulTermination: Int8,
     _ outUTF8Length: UnsafeMutablePointer<UInt>
@@ -422,7 +422,7 @@ extension __SharedStringStorage {
   }
   
   @objc(_fastUTF8StringContents:utf8Length:)
-  @_effects(readonly)
+  @_effects(releasenone) // writes through outUTF8Length; not readonly
   final internal func _fastUTF8StringContents(
     _ requiresNulTermination: Int8,
     _ outUTF8Length: UnsafeMutablePointer<UInt>
@@ -783,10 +783,10 @@ fileprivate func isEqual(
     return 0
   }
   
-  let result = unsafe withCocoaASCIIPointer(selfNS) { (selfPtr) -> Int8? in
-    //We know self is ASCII at this point
+  let result = unsafe withCocoaUTF8Pointer(selfNS) {
+    (selfPtr, selfUTF8Count) -> Int8? in
     let otherBytes = unsafe RawSpan(_unsafeStart: otherPtr, byteCount: otherByteCount)
-    let selfBytes = unsafe Span(_unsafeStart: selfPtr, count: selfCount).bytes
+    let selfBytes = unsafe RawSpan(_unsafeStart: selfPtr, byteCount: selfUTF8Count)
     switch otherEncoding {
     case _cocoaASCIIEncoding, _cocoaUTF8Encoding:
       if otherBytes.isIdentical(to: selfBytes) {
@@ -794,7 +794,10 @@ fileprivate func isEqual(
       }
       return isEqual(bytes: otherBytes, bytes: selfBytes) ? 1 : 0
     case _cocoaUTF16Encoding:
-      return isEqual(asciiBytes: selfBytes, utf16Bytes: otherBytes) ? 1 : 0
+      if selfUTF8Count == selfCount {
+        return isEqual(asciiBytes: selfBytes, utf16Bytes: otherBytes) ? 1 : 0
+      }
+      return isEqual(utf8Bytes: selfBytes, utf16Bytes: otherBytes) ? 1 : 0
     default:
       fatalError("Unsupported combination of encodings")
     }

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -91,6 +91,61 @@ extern "C" {
   BOOL _swift_NSStringIsEqualToBytesImpl(id, SEL, void *, intptr_t, uintptr_t);
 }
 
+@interface NSString (DirectCStringContents)
+- (const char *)_fastCStringContents:(BOOL)requiresNulTermination;
+@end
+
+// Only exists for older OSs, won't be installed if Foundation already has it
+static const uint8_t *
+_swift_NSStringFastUTF8StringContentsImpl(NSString *string, SEL _cmd,
+                                          BOOL requiresNulTermination,
+                                          NSUInteger *outUTF8Length) {
+  const char *contents = [string _fastCStringContents:requiresNulTermination];
+  if (!contents) return nullptr;
+  if (outUTF8Length) *outUTF8Length = [string length];
+  return reinterpret_cast<const uint8_t *>(contents);
+}
+
+/*
+  Grafts the NSString SPI that the stdlib's String bridging relies on onto
+  NSString, for Foundations that don't already have it. class_addMethod
+  leaves an existing implementation alone, so this will only ever be active if
+  the installed Foundation in the host OS doesn't have one.
+  */
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
+bool
+swift_stdlib_installNSStringCompatibilityMethods() {
+  Class NSStringClass = objc_lookUpClass("NSString");
+  if (!NSStringClass) return false;
+
+  //   BOOL(id, SEL, void *, intptr_t, uintptr_t)
+  //   const uint8_t *(id, SEL, BOOL, NSUInteger *)
+#if defined(OBJC_BOOL_IS_BOOL)
+#define SWIFT_OBJC_ENCODE_BOOL "B"
+#else
+#define SWIFT_OBJC_ENCODE_BOOL "c"
+#endif
+#if __LP64__
+  const char *isEqualToBytesTypes = "c@:^vqQ";
+  const char *fastUTF8ContentsTypes = "r*@:" SWIFT_OBJC_ENCODE_BOOL "^Q";
+#else
+  const char *isEqualToBytesTypes = "c@:^vlL";
+  const char *fastUTF8ContentsTypes = "r*@:" SWIFT_OBJC_ENCODE_BOOL "^I";
+#endif
+#undef SWIFT_OBJC_ENCODE_BOOL
+  class_addMethod(
+    NSStringClass,
+    @selector(_isEqualToBytes:count:encoding:),
+    (IMP)_swift_NSStringIsEqualToBytesImpl,
+    isEqualToBytesTypes);
+  class_addMethod(
+    NSStringClass,
+    @selector(_fastUTF8StringContents:utf8Length:),
+    (IMP)_swift_NSStringFastUTF8StringContentsImpl,
+    fastUTF8ContentsTypes);
+  return true;
+}
+
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
 bool
 swift_stdlib_connectNSBaseClasses() {
@@ -104,20 +159,7 @@ swift_stdlib_connectNSBaseClasses() {
   class_setSuperclass(NS${Class}OurClass, NS${Class}Super);
 #pragma clang diagnostic pop
 % end
-  Class NSStringClass = objc_lookUpClass("NSString");
-  if (!NSStringClass) return false;
-
-#if __LP64__
-  const char *typeString = "c@:^vqQ";
-#else
-  const char *typeString = "c@:^vlL";
-#endif
-  class_addMethod(
-    NSStringClass,
-    @selector(_isEqualToBytes:count:encoding:),
-    (IMP)_swift_NSStringIsEqualToBytesImpl,
-    typeString);
-  return true;
+  return swift_stdlib_installNSStringCompatibilityMethods();
 }
 
 @interface __SwiftNativeNSArrayBase (Compatibility)

--- a/test/stdlib/Inputs/NSSlowTaggedLocalizedString/NSSlowTaggedLocalizedString.m
+++ b/test/stdlib/Inputs/NSSlowTaggedLocalizedString/NSSlowTaggedLocalizedString.m
@@ -23,7 +23,10 @@
     
     Method fastCString = class_getInstanceMethod(ourClass, @selector(_fastCStringContents:));
     class_replaceMethod(tagClass, @selector(_fastCStringContents:), method_getImplementation(fastCString), method_getTypeEncoding(fastCString));
-    
+
+    Method fastUTF8 = class_getInstanceMethod(ourClass, @selector(_fastUTF8StringContents:utf8Length:));
+    class_replaceMethod(tagClass, @selector(_fastUTF8StringContents:utf8Length:), method_getImplementation(fastUTF8), method_getTypeEncoding(fastUTF8));
+
     Method length = class_getInstanceMethod(ourClass, @selector(length));
     class_replaceMethod(tagClass, @selector(length), method_getImplementation(length), method_getTypeEncoding(length));
     
@@ -68,6 +71,11 @@ static const char *contents = NULL;
 
 - (const char *)_fastCStringContents:(BOOL)nullTerminationRequired {
   return contents;
+}
+
+- (const uint8_t *)_fastUTF8StringContents:(BOOL)nullTerminationRequired utf8Length:(NSUInteger *)outLen {
+  *outLen = strlen(contents);
+  return (const uint8_t *)contents;
 }
 
 - (uint64_t)length {

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -241,4 +241,23 @@ StringBridgeTests.test("Equal UTF16 lengths but unequal UTF8") {
   expectFalse(nsutf8.isEqual(nsascii))
 }
 
+StringBridgeTests.test("NSString compatibility methods") {
+  // NSMutableString to force an actually-foreign NSString
+  let ascii = NSMutableString(string: "a long enough ascii nsstring")
+  expectEqual("a long enough ascii nsstring", ascii as String)
+  let unicode = NSMutableString(string: "a long enough ünicode nsstring")
+  expectEqual("a long enough ünicode nsstring", unicode as String)
+  expectEqual(31, (unicode as String).utf8.count)
+
+  for name in [
+    "_fastUTF8StringContents:utf8Length:",
+    "_isEqualToBytes:count:encoding:",
+  ] {
+    expectTrue(
+      NSString.instancesRespond(to: NSSelectorFromString(name)),
+      "NSString is missing \(name)"
+    )
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
Slightly simplifies the code, and lets us generalize _swift_NSStringIsEqualToBytesImpl to cover more combinations in the fast path.

Fixes rdar://184001652