### PR TITLE
test: Add unknown source loc expectations to some visionOS SILGen tests

### DIFF
--- a/test/SILGen/back_deployed_attr_func_visionos.swift
+++ b/test/SILGen/back_deployed_attr_func_visionos.swift
@@ -3,6 +3,10 @@
 
 // REQUIRES: OS=xros
 
+// The RUN lines override the target triple but keep the SDK that lit selected,
+// so the two can disagree. That mismatch is not relevant to what this test checks.
+// expected-warning@<unknown> * {{using sysroot for }}
+
 // -- Fallback definition of trivialFunc()
 // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy11trivialFuncyyFTwB : $@convention(thin) () -> ()
 // CHECK: bb0:

--- a/test/SILGen/unavailable_decl_optimization_stub_visionos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_visionos.swift
@@ -3,6 +3,10 @@
 
 // REQUIRES: OS=xros
 
+// The RUN lines override the target triple but keep the SDK that lit selected,
+// so the two can disagree. That mismatch is not relevant to what this test checks.
+// expected-warning@<unknown> * {{using sysroot for }}
+
 public struct S {}
 
 // CHECK-LABEL: sil{{.*}}@$s4Test19visionOSUnavailableAA1SVyF


### PR DESCRIPTION
Addresses fallout of https://github.com/swiftlang/swift/pull/91513.

Resolves rdar://186014096 and rdar://186014036.
