### PR TITLE
[test] Separate appended lit driver/frontend options with a space

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -538,8 +538,8 @@ lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 # Disable selector stubs unless specifically requested
-config.swift_frontend_test_options += '-disable-objc-msgsend-selector-stubs -disable-objc-msgsend-class-selector-stubs '
-config.swift_driver_test_options += '-Xfrontend -disable-objc-msgsend-selector-stubs -Xfrontend -disable-objc-msgsend-class-selector-stubs '
+config.swift_frontend_test_options += ' -disable-objc-msgsend-selector-stubs -disable-objc-msgsend-class-selector-stubs '
+config.swift_driver_test_options += ' -Xfrontend -disable-objc-msgsend-selector-stubs -Xfrontend -disable-objc-msgsend-class-selector-stubs '
 
 # Compare two version numbers
 def version_gt(a, b):
@@ -762,9 +762,9 @@ if test_options:
     config.swift_test_options += ' '
     config.swift_test_options += test_options
 
-config.swift_frontend_test_options += os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
-config.swift_driver_test_options += os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
-config.swift_ide_test_test_options += os.environ.get('SWIFT_IDE_TEST_TEST_OPTIONS', '')
+config.swift_frontend_test_options += ' ' + os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
+config.swift_driver_test_options += ' ' + os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
+config.swift_ide_test_test_options += ' ' + os.environ.get('SWIFT_IDE_TEST_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
 # Check if we overrode the linker; if we do, set a feature to say that, which


### PR DESCRIPTION
The existing practice in "lit files" is to append a space when doing
"+=" in options. This commit fixes an issue where we failed to do so:

`config.swift_driver_test_options` starts out holding whatever the site config
put in `SWIFT_DRIVER_TEST_OPTIONS`, which is not required to end in a
separator. wasistdlib sets it to

  " -Xclang-linker -resource-dir=<path>"

so appending "-Xfrontend -disable-objc-msgsend-selector-stubs ..." with no
leading space glued the flag onto the path and produced

  wasm-ld: error: cannot open <path>-Xfrontend/lib/wasm32-unknown-wasip1/
  libclang_rt.builtins.a: No such file or directory

and, because `-Xfrontend` was swallowed into the `-resource-dir=` value,

  warning: save unknown driver flag -disable-objc-msgsend-selector-stubs as
  additional swift-frontend flag

Add the missing separator, and do the same for the three environment-variable
appends further down, which have the same defect.

Assited by: Claude