### PR TITLE
Derive `CaseIterable` via macro

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1591,7 +1591,7 @@ MacroDecl *ASTContext::getBuiltinDerivedConformanceMacroDecl(
     break;
   case BuiltinDerivedConformanceMacroKind::DeriveCaseIterable:
     macro = makeMacro("_deriveCaseIterable", "DeriveCaseIterableMacro",
-                      {stringParam("", "infos"), stringParam("", "witness")},
+                      {stringParam("", "infos")},
                       MacroIntroducedDeclName::getArbitrary());
     break;
   case BuiltinDerivedConformanceMacroKind::DeriveEncodable:

--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -18,6 +18,7 @@ add_swift_macro_library(SwiftMacros
   TaskLocalMacro.swift
   SwiftifyImportMacro.swift
   TypeInfoParser.swift
+  DerivedConformances/DeriveCaseIterable.swift
   DerivedConformances/DeriveEquatable.swift
   SWIFT_DEPENDENCIES
     SwiftDiagnostics

--- a/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveCaseIterable.swift
+++ b/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveCaseIterable.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct DeriveCaseIterableMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Expecting #_deriveCaseIterable(<type info>)
+
+    let typeInfo = try node.arguments.expect(
+      .init(parser: NominalTypeInfo.fromStringLit))
+
+    let enumInfo: EnumTypeInfo
+    switch typeInfo.kind {
+    case .enumLike(let info):
+      enumInfo = info
+    default: fatalError("Expected an enum")
+    }
+    return [expand(enumInfo)]
+  }
+
+  /// Expands the `allCase` var declaration
+  static func expand(_ enumInfo: EnumTypeInfo) -> DeclSyntax {
+    """
+      nonisolated static var allCases: [Self] {
+        return [\(raw: enumInfo.cases.map { ".\($0.name)" }.joined(separator: ", "))]
+      }
+    """
+  }
+}

--- a/lib/Sema/DerivedConformance/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCaseIterable.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/QuotedString.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -70,6 +71,17 @@ static ArraySliceType *computeAllCasesType(NominalTypeDecl *enumDecl) {
   return ArraySliceType::get(enumType);
 }
 
+static ValueDecl *deriveCaseIterableViaMacros(DerivedConformance &derived,
+                                              ValueDecl *requirement) {
+  std::string macro;
+  auto os = llvm::raw_string_ostream(macro);
+  os << "#_deriveCaseIterable("
+     << QuotedString(getNominalTypeInfoString(derived)) << ")";
+  return deriveRequirementViaMacro(
+      derived, requirement, macro,
+      BuiltinDerivedConformanceMacroKind::DeriveCaseIterable);
+}
+
 static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
   // enum SomeEnum : CaseIterable {
   //   @derived
@@ -95,6 +107,9 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
     requirement->diagnose(diag::broken_case_iterable_requirement);
     return nullptr;
   }
+
+  if (Context.LangOpts.hasFeature(Feature::DeriveConformancesViaMacros))
+    return deriveCaseIterableViaMacros(*this, requirement);
 
   // Define the property.
   auto *returnTy = computeAllCasesType(Nominal);
@@ -130,4 +145,3 @@ Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
                          diag::broken_case_iterable_requirement);
   return nullptr;
 }
-

