### PR TITLE
[ClangImporter] Restore classifyTypedef (mis)behavior

### DIFF
--- a/lib/ClangImporter/CFTypeInfo.cpp
+++ b/lib/ClangImporter/CFTypeInfo.cpp
@@ -71,7 +71,10 @@ CFPointeeInfo::classifyTypedef(const clang::TypedefNameDecl *typedefDecl) {
     quals.removeConst();
     if (quals.empty()) {
       if (auto record = pointee->getAs<clang::RecordType>()) {
-        auto recordDecl = record->getDecl();
+        // Check the canonical decl only for backwards compatibility.
+        // FIXME: Use getMostRecentDecl() here to pick up redeclaration attrs
+        //        (which would be source-breaking)
+        auto recordDecl = record->getDecl()->getCanonicalDecl();
         if (recordDecl->hasAttr<clang::ObjCBridgeAttr>() ||
             recordDecl->hasAttr<clang::ObjCBridgeMutableAttr>() ||
             recordDecl->hasAttr<clang::ObjCBridgeRelatedAttr>() ||

--- a/test/ClangImporter/Inputs/custom-modules/CFRedeclaredTag.h
+++ b/test/ClangImporter/Inputs/custom-modules/CFRedeclaredTag.h
@@ -1,0 +1,7 @@
+// ClangImporter should pick up the `objc_bridge` attribute even though it is
+// only present on the second declaration, not the first...
+typedef struct __CFRedeclaredTag CFRedeclaredTag;
+typedef struct __attribute__((objc_bridge(id))) __CFRedeclaredTag *CFRedeclaredTagRef;
+
+// ...and should therefore import this with a non-`Unmanaged` return type.
+extern CFRedeclaredTagRef CFRedeclaredTagCreate(void);

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -17,6 +17,11 @@ module CFAndObjC {
   export *
 }
 
+module CFRedeclaredTag {
+  header "CFRedeclaredTag.h"
+  export *
+}
+
 module CInsideObjC {
   header "CInsideObjC.h"
   export *

--- a/test/ClangImporter/cf_redeclared_tag.swift
+++ b/test/ClangImporter/cf_redeclared_tag.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -disable-objc-attr-requires-foundation-module -verify-ignore-unrelated -I %S/Inputs/custom-modules %s
+
+// REQUIRES: objc_interop
+
+import CFRedeclaredTag
+
+// Equivalent, since CFRedeclaredTagRef should be imported as OpaquePointer
+let _: CFRedeclaredTagRef? = CFRedeclaredTagCreate()
+let _: OpaquePointer? = CFRedeclaredTagCreate()
+
+// Should not typecheck
+let _: Unmanaged<CFRedeclaredTagRef>? = CFRedeclaredTagCreate()
+// expected-error@-1 {{'Unmanaged' requires that 'CFRedeclaredTagRef' (aka 'OpaquePointer') be a class type}}
+// expected-note@-2 {{requirement specified as 'Instance' : 'AnyObject'}}


### PR DESCRIPTION
Until recently, a `clang::TagType` always referred to the canonical decl. This meant that when ClangImporter’s `CFPointeeInfo::classifyTypedef()` tried to decide whether a type had an `objc_bridge` attribute or similar attached to it, it would only see the attributes on the first declaration, ignoring any that were added by redeclarations.

llvm/llvm-project#147835 changed the behavior of `clang::TagType`, allowing it to point to a later redeclaration. This changed the behavior of `classifyTypedef()` by allowing it to process attributes that it previously ignored. While the new behavior is arguably more reflective of the library author’s intent, this change in behavior can be source-breaking and needs to be introduced in a controlled fashion, if at all.

Restore the original behavior by explicitly processing the canonical decl, rather than whichever redeclaration happens to be in the type.

Fixes rdar://185736513.