### PR TITLE
SILOptimizier: Expand constant folding for platform availability queries

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -835,6 +835,9 @@ public:
   // Retrieve the declaration of Swift._stdlib_isOSVersionAtLeast.
   FuncDecl *getIsOSVersionAtLeastDecl() const;
 
+  // Retrieve the declaration of Swift._stdlib_isOSVersionAtLeast_AEIC.
+  FuncDecl *getIsOSVersionAtLeastAEICDecl() const;
+
   // Retrieve the declaration of Swift._stdlib_isVariantOSVersionAtLeast.
   FuncDecl *getIsVariantOSVersionAtLeastDecl() const;
 

--- a/include/swift/AST/AvailabilityQuery.h
+++ b/include/swift/AST/AvailabilityQuery.h
@@ -19,12 +19,22 @@
 
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityRange.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/VersionTuple.h"
 
 namespace swift {
 class ASTContext;
 class FuncDecl;
+
+/// Identifies the kinds of standard library entry points that evaluate a
+/// platform availability query at runtime. Every function that carries the
+/// `availability.osversion` semantics attribute should have a kind here.
+enum class OSVersionQueryKind : uint8_t {
+  IsOSVersionAtLeast,
+  IsVariantOSVersionAtLeast,
+  IsOSVersionAtLeastOrVariantVersionAtLeast,
+};
 
 /// Represents the information needed to evaluate an `#if available` query
 /// (either at runtime or compile-time).
@@ -87,6 +97,19 @@ public:
             const std::optional<AvailabilityRange> &primaryRange,
             const std::optional<AvailabilityRange> &variantRange);
 
+  /// Returns the `AvailabilityQuery` that a call to a query function of kind
+  /// `queryKind` evaluates, where `arguments` are the integer version
+  /// components that the call passes to the function. This is the inverse of
+  /// `getDynamicQueryDeclAndArguments()` for queries in platform domains.
+  ///
+  /// Returns `std::nullopt` if `arguments` has the wrong number of elements
+  /// for `queryKind`, or if the target triples in `ctx` have no platform
+  /// domain.
+  static std::optional<AvailabilityQuery>
+  forOSVersionQueryCall(OSVersionQueryKind queryKind,
+                        llvm::ArrayRef<unsigned> arguments,
+                        const ASTContext &ctx);
+
   /// Returns a copy of the `AvailabilityQuery` that has been modified to
   /// represent an `if #unavailable` query if `isUnavailability` is true, or an
   /// `if #available` query otherwise.
@@ -121,6 +144,12 @@ public:
       return std::nullopt;
     }
   }
+
+  /// Returns true if the query is guaranteed to evaluate to true at runtime
+  /// when the code is compiled for the target triples in `ctx`, because the
+  /// deployment version of every platform whose version the query tests is at
+  /// least the version that the query requires.
+  bool isAlwaysTrueForDeploymentTargets(const ASTContext &ctx) const;
 
   /// Returns the availability range that is the first argument to query
   /// function.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -424,6 +424,13 @@ struct ASTContext::Implementation {
   ///    -> Builtin.Int1
   FuncDecl *IsOSVersionAtLeastDecl = nullptr;
 
+  /// func _stdlib_isOSVersionAtLeast_AEIC(
+  ///   Builtin.Word,
+  ///   Builtin.Word,
+  ///   Builtin.word)
+  ///  -> Builtin.Int1
+  FuncDecl *IsOSVersionAtLeastAEICDecl = nullptr;
+
   /// func _stdlib_isVariantOSVersionAtLeast(
   ///   Builtin.Word,
   ///   Builtin.Word,
@@ -2119,37 +2126,58 @@ ConstructorDecl *ASTContext::getMakeUTF8StringDecl() const {
   return nullptr;
 }
 
