### PR TITLE
[any ~Copyable] `if case let t as Type = box` no longer consumes on failure

### DIFF
--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -196,6 +196,18 @@ public:
   /// Whether the storage owns what's stored or merely borrows it.
   virtual bool isBorrow() { return false; }
 
+  /// Attempt to initialize directly out of the storage referenced by \p
+  /// initializer, rather than having the caller evaluate \p initializer as an
+  /// rvalue (which, for a noncopyable value, would consume it via a copy).
+  ///
+  /// Returns true if this initialization handled the emission itself, in which
+  /// case the caller must not evaluate \p initializer again.
+  virtual bool tryInitializeFromStorageReference(SILGenFunction &SGF,
+                                                 Expr *initializer,
+                                                 SILLocation loc) {
+    return false;
+  }
+
   /// Whether to emit a debug value during initialization.
   void setEmitDebugValueOnInit(bool emit) { EmitDebugValueOnInit = emit; }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -2067,8 +2067,8 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
           }
 
           // Try directly accessing the initializer's storage instead of copying
-	  // into an rvalue, so that we can leave it unconsumed if the pattern
-	  // fails.
+          // into an rvalue, so that we can leave it unconsumed if the pattern
+          // fails.
           if (initialization->tryInitializeFromStorageReference(
                   *this, elt.getInitializer(), loc)) {
             // We are now on the match-succeeded path, with the binding in

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1422,6 +1422,22 @@ public:
   void copyOrInitValueIntoImpl(SILGenFunction &SGF, SILLocation loc,
                                ManagedValue value, bool isInit) override;
 
+  /// Emit the cast branching straight to our failure destination, without
+  /// building an intermediate Optional. Returns false if this shape isn't
+  /// supported, in which case the caller falls back to the Optional form.
+  bool tryEmitNoncopyablePatternMatch(SILGenFunction &SGF, SILLocation loc,
+                                     ManagedValue value);
+
+  bool tryInitializeFromStorageReference(SILGenFunction &SGF, Expr *initializer,
+                                         SILLocation loc) override;
+
+  /// True if this is a cast pattern whose subject is a noncopyable
+  /// existential, which is the case the direct-branch lowering handles.
+  bool isNoncopyableExistentialSubject() const {
+    Type subjectType = pattern->getType();
+    return subjectType->isNoncopyable() && subjectType->isExistentialType();
+  }
+
   void finishInitialization(SILGenFunction &SGF) override {
     if (subInitialization.get())
       subInitialization->finishInitialization(SGF);
@@ -1429,12 +1445,153 @@ public:
 };
 } // end anonymous namespace
 
