### PR TITLE
[Test] `InlineArray.mutableSpan` does not copy the array

### DIFF
--- a/test/SILOptimizer/inline_arrays.swift
+++ b/test/SILOptimizer/inline_arrays.swift
@@ -46,6 +46,19 @@ public final class C {
   }
 }
 
+// rdar://172132851 (Getting a MutableSpan from an InlineArray causes a heap allocation that isn't really used)
+// CHECK-LABEL: sil @$s4test0A11MutableSpanySis11InlineArrayVy$511_SiGzF
+// CHECK-NOT:     alloc{{.*}}InlineArray
+// CHECK-LABEL: } // end sil function '$s4test0A11MutableSpanySis11InlineArrayVy$511_SiGzF'
+public func testMutableSpan(_ value: inout [512 of Int]) -> Int {
+    var sum = 0
+    let span = value.mutableSpan
+    for i in span.indices {
+        sum &+= span[i]
+    }
+    return sum
+}
+
 public struct S {
   let a: InlineArray<7000, UInt8>
 


### PR DESCRIPTION
This has been the case for a while. Add a regression test to enforce the behaviour.

Fixes: rdar://172132851

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
