### PR TITLE
[Sema][SwiftMacros] Add per-case runtime availability info to `EnumCaseInfo`

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -52,8 +52,32 @@ public struct EnumCaseInfo {
   /// appear in Swift source) and `nil` if there isn't one
   var associatedValueLabels: [String?]
 
-  /// Whether or not the enum case is marked as reachable
+  /// Whether a value of this case can exist at runtime. False only when the
+  /// case is unavailable in every execution context the code may run in, so a
+  /// switch over `self` may treat it as unreachable.
   var isReachable: Bool
+
+  /// Whether a reference constructing this case may be synthesized, guarded by
+  /// `runtimeAvailabilityQueries`. False when some restriction on the case
+  /// cannot be expressed as a runtime query, in which case the case must be
+  /// left out of any synthesized initializer entirely. This is stricter than
+  /// `isReachable`: a case unavailable on one of several targets is still
+  /// reachable, but cannot be constructed.
+  var isConstructible: Bool
+
+  /// The queries that must all succeed for this case to be available at
+  /// runtime. Only meaningful when `isConstructible` is true.
+  var runtimeAvailabilityQueries: [AvailabilityQuery]
+}
+
+public struct AvailabilityQuery {
+  var domain: String
+  var primaryRange: String?
+  var variantRange: String?
+
+  /// Whether this is an `#unavailable` query rather than an `#available` one.
+  var isUnavailability: Bool
+  var constantResult: Bool?
 }
 
 public struct StructTypeInfo {
@@ -505,25 +529,65 @@ extension EnumCaseInfo: TypeInfoProtocol {
     // Expecting:
     //   EnumCaseInfo(name: <String>,
     //                associatedValueLabels: <[String?]>,
-    //                isReachable: <Bool>)
+    //                isReachable: <Bool>,
+    //                isConstructible: <Bool>,
+    //                runtimeAvailabilityQueries: <[AvailabilityQuery]>)
 
-    let (name, associatedValueLabels, isReachable) = try getNamedFuncallArgs(
-      node: node,
-      name: "EnumCaseInfo"
-    ).expect(
-      .stringArg("name"),
-      .stringArg("associatedValueLabels").toOptional().toArray(),
-      .boolArg("isReachable")
-    )
+    let (name, associatedValueLabels, isReachable, isConstructible,
+         runtimeAvailabilityQueries) =
+      try getNamedFuncallArgs(
+        node: node,
+        name: "EnumCaseInfo"
+      ).expect(
+        .stringArg("name"),
+        .stringArg("associatedValueLabels").toOptional().toArray(),
+        .boolArg("isReachable"),
+        .boolArg("isConstructible"),
+        .arrayArg("runtimeAvailabilityQueries", parser: AvailabilityQuery.fromSyntax)
+      )
 
     return Self(
-      name: name, associatedValueLabels: associatedValueLabels, isReachable: isReachable)
+      name: name,
+      associatedValueLabels: associatedValueLabels,
+      isReachable: isReachable,
+      isConstructible: isConstructible,
+      runtimeAvailabilityQueries: runtimeAvailabilityQueries)
   }
 
   public var syntax: ExprSyntax {
     """
-    EnumCaseInfo(name: \(stringlit(name)), associatedValueLabels: \(arraySyntax(associatedValueLabels, {optionalSyntax($0, stringlit)})))
+    EnumCaseInfo(name: \(stringlit(name)), associatedValueLabels: \(arraySyntax(associatedValueLabels, {optionalSyntax($0, stringlit)})), isReachable: \(boollit(isReachable)), isConstructible: \(boollit(isConstructible)), runtimeAvailabilityQueries: \(arraySyntax(runtimeAvailabilityQueries, \.syntax)))
     """
+  }
+}
+
+extension AvailabilityQuery: TypeInfoProtocol {
+  public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    let (domain, primaryRange, variantRange, isUnavailability, constantResult) =
+      try getNamedFuncallArgs(
+        node: node, name: "AvailabilityQuery"
+      ).expect(
+        .stringArg("domain"),
+        .stringArg("primaryRange").toOptional(),
+        .stringArg("variantRange").toOptional(),
+        .boolArg("isUnavailability"),
+        .boolArg("constantResult").toOptional(),
+      )
+    return Self(
+      domain: domain, primaryRange: primaryRange, variantRange: variantRange,
+      isUnavailability: isUnavailability, constantResult: constantResult)
+  }
+
+  public var syntax: ExprSyntax {
+    return
+      """
+      AvailabilityQuery(
+        domain: \(stringlit(domain)),
+        primaryRange: \(optionalSyntax(primaryRange, stringlit)),
+        variantRange: \(optionalSyntax(variantRange, stringlit)),
+        isUnavailability: \(boollit(isUnavailability)),
+        constantResult: \(optionalSyntax(constantResult, boollit)))
+      """
   }
 }
 

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -571,7 +571,7 @@ extension AvailabilityQuery: TypeInfoProtocol {
         .stringArg("primaryRange").toOptional(),
         .stringArg("variantRange").toOptional(),
         .boolArg("isUnavailability"),
-        .boolArg("constantResult").toOptional(),
+        .boolArg("constantResult").toOptional()
       )
     return Self(
       domain: domain, primaryRange: primaryRange, variantRange: variantRange,

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1141,12 +1141,115 @@ swift::deriveRequirementViaMacro(DerivedConformance &derived,
   return witness;
 }
 
+bool swift::checkAvailabilityForElement(
+    const EnumElementDecl *elt, AvailabilityContext availabilityContext,
+    SmallVectorImpl<AvailabilityQuery> &availabilityQueries) {
+  auto &C = elt->getASTContext();
+
+  // A case should not be emitted for an element that is unreachable at runtime
+  // since otherwise that unavailable element could be constructed illegally via
+  // instantiation from a specific raw value. Hand-written versions of
+  // init(rawValue:) would most likely handle this by wrapping the case in an
+  // appropriate `#if` condition, which we cannot do in code synthesis. Leaving
+  // the case out also keeps its raw value from appearing in the generated code,
+  // which matters for an element that is hidden behind a disabled domain.
+  //
+  // An element of an enum that is itself unreachable is exempt. Every element
+  // of such an enum inherits its unreachability, so honoring it here would
+  // leave init(rawValue:) with no cases at all.
+  if (elt->isUnreachableAtRuntime() &&
+      !elt->getParentEnum()->isUnreachableAtRuntime())
+    return false;
+
+  for (auto const &restriction :
+       availabilityContext.allRestrictionsForDecl(elt)) {
+    // Deprecation doesn't prevent the case from being reached.
+    if (restriction.isDeprecated())
+      continue;
+
+    auto domain = restriction.getDomain();
+
+    // Unavailability restrictions must be handled carefully. If there is no
+    // way to express an availability query that corresponds to the restriction
+    // then a case cannot be synthesized for this element.
+    if (restriction.isUnavailable() &&
+        (domain.isVersioned() || !domain.supportsQueries()))
+      return false;
+
+    // Some restrictions are active for type checking but can't translate to
+    // runtime restrictions.
+    if (!restriction.isActiveForRuntimeQueries(C))
+      continue;
+
+    // There is no query that can guard the case, so it can never be reached.
+    if (!domain.supportsQueries())
+      return false;
+
+    // Comparisons must be made in the canonical domain for the current
+    // compilation, which may differ from the domain that was written.
+    auto domainAndRange = restriction.getDomainAndRange(C);
+    domain = domainAndRange.getDomain();
+
+    // Only a versioned domain takes a version argument in a query.
+    std::optional<AvailabilityRange> range;
+    if (domain.isVersioned())
+      range.emplace(domainAndRange.getRange());
+
+    auto query = AvailabilityQuery::forDomain(domain, range,
+                                              /*variantRange=*/std::nullopt)
+                     .asUnavailable(restriction.isUnavailable());
+
+    availabilityQueries.push_back(query);
+  }
+
+  return true;
+}
+
+/// Prints the minimum version of \p range as a string literal, or `nil` if the
+/// range does not constrain the version to \p out.
+static void printAvailabilityRange(llvm::raw_ostream &out,
+                                   std::optional<AvailabilityRange> range) {
+  if (!range || !range->hasMinimumVersion()) {
+    out << "nil";
+    return;
+  }
+
+  out << QuotedString(range->getRawMinimumVersion().getAsString());
+}
+
+/// Prints the AvailabilityDomain \p domain as a quoted string to \p
+/// out.
+static void printAvailabilityDomain(llvm::raw_ostream &out,
+                                    AvailabilityDomain domain) {
+  std::string scratch = {};
+  auto s = llvm::raw_string_ostream(scratch);
+  domain.print(s);
+  printAsQuotedString(out, s.str());
+}
+
+/// Prints a string containing swift syntax describing the AvailabilityQuery \p
+/// query to \p out.
+static void printAvailabilityQuery(llvm::raw_ostream &out,
+                                   const AvailabilityQuery &query) {
+  out << "AvailabilityQuery(domain: ";
+  printAvailabilityDomain(out, query.getDomain());
+  out << ", primaryRange: ";
+  printAvailabilityRange(out, query.getPrimaryRange());
+  out << ", variantRange: ";
+  printAvailabilityRange(out, query.getVariantRange());
+  out << ", isUnavailability: "
+      << (query.isUnavailability() ? "true" : "false");
+  out << ", constantResult: ";
+  auto constantResult = query.getConstantResult();
+  out << (constantResult ? ((*constantResult) ? "true" : "false") : "nil");
+  out << ")";
+}
+
 /// Prints a string containing swift syntax describing the case \p  decl with
 /// relevant information to \p out.
 static void printEnumCaseInfo(llvm::raw_ostream &out,
                               const EnumElementDecl *decl) {
-  bool markReachable = !decl->isUnreachableAtRuntime() ||
-                       decl->getParentEnum()->isUnreachableAtRuntime();
+  auto &C = decl->getASTContext();
   // Escape names as they must appear in source so a keyword-named case or
   // label (`init`, `class`, ...) round-trips as a valid reference in the
   // macros.
@@ -1165,7 +1268,21 @@ static void printEnumCaseInfo(llvm::raw_ostream &out,
                   name.str(), PrintNameContext::FunctionParameterExternal));
         }
       });