--- a/test/SILGen/synthesized_conformance_enum_macros.swift
+++ b/test/SILGen/synthesized_conformance_enum_macros.swift
@@ -31,8 +31,10 @@ enum NoValues {
 // CHECK: }
 
 // CHECK-LABEL: extension NoValues : CaseIterable {
+// CHECK:   static var allCases: [NoValues] { 
+// CHECK:     get 
+// CHECK:   }
 // CHECK:   typealias AllCases = [NoValues]
-// CHECK:   static var allCases: [NoValues] { get }
 // CHECK: }
 
 

--- a/test/Sema/derived_case_iterable_macros.swift
+++ b/test/Sema/derived_case_iterable_macros.swift
@@ -1,0 +1,86 @@
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -typecheck -verify -verify-ignore-unrelated %s
+
+// The macro-based derivation must accept and reject exactly what the legacy
+// AST-building path does, so run the same expectations without the feature.
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated %s
+
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+// REQUIRES: concurrency
+
+enum Simple: CaseIterable {
+  case a, b
+}
+
+enum Uninhabited: CaseIterable {}
+
+enum Escaped: CaseIterable {
+  case `default`, `class`, `self`, `Self`, `Type`
+}
+
+enum RawIdentifiers: CaseIterable {
+  case `foo bar`, `if let`
+}
+
+enum WithRawValue: String, CaseIterable {
+  case one, two
+}
+
+enum Generic<T>: CaseIterable {
+  case x, y
+}
+
+struct Outer {
+  enum Nested: CaseIterable {
+    case a
+  }
+}
+
+enum InExtension {
+  case a, b
+}
+
+extension InExtension: CaseIterable {}
+
+@MainActor
+enum GlobalActorIsolated: CaseIterable {
+  case a, b
+}
+
+actor SomeActor {
+  enum Nested: CaseIterable {
+    case a
+  }
+}
+
+func useThem() {
+  enum Local: CaseIterable {
+    case a, b
+  }
+
+  let _: Local.AllCases = Local.allCases
+  let _: [Local] = Local.allCases
+  let _: [Simple] = Simple.allCases
+  let _: Simple.AllCases = Simple.allCases
+  let _: [Escaped] = Escaped.allCases
+  let _: [Generic<Int>] = Generic<Int>.allCases
+  let _: [Outer.Nested] = Outer.Nested.allCases
+  let _: [InExtension] = InExtension.allCases
+  let _: [Uninhabited] = Uninhabited.allCases
+}
+
+func useIsolated() {
+  let _: [GlobalActorIsolated] = GlobalActorIsolated.allCases
+  let _: [SomeActor.Nested] = SomeActor.Nested.allCases
+}
+
+enum HasAssociatedValues: CaseIterable { // expected-error {{type 'HasAssociatedValues' does not conform to protocol 'CaseIterable'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  case a(Int)
+}
+
+enum PotentiallyUnavailableCase: CaseIterable { // expected-error {{type 'PotentiallyUnavailableCase' does not conform to protocol 'CaseIterable'}}
+  // expected-note@-1 {{add stubs for conformance}}
+  @available(macOS 99, *)
+  case a
+  case b
+}

--- a/test/decl/enum/derived_case_iterable_macros_expansion.swift
+++ b/test/decl/enum/derived_case_iterable_macros_expansion.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -typecheck -dump-macro-expansions %s 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+enum Simple: CaseIterable {
+  case a
+  case b
+}
+
+// CHECK: nonisolated static var allCases: [Self] {
+// CHECK:   return [.a, .b]
+// CHECK: }
+
+enum Uninhabited: CaseIterable {}
+
+// CHECK: nonisolated static var allCases: [Self] {
+// CHECK:   return []
+// CHECK: }
+
+enum WithRawIdentifiers: CaseIterable {
+  case `foo bar`
+  case `default`
+}
+
+// CHECK: nonisolated static var allCases: [Self] {
+// CHECK:   return [.`foo bar`, .`default`]
+// CHECK: }
+
+enum WithRawValue: Int, CaseIterable {
+  case one = 1
+  case two = 2
+}
+
+// CHECK: nonisolated static var allCases: [Self] {
+// CHECK:   return [.one, .two]
+// CHECK: }
+
+enum Generic<T>: CaseIterable {
+  case x
+  case y
+}
+
+// CHECK: nonisolated static var allCases: [Self] {
+// CHECK:   return [.x, .y]
+// CHECK: }


### PR DESCRIPTION
Move `CaseIterable` derivation to a macro under a feature flag.

Adds a `DeriveConformancesViaMacros` feature flag path for deriving `allValues` on enums. When enabled. `DerivedConformance::deriveCaseIterable` builds a `#_deriveCaseIterable(...)` macro call instead of hand-crafting the AST nodes, and the new `DeriveCaseIterableMacro` (in `SwiftMacros`) expands it.

The type alias is not synthesized in this PR.

Type info is encoded the same way as for `Equatable`, reusing `getNominalTypeInfoString`.

The non-macro path is untouched. This is opt-in via the feature flag.
 