### PR TITLE
[IRGen] diagnose fixed-layout types too large for the 32-bit size field

### DIFF
--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -67,6 +67,16 @@ ERROR(temporary_allocation_alignment_not_power_of_2,none,
 ERROR(explosion_size_oveflow,none,
       "explosion size too large", ())
 
+ERROR(fixed_type_too_large,none,
+      "type %0 is too large to be represented; the size in bytes of a "
+      "fixed-layout type must be less than 4 GiB",
+      (Type))
+
+ERROR(fixed_type_too_large_unnamed,none,
+      "type is too large to be represented; the size in bytes of a "
+      "fixed-layout type must be less than 4 GiB",
+      ())
+
 NOTE(layout_strings_blocked,none,
      "Layout string value witnesses have been disabled for module '%0' "
      "through block list entry", (StringRef))

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -23,6 +23,9 @@
 #include "TypeInfo.h"
 #include "swift/Basic/ClusteredBitVector.h"
 #include "swift/SIL/SILType.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include <limits>
 
 namespace llvm {
   class ConstantInt;
@@ -38,7 +41,20 @@ private:
   /// The spare bit mask for this type. SpareBits[0] is the LSB of the first
   /// byte. This may be empty if the type has no spare bits.
   SpareBitVector SpareBits;
-  
+
+  /// Store the given size into the 32-bit size bitfield, failing closed if it
+  /// does not fit. The size field is only 32 bits wide, so a larger size would
+  /// be silently truncated, producing a miscompile in which layouts and
+  /// allocations disagree. We enforce this in all build configurations rather
+  /// than relying on a debug-only assert.
+  void setFixedSize(Size size) {
+    if (size.getValue() > std::numeric_limits<uint32_t>::max()) {
+      llvm::report_fatal_error(
+          "fixed-layout type size exceeds 32-bit representable maximum");
+    }
+    Bits.FixedTypeInfo.Size = size.getValue();
+  }
+
 protected:
   FixedTypeInfo(IRGenModule &IGM,
                 const SerializableFixedTypeInfoRepresentation &representation);
@@ -59,8 +75,7 @@ protected:
         SpareBits(spareBits) {
     assert(SpareBits.size() == size.getValueInBits());
     assert(isFixedSize());
-    Bits.FixedTypeInfo.Size = size.getValue();
-    assert(Bits.FixedTypeInfo.Size == size.getValue() && "truncation");
+    setFixedSize(size);
   }
 
   FixedTypeInfo(llvm::Type *type, Size size,
@@ -76,8 +91,7 @@ protected:
     // SpareBits implementation is limited to 32bits.
     assert(SpareBits.size() == (size.getValueInBits() & 0xFFFFFFFF));
     assert(isFixedSize());
-    Bits.FixedTypeInfo.Size = size.getValue();
-    assert(Bits.FixedTypeInfo.Size == size.getValue() && "truncation");
+    setFixedSize(size);
   }
 
 public:
@@ -122,8 +136,7 @@ public:
   llvm::Constant *getStaticStride(IRGenModule &IGM) const override;
 
   void completeFixed(Size size, Alignment alignment) {
-    Bits.FixedTypeInfo.Size = size.getValue();
-    assert(Bits.FixedTypeInfo.Size == size.getValue() && "truncation");
+    setFixedSize(size);
     setStorageAlignment(alignment);
   }
 

--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -19,6 +19,10 @@
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
 #include "NonFixedTypeInfo.h"
+#include "swift/AST/DiagnosticsIRGen.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <limits>
 
 using namespace swift;
 using namespace irgen;
@@ -726,13 +730,28 @@ TypeConverter::convertBuiltinFixedArrayType(BuiltinFixedArrayType *T) {
   if (!fixedSize.has_value() || !elementTI.isFixedSize()) {
     return new NonFixedArrayTypeInfo(IGM.OpaqueTy, elementTI);
   }
-  
+
+  // A fixed-layout type's storage size is recorded in a 32-bit field, so a
+  // fixed-size array whose total byte size does not fit in 32 bits cannot be
+  // represented. Diagnose this instead of silently truncating the size.
+  auto &fixedElementTI = cast<FixedTypeInfo>(elementTI);
+  uint64_t stride = fixedElementTI.getFixedStride().getValue();
+  // SaturatingMultiply clamps to UINT64_MAX on overflow, so an overflowing
+  // product is still caught by the 32-bit bound check below.
+  uint64_t totalSize = llvm::SaturatingMultiply(*fixedSize, stride);
+  if (totalSize > std::numeric_limits<uint32_t>::max()) {
+    IGM.Context.Diags.diagnose(SourceLoc(), diag::fixed_type_too_large,
+                               CanType(T));
+    // Fall back to an empty type info so that IRGen can continue far enough to
+    // finish diagnosing; the error prevents any object file from being emitted.
+    return &getEmptyTypeInfo();
+  }
+
   if (*fixedSize <= BuiltinFixedArrayType::MaximumLoadableSize) {
     if (auto *loadableTI = dyn_cast<LoadableTypeInfo>(&elementTI)) {
       return new LoadableArrayTypeInfo(fixedSize.value(), *loadableTI);
     }
   }
-  
-  return new FixedArrayTypeInfo(fixedSize.value(),
-                                *cast<FixedTypeInfo>(&elementTI));
+
+  return new FixedArrayTypeInfo(fixedSize.value(), fixedElementTI);
 }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
@@ -46,6 +47,8 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include <limits>
 
 #include "Callee.h"
 #include "ClassLayout.h"
@@ -502,6 +505,14 @@ ClassLayout ClassTypeInfo::generateLayout(IRGenModule &IGM, SILType classType,
   }
 
   builder.setAsBodyOfStruct(classTy);
+
+  // The class instance size is recorded in a 32-bit metadata field, so a class
+  // whose instance size does not fit in 32 bits cannot be represented. Reject
+  // it instead of silently truncating the recorded size.
+  if (builder.getSize().getValue() > std::numeric_limits<uint32_t>::max()) {
+    IGM.Context.Diags.diagnose(SourceLoc(), diag::fixed_type_too_large,
+                               classType.getASTType());
+  }
 
   return builder.getClassLayout(classTy);
 }

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -30,6 +30,8 @@
 #include "StructLayout.h"
 #include "TypeInfo.h"
 
+#include <limits>
+
 using namespace swift;
 using namespace irgen;
 
@@ -257,6 +259,26 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
     }
 
     applyLayoutAttributes(IGM, decl, IsFixedLayout, MinimumAlign);