-  out << "], isReachable: " << (markReachable ? "true" : "false") << ")";
+  auto availabilityContext = AvailabilityContext::forDeploymentTarget(C);
+  SmallVector<AvailabilityQuery, 2> availabilityQueries;
+  bool isConstructible = checkAvailabilityForElement(decl, availabilityContext,
+                                                     availabilityQueries);
+  bool isReachable = !decl->isUnreachableAtRuntime() ||
+                     decl->getParentEnum()->isUnreachableAtRuntime();
+
+  out << "], isReachable: " << (isReachable ? "true" : "false")
+      << ", isConstructible: " << (isConstructible ? "true" : "false")
+      << ", runtimeAvailabilityQueries: [";
+  llvm::interleaveComma(availabilityQueries, out,
+                        [&out](const AvailabilityQuery &query) {
+                          printAvailabilityQuery(out, query);
+                        });
+  out << "])";
 }
 
 /// Prints a string containing swift syntax describing the enum \p

--- a/lib/Sema/DerivedConformance/DerivedConformance.h
+++ b/lib/Sema/DerivedConformance/DerivedConformance.h
@@ -18,6 +18,8 @@
 #ifndef SWIFT_SEMA_DERIVEDCONFORMANCE_DERIVEDCONFORMANCE_H
 #define SWIFT_SEMA_DERIVEDCONFORMANCE_DERIVEDCONFORMANCE_H
 