+/// If \p e names storage that may be consumed out of, return the storage
+/// reference to emit as an lvalue; otherwise return null.
+///
+/// A LoadExpr means Sema resolved the reference as an rvalue load out of
+/// mutable lvalue storage -- a `var` local, a `var` stored property, an
+/// `inout`/`consuming` parameter -- which is always consumable. That is the
+/// case findStorageReferenceExprForMoveOnly(..., Consume) recognizes, and it is
+/// why that helper can't be reused here: it requires the LoadExpr
+/// unconditionally, so it rejects every immutable-storage case below.
+///
+/// Immutable storage is referenced directly, with no load, and consuming it is
+/// only *sometimes* legal -- so test the declaration rather than inferring from
+/// the shape. A local `let` may be consumed; a borrowing parameter may not.
+/// Getting that wrong is not merely a missed optimization: consuming a
+/// borrowing parameter emits SIL that mutates an @in_guaranteed argument, which
+/// the SIL verifier rejects outright rather than diagnosing. So this fails
+/// closed -- anything unrecognized returns null and the caller falls back to
+/// the ordinary rvalue path, which is always correct, just unable to preserve
+/// the subject across a failed cast.
+static Expr *findConsumableStorageReference(Expr *e) {
+  Expr *semantic = e->getSemanticsProvidingExpr();
+
+  if (auto *load = dyn_cast<LoadExpr>(semantic))
+    return load->getSubExpr();
+
+  if (auto *dre = dyn_cast<DeclRefExpr>(semantic)) {
+    auto *vd = dyn_cast<VarDecl>(dre->getDecl());
+    // A global or static `let` is only ever borrowed, never consumed.
+    if (!vd || vd->isGlobalStorage())
+      return nullptr;
+    if (auto *pd = dyn_cast<ParamDecl>(vd)) {
+      switch (pd->getSpecifier()) {
+      case ParamSpecifier::Consuming:
+      case ParamSpecifier::LegacyOwned:
+      case ParamSpecifier::ImplicitlyCopyableConsuming:
+        return dre;
+      case ParamSpecifier::Default:
+      case ParamSpecifier::InOut:
+      case ParamSpecifier::Borrowing:
+      case ParamSpecifier::LegacyShared:
+        // Note that Default means *borrowing* for a noncopyable parameter.
+        return nullptr;
+      }
+      // An ownership specifier we don't know about: fail closed.
+      return nullptr;
+    }
+    // A local `let`.
+    return dre;
+  }
+
+  // A `let` stored property is deliberately *not* handled here, even though it
+  // would be a partial consume of a consumable base. Requesting an
+  // OwnedAddressConsume lvalue for an immutable member yields the member's
+  // address under a `begin_access [read]`, so the take_on_success cast would
+  // then consume out of storage covered by a read-only access. Compare how
+  // SILGen otherwise consumes such a property (`eat(h.v)`), which uses
+  // `begin_access [modify]` plus a `copy_addr [take]` into a temporary -- but
+  // that eager take is exactly what makes preserve-on-failure impossible. So
+  // this case needs the access-kind plumbing sorted out first; until then it
+  // falls back to the ordinary rvalue path and diagnoses rather than emitting
+  // SIL whose access marker contradicts what the instruction does.
+
+  return nullptr;
+}
+
+// Try to use the original storage directly when casting a
+// noncopyable existential source.
+bool IsPatternInitialization::tryInitializeFromStorageReference(
+    SILGenFunction &SGF, Expr *initializer, SILLocation loc) {
+  if (!isNoncopyableExistentialSubject())
+    return false;
+
+  // Is the subject stored where we can use it directly?  If not, return
+  // false and caller will copy it.
+  Expr *storageExpr = findConsumableStorageReference(initializer);
+  if (!storageExpr)
+    return false;
+
+  // Use the subject directly (not a copy) as the cast's source operand
+  // so a failed cast can leave the original intact for later use.
+  FormalEvaluationScope scope(SGF);
+  LValue lv = SGF.emitLValue(storageExpr, SGFAccessKind::OwnedAddressConsume);
+  ManagedValue addr = SGF.emitConsumedLValue(loc, std::move(lv));
+
+  return tryEmitNoncopyablePatternMatch(SGF, loc, addr);
+}
+
+// If possible, emit a cast that consumes only on success.
+bool IsPatternInitialization::tryEmitNoncopyablePatternMatch(
+    SILGenFunction &SGF, SILLocation loc, ManagedValue value) {
+  // Only the plain address-based value cast is handled here; anything else
+  // (collection downcasts, loadable representations) keeps the existing path.
+  if (pattern->getCastKind() != CheckedCastKind::ValueCast)
+    return false;
+  if (!value.getType().isAddress())
+    return false;
+
+  CanType sourceType = pattern->getType()->getCanonicalType();
+  CanType targetType = pattern->getCastType()->getCanonicalType();
+
+  auto &targetTL = SGF.getTypeLowering(targetType);
+
+  // Destination buffer for the extracted payload. Note the target may be
+  // loadable (only the existential source has to be address-only);
+  // checked_cast_addr_br writes through an address either way.
+  SILValue destAddr = SGF.emitTemporaryAllocation(loc, targetTL.getLoweredType());
+
+  SILBasicBlock *contBB = SGF.B.splitBlockForFallthrough();
+  SILBasicBlock *failBB = SGF.Cleanups.emitBlockForCleanups(getFailureDest(), loc);
+
+  auto &initInfo = getInitInfo();
+  SGF.B.createCheckedCastAddrBranch(
+      loc, CheckedCastInstOptions(), CastConsumptionKind::TakeOnSuccess,
+      value.forward(SGF), sourceType, destAddr, targetType, contBB, failBB,
+      initInfo.numTrueTaken, initInfo.numFalseTaken);
+
+  // On the success edge the payload has been moved into destAddr and is ours
+  // to bind.
+  SGF.B.setInsertionPoint(contBB);
+  ManagedValue payload;
+  if (targetTL.isAddressOnly()) {
+    payload = SGF.emitManagedBufferWithCleanup(destAddr, targetTL);
+  } else {
+    payload = SGF.emitManagedRValueWithCleanup(
+        SGF.B.createLoad(loc, destAddr, LoadOwnershipQualifier::Take), targetTL);
+  }
+  subInitialization->copyOrInitValueInto(SGF, loc, payload, /*isInit=*/true);
+  // Note: our own finishInitialization() forwards to subInitialization, so
+  // don't finish it here -- doing so would emit the local twice.
+  return true;
+}
+
 void IsPatternInitialization::copyOrInitValueIntoImpl(SILGenFunction &SGF,
                                                       SILLocation loc,
                                                       ManagedValue value,
                                                       bool isInit) {
   assert(isInit && "Only initialization is supported for refutable patterns");
-  
+
+  // For a noncopyable existential, first try emitting the direct-branch form
+  // without producing the intermediate optional.  That encodes the success
+  // status in the CFG which makes it possible to selectively consume only on
+  // success.
+  if (isNoncopyableExistentialSubject() &&
+      tryEmitNoncopyablePatternMatch(SGF, loc, value)) {
+    return;
+  }
+
   // Try to perform the cast to the destination type, producing an optional that
   // indicates whether we succeeded.
   auto destType = OptionalType::get(pattern->getCastType());
@@ -1906,6 +2063,17 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
 
           if (initialization->isBorrow()) {
             emitExprInto(elt.getInitializer(), initialization.get(), loc);
+            continue;
+          }
+
+          // Try directly accessing the initializer's storage instead of copying
+	  // into an rvalue, so that we can leave it unconsumed if the pattern
+	  // fails.
+          if (initialization->tryInitializeFromStorageReference(
+                  *this, elt.getInitializer(), loc)) {
+            // We are now on the match-succeeded path, with the binding in
+            // place; finish it as forwardInto() would have.
+            initialization->finishInitialization(*this);
             continue;
           }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1565,7 +1565,7 @@ bool IsPatternInitialization::tryEmitNoncopyablePatternMatch(
   // to bind.
   SGF.B.setInsertionPoint(contBB);
   ManagedValue payload;
-  if (targetTL.isAddressOnly()) {
+  if (!targetTL.isLoadableOrOpaque(SGF.F)) {
     payload = SGF.emitManagedBufferWithCleanup(destAddr, targetTL);
   } else {
     payload = SGF.emitManagedRValueWithCleanup(

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2706,6 +2706,32 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
     return true;
   }
 
+  // For TakeOnSuccess, only a successful cast consumes Src.  A failed cast
+  // leaves Src in place. Model this by recording the take at the entry of the
+  // success block rather than at the branch itself, so liveness treats Src as
+  // consumed starting there while still live from the branch to the failure
+  // edge.
+  if (auto *ccabi = dyn_cast<CheckedCastAddrBranchInst>(user)) {
+    if (ccabi->getSrc() == op->get() &&
+        ccabi->getConsumptionKind() == CastConsumptionKind::TakeOnSuccess) {
+      LLVM_DEBUG(llvm::dbgs() << "Found checked_cast_addr_br "
+                                 "take_on_success Src: " << *user);
+      SmallVector<TypeTreeLeafTypeRange, 2> leafRanges;
+      TypeTreeLeafTypeRange::get(op, getRootAddress(), leafRanges);
+      if (!leafRanges.size()) {
+        LLVM_DEBUG(llvm::dbgs() << "Failed to form leaf type range!\n");
+        return false;
+      }
+
+      auto *successEntry = &ccabi->getSuccessBB()->front();
+      for (auto leafRange : leafRanges) {
+        useState.recordTakeUse(successEntry, leafRange);
+        useState.recordLivenessUse(user, leafRange);
+      }
+      return true;
+    }
+  }
+
   // Now that we have handled or loadTakeOrCopy, we need to now track our
   // additional pure takes.
   if (noncopyable::memInstMustConsume(op)) {

--- a/test/IRGen/noncopyable_existential_cast_runtime.sil
+++ b/test/IRGen/noncopyable_existential_cast_runtime.sil
@@ -7,6 +7,13 @@
 
 // REQUIRES: executable_test
 
+// This exercises the take-instead-of-copy support added to swift_dynamicCast
+// (tryCastUnwrappingExistentialSource). An older, OS-resident runtime copies
+// the payload instead, which traps in the noncopyable type's copy value
+// witness -- so this cannot run against the OS stdlib or a back-deployed one.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // TODO: Remove this as soon as we can get all of this working
 // under -O
 // REQUIRES: swift_test_mode_optimize_none

--- a/test/Interpreter/noncopyable_existential_casting.swift
+++ b/test/Interpreter/noncopyable_existential_casting.swift
@@ -104,12 +104,126 @@ print("is boxed true:", isCheckBoxed(
 // CHECK: is boxed false: false
 print("is boxed false:", isCheckBoxed(Unrelated()))
 
-// Leak/double-free check: construct the boxed, canary-carrying payload
-// directly as a call argument (never bound to a named local -- doing so
-// currently trips an unrelated, pre-existing move-only-checker crash for
-// *any* consuming use of a boxed noncopyable existential local, unrelated
-// to casting), exercise a successful `is` check on it, and confirm the
-// class reference inside gets destroyed exactly once.
-_ = takeCanary(BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0))
+// Leak/double-free check: bind the boxed, canary-carrying payload to a local,
+// exercise a successful `is` check on it, and confirm the class reference
+// inside gets destroyed exactly once.
+func canaryLocalCheck() {
+  let canaryBox: any P & ~Copyable =
+    BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+  _ = takeCanary(canaryBox)
+}
+canaryLocalCheck()
 // CHECK: canary deinit count: 1
 print("canary deinit count:", Canary.deinitCount)
+
+// MARK: - Cast patterns (`if case let x as T`)
+//
+// A *failed* cast pattern must leave the subject untouched, so a later pattern
+// can still match it.
+
+func classifyInline(_ box: consuming any P & ~Copyable) -> Int {
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let s as Small = box { return s.tag }
+  return -2
+}
+
+func classifyBoxed(_ box: consuming any P & ~Copyable) -> Int {
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let b as Big = box { return b.tag }
+  return -2
+}
+
+// The first pattern fails, so the second must still see an intact subject.
+// CHECK: if case chained inline: 7
+print("if case chained inline:", classifyInline(Small(tag: 7)))
+// CHECK: if case chained boxed: 8
+print("if case chained boxed:", classifyBoxed(
+  Big(tag: 8, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)))
+
+// All patterns fail: the subject was never consumed, so it must be destroyed
+// exactly once when it goes out of scope -- not zero times (leak) and not
+// twice (double free).
+func allPatternsFail(_ box: consuming any P & ~Copyable) -> Int {
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let s as Small = box { _ = s; return -2 }
+  return 0
+}
+// CHECK: if case all failed: 0
+print("if case all failed:", allPatternsFail(
+  BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)))
+// CHECK: canary deinit count after failed patterns: 2
+print("canary deinit count after failed patterns:", Canary.deinitCount)
+
+// The subject may also be a local variable or a stored property, not just a
+// consuming parameter. These reach the cast's source operand through different
+// storage (project_box / struct_element_addr), so cover them too: a failed
+// pattern must still leave the subject intact.
+
+func chainedOnLocal() -> Int {
+  let box: any P & ~Copyable =
+    Big(tag: 11, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let b as Big = box { return b.tag }
+  return -2
+}
+// CHECK: if case chained on local: 11
+print("if case chained on local:", chainedOnLocal())
+
+struct Holder: ~Copyable {
+  var inner: any P & ~Copyable
+}
+
+func chainedOnProperty(_ h: consuming Holder) -> Int {
+  if case let u as Unrelated = h.inner { _ = u; return -1 }
+  if case let b as Big = h.inner { return b.tag }
+  return -2
+}
+// CHECK: if case chained on property: 12
+print("if case chained on property:", chainedOnProperty(Holder(
+  inner: Big(tag: 12, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0))))
+
+// A local that no pattern matches is never consumed, so it must be destroyed
+// exactly once when it goes out of scope.
+func localAllPatternsFail() -> Int {
+  let box: any P & ~Copyable =
+    BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+  if case let u as Unrelated = box { _ = u; return -1 }
+  return 0
+}
+// CHECK: if case local all failed: 0
+print("if case local all failed:", localAllPatternsFail())
+// CHECK: canary deinit count after local failed patterns: 3
+print("canary deinit count after local failed patterns:", Canary.deinitCount)
+
+// MARK: - `as?` consumes unconditionally, unlike a cast pattern
+//
+// Forming an `Optional` with `as?` consumes the subject whether or not the cast
+// succeeds: the result is a value, so there is no failure edge to leave the
+// subject on. Only control-flow-affecting cast operations (cast patterns)
+// consume conditionally. These two probes read the deinit count *before* scope
+// exit, which distinguishes "consumed by the failed cast" from "still alive,
+// destroyed later at scope exit".
+
+func optionalFormConsumesOnFailure() -> Int {
+  let box: any P & ~Copyable =
+    BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+  if let u = box as? Unrelated { _ = u; return -1 }
+  // The `as?` failed, but it still consumed `box`, so the canary is already
+  // gone by the time we get here.
+  return Canary.deinitCount
+}
+// CHECK: as? consumed on failure (4 => yes): 4
+print("as? consumed on failure (4 => yes):", optionalFormConsumesOnFailure())
+
+func patternFormDoesNotConsumeOnFailure() -> Int {
+  let before = Canary.deinitCount
+  let box: any P & ~Copyable =
+    BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+  if case let u as Unrelated = box { _ = u; return -1 }
+  // The pattern failed and left `box` intact, so nothing has been destroyed
+  // yet -- it goes out of scope after this.
+  return Canary.deinitCount - before
+}
+// CHECK: pattern left subject alive on failure (0 => yes): 0
+print("pattern left subject alive on failure (0 => yes):",
+      patternFormDoesNotConsumeOnFailure())

--- a/test/Interpreter/noncopyable_extended_existential_casting.swift
+++ b/test/Interpreter/noncopyable_extended_existential_casting.swift
@@ -115,12 +115,76 @@ print("is boxed true:", isCheckBoxed(
 // CHECK: is boxed false: false
 print("is boxed false:", isCheckBoxed(Unrelated()))
 
-// Leak/double-free check: construct the boxed, canary-carrying payload
-// directly as a call argument (never bound to a named local -- doing so
-// currently trips an unrelated, pre-existing move-only-checker crash for
-// *any* consuming use of a boxed noncopyable existential local, unrelated
-// to casting), exercise a successful `is` check on it, and confirm the
-// class reference inside gets destroyed exactly once.
-_ = takeCanary(BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0))
+// Leak/double-free check: bind the boxed, canary-carrying payload to a local,
+// exercise a successful `is` check on it, and confirm the class reference
+// inside gets destroyed exactly once.
+func canaryLocalCheck() {
+  let canaryBox: any P<Int> & ~Copyable =
+    BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+  _ = takeCanary(canaryBox)
+}
+canaryLocalCheck()
 // CHECK: canary deinit count: 1
 print("canary deinit count:", Canary.deinitCount)
+
+// MARK: - Cast patterns (`if case let x as T`)
+//
+// Same failed-cast-leaves-the-subject-intact property as the plain existential
+// test, but going through tryCastUnwrappingExtendedExistentialSource.
+
+func classifyInline(_ box: consuming any P<Int> & ~Copyable) -> Int {
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let s as Small = box { return s.tag }
+  return -2
+}
+
+func classifyBoxed(_ box: consuming any P<Int> & ~Copyable) -> Int {
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let b as Big = box { return b.tag }
+  return -2
+}
+
+// CHECK: if case chained inline: 7
+print("if case chained inline:", classifyInline(Small(tag: 7)))
+// CHECK: if case chained boxed: 8
+print("if case chained boxed:", classifyBoxed(
+  Big(tag: 8, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0, pad6: 0)))
+
+// All patterns fail: the subject was never consumed, so it must be destroyed
+// exactly once at scope exit.
+func allPatternsFail(_ box: consuming any P<Int> & ~Copyable) -> Int {
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let s as Small = box { _ = s; return -2 }
+  return 0
+}
+// CHECK: if case all failed: 0
+print("if case all failed:", allPatternsFail(
+  BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)))
+// CHECK: canary deinit count after failed patterns: 2
+print("canary deinit count after failed patterns:", Canary.deinitCount)
+
+// MARK: - `as?` consumes unconditionally, unlike a cast pattern
+//
+// Same invariant as the plain existential test, through the extended-existential
+// runtime path: forming an Optional with `as?` consumes the subject even when
+// the cast fails, while a cast pattern leaves it intact on the failure edge.
+
+func optionalFormConsumesOnFailure() -> Int {
+  let box: any P<Int> & ~Copyable =
+    BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+  if let u = box as? Unrelated { _ = u; return -1 }
+  return Canary.deinitCount
+}
+// CHECK: as? consumed on failure (3 => yes): 3
+print("as? consumed on failure (3 => yes):", optionalFormConsumesOnFailure())
+
+func patternFormDoesNotConsumeOnFailure() -> Int {
+  let before = Canary.deinitCount
+  let box: any P<Int> & ~Copyable =
+    BigWithCanary(canary: Canary(), pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+  if case let u as Unrelated = box { _ = u; return -1 }
+  return Canary.deinitCount - before
+}
+// CHECK: pattern left subject alive on failure (0 => yes): 0
+print("pattern left subject alive on failure (0 => yes):",
+      patternFormDoesNotConsumeOnFailure())

--- a/test/SILOptimizer/moveonly_noncopyable_existential_cast_patterns.swift
+++ b/test/SILOptimizer/moveonly_noncopyable_existential_cast_patterns.swift
@@ -1,0 +1,99 @@
+// RUN: %target-swift-emit-sil %s -sil-verify-all -verify -enable-experimental-feature NoncopyableCasting
+
+// REQUIRES: swift_feature_NoncopyableCasting
+
+// A cast pattern over a noncopyable existential consumes its subject directly
+// out of the subject's own storage, so that a *failed* cast can leave the
+// subject intact for a later pattern (see
+// IsPatternInitialization::tryInitializeFromStorageReference). That is only
+// legal when the storage may actually be consumed. Where it may not, this must
+// produce an ordinary diagnostic -- emitting a consuming cast against
+// non-consumable storage instead produces SIL that the verifier rejects
+// outright, which shows up as a compiler crash rather than an error.
+
+protocol P: ~Copyable {}
+
+struct Big: ~Copyable, P {
+  var tag: Int
+  var pad0, pad1, pad2, pad3, pad4, pad5: Int
+}
+
+struct Unrelated: ~Copyable, P {}
+
+func mk(_ t: Int) -> Big {
+  Big(tag: t, pad0: 0, pad1: 0, pad2: 0, pad3: 0, pad4: 0, pad5: 0)
+}
+
+// MARK: - Consumable subjects: these must compile
+
+func consumingParam(_ box: consuming any P & ~Copyable) -> Int {
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let b as Big = box { return b.tag }
+  return -2
+}
+
+func localLet() -> Int {
+  let box: any P & ~Copyable = mk(1)
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let b as Big = box { return b.tag }
+  return -2
+}
+
+func localVar() -> Int {
+  var box: any P & ~Copyable = mk(2)
+  _ = consume box
+  box = mk(2)
+  if case let u as Unrelated = box { _ = u; return -1 }
+  if case let b as Big = box { return b.tag }
+  return -2
+}
+
+struct VarHolder: ~Copyable {
+  var inner: any P & ~Copyable
+}
+
+func varStoredProperty(_ h: consuming VarHolder) -> Int {
+  if case let u as Unrelated = h.inner { _ = u; return -1 }
+  if case let b as Big = h.inner { return b.tag }
+  return -2
+}
+
+// MARK: - Non-consumable subjects: these must diagnose, not crash
+
+// A borrowing parameter is passed @in_guaranteed. Consuming it emits a mutating
+// use of that argument, which fails SIL verification rather than diagnosing --
+// this is the case that regressed into a crash.
+func borrowingParam(_ box: borrowing any P & ~Copyable) -> Int {
+  // expected-error @-1 {{'box' is borrowed and cannot be consumed}}
+  if case let b as Big = box { return b.tag } // expected-note {{consumed here}}
+  return -1
+}
+
+let global: any P & ~Copyable = mk(3)
+
+// A global (or static) `let` is only ever borrowed, never consumed.
+func globalLet() -> Int {
+  if case let b as Big = global { return b.tag }
+  // expected-error @-1 {{'global' is borrowed and cannot be consumed}}
+  // expected-note @-2 {{consumed here}}
+  return -1
+}
+
+// MARK: - Known limitation
+
+// A `let` stored property is a partial consume of a consumable base, so this
+// could work in principle, but requesting a consuming access to an immutable
+// member currently yields the member's address under a `begin_access [read]`.
+// Rather than emit a take out of read-only-marked storage, this falls back to
+// the ordinary rvalue path -- which consumes the subject unconditionally, so
+// chaining two patterns reports a double consume.
+struct LetHolder: ~Copyable {
+  let inner: any P & ~Copyable
+}
+
+func letStoredProperty(_ h: consuming LetHolder) -> Int {
+  // expected-error @-1 {{'h' consumed more than once}}
+  if case let u as Unrelated = h.inner { _ = u; return -1 } // expected-note {{consumed here}}
+  if case let b as Big = h.inner { return b.tag } // expected-note {{consumed again here}}
+  return -2
+}


### PR DESCRIPTION
In particular, this makes it possible to try-cast a noncopyable existential to several different types.
Casting success is still necessarily consuming, so the existential box is dead as soon as a cast succeeds.

```
if case let x as NCType = box {
  ... box is consumed here ...
} else if case let x as NCType2 = box {
  ... box is consumed here ...
} else {
  ... box is NOT consumed here ...
}
```

But note that plain cast expressions remain unconditionally consuming:
```
let x: NCType? = box as? NCType
... box is consumed here ...
```

There are a number of nuances:

* This PR does not cover `if let x as? NCType`
* This PR does not cover `switch box { case let x as NCType`
* Some values cannot (yet) be consistently consumed, so this work does not (yet) support them, including global values, `let` stored properties, borrowing parameters.

This is gated by the `NoncopyableCasting` experimental feature flag.  That flag remains disabled by default.