-FuncDecl *ASTContext::getIsOSVersionAtLeastDecl() const {
-  if (getImpl().IsOSVersionAtLeastDecl)
-    return getImpl().IsOSVersionAtLeastDecl;
-
-  // Look for the function.
-  auto decl =
-      findLibraryIntrinsic(*this, "_stdlib_isOSVersionAtLeast");
-  if (!decl)
-    return nullptr;
-
+/// Returns true if `decl` has the signature that the OS version query
+/// functions which take a single version share:
+/// `(Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1`.
+static bool hasOSVersionQuerySignature(FuncDecl *decl) {
   auto *fnType = getIntrinsicCandidateType(decl, /*allowTypeMembers=*/false);
   if (!fnType)
-    return nullptr;
+    return false;
 
   // Input must be (Builtin.Word, Builtin.Word, Builtin.Word)
   auto intrinsicsParams = fnType->getParams();
   if (intrinsicsParams.size() != 3)
-    return nullptr;
+    return false;
 
   if (llvm::any_of(intrinsicsParams, [](AnyFunctionType::Param param) {
     return (param.isVariadic() || param.isInOut() ||
             !isBuiltinWordType(param.getPlainType()));
   })) {
-    return nullptr;
+    return false;
   }
 
   // Output must be Builtin.Int1
-  if (!isBuiltinInt1Type(fnType->getResult()))
+  return isBuiltinInt1Type(fnType->getResult());
+}
+
+FuncDecl *ASTContext::getIsOSVersionAtLeastDecl() const {
+  if (getImpl().IsOSVersionAtLeastDecl)
+    return getImpl().IsOSVersionAtLeastDecl;
+
+  // Look for the function.
+  auto decl = findLibraryIntrinsic(*this, "_stdlib_isOSVersionAtLeast");
+  if (!decl)
+    return nullptr;
+
+  if (!hasOSVersionQuerySignature(decl))
     return nullptr;
 
   getImpl().IsOSVersionAtLeastDecl = decl;
+  return decl;
+}
+
+FuncDecl *ASTContext::getIsOSVersionAtLeastAEICDecl() const {
+  if (getImpl().IsOSVersionAtLeastAEICDecl)
+    return getImpl().IsOSVersionAtLeastAEICDecl;
+
+  auto decl = findLibraryIntrinsic(*this, "_stdlib_isOSVersionAtLeast_AEIC");
+  if (!decl)
+    return nullptr;
+
+  if (!hasOSVersionQuerySignature(decl))
+    return nullptr;
+
+  getImpl().IsOSVersionAtLeastAEICDecl = decl;
   return decl;
 }
 

--- a/lib/AST/AvailabilityQuery.cpp
+++ b/lib/AST/AvailabilityQuery.cpp
@@ -13,6 +13,7 @@
 #include "swift/AST/AvailabilityQuery.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/PlatformKindUtils.h"
 #include "swift/Basic/Platform.h"
 
 using namespace swift;
@@ -232,4 +233,128 @@ FuncDecl *AvailabilityQuery::getDynamicQueryDeclAndArguments(
   case AvailabilityDomain::Kind::Custom:
     return domain.getCustomDomain()->getPredicateFunc();
   }
+}
+
+/// Returns the version tuple that `arguments`, the three integer components of
+/// a version that is passed to an OS version query function, describes.
+static llvm::VersionTuple packVersion(llvm::ArrayRef<unsigned> arguments) {
+  ASSERT(arguments.size() == 3);
+  return llvm::VersionTuple(arguments[0], arguments[1], arguments[2]);
+}
+
+std::optional<AvailabilityQuery>
+AvailabilityQuery::forOSVersionQueryCall(OSVersionQueryKind queryKind,
+                                         llvm::ArrayRef<unsigned> arguments,
+                                         const ASTContext &ctx) {
+  std::optional<AvailabilityRange> osRange;
+  std::optional<AvailabilityRange> variantOSRange;
+
+  switch (queryKind) {
+  case OSVersionQueryKind::IsOSVersionAtLeast:
+    if (arguments.size() != 3)
+      return std::nullopt;
+
+    osRange = AvailabilityRange(packVersion(arguments));
+    break;
+
+  case OSVersionQueryKind::IsVariantOSVersionAtLeast:
+    if (arguments.size() != 3)
+      return std::nullopt;
+
+    variantOSRange = AvailabilityRange(packVersion(arguments));
+    break;
+
+  case OSVersionQueryKind::IsOSVersionAtLeastOrVariantVersionAtLeast:
+    if (arguments.size() != 6)
+      return std::nullopt;
+
+    osRange = AvailabilityRange(packVersion(arguments.slice(0, 3)));
+    variantOSRange = AvailabilityRange(packVersion(arguments.slice(3, 3)));
+    break;
+  }
+
+  // If necessary, swap the order of the osRange and variantOSRange arguments
+  // to match the order expected by this compilation context. When encoded
+  // as a function call, the non-macCatalyst version argument always comes
+  // first, but if the -target specified for this compilation context is a
+  // macCatalyst triple then the primary version range is expected to be the
+  // macCatalyst one.
+  bool targetIsMacCatalyst =
+      tripleIsMacCatalystEnvironment(ctx.LangOpts.Target);
+  auto primaryRange = targetIsMacCatalyst ? variantOSRange : osRange;
+  auto variantRange = targetIsMacCatalyst ? osRange : variantOSRange;
+
+  // The query belongs to the domain of the platform whose version it tests.
+  // When it tests the versions of both platforms, the `-target` platform's
+  // domain is the one to use.
+  auto platform = primaryRange ? targetPlatform(ctx.LangOpts)
+                               : targetVariantPlatform(ctx.LangOpts);
+  if (!platform)
+    return std::nullopt;
+
+  return dynamic(AvailabilityDomain::forPlatform(*platform), primaryRange,
+                 variantRange);
+}
+
+/// Returns the range of versions of the `-target-variant` platform that the
+/// module being compiled deploys to, or `std::nullopt` if there is no
+/// `-target-variant`.
+static std::optional<AvailabilityRange>
+deploymentRangeForTargetVariant(const ASTContext &ctx) {
+  if (!ctx.LangOpts.TargetVariant)
+    return std::nullopt;
+
+  return AvailabilityRange(getVersionForTriple(*ctx.LangOpts.TargetVariant));
+}
+
+bool AvailabilityQuery::isAlwaysTrueForDeploymentTargets(
+    const ASTContext &ctx) const {
+  // A constant query doesn't depend on the deployment targets at all.
+  if (auto constantResult = getConstantResult())
+    return *constantResult;
+
+  // An `#unavailable` query is true when the version test that it performs
+  // fails. A deployment target is only a lower bound on the version of the OS
+  // that runs the code, so it can never prove that a version test fails.
+  if (isUnavailability())
+    return false;
+
+  switch (domain.getKind()) {
+  case AvailabilityDomain::Kind::Universal:
+  case AvailabilityDomain::Kind::SwiftLanguageMode:
+  case AvailabilityDomain::Kind::PackageDescription:
+  case AvailabilityDomain::Kind::Embedded:
+    // These domains only support constant queries, which are handled above.
+    return false;
+
+  case AvailabilityDomain::Kind::StandaloneSwiftRuntime:
+    // The version of the Swift runtime that the code runs against is not
+    // analyzed here.
+    return false;
+
+  case AvailabilityDomain::Kind::Custom:
+    // The enablement of a dynamic custom domain is decided at runtime.
+    return false;
+
+  case AvailabilityDomain::Kind::Platform:
+    break;
+  }
+
+  // A version must be specified for a platform query.
+  DEBUG_ASSERT(primaryRange || variantRange);
+
+  if (primaryRange) {
+    if (!AvailabilityRange::forDeploymentTarget(ctx).isContainedIn(
+            *primaryRange))
+      return false;
+  }
+
+  if (variantRange) {
+    if (auto variantDeployment = deploymentRangeForTargetVariant(ctx)) {
+      if (!variantDeployment->isContainedIn(*variantRange))
+        return false;
+    }
+  }
+
+  return true;
 }

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SILOptimizer/Utils/ConstantFolding.h"
 
