### PR TITLE
AST: Skip printing property wrapper storage in swiftinterfaces

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -334,6 +334,19 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       if (options.printPublicInterface() && shouldSkipDeclInPublicInterface(D))
         return false;
 
+      // Skip the backing storage property of a wrapped property when the
+      // wrapped property itself is printed. The attached wrapper attribute is
+      // printed too, so the backing storage property is synthesized again when
+      // the interface is compiled. Printing it here as well would be an
+      // invalid redeclaration.
+      if (auto *VD = dyn_cast<VarDecl>(D)) {
+        if (auto *wrappedVar = VD->getOriginalWrappedProperty(
+                PropertyWrapperSynthesizedPropertyKind::Backing)) {
+          if (shouldPrint(wrappedVar, options))
+            return false;
+        }
+      }
+
       if (auto *VD = dyn_cast<ValueDecl>(D)) {
         // Skip anything that isn't 'public' or '@usableFromInline' or has a
         // _specialize attribute with a targetFunction parameter.

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -131,3 +131,39 @@ public struct HasWrappers {
   // CHECK: public func hasParameterWithAPIWrapperComposed(@TestResilient::ProjectedValueWrapper<TestResilient::Wrapper<Swift::Int>> @TestResilient::Wrapper x: Swift::Int)
   public func hasParameterWithAPIWrapperComposed(@ProjectedValueWrapper @Wrapper x: Int) { }
 }
+
+// CHECK: @frozen public struct HasWrappersFrozen {
+@frozen
+public struct HasWrappersFrozen {
+  // CHECK:      @TestResilient::Wrapper<Swift::Int> public var x: Swift::Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  // CHECK-NOT:  _x
+  @Wrapper public var x: Int
+
+  // The backing storage of a non-public wrapped property is still printed,
+  // because it contributes to the layout of the frozen struct and the wrapped
+  // property itself is not printed.
+  // CHECK: private var _y: TestResilient::Wrapper<Swift::Int>
+  @Wrapper internal var y: Int
+
+  // CHECK:      @TestResilient::WrapperWithInitialValue<Swift::Int> @_projectedValueProperty($z) public var z: Swift::Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  // CHECK-NOT:  _z
+  // CHECK:      public var $z: TestResilient::Wrapper<Swift::Int> {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   set
+  // CHECK-NEXT: }
+  @WrapperWithInitialValue public var z = 17
+
+  // CHECK: public init(x: Swift::Int, y: Swift::Int)
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+}


### PR DESCRIPTION
Skip printing the backing storage property of a wrapped property when the wrapped property itself is printed. The attached wrapper attribute is printed too, so the backing storage property is synthesized again when the interface is compiled and printing it causes an invalid redeclaration diagnostic when compiling the interface.

Resolves rdar://53555890.
