### PR TITLE
Fix Sendable key path function isolation

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5003,9 +5003,20 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
         computeClosureIsolationFromParent(closure, parentIsolation,
                                           checkIsolatedCapture);
 
+    bool isSendableKeyPathConversion = false;
+    if (auto *autoClosure = dyn_cast<AutoClosureExpr>(closure);
+        autoClosure &&
+        isa<KeyPathApplicationExpr>(autoClosure->getSingleExpressionBody())) {
+      if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
+        isSendableKeyPathConversion =
+            fce->getType()->castTo<FunctionType>()->isSendable();
+      }
+    }
+
     bool isIsolationBoundary =
         isIsolationInferenceBoundaryClosure(closure,
-                                            /*canInheritActorContext=*/true);
+                                            /*canInheritActorContext=*/true) ||
+        isSendableKeyPathConversion;
 
     bool isArgumentOfNonisolatedNonsendingApply = false;
     if (auto *apply = dyn_cast_or_null<CallExpr>(getImmediateApply())) {

--- a/test/Concurrency/keypath_function_isolation.swift
+++ b/test/Concurrency/keypath_function_isolation.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-silgen -swift-version 6 -strict-concurrency=complete -enable-actor-data-race-checks -Xllvm -sil-print-types -module-name keypath_function_isolation %s | %FileCheck %s
+
+// REQUIRES: concurrency
+
+@MainActor
+func sendableKeyPathFunction() -> @Sendable (String) -> Int {
+  \.count
+}
+
+// CHECK-LABEL: // implicit closure #1 in sendableKeyPathFunction()
+// CHECK-NEXT: // Isolation: nonisolated
+// CHECK-NOT: _checkExpectedExecutor
+// CHECK: } // end sil function


### PR DESCRIPTION
Key paths converted to `@Sendable` functions currently inherit actor isolation from their surrounding context. This leaves an executor check in the synthesised closure, causing it to trap when called from another executor.

Once the solver has accepted the `@Sendable` conversion, treat the synthesised key-path closure as an isolation boundary.

Fixes #91877