+#include "swift/AST/AvailabilityQuery.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/SemanticAttrs.h"
@@ -1553,6 +1554,43 @@ static bool isApplyOfBuiltin(SILInstruction &I, BuiltinValueKind kind) {
   return false;
 }
 
+/// Returns the kind of OS version query function that `callee` is, or
+/// `std::nullopt` if `callee` is not one of those functions.
+///
+/// Every OS version query function that the standard library declares carries
+/// the `availability.osversion` semantics attribute, and every one of them is
+/// matched here. A function that carries the attribute and matches none of
+/// them is a query function that this list is missing, so this aborts rather
+/// than silently treat it as one of the functions it does know.
+static std::optional<OSVersionQueryKind>
+getOSVersionQueryKind(SILFunction *callee) {
+  if (!callee->hasSemanticsAttr(semantics::AVAILABILITY_OSVERSION))
+    return std::nullopt;
+
+  auto &module = callee->getModule();
+  auto &ctx = module.getASTContext();
+  auto isCallee = [&module, callee](FuncDecl *decl) {
+    return decl && module.lookUpFunction(SILDeclRef(decl)) == callee;
+  };
+
+  // On iOS `_stdlib_isOSVersionAtLeast()` is `@_transparent` and does not carry
+  // the semantics attribute, so a query there reaches this pass as a call to
+  // `_stdlib_isOSVersionAtLeast_AEIC()` instead.
+  if (isCallee(ctx.getIsOSVersionAtLeastDecl()) ||
+      isCallee(ctx.getIsOSVersionAtLeastAEICDecl()))
+    return OSVersionQueryKind::IsOSVersionAtLeast;
+
+  if (isCallee(ctx.getIsVariantOSVersionAtLeastDecl()))
+    return OSVersionQueryKind::IsVariantOSVersionAtLeast;
+
+  if (isCallee(ctx.getIsOSVersionAtLeastOrVariantVersionAtLeast()))
+    return OSVersionQueryKind::IsOSVersionAtLeastOrVariantVersionAtLeast;
+
+  ABORT([callee](auto &out) {
+    out << "unrecognized OS version query function: " << callee->getName();
+  });
+}
+
 static bool isApplyOfKnownAvailability(SILInstruction &I) {
   // Inlinable functions can be deserialized in other modules which can be
   // compiled with a different deployment target.
@@ -1565,28 +1603,28 @@ static bool isApplyOfKnownAvailability(SILInstruction &I) {
   auto callee = apply.getReferencedFunctionOrNull();
   if (!callee)
     return false;
-  if (!callee->hasSemanticsAttr("availability.osversion"))
-    return false;
-  auto &context = I.getFunction()->getASTContext();
-  auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(context);
-  if (apply.getNumArguments() != 3)
-    return false;
-  auto arg0 = dyn_cast<IntegerLiteralInst>(apply.getArgument(0));
-  if (!arg0)
-    return false;
-  auto arg1 = dyn_cast<IntegerLiteralInst>(apply.getArgument(1));
-  if (!arg1)
-    return false;
-  auto arg2 = dyn_cast<IntegerLiteralInst>(apply.getArgument(2));
-  if (!arg2)
+
+  auto queryKind = getOSVersionQueryKind(callee);
+  if (!queryKind)
     return false;
 
-  auto version = VersionRange::allGTE(llvm::VersionTuple(
-      arg0->getValue().getLimitedValue(), arg1->getValue().getLimitedValue(),
-      arg2->getValue().getLimitedValue()));
+  // Give up unless the arguments are all integer literals. Each argument is one
+  // component of one of the versions that the query tests.
+  SmallVector<unsigned, 6> arguments;
+  for (auto argument : apply.getArguments()) {
+    auto *literal = dyn_cast<IntegerLiteralInst>(argument);
+    if (!literal)
+      return false;
+    arguments.push_back(literal->getValue().getLimitedValue());
+  }
 
-  auto callAvailability = AvailabilityRange(version);
-  return deploymentAvailability.isContainedIn(callAvailability);
+  auto &ctx = I.getFunction()->getASTContext();
+  auto query =
+      AvailabilityQuery::forOSVersionQueryCall(*queryKind, arguments, ctx);
+  if (!query)
+    return false;
+
+  return query->isAlwaysTrueForDeploymentTargets(ctx);
 }
 
 static bool isApplyOfStringConcat(SILInstruction &I) {

--- a/test/SILOptimizer/Inputs/constant_propagation_availability_zippered_lib.swift
+++ b/test/SILOptimizer/Inputs/constant_propagation_availability_zippered_lib.swift
@@ -1,0 +1,69 @@
+// The library half of
+// test/SILOptimizer/constant_propagation_availability_maccatalyst_zippered.swift.
+
+@available(macOS 10.52, iOS 50.0, *)
+public func newerOnBoth() -> Int { return 1 }
+
+@available(macOS 10.52, *)
+public func newerOnMacOS() -> Int { return 2 }
+
+@available(iOS 50.0, *)
+public func newerOnMacCatalyst() -> Int { return 3 }
+
+public func older() -> Int { return 0 }
+
+@inlinable
+public func queryBothBelow() -> Int {
+  if #available(macOS 10.52, iOS 50.0, *) {
+    return newerOnBoth()
+  }
+  return older()
+}
+
+@inlinable
+public func queryBothAboveMacOS() -> Int {
+  if #available(macOS 10.54, iOS 50.0, *) {
+    return newerOnBoth()
+  }
+  return older()
+}
+
+@inlinable
+public func queryBothAboveMacCatalyst() -> Int {
+  if #available(macOS 10.52, iOS 52.0, *) {
+    return newerOnBoth()
+  }
+  return older()
+}
+
+@inlinable
+public func queryMacOSBelow() -> Int {
+  if #available(macOS 10.52, *) {
+    return newerOnMacOS()
+  }
+  return older()
+}
+
+@inlinable
+public func queryMacOSAbove() -> Int {
+  if #available(macOS 10.54, *) {
+    return newerOnMacOS()
+  }
+  return older()
+}
+
+@inlinable
+public func queryMacCatalystBelow() -> Int {
+  if #available(iOS 50.0, *) {
+    return newerOnMacCatalyst()
+  }
+  return older()
+}
+
+@inlinable
+public func queryMacCatalystAbove() -> Int {
+  if #available(iOS 52.0, *) {
+    return newerOnMacCatalyst()
+  }
+  return older()
+}

