### PR TITLE
[Strict memory safety] Metatypes of unsafe types are safe

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4965,6 +4965,7 @@ MetatypeType *MetatypeType::get(Type T,
                                 std::optional<MetatypeRepresentation> Repr,
                                 const ASTContext &Ctx) {
   auto properties = T->getRecursiveProperties();
+  properties.removeIsUnsafe();
   auto arena = getArena(properties);
 
   unsigned reprKey;
@@ -4997,6 +4998,7 @@ ExistentialMetatypeType::get(Type T, std::optional<MetatypeRepresentation> repr,
     T = existential->getConstraintType();
 
   auto properties = T->getRecursiveProperties();
+  properties.removeIsUnsafe();
   auto arena = getArena(properties);
 
   unsigned reprKey;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -221,6 +221,11 @@ Type TypeBase::findUnsafeType(
         return Action::SkipNode;
       }
 
+      // Do not recurse into metatypes. The metatype itself is safe independent
+      // of whether its underlying type is safe.
+      if (isa<AnyMetatypeType>(type.getPointer()))
+        return Action::SkipNode;
+
       return Action::Continue;
     }
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -680,10 +680,10 @@ public:
                                       /*isImplicitlyAsync=*/false,
                                       /*isImplicitlyThrows=*/false);
     } else if (auto ECE = dyn_cast<ExplicitCastExpr>(E)) {
-      recurse = asImpl().checkType(E, ECE->getCastTypeRepr(), ECE->getCastType());
+      recurse = asImpl().checkType(E, ECE->getCastTypeRepr(), ECE->getCastType(), /*isMetatype=*/false);
     } else if (auto TE = dyn_cast<TypeExpr>(E)) {
       if (!TE->isImplicit()) {
-        recurse = asImpl().checkType(TE, TE->getTypeRepr(), TE->getInstanceType());
+        recurse = asImpl().checkType(TE, TE->getTypeRepr(), TE->getInstanceType(), /*isMetatype=*/true);
       }
     } else if (auto KPE = dyn_cast<KeyPathExpr>(E)) {
       for (auto &component : KPE->getComponents()) {
@@ -2275,7 +2275,8 @@ private:
       return ShouldRecurse;
     }
 
-    ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type) {
+    ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type,
+                              bool isMetatype) {
       return ShouldRecurse;
     }
 
@@ -2428,7 +2429,8 @@ private:
       return ShouldRecurse;
     }
 
-    ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type) {
+    ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type,
+                              bool isMetatype) {
       return ShouldRecurse;
     }
 
@@ -2542,8 +2544,9 @@ private:
       return ShouldRecurse;
     }
 
