### PR TITLE
Treat yield as a deinit barrier

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -156,7 +156,7 @@ public class Instruction : CustomStringConvertible, Hashable {
 
   public final var isDeinitBarrier: Bool {
     switch self {
-    case SIL.isFullApplySite, is EndApplyInst, is AbortApplyInst:
+    case SIL.isFullApplySite, is EndApplyInst, is AbortApplyInst, is YieldInst:
       return true
 
     case is LoadWeakInst, is LoadUnownedInst, is StrongCopyUnownedValueInst, is StrongCopyUnmanagedValueInst:

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -876,6 +876,39 @@ entry:
   return %retval : $()
 }
 
+// Test that copy propagation doesn't hoist a destroy_value corresponding to a
+// move_value [lexical] over a yield.
+// CHECK-LABEL: sil [ossa] @dont_hoist_move_value_lexical_destroy_over_yield : {{.*}} {
+// CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical]
+// CHECK:         [[TAKE_GUARANTEED_C:%[^,]+]] = function_ref @takeGuaranteedC
+// CHECK:         apply [[TAKE_GUARANTEED_C]]([[LIFETIME]])
+// CHECK-NOT:     destroy_value
+// CHECK:         yield {{.*}}, resume [[RESUME:bb[0-9]+]], unwind [[UNWIND:bb[0-9]+]]
+// CHECK:       [[RESUME]]:
+// CHECK:         destroy_value [[LIFETIME]]
+// CHECK:       [[UNWIND]]:
+// CHECK:         destroy_value [[LIFETIME]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function 'dont_hoist_move_value_lexical_destroy_over_yield'
+sil [ossa] @dont_hoist_move_value_lexical_destroy_over_yield : $@yield_once @convention(thin) (@inout C) -> @yields @inout C {
+entry(%slot : $*C):
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %instance = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
+  %lifetime = move_value [lexical] %instance : $C
+  %takeGuaranteedC = function_ref @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
+  apply %takeGuaranteedC(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  yield %slot : $*C, resume resume_bb, unwind unwind_bb
+
+resume_bb:
+  destroy_value %lifetime : $C
+  %retval = tuple ()
+  return %retval : $()
+
+unwind_bb:
+  destroy_value %lifetime : $C
+  unwind
+}
+
 // Canonicalize the moved-from value when a move_value is deemed redundant and
 // eliminated.
 // CHECK-LABEL: sil [ossa] @canonicalize_source_of_redundant_move_value : {{.*}} {

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -110,6 +110,28 @@ sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
   return %retval : $()
 }
 
+// CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_yield: is_deinit_barrier
+// CHECK:  yield
+// CHECK:  true
+// CHECK-LABEL: end running test 1 of {{[0-9]+}} on test_yield: is_deinit_barrier
+sil [ossa] @test_yield : $@yield_once @convention(thin) (@owned A) -> @yields @guaranteed A {
+bb0(%0 : @owned $A):
+  %borrow = begin_borrow %0 : $A
+  specify_test "is_deinit_barrier @instruction"
+  yield %borrow : $A, resume bb1, unwind bb2
+
+bb1:
+  end_borrow %borrow : $A
+  destroy_value %0 : $A
+  %retval = tuple ()
+  return %retval : $()
+
+bb2:
+  end_borrow %borrow : $A
+  destroy_value %0 : $A
+  unwind
+}
+
 // CHECK-LABEL: begin running test 1 of {{[0-9]+}} on test_instructions_1: is_deinit_barrier
 // CHECK:  debug_step
 // CHECK:  false


### PR DESCRIPTION
A yield hands control to the caller between begin_apply and end_apply/abort_apply, where arbitrary code (load weak/unowned, raw pointer access etc) may run, so it must be a deinit barrier.

rdar://183451462
