### PR TITLE
IRGen: store COM interface IDs inline in protocol descriptors

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1846,6 +1846,11 @@ TargetTupleTypeMetadata<Runtime>::getOffsetToNumElements() -> StoredSize {
 }
 
 template <typename Runtime>
+struct TargetCOMInterfaceID {
+  uint8_t Bytes[16];
+};
+
+template <typename Runtime>
 struct swift_ptrauth_struct_context_descriptor(ProtocolDescriptor)
     TargetProtocolDescriptor;
 
@@ -3376,15 +3381,18 @@ struct swift_ptrauth_struct_context_descriptor(ProtocolDescriptor)
     : TargetContextDescriptor<Runtime>,
       swift::ABI::TrailingObjects<
         TargetProtocolDescriptor<Runtime>,
+        TargetCOMInterfaceID<Runtime>,
         TargetGenericRequirementDescriptor<Runtime>,
         TargetProtocolRequirement<Runtime>>
 {
 private:
-  using TrailingObjects
-    = swift::ABI::TrailingObjects<
-        TargetProtocolDescriptor<Runtime>,
-        TargetGenericRequirementDescriptor<Runtime>,
-        TargetProtocolRequirement<Runtime>>;
+  using COMInterfaceID = TargetCOMInterfaceID<Runtime>;
+
+  using TrailingObjects =
+      swift::ABI::TrailingObjects<TargetProtocolDescriptor<Runtime>,
+                                  COMInterfaceID,
+                                  TargetGenericRequirementDescriptor<Runtime>,
+                                  TargetProtocolRequirement<Runtime>>;
 
   friend TrailingObjects;
 
@@ -3392,6 +3400,12 @@ private:
   using OverloadToken = typename TrailingObjects::template OverloadToken<T>;
 
 public:
+  size_t numTrailingObjects(OverloadToken<COMInterfaceID>) const {
+    SpecialProtocol protocol =
+        getProtocolContextDescriptorFlags().getSpecialProtocol();
+    return protocol == SpecialProtocol::COM ? 1 : 0;
+  }
+
   size_t numTrailingObjects(
             OverloadToken<TargetGenericRequirementDescriptor<Runtime>>) const {
     return NumRequirementsInSignature;
@@ -3422,6 +3436,20 @@ public:
 
   ProtocolContextDescriptorFlags getProtocolContextDescriptorFlags() const {
     return ProtocolContextDescriptorFlags(this->Flags.getKindSpecificFlags());
+  }
+
+  /// Retrieve the target-native 16-byte interface identifier for this COM
+  /// interface protocol.
+  ///
+  /// A COM protocol descriptor carries the bytes inline immediately after its
+  /// fixed header. Other protocol descriptors have no such trailing field,
+  /// preserving their existing layout.
+  const uint8_t *getCOMInterfaceID() const {
+    SpecialProtocol protocol =
+        getProtocolContextDescriptorFlags().getSpecialProtocol();
+    if (protocol == SpecialProtocol::COM)
+      return this->template getTrailingObjects<COMInterfaceID>()->Bytes;
+    return nullptr;
   }
 
   /// Retrieve the requirements that make up the requirement signature of

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -925,6 +925,7 @@ namespace {
       NumRequirementsInSignature = B.addPlaceholderWithSize(IGM.Int32Ty);
       NumRequirements = B.addPlaceholderWithSize(IGM.Int32Ty);
       asImpl().addAssociatedTypeNames();
+      asImpl().addCOMInterfaceID();
       asImpl().addRequirementSignature();
       asImpl().addRequirements();
       auto addr = IGM.getAddrOfProtocolDescriptor(Proto,
@@ -939,6 +940,16 @@ namespace {
       auto nameStr = IGM.getAddrOfGlobalIdentifierString(Proto->getName().str(),
                                            /*willBeRelativelyAddressed*/ true);
       B.addRelativeAddress(nameStr);
+    }
+
+    void addCOMInterfaceID() {
+      if (!Proto->isCOMInterface())
+        return;
+
+      const COMDeclInfo *info = Proto->getCOMDeclInfo();
+      ASSERT(info && info->isInterface());
+
+      B.add(IGM.getCOMIdentityConstant(info->getInterfaceID()));
     }
 
     void addRequirementSignature() {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/CodeGenerationModel.h"
+#include "swift/Basic/UUID.h"
 #include "swift/Basic/LLVMExtras.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/ManglingMacros.h"
@@ -1359,6 +1360,24 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
   }
 
 #include "swift/Runtime/RuntimeFunctions.def"
+
+llvm::Constant *
+IRGenModule::getCOMIdentityConstant(StringRef identity) {
+  std::optional<UUID> uuid = UUID::fromString(identity.str().c_str());
+  ASSERT(uuid && "COM interface ID should have been validated by Sema");
+
+  unsigned char bytes[UUID::Size];
+  uuid->getCanonicalBytes(bytes);
+
+  if (!Triple.isLittleEndian())
+    return llvm::ConstantDataArray::get(getLLVMContext(), llvm::ArrayRef(bytes));
+
+  std::reverse(bytes + 0, bytes + 4);
+  std::reverse(bytes + 4, bytes + 6);
+  std::reverse(bytes + 6, bytes + 8);
+
+  return llvm::ConstantDataArray::get(getLLVMContext(), llvm::ArrayRef(bytes));
+}
 
 std::pair<llvm::GlobalVariable *, llvm::Constant *>
 IRGenModule::createStringConstant(StringRef Str, bool willBeRelativelyAddressed,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1708,6 +1708,9 @@ public:
 public:
   llvm::LLVMContext &getLLVMContext() const { return *LLVMContext; }
 
+  /// Form the target-native bytes for a COM identity.
+  llvm::Constant *getCOMIdentityConstant(llvm::StringRef identity);
+
   void emitSourceFile(SourceFile &SF);
   void emitSynthesizedFileUnit(SynthesizedFileUnit &SFU);
 

--- a/test/IRGen/com-protocol-descriptor-iid.swift
+++ b/test/IRGen/com-protocol-descriptor-iid.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-com-interop -emit-module-path %t/COM.swiftmodule -module-name COM %S/../Inputs/COM.swift
+// RUN: %target-swift-frontend -enable-experimental-com-interop -module-name Interfaces -I %t -emit-ir %s | %FileCheck %s
+
+@com(interface: "01010101-0202-0303-0404-050505050505")
+public protocol IWidget {
+  func draw()
+}
+
+public protocol Protocol {
+  func draw()
+}
+
+// A COM protocol has exactly one IID value stored inline in the descriptor. The
+// COMInterface IID requirement reads from this storage.
+
+// CHECK: @"$s10Interfaces7IWidgetMp" = {{.*}}constant <{ i32, i32, i32, i32, i32, i32, [16 x i8],
+// CHECK-SAME: [16 x i8] c"\01\01\01\01\02\02\03\03\04\04\05\05\05\05\05\05"
+
+// An ordinary protocol retains its existing descriptor layout: the requirement
+// follows the six-word fixed header without an intervening IID.
+
+// CHECK: @"$s10Interfaces8ProtocolMp" = {{.*}}constant <{ i32, i32, i32, i32, i32, i32, %swift.protocol_requirement }>

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -224,25 +224,27 @@ ProtocolDescriptor ProtocolError{
     .withSpecialProtocol(SpecialProtocol::Error)
 };
 
-ProtocolDescriptor ProtocolCOM{
-  "_TMp8Metadata11ProtocolCOM",
-  nullptr,
-  ProtocolDescriptorFlags()
-    .withSwift(true)
-    .withClassConstraint(ProtocolClassConstraint::Any)
-    .withDispatchStrategy(ProtocolDispatchStrategy::Swift)
-    .withSpecialProtocol(SpecialProtocol::COM)
+struct COMProtocolDescriptorStorage {
+  ProtocolDescriptor Descriptor;
+  TargetCOMInterfaceID<InProcess> InterfaceID{};
+
+  COMProtocolDescriptorStorage(const char *name)
+      : Descriptor{name, nullptr,
+                   ProtocolDescriptorFlags()
+                     .withSwift(true)
+                     .withClassConstraint(ProtocolClassConstraint::Any)
+                     .withDispatchStrategy(ProtocolDispatchStrategy::Swift)
+                     .withSpecialProtocol(SpecialProtocol::COM)} {
+    }
 };
 
-ProtocolDescriptor ProtocolCOMBase{
-  "_TMp8Metadata15ProtocolCOMBase",
-  nullptr,
-  ProtocolDescriptorFlags()
-    .withSwift(true)
-    .withClassConstraint(ProtocolClassConstraint::Any)
-    .withDispatchStrategy(ProtocolDispatchStrategy::Swift)
-    .withSpecialProtocol(SpecialProtocol::COM)
-};
+COMProtocolDescriptorStorage
+ProtocolCOMStorage{"_TMp8Metadata11ProtocolCOM"};
+ProtocolDescriptor &ProtocolCOM = ProtocolCOMStorage.Descriptor;
+
+COMProtocolDescriptorStorage
+ProtocolCOMBaseStorage{"_TMp8Metadata15ProtocolCOMBase"};
+ProtocolDescriptor &ProtocolCOMBase = ProtocolCOMBaseStorage.Descriptor;
 
 ProtocolDescriptor ProtocolClassConstrained{
   "_TMp8Metadata24ProtocolClassConstrained",
@@ -475,6 +477,12 @@ TEST(MetadataTest, getExistentialMetadata) {
                 special->getSuperclassConstraint());
       return special;
     });
+}
+
+TEST(MetadataTest, getCOMInterfaceID) {
+  EXPECT_EQ(ProtocolCOMStorage.InterfaceID.Bytes,
+            ProtocolCOM.getCOMInterfaceID());
+  EXPECT_EQ(nullptr, ProtocolA.getCOMInterfaceID());
 }
 
 namespace {


### PR DESCRIPTION
Operations on COM existentials need a canonical IID address that can be recovered directly from protocol metadata without a runtime lookup or a second global.

Store the target-native 16-byte IID inline after the fixed protocol descriptor header. `SpecialProtocol::COM` remains the presence discriminator, ordinary protocol layouts are unchanged, and the variable-length requirement arrays continue after the inline bytes.

This leaves each interface with exactly one addressable GUID representation, removes the private IID global and its relocation, and lets clients share the defining protocol descriptor.