-    ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type) {
-      if (!assumedSafeArguments.contains(E)) {
+    ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type,
+                              bool isMetatype) {
+      if (!assumedSafeArguments.contains(E) && !isMetatype) {
         SourceLoc loc = typeRepr ? typeRepr->getLoc() : E->getLoc();
         classification.merge(
             Classification::forType(type, loc).onlyUnsafe());
@@ -4098,13 +4101,13 @@ private:
     return ShouldRecurse;
   }
 
-  ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type) {
+  ShouldRecurse_t checkType(Expr *E, TypeRepr *typeRepr, Type type, bool isMetatype) {
     SourceLoc loc = typeRepr ? typeRepr->getLoc() : E->getLoc();
     auto classification = Classification::forType(type, loc);
 
-    // If this expression is covered as a safe argument, drop the unsafe
-    // classification.
-    if (assumedSafeArguments.contains(E))
+    // If this expression is covered as a safe argument or this is a metatype,
+    // drop the unsafe classification.
+    if (assumedSafeArguments.contains(E) || isMetatype)
       classification = classification.withoutUnsafe();
 
     checkEffectSite(E, /*requiresTry=*/false, classification);

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -62,7 +62,7 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal static func split(_ element: Int) -> (word: Int, bit: Int) {
-    return unsafe (word(for: element), bit(for: element))
+    return (word(for: element), bit(for: element))
   }
 
   @inlinable
@@ -77,7 +77,7 @@ extension _UnsafeBitset {
   @inlinable
   @inline(__always)
   internal static func wordCount(forCapacity capacity: Int) -> Int {
-    return unsafe word(for: capacity &+ Word.capacity &- 1)
+    return word(for: capacity &+ Word.capacity &- 1)
   }
 
   @inlinable
@@ -98,7 +98,7 @@ extension _UnsafeBitset {
   @inline(__always)
   internal func uncheckedContains(_ element: Int) -> Bool {
     unsafe _internalInvariant(isValid(element))
-    let (word, bit) = unsafe _UnsafeBitset.split(element)
+    let (word, bit) = _UnsafeBitset.split(element)
     return unsafe words[word].uncheckedContains(bit)
   }
 
@@ -107,7 +107,7 @@ extension _UnsafeBitset {
   @discardableResult
   internal func uncheckedInsert(_ element: Int) -> Bool {
     unsafe _internalInvariant(isValid(element))
-    let (word, bit) = unsafe _UnsafeBitset.split(element)
+    let (word, bit) = _UnsafeBitset.split(element)
     return unsafe words[word].uncheckedInsert(bit)
   }
 
@@ -116,7 +116,7 @@ extension _UnsafeBitset {
   @discardableResult
   internal func uncheckedRemove(_ element: Int) -> Bool {
     unsafe _internalInvariant(isValid(element))
-    let (word, bit) = unsafe _UnsafeBitset.split(element)
+    let (word, bit) = _UnsafeBitset.split(element)
     return unsafe words[word].uncheckedRemove(bit)
   }
 
@@ -373,7 +373,7 @@ extension _UnsafeBitset {
     capacity: Int,
     body: (_UnsafeBitset) throws(E) -> R
   ) throws(E) -> R {
-    let wordCount = unsafe Swift.max(1, Self.wordCount(forCapacity: capacity))
+    let wordCount = Swift.max(1, Self.wordCount(forCapacity: capacity))
     return try unsafe _withTemporaryUninitializedBitset(
       wordCount: wordCount
     ) { (bitset: _UnsafeBitset) throws(E) -> R in

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -689,7 +689,7 @@ extension __CocoaDictionary.Index {
   internal var age: Int32 {
     @_effects(readonly)
     get {
-      return unsafe _HashTable.age(for: storage.base.object)
+      return _HashTable.age(for: storage.base.object)
     }
   }
 }

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -437,14 +437,14 @@ extension _DictionaryStorage {
     capacity: Int,
     move: Bool
   ) -> _DictionaryStorage {
-    let scale = unsafe _HashTable.scale(forCapacity: capacity)
+    let scale = _HashTable.scale(forCapacity: capacity)
     return unsafe allocate(scale: scale, age: nil, seed: nil)
   }
 
   @usableFromInline
   @_effects(releasenone)
   static internal func allocate(capacity: Int) -> _DictionaryStorage {
-    let scale = unsafe _HashTable.scale(forCapacity: capacity)
+    let scale = _HashTable.scale(forCapacity: capacity)
     return unsafe allocate(scale: scale, age: nil, seed: nil)
   }
 
@@ -455,8 +455,8 @@ extension _DictionaryStorage {
     _ cocoa: __CocoaDictionary,
     capacity: Int
   ) -> _DictionaryStorage {
-    let scale = unsafe _HashTable.scale(forCapacity: capacity)
-    let age = unsafe _HashTable.age(for: cocoa.object)
+    let scale = _HashTable.scale(forCapacity: capacity)
+    let age = _HashTable.age(for: cocoa.object)
     return unsafe allocate(scale: scale, age: age, seed: nil)
   }
 #endif
@@ -471,7 +471,7 @@ extension _DictionaryStorage {
     _internalInvariant(scale >= 0 && scale < Int.bitWidth - 1)
 
     let bucketCount = (1 as Int) &<< scale
-    let wordCount = unsafe _UnsafeBitset.wordCount(forCapacity: bucketCount)
+    let wordCount = _UnsafeBitset.wordCount(forCapacity: bucketCount)
     let storage = unsafe Builtin.allocWithTailElems_3(
       _DictionaryStorage<Key, Value>.self,
       wordCount._builtinWordValue, _HashTable.Word.self,
@@ -486,7 +486,7 @@ extension _DictionaryStorage {
       keysAddr, bucketCount._builtinWordValue, Key.self,
       Value.self)
     unsafe storage._count = 0
-    unsafe storage._capacity = unsafe _HashTable.capacity(forScale: scale)
+    unsafe storage._capacity = _HashTable.capacity(forScale: scale)
     unsafe storage._scale = scale
     unsafe storage._reservedScale = 0
     unsafe storage._extra = 0

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -702,7 +702,7 @@ func isValidPointerForNativeRetain(object: Builtin.RawPointer) -> Bool {
   if objectBits == 0 { return false }
 
   #if _pointerBitWidth(_64)
-  if unsafe (objectBits & HeapObject.immortalObjectPointerBit) != 0 { return false }
+  if (objectBits & HeapObject.immortalObjectPointerBit) != 0 { return false }
   #endif
 
   return true
@@ -778,7 +778,7 @@ public func swift_bridgeObjectRetain(object: Builtin.RawPointer) -> Builtin.RawP
 @c
 public func swift_bridgeObjectRetain_n(object: Builtin.RawPointer, n: UInt32) -> Builtin.RawPointer {
   let objectBits = UInt(Builtin.ptrtoint_Word(object))
-  let untaggedObject = unsafe Builtin.inttoptr_Word((objectBits & HeapObject.bridgeObjectToPlainObjectMask)._builtinWordValue)
+  let untaggedObject = Builtin.inttoptr_Word((objectBits & HeapObject.bridgeObjectToPlainObjectMask)._builtinWordValue)
   _ = swift_retain_n(object: untaggedObject, n: n)
   return object
 }
@@ -828,7 +828,7 @@ func swift_release_n_(object: UnsafeMutablePointer<HeapObject>?, n: UInt32, isBo
 
   let refcount = unsafe refcountPointer(for: object)
   let loadedRefcount = unsafe loadRelaxed(refcount)
-  if unsafe loadedRefcount & HeapObject.refcountMask == HeapObject.immortalRefCount {
+  if loadedRefcount & HeapObject.refcountMask == HeapObject.immortalRefCount {
     return
   }
 
@@ -843,7 +843,7 @@ func swift_release_n_(object: UnsafeMutablePointer<HeapObject>?, n: UInt32, isBo
     // There can only be one thread with a reference at this point (because
     // we're releasing the last existing reference), so a relaxed store is
     // enough.
-    let doNotFree = unsafe (loadedRefcount & HeapObject.doNotFreeBit) != 0
+    let doNotFree = (loadedRefcount & HeapObject.doNotFreeBit) != 0
     unsafe storeRelaxed(refcount, newValue: HeapObject.immortalRefCount | (doNotFree ? HeapObject.doNotFreeBit : 0))
 
     if isBoxRelease {
@@ -899,7 +899,7 @@ public func swift_bridgeObjectRelease(object: Builtin.RawPointer) {
 @c
 public func swift_bridgeObjectRelease_n(object: Builtin.RawPointer, n: UInt32) {
   let objectBits = UInt(Builtin.ptrtoint_Word(object))
-  let untaggedObject = unsafe Builtin.inttoptr_Word((objectBits & HeapObject.bridgeObjectToPlainObjectMask)._builtinWordValue)
+  let untaggedObject = Builtin.inttoptr_Word((objectBits & HeapObject.bridgeObjectToPlainObjectMask)._builtinWordValue)
   swift_release_n(object: untaggedObject, n: n)
 }
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -77,7 +77,7 @@ extension _HashTable {
 
   internal static func capacity(forScale scale: Int8) -> Int {
     let bucketCount = (1 as Int) &<< scale
-    return unsafe Int(Double(bucketCount) * maxLoadFactor)
+    return Int(Double(bucketCount) * maxLoadFactor)
   }
 
   internal static func scale(forCapacity capacity: Int) -> Int8 {
@@ -85,7 +85,7 @@ extension _HashTable {
     // Calculate the minimum number of entries we need to allocate to satisfy
     // the maximum load factor. `capacity + 1` below ensures that we always
     // leave at least one hole.
-    let minimumEntries = unsafe Swift.max(
+    let minimumEntries = Swift.max(
       Int((Double(capacity) / maxLoadFactor).rounded(.up)),
       capacity + 1)
     // The actual number of entries we need to allocate is the lowest power of
@@ -95,7 +95,7 @@ extension _HashTable {
     _internalInvariant(exponent >= 0 && exponent < Int.bitWidth)
     // The scale is the exponent corresponding to the bucket count.
     let scale = Int8(truncatingIfNeeded: exponent)
-    unsafe _internalInvariant(self.capacity(forScale: scale) >= capacity)
+    _internalInvariant(self.capacity(forScale: scale) >= capacity)
     return scale
   }
 
@@ -148,20 +148,20 @@ extension _HashTable {
     @inlinable
     @inline(__always)
     internal init(word: Int, bit: Int) {
-      self.offset = unsafe _UnsafeBitset.join(word: word, bit: bit)
+      self.offset = _UnsafeBitset.join(word: word, bit: bit)
     }
 
     @inlinable
     internal var word: Int {
       @inline(__always) get {
-        return unsafe _UnsafeBitset.word(for: offset)
+        return _UnsafeBitset.word(for: offset)
       }
     }
 
     @inlinable
     internal var bit: Int {
       @inline(__always) get {
-        return unsafe _UnsafeBitset.bit(for: offset)
+        return _UnsafeBitset.bit(for: offset)
       }
     }
   }

--- a/stdlib/public/core/Prespecialize.swift
+++ b/stdlib/public/core/Prespecialize.swift
@@ -103,7 +103,7 @@ internal func _prespecialize() {
   consume(Optional<Set<String>>.self)
   consume(Optional<TextOutputStreamable>.self)
   consume(Optional<UInt8>.self)
-  unsafe consume(Optional<UnsafeBufferPointer<AnyObject>>.self)
+  consume(Optional<UnsafeBufferPointer<AnyObject>>.self)
   consume(PartialRangeFrom<Int>.self)
   consume(Range<String.Index>.self)
   consume(ReversedCollection<Range<Int>>.self)
@@ -112,10 +112,10 @@ internal func _prespecialize() {
   consume(Set<String>.self)
   consume(Set<String>.Iterator.self)
   consume(Set<String>.self)
-  unsafe consume(Unmanaged<AnyObject>.self)
-  unsafe consume(UnsafeBufferPointer<AnyObject>.self)
-  unsafe consume(UnsafeBufferPointer<Int8>.self)
-  unsafe consume(UnsafePointer<Int8>.self)
+  consume(Unmanaged<AnyObject>.self)
+  consume(UnsafeBufferPointer<AnyObject>.self)
+  consume(UnsafeBufferPointer<Int8>.self)
+  consume(UnsafePointer<Int8>.self)
 }
 
 @_specializeExtension

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -531,7 +531,7 @@ extension __CocoaSet.Index {
   internal var age: Int32 {
     @_effects(releasenone)
     get {
-      return unsafe _HashTable.age(for: storage.base.object)
+      return _HashTable.age(for: storage.base.object)
     }
   }
 }

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -329,14 +329,14 @@ extension _SetStorage {
     capacity: Int,
     move: Bool
   ) -> _SetStorage {
-    let scale = unsafe _HashTable.scale(forCapacity: capacity)
+    let scale = _HashTable.scale(forCapacity: capacity)
     return unsafe allocate(scale: scale, age: nil, seed: nil)
   }
 
   @usableFromInline
   @_effects(releasenone)
   static internal func allocate(capacity: Int) -> _SetStorage {
-    let scale = unsafe _HashTable.scale(forCapacity: capacity)
+    let scale = _HashTable.scale(forCapacity: capacity)
     return unsafe allocate(scale: scale, age: nil, seed: nil)
   }
 
@@ -347,8 +347,8 @@ extension _SetStorage {
     _ cocoa: __CocoaSet,
     capacity: Int
   ) -> _SetStorage {
-    let scale = unsafe _HashTable.scale(forCapacity: capacity)
-    let age = unsafe _HashTable.age(for: cocoa.object)
+    let scale = _HashTable.scale(forCapacity: capacity)
+    let age = _HashTable.age(for: cocoa.object)
     return unsafe allocate(scale: scale, age: age, seed: nil)
   }
 #endif
@@ -363,7 +363,7 @@ extension _SetStorage {
     _internalInvariant(scale >= 0 && scale < Int.bitWidth - 1)
 
     let bucketCount = (1 as Int) &<< scale
-    let wordCount = unsafe _UnsafeBitset.wordCount(forCapacity: bucketCount)
+    let wordCount = _UnsafeBitset.wordCount(forCapacity: bucketCount)
     let storage = unsafe Builtin.allocWithTailElems_2(
       _SetStorage<Element>.self,
       wordCount._builtinWordValue, _HashTable.Word.self,
@@ -374,7 +374,7 @@ extension _SetStorage {
       metadataAddr, wordCount._builtinWordValue, _HashTable.Word.self,
       Element.self)
     unsafe storage._count = 0
-    unsafe storage._capacity = unsafe _HashTable.capacity(forScale: scale)
+    unsafe storage._capacity = _HashTable.capacity(forScale: scale)
     unsafe storage._scale = scale
     unsafe storage._reservedScale = 0
     unsafe storage._extra = 0

--- a/test/Unsafe/always_unsafe.swift
+++ b/test/Unsafe/always_unsafe.swift
@@ -94,10 +94,8 @@ func testGenericSubstitution() {
   generic(AlwaysUnsafeType())
   // expected-error@-1{{expression uses constructs that are very hard to use correctly and must be marked with 'unsafe'}}{{documentation-file=always-unsafe}}
   // expected-note@-2{{argument #0 in call to global function 'generic' has unsafe type 'AlwaysUnsafeType'}}
-  // expected-note@-3{{argument 'self' in call to initializer 'init' has unsafe type 'AlwaysUnsafeType.Type'}}
-  // expected-note@-4{{reference to unsafe type 'AlwaysUnsafeType'}}
-  // expected-note@-5{{reference to unsafe type 'AlwaysUnsafeType'}}
-  // expected-note@-6{{reference to initializer 'init()' involves unsafe type 'AlwaysUnsafeType'}}
+  // expected-note@-3{{reference to unsafe type 'AlwaysUnsafeType'}}
+  // expected-note@-4{{reference to initializer 'init()' involves unsafe type 'AlwaysUnsafeType'}}
 
   unsafe generic(AlwaysUnsafeType())
 }

--- a/test/Unsafe/always_unsafe_rendering.swift
+++ b/test/Unsafe/always_unsafe_rendering.swift
@@ -35,12 +35,6 @@ TMP_DIR/test.swift:9:11: note: argument #0 in call to global function 'generic' 
 TMP_DIR/test.swift:9:3: note: reference to unsafe type 'AlwaysUnsafeType'
   generic(AlwaysUnsafeType())
   ^
-TMP_DIR/test.swift:9:11: note: argument 'self' in call to initializer 'init' has unsafe type 'AlwaysUnsafeType.Type'
-  generic(AlwaysUnsafeType())
-          ^~~~~~~~~~~~~~~~
-TMP_DIR/test.swift:9:11: note: reference to unsafe type 'AlwaysUnsafeType'
-  generic(AlwaysUnsafeType())
-          ^
 TMP_DIR/test.swift:9:11: note: reference to initializer 'init()' involves unsafe type 'AlwaysUnsafeType'
   generic(AlwaysUnsafeType())
           ^

--- a/test/Unsafe/always_unsafe_strict.swift
+++ b/test/Unsafe/always_unsafe_strict.swift
@@ -54,6 +54,5 @@ struct AlwaysUnsafeWrapper {
 struct UsesWrapper {
   @AlwaysUnsafeWrapper var value: Int = 0
   // expected-warning@-1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{documentation-file=strict-memory-safety}}
-  // expected-note@-2{{argument 'self' in call to initializer 'init' has unsafe type 'AlwaysUnsafeWrapper.Type'}}
-  // expected-note@-3{{reference to initializer 'init(wrappedValue:)' involves unsafe type 'AlwaysUnsafeWrapper'}}
+  // expected-note@-2{{reference to initializer 'init(wrappedValue:)' involves unsafe type 'AlwaysUnsafeWrapper'}}
 }

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -151,10 +151,9 @@ func casting(value: Any, i: Int) {
 }
 
 func metatypes() {
-  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
-  let _: Any.Type = UnsafeType.self // expected-note{{reference to unsafe type 'UnsafeType'}}
+  let _: Any.Type = UnsafeType.self
 
-  let _: Any.Type = unsafe UnsafeType.self
+  let _: Any.Type = unsafe UnsafeType.self // expected-warning{{no unsafe operations occur within 'unsafe' expression}}
 }
 
 func testKeyPath() {

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -49,8 +49,7 @@ extension ConformsToMultiP: MultiP {
   // expected-note@-1{{unsafe type 'UnsafeSuper' cannot satisfy safe associated type 'Ptr'}}
   @unsafe func f() -> UnsafeSuper {
     .init() // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}
-    // expected-note@-1{{argument 'self' in call to initializer 'init' has unsafe type 'UnsafeSuper.Type'}}
-    // expected-note@-2{{reference to initializer 'init()' involves unsafe type 'UnsafeSuper'}}
+    // expected-note@-1{{reference to initializer 'init()' involves unsafe type 'UnsafeSuper'}}
   }
 }
 


### PR DESCRIPTION
The structural rules around propagating unsafety implied that a metatype of a type (e.g., S.Type) is unsafe when the type (S in this case) is unsafe. However, metatypes themselves aren't unsafe, and have no unsafe operations. To use them in an unsafe manner requires use of something else that will be treated as unsafe (e.g., calling an initializer).

Therefore, treat metatypes as safe, eliminating extraneous memory-safety diagnostics.

Fixes rdar://186396748.