--- a/test/SILOptimizer/constant_propagation_availability.swift
+++ b/test/SILOptimizer/constant_propagation_availability.swift
@@ -1,72 +1,88 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos10.15 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_15 %s
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos10.14 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_14 %s
-// RUN: %target-swift-frontend -O -target %target-cpu-apple-macos10.15 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_15 --check-prefix=CHECK-macosx10_15_opt %s
-// RUN: %target-swift-frontend -O -target %target-cpu-apple-macos10.14 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_14 %s
+// Availability queries fold when the deployment target satisfies the queried
+// version.
 
-// RUN: %empty-directory(%t) 
-// RUN: %target-swift-frontend -O -target %target-cpu-apple-macos10.15 -module-name=Test -emit-module -emit-module-path %t/Test.swiftmodule %s
-// RUN: %sil-opt -target %target-cpu-apple-macos10.15 %t/Test.swiftmodule | %FileCheck --check-prefix=CHECK-inlinable %s
+// RUN: %empty-directory(%t)
 
-// REQUIRES: OS=macosx
+// The queries name the versions that shipped SwiftStdlib 6.0. The first target
+// deploys there, so every query folds. The second deploys to SwiftStdlib 5.10,
+// below it, so the queries stay.
 
-@available(macOS 10.15, *)
+// RUN: %target-swift-frontend -O -emit-sil -target %target-swift-6.0-abi-triple %s | %FileCheck %s --check-prefixes=CHECK,FOLDED,INLINABLE-FOLDED
+// RUN: %target-swift-frontend -O -emit-sil -target %target-swift-5.10-abi-triple %s | %FileCheck %s --check-prefixes=CHECK,KEPT,INLINABLE-KEPT
+
+// Folding a query in an ordinary function doesn't need `-O`. An inlinable
+// function is still serialized at that point, so its query only folds at `-O`.
+// RUN: %target-swift-frontend -emit-sil -target %target-swift-6.0-abi-triple %s | %FileCheck %s --check-prefixes=CHECK,FOLDED,INLINABLE-KEPT
+// RUN: %target-swift-frontend -emit-sil -target %target-swift-5.10-abi-triple %s | %FileCheck %s --check-prefixes=CHECK,KEPT,INLINABLE-KEPT
+
+// An inlinable function can be deserialized into a module with a lower
+// deployment target, so its query survives serialization even when the module
+// that defines it folds its own copy.
+
+// RUN: %target-swift-frontend -O -target %target-swift-6.0-abi-triple -module-name Test -emit-module -emit-module-path %t/Test.swiftmodule %s
+// RUN: %sil-opt -target %target-swift-6.0-abi-triple %t/Test.swiftmodule | %FileCheck %s --check-prefix=SERIALIZED
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos || OS=xros
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @inline(never)
-public func newFunction() -> Int {
-  return 0
-}
+public func newFunction() {}
 
 @inline(never)