+#include "swift/AST/AvailabilityContext.h"
+#include "swift/AST/AvailabilityQuery.h"
 #include "swift/AST/Builtins.h"
 #include "swift/Basic/LLVM.h"
 #include <utility>
@@ -477,6 +479,13 @@ deriveRequirementViaMacro(DerivedConformance &derived, ValueDecl *requirement,
 /// for by producing valid swift syntax.
 std::string getNominalTypeInfoString(DerivedConformance &derived);
 
+/// Checks whether the case may be reached at runtime. If it can never be
+/// reached, returns false. Otherwise, returns true and appends a query to
+/// \c availabilityQueries for each domain that the case must be checked in at
+/// runtime.
+bool checkAvailabilityForElement(
+    const EnumElementDecl *elt, AvailabilityContext availabilityContext,
+    SmallVectorImpl<AvailabilityQuery> &availabilityQueries);
 
 } // namespace swift
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -232,75 +232,6 @@ static Stmt *createAvailabilityGuardStmt(ASTContext &C,
   return guardStmt;
 }
 
-/// Checks whether the case may be reached at runtime. If it can never be
-/// reached, returns false. Otherwise, returns true and appends a query to
-/// \c availabilityQueries for each domain that the case must be checked in at
-/// runtime.
-static bool
-checkAvailability(const EnumElementDecl *elt,
-                  AvailabilityContext availabilityContext,
-                  SmallVectorImpl<AvailabilityQuery> &availabilityQueries) {
-  auto &C = elt->getASTContext();
-
-  // A case should not be emitted for an element that is unreachable at runtime
-  // since otherwise that unavailable element could be constructed illegally via
-  // instantiation from a specific raw value. Hand-written versions of
-  // init(rawValue:) would most likely handle this by wrapping the case in an
-  // appropriate `#if` condition, which we cannot do in code synthesis. Leaving
-  // the case out also keeps its raw value from appearing in the generated code,
-  // which matters for an element that is hidden behind a disabled domain.
-  //
-  // An element of an enum that is itself unreachable is exempt. Every element
-  // of such an enum inherits its unreachability, so honoring it here would
-  // leave init(rawValue:) with no cases at all.
-  if (elt->isUnreachableAtRuntime() &&
-      !elt->getParentEnum()->isUnreachableAtRuntime())
-    return false;
-
-  for (auto const &restriction :
-       availabilityContext.allRestrictionsForDecl(elt)) {
-    // Deprecation doesn't prevent the case from being reached.
-    if (restriction.isDeprecated())
-      continue;
-
-    auto domain = restriction.getDomain();
-
-    // Unavailability restrictions must be handled carefully. If there is no
-    // way to express an availability query that corresponds to the restriction
-    // then a case cannot be synthesized for this element.
-    if (restriction.isUnavailable() &&
-        (domain.isVersioned() || !domain.supportsQueries()))
-      return false;
-
-    // Some restrictions are active for type checking but can't translate to
-    // runtime restrictions.
-    if (!restriction.isActiveForRuntimeQueries(C))
-      continue;
-
-    // There is no query that can guard the case, so it can never be reached.
-    if (!domain.supportsQueries())
-      return false;
-
-    // Comparisons must be made in the canonical domain for the current
-    // compilation, which may differ from the domain that was written.
-    auto domainAndRange = restriction.getDomainAndRange(C);
-    domain = domainAndRange.getDomain();
-
-    // Only a versioned domain takes a version argument in a query.
-    std::optional<AvailabilityRange> range;
-    if (domain.isVersioned())
-      range.emplace(domainAndRange.getRange());
-
-    auto query = AvailabilityQuery::forDomain(domain, range,
-                                              /*variantRange=*/std::nullopt)
-                     .asUnavailable(restriction.isUnavailable());
-
-    availabilityQueries.push_back(query);
-  }
-
-  return true;
-}
-
 static std::pair<BraceStmt *, bool>
 deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
   // enum SomeEnum : SomeType {
@@ -347,7 +278,8 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
     // unavailable, skip it. If it might be unavailable at runtime, save the
     // queries it needs in availabilityQueries and keep processing this element.
     SmallVector<AvailabilityQuery, 1> availabilityQueries;
-    if (!checkAvailability(elt, availabilityContext, availabilityQueries))
+    if (!checkAvailabilityForElement(elt, availabilityContext,
+                                     availabilityQueries))
       continue;
 
     // litPat = elt.rawValueExpr as a pattern


### PR DESCRIPTION
Some soon-to-be derived via macros conformances need per-case runtime availability infos for enums (e.g. `RawRepresentable` and `CodingKey`). 

This PR adds a `runtimeAvailabilityQueries` field to `EnumCaseInfo` and fixes the parser type information in `SwiftMacros` accordingly.

Note: This field isn't used yet.

This is only reachable under the `DeriveConformancesViaMacros` experimental feature flag.