### PR TITLE
AliasAnalysis: let TBAA handle Builtin.BridgeObject

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -153,6 +153,7 @@ extension TypeProperties {
   public var isBuiltinFloat: Bool { rawType.bridged.isBuiltinFloat() }
   public var isBuiltinVector: Bool { rawType.bridged.isBuiltinVector() }
   public var isBuiltinFixedArray: Bool { rawType.bridged.isBuiltinFixedArray() }
+  public var isBuiltinBridgeObject: Bool { rawType.bridged.isBuiltinBridgeObject() }
 
   public var isClass: Bool {
     if let nominal = nominal, nominal is ClassDecl {

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -966,7 +966,7 @@ private extension Type {
     }
     // Only support the most important builtin types to be on the safe side.
     // Historically we assumed that Builtin.RawPointer can alias everything (but why?).
-    if isBuiltinInteger || isBuiltinFloat {
+    if isBuiltinInteger || isBuiltinFloat || isBuiltinBridgeObject {
       return true
     }
     return false

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -3177,6 +3177,7 @@ struct BridgedASTType {
   BRIDGED_INLINE bool isBuiltinFloat() const;
   BRIDGED_INLINE bool isBuiltinVector() const;
   BRIDGED_INLINE bool isBuiltinFixedArray() const;
+  BRIDGED_INLINE bool isBuiltinBridgeObject() const;
   BRIDGED_INLINE bool isBox() const;
   BRIDGED_INLINE bool isPack() const;
   BRIDGED_INLINE bool isSILPack() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -673,6 +673,10 @@ bool BridgedASTType::isBuiltinFixedArray() const {
   return unbridged()->is<swift::BuiltinFixedArrayType>();
 }
 
+bool BridgedASTType::isBuiltinBridgeObject() const {
+  return unbridged()->is<swift::BuiltinBridgeObjectType>();
+}
+
 bool BridgedASTType::isBox() const {
   return unbridged()->is<swift::SILBoxType>();
 }

--- a/test/SILOptimizer/typed-access-tb-aa_unit.sil
+++ b/test/SILOptimizer/typed-access-tb-aa_unit.sil
@@ -233,6 +233,88 @@ bb0:
   return %21 : $()
 }
 
+// CHECK-LABEL: @bridge_object_test
+
+// A BridgeObject may alias itself and all the types which are not eligible for TBAA,
+// i.e. RawPointer, NativeObject and AnyObject.
+
+// CHECK:      PAIR #0.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:   MayAlias
+// CHECK:      PAIR #1.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %1 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.RawPointer
+// CHECK-NEXT:   MayAlias
+// CHECK:      PAIR #2.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %2 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+// CHECK-NEXT:   MayAlias
+// CHECK:      PAIR #3.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %3 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*AnyObject
+// CHECK-NEXT:   MayAlias
+
+// But it does not alias other builtin scalar types, class references or
+// aggregates which don't contain a BridgeObject.
+
+// CHECK:      PAIR #4.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %4 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.Int64
+// CHECK-NEXT:   NoAlias
+// CHECK:      PAIR #5.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %5 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*BOTest_C1
+// CHECK-NEXT:   NoAlias
+// CHECK:      PAIR #6.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %6 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*BOTest_S1
+// CHECK-NEXT:   MayAlias
+// CHECK:      PAIR #7.
+// CHECK-NEXT:     %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+// CHECK-NEXT:     %7 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*BOTest_S2
+// CHECK-NEXT:   NoAlias
+
+class BOTest_C1 {
+  var x : Builtin.Int32
+  init()
+}
+
+// A struct which contains a BridgeObject.
+struct BOTest_S1 {
+  var b : Builtin.BridgeObject
+}
+
+// A struct which does not contain a BridgeObject.
+struct BOTest_S2 {
+  var i : Builtin.Int32
+}
+
+sil @bridge_object_test : $@convention(thin) () -> () {
+bb0:
+  specify_test "aliasing"
+  %0 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.BridgeObject
+  %1 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.RawPointer
+  %2 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  %3 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.AnyObject
+  %4 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*Builtin.Int64
+  %5 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*BOTest_C1
+  %6 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*BOTest_S1
+  %7 = pointer_to_address undef : $Builtin.RawPointer to [strict] $*BOTest_S2
+
+  fix_lifetime %0 : $*Builtin.BridgeObject
+  fix_lifetime %1 : $*Builtin.RawPointer
+  fix_lifetime %2 : $*Builtin.NativeObject
+  fix_lifetime %3 : $*Builtin.AnyObject
+  fix_lifetime %4 : $*Builtin.Int64
+  fix_lifetime %5 : $*BOTest_C1
+  fix_lifetime %6 : $*BOTest_S1
+  fix_lifetime %7 : $*BOTest_S2
+
+  %r = tuple()
+  return %r : $()
+}
+
 
 // Make sure that struct addresses:
 //


### PR DESCRIPTION
A BridgeObject address does not alias addresses of other unrelated types, e.g. scalar builtin types or class references.
Unlike Builtin.NativeObject and Builtin.AnyObject, which are still treated conservatively, BridgeObject is only reinterpreted at the value level, so memory typed as BridgeObject cannot be reached by a differently typed strict access.

Also add the required `isBuiltinBridgeObject` type predicate and its bridging.