-public func oldFunction() -> Int {
-  return 1
-}
+public func oldFunction() {}
 
-public func testAvailabilityPropagation() -> Int {
-  if #available(macOS 10.15, *) {
-    return newFunction()
+// A folded query keeps no version check and no branch, and the branch that
+// survives is the one that runs when the query succeeds.
+
+// The checks below match `OSVersionAtLeast` instead of one entry point, because
+// the entry point differs by platform. On iOS `_stdlib_isOSVersionAtLeast()` is
+// `@_transparent`, so a query there calls `_stdlib_isOSVersionAtLeast_AEIC()`,
+// which `-O` inlines into the `targetOSVersionAtLeast` builtin.
+
+// CHECK-LABEL: sil{{.*}}@$s33constant_propagation_availability27testAvailabilityPropagationyyF :
+// FOLDED-NOT:    OSVersionAtLeast
+// FOLDED-NOT:    cond_br
+// KEPT:          OSVersionAtLeast
+// KEPT:          cond_br
+// CHECK:         function_ref @$s33constant_propagation_availability11newFunctionyyF
+// KEPT:          function_ref @$s33constant_propagation_availability11oldFunctionyyF
+// FOLDED-NOT:    OSVersionAtLeast
+// FOLDED-NOT:    cond_br
+// FOLDED-NOT:    function_ref @$s33constant_propagation_availability11oldFunctionyyF
+// CHECK:       } // end sil function '$s33constant_propagation_availability27testAvailabilityPropagationyyF'
+public func testAvailabilityPropagation() {
+  if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+    newFunction()
   } else {
-    return oldFunction()
+    oldFunction()
   }
 }
 
