### PR TITLE
[Emacs] Add lexical binding cookies for Emacs 31+

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: nil; -*-
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 

--- a/utils/inferior-swift-mode.el
+++ b/utils/inferior-swift-mode.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: nil; -*-
 ;===--- inferior-swift.el --------------------------------------------------===;
 ;
 ; This source file is part of the Swift.org open source project

--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: nil; -*-
 ;;===--- sil-mode.el ------------------------------------------------------===;;
 ;;
 ;; This source file is part of the Swift.org open source project

--- a/utils/swift-mode.el
+++ b/utils/swift-mode.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: nil; -*-
 ;===--- swift-mode.el ----------------------------------------------------===;
 ;
 ; This source file is part of the Swift.org open source project

--- a/utils/swift-project-settings.el
+++ b/utils/swift-project-settings.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: nil; -*-
 ;===--- swift-project-settings.el - Swift project's format conventions ---===;
 ;
 ; This source file is part of the Swift.org open source project


### PR DESCRIPTION
Emacs 31+ requires a "lexical binding cookie" to indicate whether this particular file expects dynamic binding (the legacy default) or lexical binding (which will be the default in some future version).

I've set all of these to dynamic binding for compatibility with older Emacs versions.
