### PR TITLE
[SwiftCaching] Make the caching reproducer self-contained and editable

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -532,7 +532,9 @@ GROUPED_ERROR(error_load_input_from_cas, CompilationCaching, none, "failed to lo
 GROUPED_ERROR(error_wrong_input_num_for_input_file_key, CompilationCaching, none, "-input-file-key only support one input file", ())
 
 ERROR(error_gen_reproducer_not_caching, none, "-gen-reproducer only supports swift caching (-cache-compile-job)", ())
-ERROR(error_cannot_create_reproducer_dir, none, "failed to create reproducer director '%0': %1", (StringRef, StringRef))
+ERROR(error_cannot_create_reproducer_dir, none, "failed to create reproducer directory '%0': %1", (StringRef, StringRef))
+ERROR(error_cannot_write_reproducer_file, none, "failed to write '%0' into reproducer: %1", (StringRef, StringRef))
+WARNING(warn_cannot_capture_reproducer_file, none, "failed to capture '%0' in reproducer: %1", (StringRef, StringRef))
 
 NOTE(note_reproducer, none, "reproducer is available at: %0", (StringRef))
 

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -60,13 +60,19 @@ public:
   /// Has immutable file system input.
   bool HasImmutableFileSystem = false;
 
+  /// Read the input files from disk and overlay them on top of the CAS file
+  /// system, instead of expecting the CAS to provide them. This makes the
+  /// input files editable, and is incompatible with caching since their
+  /// content no longer contributes to the cache key.
+  bool CASFSInputOverlay = false;
+
   /// Get the CAS configuration flags.
   void enumerateCASConfigurationFlags(
       llvm::function_ref<void(llvm::StringRef)> Callback) const;
 
   /// Check to see if a CASFileSystem is required.
   bool requireCASFS() const {
-    return EnableCaching &&
+    return (EnableCaching || CASFSInputOverlay) &&
            (!ClangIncludeTree.empty() || !ClangIncludeTreeFileList.empty() ||
             !InputFileKey.empty() || !BridgingHeaderPCHCacheKey.empty());
   }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -210,7 +210,7 @@ public:
 
   bool requiresCAS() const {
     return CASOpts.EnableCaching || IRGenOpts.UseCASBackend ||
-           CASOpts.ImportModuleFromCAS;
+           CASOpts.ImportModuleFromCAS || CASOpts.CASFSInputOverlay;
   }
 
   void setClangModuleCachePath(StringRef Path) {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1693,6 +1693,11 @@ def clang_include_tree_root: Separate<["-"], "clang-include-tree-root">,
 def clang_include_tree_filelist: Separate<["-"], "clang-include-tree-filelist">,
   HelpText<"Clang Include Tree FileList CASID">, MetaVarName<"<cas-id>">;
 
+def cas_fs_input_overlay: Flag<["-"], "cas-fs-input-overlay">,
+  HelpText<"Read the input files from disk and overlay them on the CAS file "
+           "system. This disables caching, since the content of the input "
+           "files no longer contributes to the cache key">;
+
 def experimental_spi_only_imports :
   Flag<["-"], "experimental-spi-only-imports">,
   HelpText<"Enable use of @_spiOnly imports">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -895,6 +895,15 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   if (!Opts.ClangIncludeTree.empty() || !Opts.ClangIncludeTreeFileList.empty())
     Opts.HasImmutableFileSystem = true;
 
+  Opts.CASFSInputOverlay |= Args.hasArg(OPT_cas_fs_input_overlay);
+  if (Opts.CASFSInputOverlay && Opts.EnableCaching) {
+    // The content of the input files is read from disk, so it no longer
+    // contributes to the cache key.
+    Diags.diagnose(SourceLoc(), diag::error_argument_not_allowed_with,
+                   "-cas-fs-input-overlay", "-cache-compile-job");
+    return true;
+  }
+
   return false;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -748,6 +748,30 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
     llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayVFS =
         new llvm::vfs::OverlayFileSystem(MemFS);
     OverlayVFS->pushOverlay(SourceMgr.getFileSystem());
+
+    if (CASOpts.CASFSInputOverlay) {
+      // Overlay the input files that exist on disk on top of the CAS file
+      // system, so that editing them takes effect while every other file the
+      // compilation sees still comes from the CAS.
+      llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> InputFS =
+          new llvm::vfs::InMemoryFileSystem();
+      for (const auto &Input :
+           Invocation.getFrontendOptions().InputsAndOutputs.getAllInputs()) {
+        StringRef InputPath = Input.getFileName();
+        // An input that is not on disk is provided by the CAS file system.
+        if (InputPath == "-" || !llvm::sys::fs::exists(InputPath))
+          continue;
+        auto Buffer = llvm::MemoryBuffer::getFile(InputPath);
+        if (!Buffer) {
+          Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
+                               InputPath, Buffer.getError().message());
+          return true;
+        }
+        InputFS->addFile(InputPath, 0, std::move(*Buffer));
+      }
+      OverlayVFS->pushOverlay(std::move(InputFS));
+    }
+
     SourceMgr.setFileSystem(std::move(OverlayVFS));
   }
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1815,8 +1815,10 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     GenericArgs.push_back(clangImporterOpts.BuildSessionFilePath);
   }
 