+// The same query folds the same way in a function that is inlinable, but only
+// once the optimizer drops the serialized flag. Before that the body may still
+// be deserialized into a module with a lower deployment target.
+
+// CHECK-LABEL:            sil{{.*}}@$s33constant_propagation_availability13testInlinableyyF :
+// INLINABLE-FOLDED-NOT:     OSVersionAtLeast
+// INLINABLE-FOLDED-NOT:     cond_br
+// INLINABLE-KEPT:           OSVersionAtLeast
+// INLINABLE-KEPT:           cond_br
+// CHECK:                    function_ref @$s33constant_propagation_availability11newFunctionyyF
+// INLINABLE-FOLDED-NOT:     OSVersionAtLeast
+// INLINABLE-FOLDED-NOT:     cond_br
+// CHECK:                  } // end sil function '$s33constant_propagation_availability13testInlinableyyF'
 @inlinable
-public func testInlinable() -> Int {
-  if #available(macOS 10.15, *) {
-    return newFunction()
-  } else {
-    return 0
+public func testInlinable() {
+  if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+    newFunction()
   }
 }
 
-// CHECK-macosx10_15-LABEL: sil @$s33constant_propagation_availability27testAvailabilityPropagationSiyF : $@convention(thin) () -> Int {
-// CHECK-macosx10_15-NOT: apply
-// CHECK-macosx10_15:  [[F:%.*]] = function_ref @$s33constant_propagation_availability11newFunctionSiyF
-// CHECK-macosx10_15:  apply [[F]]() : $@convention(thin) () -> Int
-// CHECK-macosx10_15-NOT: apply
-// CHECK-macosx10_15: } // end sil function '$s33constant_propagation_availability27testAvailabilityPropagationSiyF'
+// The serialized body of the inlinable function keeps its query, because a
+// module with a lower deployment target may deserialize it.
 
-// After serialization, availability checks can be constant folded.
-
-// CHECK-macosx10_15_opt-LABEL: sil @$s33constant_propagation_availability13testInlinableSiyF : $@convention(thin) () -> Int {
-// CHECK-macosx10_15_opt-NOT: apply
-// CHECK-macosx10_15_opt:  [[F:%.*]] = function_ref @$s33constant_propagation_availability11newFunctionSiyF
-// CHECK-macosx10_15_opt:  apply [[F]]() : $@convention(thin) () -> Int
-// CHECK-macosx10_15_opt-NOT: apply
-// CHECK-macosx10_15_opt: } // end sil function '$s33constant_propagation_availability13testInlinableSiyF'
-
-// CHECK-macosx10_14-LABEL: sil @$s33constant_propagation_availability27testAvailabilityPropagationSiyF : $@convention(thin) () -> Int {
-// CHECK-macosx10_14:  [[F:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
-// CHECK-macosx10_14:  apply [[F]]
-// CHECK-macosx10_14:  [[F:%.*]] = function_ref @$s33constant_propagation_availability11newFunctionSiyF
-// CHECK-macosx10_14:  apply [[F]]() : $@convention(thin) () -> Int
-// CHECK-macosx10_14:  [[F:%.*]] = function_ref @$s33constant_propagation_availability11oldFunctionSiyF
-// CHECK-macosx10_14:  apply [[F]]
-// CHECK-macosx10_14: } // end sil function '$s33constant_propagation_availability27testAvailabilityPropagationSiyF'
-
-// CHECK-macosx10_14: sil [no_locks] [readnone] [_semantics "availability.osversion"] @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
-
-// CHECK-inlinable-LABEL: sil {{.*}} @$s4Test13testInlinableSiyF  : $@convention(thin) () -> Int {
-// CHECK-inlinable:  [[F:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
-// CHECK-inlinable:  apply [[F]]
-// CHECK-inlinable:  [[F:%.*]] = function_ref @$s4Test11newFunctionSiyF
-// CHECK-inlinable:  apply [[F]]() : $@convention(thin) () -> Int
-// CHECK-inlinable: } // end sil function '$s4Test13testInlinableSiyF'
+// SERIALIZED-LABEL: sil{{.*}}@$s4Test13testInlinableyyF :
+// SERIALIZED:         OSVersionAtLeast
+// SERIALIZED:         cond_br
+// SERIALIZED:         function_ref @$s4Test11newFunctionyyF
+// SERIALIZED:       } // end sil function '$s4Test13testInlinableyyF'