+  }
+
+  // A fixed-layout type's storage size is recorded in a 32-bit field, so a
+  // type whose size does not fit in 32 bits cannot be represented. Reject it
+  // and fall back to a non-fixed layout so we never build a fixed-size type
+  // info with a truncated size.
+  if (IsFixedLayout &&
+      MinimumSize.getValue() > std::numeric_limits<uint32_t>::max()) {
+    if (type)
+      IGM.Context.Diags.diagnose(SourceLoc(), diag::fixed_type_too_large,
+                                 *type);
+    else
+      IGM.Context.Diags.diagnose(SourceLoc(),
+                                 diag::fixed_type_too_large_unnamed);
+    IsFixedLayout = false;
+    IsLoadable = false;
+    IsKnownAlwaysFixedSize = IsNotFixedSize;
+    MinimumSize = Size(0);
+    SpareBits.clear();
+    Ty = (typeToFill ? typeToFill : IGM.OpaqueTy);
   }
 }
 

--- a/test/IRGen/inline_array_too_large.swift
+++ b/test/IRGen/inline_array_too_large.swift
@@ -1,0 +1,49 @@
+// A fixed-layout type's storage size (and a class's instance size) is recorded
+// in a 32-bit field, both in the compiler and in the runtime metadata. A type
+// whose size does not fit in 32 bits must be rejected instead of silently
+// truncating the size, which would otherwise produce a miscompile in which
+// layouts and allocations disagree (a linear heap overflow for classes).
+//
+// Each variant is compiled in isolation so that an earlier error does not stop
+// IR generation before the later type is laid out.
+
+// RUN: not %target-swift-frontend -disable-availability-checking -primary-file %s -DARRAY  -O -emit-ir -o /dev/null 2>&1 | %FileCheck %s --check-prefix=ARRAY
+// RUN: not %target-swift-frontend -disable-availability-checking -primary-file %s -DSTRUCT -O -emit-ir -o /dev/null 2>&1 | %FileCheck %s --check-prefix=STRUCT
+// RUN: not %target-swift-frontend -disable-availability-checking -primary-file %s -DCLASS  -O -emit-ir -o /dev/null 2>&1 | %FileCheck %s --check-prefix=CLASS
+// RUN: not %target-swift-frontend -disable-availability-checking -primary-file %s -DTUPLE  -O -emit-ir -o /dev/null 2>&1 | %FileCheck %s --check-prefix=TUPLE
+
+#if ARRAY
+// A single fixed array whose byte size exceeds 32 bits:
+// 536870913 * 8 = 4294967304 > UINT32_MAX.
+struct S {
+  var a: InlineArray<536870913, Int64>
+  var b: Int64
+}
+func use() -> Int { MemoryLayout<S>.size }
+// ARRAY: error: type 'Builtin.FixedArray<536870913, Int64>' is too large to be represented
+
+#elseif STRUCT
+// Two fields, each under UINT32_MAX (300000000 * 8 = 2400000000), that sum to
+// more than UINT32_MAX.
+struct Big {
+  var a: InlineArray<300000000, Int64>
+  var b: InlineArray<300000000, Int64>
+}
+func use() -> Int { MemoryLayout<Big>.size }
+// STRUCT: error: type 'Big' is too large to be represented
+
+#elseif CLASS
+// A class whose instance size exceeds the 32-bit InstanceSize metadata field.
+class C {
+  var a = InlineArray<300000000, Int64>(repeating: 0)
+  var b = InlineArray<300000000, Int64>(repeating: 0)
+}
+func use() -> C { C() }
+// CLASS: error: type 'C' is too large to be represented
+
+#elseif TUPLE
+typealias T = (InlineArray<300000000, Int64>, InlineArray<300000000, Int64>)
+func use() -> Int { MemoryLayout<T>.size }
+// TUPLE: error: type is too large to be represented
+
+#endif


### PR DESCRIPTION
rdar://185692298

Fixed-layout type sizes and class instance sizes are stored in 32-bit fields. A size exceeding UINT32_MAX was silently truncated, causing a miscompile where layouts and allocations disagree. Now reject such types with a new diagnostic in FixedTypeInfo, GenArray, StructLayout, and GenClass instead of truncating.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