-  if (casOpts.EnableCaching) {
+  if (casOpts.EnableCaching || casOpts.ImportModuleFromCAS) {
     genericSubInvocation.getCASOptions().EnableCaching = casOpts.EnableCaching;
+    genericSubInvocation.getCASOptions().ImportModuleFromCAS =
+        casOpts.ImportModuleFromCAS;
     genericSubInvocation.getCASOptions().Config = casOpts.Config;
     genericSubInvocation.getCASOptions().HasImmutableFileSystem =
         casOpts.HasImmutableFileSystem;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -43,6 +43,7 @@
 #include "swift/Basic/Edit.h"
 #include "swift/Basic/FileSystem.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/OutputFileMap.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/SourceManager.h"
@@ -89,6 +90,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IRReader/IRReader.h"
+#include "llvm/Option/ArgList.h"
 #include "llvm/Option/OptTable.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/CommandLine.h"
@@ -97,6 +99,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/LineIterator.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/VirtualOutputBackend.h"
@@ -1605,6 +1608,81 @@ static bool tryReplayCompilerResults(CompilerInstance &Instance) {
   return replayed;
 }
 
+/// Compute the location, relative to the reproducer directory, that is used to
+/// store \p path inside \p subDir. The original directory structure is
+/// preserved so files that share a base name don't collide. The root name, if
+/// any, becomes a directory of its own, e.g. `C:\dir\file` is stored as
+/// `<subDir>\C\dir\file`, since it cannot appear as-is inside a path.
+static std::string getReproducerRelativePath(StringRef subDir, StringRef path) {
+  llvm::SmallString<256> absolute(path);
+  llvm::sys::fs::make_absolute(absolute);
+  llvm::sys::path::remove_dots(absolute, /*remove_dot_dot=*/true);
+
+  llvm::SmallString<8> rootName;
+  for (char c : llvm::sys::path::root_name(absolute))
+    if (c != ':' && !llvm::sys::path::is_separator(c))
+      rootName.push_back(c);
+
+  llvm::SmallString<256> relative(subDir);
+  if (!rootName.empty())
+    llvm::sys::path::append(relative, StringRef(rootName));
+  llvm::sys::path::append(relative, llvm::sys::path::relative_path(absolute));
+  return std::string(relative);
+}
+
+/// Whether an input of \p type is a source file that is worth capturing as a
+/// regular file inside the reproducer, so it can be edited while reducing.
+static bool isCapturableReproducerInput(file_types::ID type) {
+  switch (type) {
+  case file_types::TY_Swift:
+  case file_types::TY_SIL:
+  case file_types::TY_SIB:
+  case file_types::TY_SwiftModuleInterfaceFile:
+  case file_types::TY_PrivateSwiftModuleInterfaceFile:
+  case file_types::TY_PackageSwiftModuleInterfaceFile:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// Whether \p opt names an output that the reproducer should redirect into its
+/// own directory, so running the reproducer doesn't overwrite the outputs of
+/// the original invocation.
+///
+/// Note this doesn't cover `-index-unit-output-path`, which names the output
+/// path recorded in the index data rather than a file that gets written.
+static bool isReproducerOutputOption(const llvm::opt::Option &opt) {
+  switch (opt.getID()) {
+  case options::OPT_o:
+  case options::OPT_index_store_path:
+  // The supplementary outputs that are only known to the frontend don't carry
+  // the `SupplementaryOutput` flag.
+  case options::OPT_dump_api_path:
+  case options::OPT_emit_abi_descriptor_path:
+  case options::OPT_emit_dependencies_path:
+  case options::OPT_emit_fixits_path:
+  case options::OPT_emit_module_doc_path:
+  case options::OPT_emit_module_semantic_info_path:
+  case options::OPT_emit_reference_dependencies_path:
+  case options::OPT_emit_variant_abi_descriptor_path:
+  case options::OPT_emit_variant_module_doc_path:
+    return true;
+  default:
+    return opt.hasFlag(options::SupplementaryOutput) &&
+           opt.hasFlag(options::ArgumentIsPath);
+  }
+}
+
+/// Whether the value of \p opt is a directory rather than a file.
+static bool isReproducerOutputDirOption(const llvm::opt::Option &opt) {
+  return opt.matches(options::OPT_index_store_path) ||
+         opt.matches(options::OPT_dump_api_path) ||
+         opt.matches(options::OPT_emit_symbol_graph_dir) ||
+         opt.matches(options::OPT_sil_output_dir) ||
+         opt.matches(options::OPT_ir_output_dir);
+}
+
 /// Generate reproducer.
 ///
 /// Return false if reproducer generation has error.
@@ -1654,13 +1732,122 @@ static bool generateReproducer(CompilerInstance &Instance,
   if (!db) {
     diags.diagnose(SourceLoc(), diag::error_cas_initialization,
                    toString(db.takeError()));
-    return false;
+    return true;
   }
 
-  llvm::StringMap<const char *> idsToUpdate;
+  llvm::StringMap<const char *> argsToUpdate;
   llvm::BumpPtrAllocator alloc;
   llvm::StringSaver argSaver(alloc);
   auto newArgs = Args.vec();
+  bool hadError = false;
+
+  // Everything the reproducer owns lives inside the reproducer directory and is
+  // addressed relative to it, so the directory as a whole can be relocated. The
+  // reproducer is meant to be run with that directory as working directory.
+  auto writeReproducerFile = [&](StringRef relativePath,
+                                 StringRef content) -> bool {
+    llvm::SmallString<256> destPath(reproDir);
+    llvm::sys::path::append(destPath, relativePath);
+    auto destDir = llvm::sys::path::parent_path(destPath);
+    if (auto errCode = llvm::sys::fs::create_directories(destDir)) {
+      diags.diagnose(SourceLoc(), diag::error_cannot_create_reproducer_dir,
+                     destDir, errCode.message());
+      hadError = true;
+      return true;
+    }
+    std::error_code errCode;
+    llvm::raw_fd_ostream os(destPath, errCode, llvm::sys::fs::OF_None);
+    if (errCode) {
+      diags.diagnose(SourceLoc(), diag::error_cannot_write_reproducer_file,
+                     destPath, errCode.message());
+      hadError = true;
+      return true;
+    }
+    os << content;
+    return false;
+  };
+
+  // Input files can be provided by the CAS file system, while file lists and
+  // output file maps are always read from disk.
+  auto readInputFile =
+      [&](StringRef path) -> std::unique_ptr<llvm::MemoryBuffer> {
+    if (auto buffer =
+            Instance.getSourceMgr().getFileSystem()->getBufferForFile(path))
+      return std::move(*buffer);
+    if (auto buffer = llvm::MemoryBuffer::getFile(path))
+      return std::move(*buffer);
+    return nullptr;
+  };
+
+  // Capture an input file as a regular file inside the reproducer directory so
+  // it can be edited when reducing the reproducer. Returns the new path, or
+  // nullptr if the file couldn't be captured.
+  llvm::StringMap<const char *> capturedInputs;
+  auto captureInput = [&](StringRef path) -> const char * {
+    if (path.empty() || path == "-")
+      return nullptr;
+
+    auto captured = capturedInputs.find(path);
+    if (captured != capturedInputs.end())
+      return captured->second;
+
+    auto buffer = readInputFile(path);
+    if (!buffer) {
+      diags.diagnose(SourceLoc(), diag::warn_cannot_capture_reproducer_file,
+                     path, "cannot read file");
+      return nullptr;
+    }
+    auto relativePath = getReproducerRelativePath("inputs", path);
+    if (writeReproducerFile(relativePath, buffer->getBuffer()))
+      return nullptr;
+
+    auto *newPath = argSaver.save(relativePath).data();
+    capturedInputs[path] = newPath;
+    return newPath;
+  };
+
+  // Compute a path inside the reproducer directory for an output file and
+  // create the directory it lives in.
+  llvm::StringMap<std::string> redirectedOutputs;
+  auto redirectOutput = [&](StringRef path, bool isDirectory) -> std::string {
+    if (path.empty() || path == "-")
+      return path.str();
+
+    auto redirected = redirectedOutputs.find(path);
+    if (redirected != redirectedOutputs.end())
+      return redirected->second;
+
+    auto relativePath = getReproducerRelativePath("outputs", path);
+    llvm::SmallString<256> outputDir(reproDir);
+    llvm::sys::path::append(
+        outputDir, isDirectory ? StringRef(relativePath)
+                               : llvm::sys::path::parent_path(relativePath));
+    if (auto errCode = llvm::sys::fs::create_directories(outputDir)) {
+      diags.diagnose(SourceLoc(), diag::error_cannot_create_reproducer_dir,
+                     outputDir, errCode.message());
+      hadError = true;
+      return path.str();
+    }
+    redirectedOutputs[path] = relativePath;
+    return relativePath;
+  };
+
+  // Capture all the source inputs on disk and rewrite the paths that refer to
+  // them. Note the file lists that carry input paths are rewritten below.
+  const auto &inputsAndOutputs =
+      Instance.getInvocation().getFrontendOptions().InputsAndOutputs;
+  bool capturedAllInputs = inputsAndOutputs.hasInputs();
+  for (const auto &input : inputsAndOutputs.getAllInputs()) {
+    const char *newPath = isCapturableReproducerInput(input.getType())
+                              ? captureInput(input.getFileName())
+                              : nullptr;
+    if (!newPath) {
+      capturedAllInputs = false;
+      continue;
+    }
+    argsToUpdate[input.getFileName()] = newPath;
+  }
+
   // Import all dependencies.
   auto importID = [&](StringRef str) {
     if (str.empty())
@@ -1687,7 +1874,7 @@ static bool generateReproducer(CompilerInstance &Instance,
 
     auto newID = db->first->getID(*imported).toString();
     if (newID != str)
-      idsToUpdate[str] = argSaver.save(newID).data();
+      argsToUpdate[str] = argSaver.save(newID).data();
 
     return false;
   };
@@ -1777,7 +1964,7 @@ static bool generateReproducer(CompilerInstance &Instance,
       return true;
 
     if (*imported != key)
-      idsToUpdate[key] = argSaver.save(*imported).data();
+      argsToUpdate[key] = argSaver.save(*imported).data();
 
     return false;
   };
@@ -1785,7 +1972,13 @@ static bool generateReproducer(CompilerInstance &Instance,
   importID(casOpts.ClangIncludeTree);
   importID(casOpts.ClangIncludeTreeFileList);
 
-  mapKey(casOpts.InputFileKey);
+  // The input file is captured on disk instead, so the cache key that carries
+  // its content is no longer needed. Only drop it when an include tree keeps
+  // providing a CAS file system, which caching requires.
+  bool dropInputFileKey = !casOpts.InputFileKey.empty() && capturedAllInputs &&
+                          casOpts.HasImmutableFileSystem;
+  if (!dropInputFileKey)
+    mapKey(casOpts.InputFileKey);
   mapKey(casOpts.BridgingHeaderPCHCacheKey);
 
   // Import module dependencies.
@@ -1861,35 +2054,165 @@ static bool generateReproducer(CompilerInstance &Instance,
     }
     auto newMapArg = db->first->getID(*newMapRef).toString();
     if (newMapArg != mapOpts)
-      idsToUpdate[mapOpts] = argSaver.save(newMapArg).data();
+      argsToUpdate[mapOpts] = argSaver.save(newMapArg).data();
   }
+
+  // Parse the command-line so the options carrying a file list or an output
+  // path can be found and rewritten. This has to happen before any option is
+  // dropped below, since the rewriting is done by argument index.
+  unsigned missingIndex, missingCount;
+  std::unique_ptr<llvm::opt::OptTable> optTable = createSwiftOptTable();
+  llvm::opt::InputArgList parsedArgs = optTable->ParseArgs(
+      Args, missingIndex, missingCount, options::FrontendOption);
+
+  auto setArgValue = [&](const llvm::opt::Arg *arg, StringRef value) {
+    unsigned index = arg->getIndex();
+    if (StringRef(newArgs[index]) == arg->getSpelling()) {
+      // Separate spelling, e.g. `-o file`.
+      ASSERT(index + 1 < newArgs.size());
+      newArgs[index + 1] = argSaver.save(value).data();
+    } else {
+      // Joined spelling, e.g. `-ofile`.
+      newArgs[index] = argSaver.save(arg->getSpelling() + value).data();
+    }
+  };
+
+  // Copy a file list into the reproducer directory, remapping each of its
+  // entries, and point the command-line at the copy.
+  auto captureFileList =
+      [&](const llvm::opt::Arg *arg,
+          llvm::function_ref<std::string(StringRef)> remapEntry) {
+        StringRef path = arg->getValue();
+        auto buffer = llvm::MemoryBuffer::getFile(path);
+        if (!buffer) {
+          diags.diagnose(SourceLoc(), diag::warn_cannot_capture_reproducer_file,
+                         path, buffer.getError().message());
+          return;
+        }
+        std::string content;
+        llvm::raw_string_ostream contentOS(content);
+        for (StringRef entry :
+             llvm::make_range(llvm::line_iterator(**buffer), {}))
+          contentOS << remapEntry(entry) << "\n";
+
+        auto relativePath = getReproducerRelativePath("inputs", path);
+        if (!writeReproducerFile(relativePath, content))
+          setArgValue(arg, relativePath);
+      };
+
+  for (const auto *arg : parsedArgs.filtered(options::OPT_filelist,
+                                             options::OPT_primary_filelist))
+    captureFileList(arg, [&](StringRef entry) {
+      auto captured = capturedInputs.find(entry);
+      return captured == capturedInputs.end() ? entry.str()
+                                              : std::string(captured->second);
+    });
+
+  for (const auto *arg : parsedArgs.filtered(options::OPT_output_filelist))
+    captureFileList(arg, [&](StringRef entry) {
+      return redirectOutput(entry, /*isDirectory=*/false);
+    });
+
+  // The index unit output paths only name the outputs in the index data, so
+  // they are copied over as they are.
+  for (const auto *arg :
+       parsedArgs.filtered(options::OPT_index_unit_output_path_filelist))
+    captureFileList(arg, [](StringRef entry) { return entry.str(); });
+
+  // Redirect the outputs that are named directly on the command-line.
+  for (const auto *arg : parsedArgs) {
+    const auto &opt = arg->getOption();
+    if (!isReproducerOutputOption(opt) || arg->getNumValues() != 1)
+      continue;
+    setArgValue(
+        arg, redirectOutput(arg->getValue(), isReproducerOutputDirOption(opt)));
+  }
+
+  // The supplementary output file map is keyed by the input files and points at
+  // the outputs, so it needs both halves of the rewriting.
+  if (const auto *arg =
+          parsedArgs.getLastArg(options::OPT_supplementary_output_file_map)) {
+    StringRef path = arg->getValue();
+    auto outputFileMap =
+        OutputFileMap::loadFromPath(path, /*workingDirectory=*/"");
+    if (!outputFileMap) {
+      diags.diagnose(SourceLoc(), diag::warn_cannot_capture_reproducer_file,
+                     path, toString(outputFileMap.takeError()));
+    } else {
+      OutputFileMap newOutputFileMap;
+      std::vector<std::string> newInputs;
+      auto addEntry = [&](StringRef input) {
+        auto captured = capturedInputs.find(input);
+        newInputs.push_back(captured == capturedInputs.end()
+                                ? input.str()
+                                : std::string(captured->second));
+        const auto *outputs = outputFileMap->getOutputMapForInput(input);
+        // Leave inputs without any output out of the new map; they are written
+        // back as an empty entry.
+        if (!outputs || outputs->empty())
+          return;
+        auto &newOutputs =
+            newOutputFileMap.getOrCreateOutputMapForInput(newInputs.back());
+        for (const auto &output : *outputs)
+          newOutputs[output.first] =
+              redirectOutput(output.second, /*isDirectory=*/false);
+      };
+      for (const auto &input : inputsAndOutputs.getAllInputs())
+        addEntry(input.getFileName());
+      // A map can also carry a single entry for the entire compilation.
+      if (outputFileMap->getOutputMapForSingleOutput())
+        addEntry(StringRef());
+
+      std::vector<StringRef> newInputRefs(newInputs.begin(), newInputs.end());
+      std::string content;
+      llvm::raw_string_ostream contentOS(content);
+      newOutputFileMap.write(contentOS, newInputRefs);
+
+      auto relativePath = getReproducerRelativePath("inputs", path);
+      if (!writeReproducerFile(relativePath, content))
+        setArgValue(arg, relativePath);
+    }
+  }
+
+  // Finish capturing inputs. If there are errors, error out before handling
+  // command-line arguments.
+  if (hadError)
+    return true;
 
   // Drop all the options that no longer applies.
   auto dropArg = [&newArgs](StringRef arg, bool hasArg = true) {
-    auto found =
-        llvm::find_if(newArgs, [&](const char *a) { return arg == a; });
-    if (found != newArgs.end())
-      found = newArgs.erase(found);
-    if (hasArg && found != newArgs.end())
-      found = newArgs.erase(found);
+    for (auto it = newArgs.begin(); it != newArgs.end();) {
+      if (arg != *it) {
+        ++it;
+        continue;
+      }
+      it = newArgs.erase(it);
+      if (hasArg && it != newArgs.end())
+        it = newArgs.erase(it);
+    }
   };
   dropArg("-cas-path");
   dropArg("-cas-plugin-path");
   dropArg("-cas-plugin-option");
   dropArg("-gen-reproducer", false);
   dropArg("-gen-reproducer-dir");
+  if (dropInputFileKey)
+    dropArg("-input-file-key");
+  // The input files are read from disk, so their content no longer contributes
+  // to the cache key and the compilation can't be cached.
+  dropArg("-cache-compile-job", false);
 
   // Now upgrade the entire command-line.
   for (auto &arg : newArgs) {
-    if (idsToUpdate.count(arg))
-      arg = idsToUpdate[arg];
+    if (argsToUpdate.count(arg))
+      arg = argsToUpdate[arg];
   }
 
-  // Add the configuration for the new CAS options. Note those options and only
-  // these options will need to be adjusted if the reproducer is copied into a
-  // different location.
+  // Add the configuration for the new CAS options. The CAS lives inside the
+  // reproducer directory, like everything else the reproducer owns, so the
+  // reproducer needs to run with that directory as working directory.
   newArgs.push_back("-cas-path");
-  newArgs.push_back(casPath.c_str());
+  newArgs.push_back("cas");
   if (!newCAS.PluginPath.empty()) {
     newArgs.push_back("-cas-plugin-path");
     newArgs.push_back(newCAS.PluginPath.c_str());
@@ -1899,6 +2222,11 @@ static bool generateReproducer(CompilerInstance &Instance,
           argSaver.save(llvm::Twine(Opt.first) + "=" + Opt.second).data());
     }
   }
+  // The captured inputs are regular files on disk, which the CAS file system
+  // built from the include tree doesn't know about. The module dependencies
+  // are still loaded from the CAS, which caching used to take care of.
+  newArgs.push_back("-cas-fs-input-overlay");
+  newArgs.push_back("-module-import-from-cas");
 
   // Write shell script.
   llvm::SmallString<256> scriptPath(reproDir);
@@ -1909,7 +2237,7 @@ static bool generateReproducer(CompilerInstance &Instance,
                                 llvm::sys::fs::FA_Write,
                                 llvm::sys::fs::OF_Text);
   if (ec) {
-    diags.diagnose(SourceLoc(), diag::error_cannot_create_reproducer_dir,
+    diags.diagnose(SourceLoc(), diag::error_cannot_write_reproducer_file,
                    scriptPath, ec.message());
     return true;
   }

--- a/test/CAS/reproducer-input-file-key.swift
+++ b/test/CAS/reproducer-input-file-key.swift
@@ -1,0 +1,52 @@
+/// Check the reproducer for a compilation whose input is provided by
+/// `-input-file-key`: the input is captured on disk instead, so the reproducer
+/// runs without the original file and without the cache key.
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/cas
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/Test.swift -o %t/deps.json -module-name Test \
+// RUN:   -swift-version 5 -cache-compile-job -cas-path %t/cas -parse-stdlib \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+
+/// Emit the module interface into the CAS and extract the cache key of that output.
+// RUN: %target-swift-frontend-plain -emit-module -emit-module-path %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface \
+// RUN:   -disable-implicit-swift-modules -module-cache-path %t/module-cache -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/Test.swift -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution -parse-stdlib \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import @%t/MyApp.cmd
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend-plain -emit-module -emit-module-path %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface \
+// RUN:   -disable-implicit-swift-modules -module-cache-path %t/module-cache -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/Test.swift -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution -parse-stdlib \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import @%t/MyApp.cmd > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json %t/Test.swift > %t/key
+
+// RUN: %target-swift-frontend-plain -typecheck-module-from-interface %t/Test.swiftinterface -disable-implicit-swift-modules \
+// RUN:   -module-cache-path %t/module-cache -explicit-swift-module-map-file @%t/map.casid -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -enable-library-evolution -parse-stdlib -explicit-interface-module-build \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   @%t/MyApp.cmd -input-file-key @%t/key -gen-reproducer -gen-reproducer-dir %t/crash
+
+/// The interface is captured on disk and the cache key is no longer needed.
+// RUN: %FileCheck %s --input-file=%t/crash/reproduce.sh
+// CHECK-NOT: -input-file-key
+// CHECK: "inputs{{.*}}Test.swiftinterface"
+// CHECK: "-cas-fs-input-overlay"
+
+// RUN: rm %t/Test.swiftinterface
+// RUN: cd %t/crash && %swift_frontend_plain @reproduce.sh
+
+/// The captured interface takes precedence over what the CAS provides. Note
+/// `%:t` is the layout the reproducer mirrors: the path of `%t` with the root
+/// turned into a regular directory, e.g. `C:/dir` becomes `C/dir`.
+// RUN: echo "public func added() -> NotAType {}" >> %t/crash/inputs/%:t/Test.swiftinterface
+// RUN: cd %t/crash && not %swift_frontend_plain @reproduce.sh 2>&1 | %FileCheck %s --check-prefix=EDITED
+// EDITED: error: cannot find type 'NotAType' in scope
+
+//--- Test.swift
+public func test() {}

--- a/test/CAS/reproducer.swift
+++ b/test/CAS/reproducer.swift
@@ -28,12 +28,30 @@
 // RUN:  -module-name Test -o %t/test.o -cache-compile-job -cas-path %t/cas @%t/MyApp.cmd -gen-reproducer -gen-reproducer-dir %t/crash
 
 // RUN: %FileCheck %s --input-file=%t/crash/reproduce.sh
-// CHECK: -cache-compile-job
 // CHECK-NOT: -gen-reproducer
 
-/// Delete some inputs from original compilation and run the reproducer.
-// RUN: rm -rf %t/include
-// RUN: %swift_frontend_plain @%t/crash/reproduce.sh
+/// The inputs are captured as regular files inside the reproducer and all the
+/// paths owned by the reproducer are relative to the reproducer directory.
+// RUN: %FileCheck %s --check-prefix=RELATIVE --input-file=%t/crash/reproduce.sh
+// RELATIVE: "inputs{{.*}}test.swift" "inputs{{.*}}foo.swift"
+// RELATIVE: "-emit-module-path" "outputs{{.*}}Test.swiftmodule"
+// RELATIVE: "-o" "outputs{{.*}}test.o"
+// RELATIVE: "-cas-path" "cas"
+// RELATIVE: "-cas-fs-input-overlay" "-module-import-from-cas"
+
+/// Delete all inputs from the original compilation and run the reproducer.
+// RUN: rm -rf %t/include %t/test.swift %t/foo.swift
+// RUN: cd %t/crash && %swift_frontend_plain @reproduce.sh
+
+/// The reproducer writes its outputs into its own directory. Note `%:t` is the
+/// layout the reproducer mirrors: the path of `%t` with the root turned into a
+/// regular directory, e.g. `C:/dir` becomes `C/dir`.
+// RUN: ls %t/crash/outputs/%:t/test.o
+
+/// The captured inputs are editable and take precedence over the CAS content.
+// RUN: echo "public func added() { undefined_function() }" >> %t/crash/inputs/%:t/foo.swift
+// RUN: cd %t/crash && not %swift_frontend_plain @reproduce.sh 2>&1 | %FileCheck %s --check-prefix=EDITED
+// EDITED: error: cannot find 'undefined_function' in scope
 
 /// Also test module jobs.
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
@@ -41,10 +59,65 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Simple > %t/simple.cmd
 // RUN: %swift_frontend_plain @%t/dummy.cmd -gen-reproducer -gen-reproducer-dir %t/crash-2
 // RUN: %FileCheck %s --input-file=%t/crash-2/reproduce.sh
-// RUN: %swift_frontend_plain @%t/crash-2/reproduce.sh
+// RUN: cd %t/crash-2 && %swift_frontend_plain @reproduce.sh
 // RUN: %swift_frontend_plain @%t/simple.cmd -gen-reproducer -gen-reproducer-dir %t/crash-3
 // RUN: %FileCheck %s --input-file=%t/crash-3/reproduce.sh
-// RUN: %swift_frontend_plain @%t/crash-3/reproduce.sh
+// RUN: cd %t/crash-3 && %swift_frontend_plain @reproduce.sh
+
+/// Test the file list and output file map inputs. Recreate the sources that
+/// were deleted above. The paths that are matched back against the input names,
+/// i.e. the file list entries and the output file map keys, all have to be
+/// spelled the same way, hence `%/t` throughout.
+// RUN: split-file %s %t
+// RUN: echo "%/t/test.swift" > %t/inputs.txt
+// RUN: echo "%/t/foo.swift" >> %t/inputs.txt
+// RUN: echo "%/t/test.swift" > %t/primary.txt
+// RUN: echo "%/t/test.o" > %t/output.txt
+// RUN: echo "%/t/test.o" > %t/index-unit.txt
+// RUN: sed -e "s@TMP_DIR@%{/t:regex_replacement}@g" %t/supp.map > %t/supp.json
+
+// RUN: %target-swift-frontend-plain -filelist %t/inputs.txt -primary-filelist %t/primary.txt \
+// RUN:   -output-filelist %t/output.txt -index-unit-output-path-filelist %t/index-unit.txt \
+// RUN:   -supplementary-output-file-map %t/supp.json -O -emit-module -c -module-name Test \
+// RUN:   -cache-compile-job -cas-path %t/cas @%t/MyApp.cmd -gen-reproducer -gen-reproducer-dir %t/crash-4
+
+/// Every file list is captured in the reproducer and points back into it.
+// RUN: %FileCheck %s --check-prefix=FILELIST --input-file=%t/crash-4/reproduce.sh
+// FILELIST-DAG: "-filelist" "inputs{{.*}}inputs.txt"
+// FILELIST-DAG: "-primary-filelist" "inputs{{.*}}primary.txt"
+// FILELIST-DAG: "-output-filelist" "inputs{{.*}}output.txt"
+// FILELIST-DAG: "-index-unit-output-path-filelist" "inputs{{.*}}index-unit.txt"
+// FILELIST-DAG: "-supplementary-output-file-map" "inputs{{.*}}supp.json"
+
+// RUN: %FileCheck %s --check-prefix=INPUT-LIST --input-file=%t/crash-4/inputs/%:t/inputs.txt
+// INPUT-LIST: inputs{{.*}}test.swift
+// INPUT-LIST: inputs{{.*}}foo.swift
+
+// RUN: %FileCheck %s --check-prefix=OUTPUT-LIST --input-file=%t/crash-4/inputs/%:t/output.txt
+// OUTPUT-LIST: outputs{{.*}}test.o
+
+/// The index unit output paths only name the outputs in the index data, so they
+/// are copied over unchanged.
+// RUN: %FileCheck %s --check-prefix=INDEX-LIST --input-file=%t/crash-4/inputs/%:t/index-unit.txt
+// INDEX-LIST-NOT: {{^}}outputs
+// INDEX-LIST: {{^}}{{.*}}test.o
+
+/// The output file map is rewritten to use the captured inputs and to write the
+/// supplementary outputs inside the reproducer.
+// RUN: %FileCheck %s --check-prefix=SUPP --input-file=%t/crash-4/inputs/%:t/supp.json
+// SUPP: "inputs{{.*}}test.swift"
+// SUPP-DAG: swiftmodule: "outputs{{.*}}Test.swiftmodule"
+// SUPP-DAG: swiftdoc: "outputs{{.*}}Test.swiftdoc"
+
+/// Delete the original inputs and run the reproducer.
+// RUN: rm -rf %t/include %t/test.swift %t/foo.swift %t/inputs.txt %t/primary.txt %t/output.txt %t/index-unit.txt %t/supp.json
+// RUN: cd %t/crash-4 && %swift_frontend_plain @reproduce.sh
+// RUN: ls %t/crash-4/outputs/%:t/Test.swiftmodule
+
+/// Caching and the input overlay are mutually exclusive.
+// RUN: not %target-swift-frontend-plain -typecheck %t/test.swift -module-name Test \
+// RUN:   -cache-compile-job -cas-path %t/cas -cas-fs-input-overlay 2>&1 | %FileCheck %s --check-prefix=CONFLICT
+// CONFLICT: error: argument '-cas-fs-input-overlay' is not allowed with '-cache-compile-job'
 
 //--- test.swift
 import Dummy
@@ -60,6 +133,11 @@ public func foo() {}
 
 //--- Bridging.h
 void bridge(void);
+
+//--- supp.map
+"TMP_DIR/test.swift":
+  swiftmodule: "TMP_DIR/Test.swiftmodule"
+  swiftdoc: "TMP_DIR/Test.swiftdoc"
 
 //--- include/module.modulemap
 module Dummy {


### PR DESCRIPTION
The reproducer created by `-gen-reproducer` did not capture the file lists (`-filelist`, `-primary-filelist`, `-output-filelist`, `-index-unit-output-path-filelist`) or the supplementary output file map, so it stopped working as soon as the original build directory was gone, and its source inputs were only reachable through the immutable CAS file system, which made them impossible to edit while reducing.

Capture all of them inside the reproducer directory, rewrite the paths they contain, and redirect the outputs there as well so that running the reproducer no longer overwrites the outputs of the original invocation. Everything the reproducer owns is now addressed relative to the reproducer directory, so the directory can be relocated; it is meant to be run with that directory as the working directory.

Add `-cas-fs-input-overlay` to read the captured inputs from disk and overlay them on top of the CAS file system. Their content no longer contributes to the cache key, so the option is incompatible with `-cache-compile-job`, and the reproducer uses `-module-import-from-cas` instead to keep loading the module dependencies from the CAS. That combination also requires the interface sub-instance spawned by `-typecheck-module-from-interface` to inherit the CAS configuration, so that it can read `-explicit-swift-module-map-file` as a CASID.

rdar://185930364

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