--- a/test/SILOptimizer/constant_propagation_availability_maccatalyst_zippered.swift
+++ b/test/SILOptimizer/constant_propagation_availability_maccatalyst_zippered.swift
@@ -1,0 +1,111 @@
+// Build the same zippered library twice. macOS clients load the build that has
+// macOS as its primary target, and macCatalyst clients load the build that has
+// macCatalyst as its primary target. Both builds emit the same availability
+// query entry points.
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/macos)
+// RUN: %empty-directory(%t/maccatalyst)
+
+// RUN: %target-swift-frontend -O -module-name ZipperedLib -emit-module -emit-module-path %t/macos/ZipperedLib.swiftmodule -target %target-cpu-apple-macosx10.15 -target-variant %target-cpu-apple-ios13.1-macabi %S/Inputs/constant_propagation_availability_zippered_lib.swift
+// RUN: %target-swift-frontend -O -module-name ZipperedLib -emit-module -emit-module-path %t/maccatalyst/ZipperedLib.swiftmodule -target %target-cpu-apple-ios13.1-macabi -target-variant %target-cpu-apple-macosx10.15 %S/Inputs/constant_propagation_availability_zippered_lib.swift
+
+// Every client below deploys to macOS 10.53, to macCatalyst 51.0, or to both.
+// The library queries versions on either side of those two, so the queried
+// version decides whether a query folds.
+
+// A zippered client deploys to both platforms.
+// RUN: %target-swift-frontend -O -emit-sil -module-name Client -I %t/macos %s -target %target-cpu-apple-macosx10.53 -target-variant %target-cpu-apple-ios51.0-macabi | %FileCheck %s --check-prefixes=CHECK,DEPLOYS-MACOS,DEPLOYS-MACCATALYST
+
+// A macOS only client deploys to macOS alone.
+// RUN: %target-swift-frontend -O -emit-sil -module-name Client -I %t/macos %s -target %target-cpu-apple-macosx10.53 | %FileCheck %s --check-prefixes=CHECK,DEPLOYS-MACOS,MACOS-ONLY
+
+// A macCatalyst only client deploys to macCatalyst alone.
+// RUN: %target-swift-frontend -O -emit-sil -module-name Client -I %t/maccatalyst %s -target %target-cpu-apple-ios51.0-macabi | %FileCheck %s --check-prefixes=CHECK,DEPLOYS-MACCATALYST,MACCATALYST-ONLY
+
+// REQUIRES: OS=macosx || OS=maccatalyst
+// REQUIRES: maccatalyst_support
+
+import ZipperedLib
+
+// CHECK-LABEL:           sil{{.*}}@$s6Client13testBothBelowSiyF :
+// CHECK-NOT:               OSVersionAtLeast
+// CHECK-NOT:               cond_br
+// CHECK:                   function_ref @$s11ZipperedLib11newerOnBothSiyF
+// CHECK-NOT:               OSVersionAtLeast
+// CHECK-NOT:               cond_br
+// CHECK:                 } // end sil function '$s6Client13testBothBelowSiyF'
+public func testBothBelow() -> Int {
+  return queryBothBelow()
+}
+
+// CHECK-LABEL:           sil{{.*}}@$s6Client18testBothAboveMacOSSiyF :
+// MACCATALYST-ONLY-NOT:    OSVersionAtLeast
+// MACCATALYST-ONLY-NOT:    cond_br
+// DEPLOYS-MACOS:           function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF
+// DEPLOYS-MACOS:           cond_br
+// CHECK:                   function_ref @$s11ZipperedLib11newerOnBothSiyF
+// MACCATALYST-ONLY-NOT:    OSVersionAtLeast
+// MACCATALYST-ONLY-NOT:    cond_br
+// CHECK:                 } // end sil function '$s6Client18testBothAboveMacOSSiyF'
+public func testBothAboveMacOS() -> Int {
+  return queryBothAboveMacOS()
+}
+
+// CHECK-LABEL:           sil{{.*}}@$s6Client24testBothAboveMacCatalystSiyF :
+// MACOS-ONLY-NOT:          OSVersionAtLeast
+// MACOS-ONLY-NOT:          cond_br
+// DEPLOYS-MACCATALYST:     function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF
+// DEPLOYS-MACCATALYST:     cond_br
+// CHECK:                   function_ref @$s11ZipperedLib11newerOnBothSiyF
+// MACOS-ONLY-NOT:          OSVersionAtLeast
+// MACOS-ONLY-NOT:          cond_br
+// CHECK:                 } // end sil function '$s6Client24testBothAboveMacCatalystSiyF'
+public func testBothAboveMacCatalyst() -> Int {
+  return queryBothAboveMacCatalyst()
+}
+
+// CHECK-LABEL:           sil{{.*}}@$s6Client14testMacOSBelowSiyF :
+// DEPLOYS-MACOS-NOT:       OSVersionAtLeast
+// DEPLOYS-MACOS-NOT:       cond_br
+// MACCATALYST-ONLY:        builtin "targetOSVersionAtLeast"
+// MACCATALYST-ONLY:        cond_br
+// CHECK:                   function_ref @$s11ZipperedLib12newerOnMacOSSiyF
+// DEPLOYS-MACOS-NOT:       OSVersionAtLeast
+// DEPLOYS-MACOS-NOT:       cond_br
+// CHECK:                 } // end sil function '$s6Client14testMacOSBelowSiyF'
+public func testMacOSBelow() -> Int {
+  return queryMacOSBelow()
+}
+
+// CHECK-LABEL:           sil{{.*}}@$s6Client14testMacOSAboveSiyF :
+// DEPLOYS-MACOS:           function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// MACCATALYST-ONLY:        builtin "targetOSVersionAtLeast"
+// CHECK:                   cond_br
+// CHECK:                   function_ref @$s11ZipperedLib12newerOnMacOSSiyF
+// CHECK:                 } // end sil function '$s6Client14testMacOSAboveSiyF'
+public func testMacOSAbove() -> Int {
+  return queryMacOSAbove()
+}
+
+// CHECK-LABEL:           sil{{.*}}@$s6Client20testMacCatalystBelowSiyF :
+// DEPLOYS-MACCATALYST-NOT: OSVersionAtLeast
+// DEPLOYS-MACCATALYST-NOT: cond_br
+// MACOS-ONLY:              function_ref @$ss33_stdlib_isVariantOSVersionAtLeastyBi1_Bw_BwBwtF
+// MACOS-ONLY:              cond_br
+// CHECK:                   function_ref @$s11ZipperedLib18newerOnMacCatalystSiyF
+// DEPLOYS-MACCATALYST-NOT: OSVersionAtLeast
+// DEPLOYS-MACCATALYST-NOT: cond_br
+// CHECK:                 } // end sil function '$s6Client20testMacCatalystBelowSiyF'
+public func testMacCatalystBelow() -> Int {
+  return queryMacCatalystBelow()
+}
+
+// CHECK-LABEL:           sil{{.*}}@$s6Client20testMacCatalystAboveSiyF :
+// CHECK:                   function_ref @$ss33_stdlib_isVariantOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK:                   cond_br
+// CHECK:                   function_ref @$s11ZipperedLib18newerOnMacCatalystSiyF
+// CHECK:                 } // end sil function '$s6Client20testMacCatalystAboveSiyF'
+public func testMacCatalystAbove() -> Int {
+  return queryMacCatalystAbove()
+}


### PR DESCRIPTION
The optimizer already folded `_stdlib_isOSVersionAtLeast()` checks that will always return true. Fold calls to `_stdlib_isVariantOSVersionAtLeast()` and `_stdlib_isOSVersionAtLeastOrVariantVersionAtLeast()` as well, so that unnecessary availability checks can are also removed from zippered macOS libraries and modules built for macCatalyst. This is important because many low level libraries on macOS (the standard library included) are built zippered and therefore were previously not getting the benefit of this optimization.

Resolves rdar://154093989.