### PR TITLE
Sema: Minor improvements to subtyping checks

### DIFF
--- a/include/swift/IDE/PostfixCompletion.h
+++ b/include/swift/IDE/PostfixCompletion.h
@@ -68,7 +68,7 @@ class PostfixCompletionCallback : public TypeCheckCompletionCallback {
 
     /// Merge this result with \p Other, returning \c true if
     /// successful, else \c false.
-    bool tryMerge(const Result &Other, DeclContext *DC);
+    bool tryMerge(const Result &Other);
   };
 
   CodeCompletionExpr *CompletionExpr;

--- a/include/swift/IDE/UnresolvedMemberCompletion.h
+++ b/include/swift/IDE/UnresolvedMemberCompletion.h
@@ -35,7 +35,7 @@ class UnresolvedMemberTypeCheckCompletionCallback
 
     /// Attempts to merge this result with \p Other, returning \c true if
     /// successful, else \c false.
-    bool tryMerge(const Result &Other, DeclContext *DC);
+    bool tryMerge(const Result &Other);
   };
 
   CodeCompletionExpr *CompletionExpr;

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -65,15 +65,12 @@ namespace swift {
   /// general this means preferring a subtype over a supertype, but can also e.g
   /// prefer an optional over a non-optional. If the two types are incompatible,
   /// null is returned.
-  Type tryMergeBaseTypeForCompletionLookup(Type ty1, Type ty2, DeclContext *dc);
+  Type tryMergeBaseTypeForCompletionLookup(Type ty1, Type ty2);
 
   /// Check if T1 is convertible to T2.
   ///
   /// \returns true on convertible, false on not.
   bool isConvertibleTo(Type T1, Type T2, bool openArchetypes, DeclContext &DC);
-
-  /// Check whether \p T1 is a subtype of \p T2.
-  bool isSubtypeOf(Type T1, Type T2, DeclContext *DC);
 
   void collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
                         llvm::SmallDenseMap<ValueDecl*, ValueDecl*> &DefaultMap);

--- a/include/swift/Sema/Subtyping.h
+++ b/include/swift/Sema/Subtyping.h
@@ -194,7 +194,7 @@ ConflictReason checkConversion(ConformanceCache &cache,
 /// More meaningful overload for when you want a boolean result.
 bool canConvertTo(ConformanceCache &cache,
                   Type lhs, Type rhs,
-                  GenericSignature sig);
+                  GenericSignature sig = GenericSignature());
 
 /// Computes the join between two types.
 ///

--- a/include/swift/Sema/Subtyping.h
+++ b/include/swift/Sema/Subtyping.h
@@ -168,7 +168,15 @@ enum ConflictFlag : unsigned {
   Conformance = 1 << 10,
   TupleArity = 1 << 11,
   TupleElement = 1 << 12,
-  Existential = 1 << 13
+  Existential = 1 << 13,
+  FunctionResult = 1 << 14,
+  FunctionParamCount = 1 << 15,
+  FunctionParamFlags = 1 << 16,
+  FunctionParamType = 1 << 17,
+  FunctionNoEscape = 1 << 18,
+  FunctionAsync = 1 << 19,
+  FunctionThrows = 1 << 20,
+  FunctionSendable = 1 << 21
 };
 using ConflictReason = OptionSet<ConflictFlag>;
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -32,7 +32,9 @@
 #include "swift/IDE/IDERequests.h"
 #include "swift/IDE/SourceEntityWalker.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Sema/ConformanceCache.h"
 #include "swift/Sema/IDETypeCheckingRequests.h"
+#include "swift/Sema/Subtyping.h"
 #include "swift/Subsystems.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -911,8 +913,7 @@ bool swift::isMemberDeclApplied(const DeclContext *DC, Type BaseTy,
     IsDeclApplicableRequest(DeclApplicabilityOwner(DC, BaseTy, VD)), false);
 }
 
-Type swift::tryMergeBaseTypeForCompletionLookup(Type ty1, Type ty2,
-                                                DeclContext *dc) {
+Type swift::tryMergeBaseTypeForCompletionLookup(Type ty1, Type ty2) {
   // Easy case, equivalent so just pick one.
   if (ty1->isEqual(ty2))
     return ty1;
@@ -940,8 +941,9 @@ Type swift::tryMergeBaseTypeForCompletionLookup(Type ty1, Type ty2,
       return Type();
   }
 
-  auto lt = isSubtypeOf(ty1, ty2, dc);
-  auto gt = isSubtypeOf(ty2, ty1, dc);
+  constraints::ConformanceCache cache;
+  auto lt = canConvertTo(cache, ty1, ty2);
+  auto gt = canConvertTo(cache, ty2, ty1);
 
   if (lt && gt) {
     // The two types convert to each other, but they're distinct. Give up.
@@ -962,12 +964,6 @@ bool swift::isConvertibleTo(Type T1, Type T2, bool openArchetypes,
   return evaluateOrDefault(DC.getASTContext().evaluator,
     TypeRelationCheckRequest(TypeRelationCheckInput(&DC, T1, T2,
       TypeRelation::ConvertTo, openArchetypes)), false);
-}
-
-bool swift::isSubtypeOf(Type T1, Type T2, DeclContext *DC) {
-  return evaluateOrDefault(DC->getASTContext().evaluator,
-    TypeRelationCheckRequest(TypeRelationCheckInput(DC, T1, T2,
-      TypeRelation::SubtypeOf, /*openArchetypes*/ false)), false);
 }
 
 Type swift::getRootTypeOfKeypathDynamicMember(SubscriptDecl *SD) {

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -21,15 +21,14 @@ using namespace swift;
 using namespace swift::constraints;
 using namespace swift::ide;
 
-bool PostfixCompletionCallback::Result::tryMerge(const Result &Other,
-                                                 DeclContext *DC) {
+bool PostfixCompletionCallback::Result::tryMerge(const Result &Other) {
   if (BaseDecl != Other.BaseDecl)
     return false;
 
   // This should match if we are talking about the same BaseDecl.
   assert(BaseIsStaticMetaType == Other.BaseIsStaticMetaType);
 
-  auto baseTy = tryMergeBaseTypeForCompletionLookup(BaseTy, Other.BaseTy, DC);
+  auto baseTy = tryMergeBaseTypeForCompletionLookup(BaseTy, Other.BaseTy);
   if (!baseTy)
     return false;
 
@@ -65,7 +64,7 @@ bool PostfixCompletionCallback::Result::tryMerge(const Result &Other,
 
 void PostfixCompletionCallback::addResult(const Result &Res) {
   for (auto idx : indices(Results)) {
-    if (Results[idx].tryMerge(Res, DC))
+    if (Results[idx].tryMerge(Res))
       return;
   }
   Results.push_back(Res);

--- a/lib/IDE/UnresolvedMemberCompletion.cpp
+++ b/lib/IDE/UnresolvedMemberCompletion.cpp
@@ -22,9 +22,9 @@ using namespace swift::constraints;
 using namespace swift::ide;
 
 bool UnresolvedMemberTypeCheckCompletionCallback::Result::tryMerge(
-    const Result &Other, DeclContext *DC) {
+    const Result &Other) {
   auto expectedTy = tryMergeBaseTypeForCompletionLookup(ExpectedTy,
-                                                        Other.ExpectedTy, DC);
+                                                        Other.ExpectedTy);
   if (!expectedTy)
     return false;
 
@@ -38,7 +38,7 @@ bool UnresolvedMemberTypeCheckCompletionCallback::Result::tryMerge(
 void UnresolvedMemberTypeCheckCompletionCallback::addExprResult(
     const Result &Res) {
   for (auto idx : indices(ExprResults)) {
-    if (ExprResults[idx].tryMerge(Res, DC))
+    if (ExprResults[idx].tryMerge(Res))
       return;
   }
   ExprResults.push_back(Res);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1539,8 +1539,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // Existing exact binding must be a supertype of the new lower bound.
-      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType,
-                        GenericSignature())) {
+      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType)) {
         SUBSUME_DEBUG("Exact vs supertype conflict");
         return SubsumeBindingResult::Conflict;
       }
@@ -1560,8 +1559,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // Existing exact binding must be a subtype of the new upper bound.
-      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType,
-                        GenericSignature())) {
+      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType)) {
         SUBSUME_DEBUG("Exact vs subtype conflict");
         return SubsumeBindingResult::Conflict;
       }
@@ -1588,8 +1586,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // Exact binding must be a supertype of the existing lower bound.
-      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType,
-                        GenericSignature())) {
+      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType)) {
         SUBSUME_DEBUG("Supertype vs exact conflict");
         return SubsumeBindingResult::Conflict;
       }
@@ -1641,8 +1638,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // The existing lower bound should be a subtype of the new upper bound.
-      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType,
-                        GenericSignature())) {
+      if (!canConvertTo(CS.CC, existing.BindingType, binding.BindingType)) {
         SUBSUME_DEBUG("Supertype vs subtype conflict");
         return SubsumeBindingResult::Conflict;
       }
@@ -1688,8 +1684,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // The new exact binding should be a subtype of the existing upper bound.
-      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType,
-                        GenericSignature())) {
+      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType)) {
         SUBSUME_DEBUG("Subtype vs exact conflict");
         return SubsumeBindingResult::Conflict;
       }
@@ -1716,8 +1711,7 @@ BindingSet::subsumeBinding(const PotentialBinding &binding,
     // FIXME: Do this in diagnostic mode also
     if (!CS.shouldAttemptFixes()) {
       // The new lower bound should be a subtype of the existing upper bound.
-      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType,
-                        GenericSignature())) {
+      if (!canConvertTo(CS.CC, binding.BindingType, existing.BindingType)) {
         SUBSUME_DEBUG("Subtype vs supertype conflict");
         return SubsumeBindingResult::Conflict;
       }
@@ -2521,12 +2515,12 @@ bool LiteralRequirement::isCoveredBy(AllowedBindingKind kind, Type type,
     case AllowedBindingKind::Supertypes:
       if (!type->getAnyNominal() && !type->isExistentialType())
         return false;
-      return canConvertTo(CS.CC, defaultType, type, GenericSignature());
+      return canConvertTo(CS.CC, defaultType, type);
 
     case AllowedBindingKind::Subtypes:
       if (!type->getAnyNominal() && !type->isExistentialType())
         return false;
-      return canConvertTo(CS.CC, type, defaultType, GenericSignature());
+      return canConvertTo(CS.CC, type, defaultType);
     }
   }
 }

--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -1003,7 +1003,7 @@ static std::optional<AnyFunctionType::ExtInfo>
 extInfoJoinMeetImpl(Operation op,
                     AnyFunctionType::ExtInfo lhsInfo,
                     AnyFunctionType::ExtInfo rhsInfo) {
-  bool noEscape, sendable, throwing;
+  bool noEscape, sendable, throwing, async;
   Type sendableDep;
   Type thrownError;
 
@@ -1016,6 +1016,7 @@ extInfoJoinMeetImpl(Operation op,
 
   if (op == Operation::Join) {
     noEscape = lhsInfo.isNoEscape() || rhsInfo.isNoEscape();
+    async = lhsInfo.isAsync() || rhsInfo.isAsync();
 
     if (lhsSendableDep && rhsSendableDep) {
       // Form a tuple; its Sendable iff both components are Sendable.
@@ -1050,6 +1051,7 @@ extInfoJoinMeetImpl(Operation op,
     }
   } else {
     noEscape = lhsInfo.isNoEscape() && rhsInfo.isNoEscape();
+    async = lhsInfo.isAsync() && rhsInfo.isAsync();
 
     if (lhsSendableDep && rhsSendableDep) {
       // We cannot represent the meet of two sendable-dependent types.
@@ -1093,6 +1095,7 @@ extInfoJoinMeetImpl(Operation op,
   return lhsInfo.intoBuilder()
       .withNoEscape(noEscape)
       .withThrows(throwing, thrownError)
+      .withAsync(async)
       .withSendable(sendable)
       .withSendableDependentType(sendableDep)
       .build();
@@ -1216,15 +1219,15 @@ static Type subtypeJoinMeetImpl(Operation op, Type lhs, Type rhs,
       auto *lhsFunc = lhs->castTo<FunctionType>();
       auto *rhsFunc = rhs->castTo<FunctionType>();
 
-      auto result = rec(lhsFunc->getResult(), rhsFunc->getResult());
-
-      SmallVector<AnyFunctionType::Param, 4> params;
-
       // Note: getConversionBehavior() guarantees the function types don't
       // contain any parameter packs, so we may assume their lengths are
       // known.
       if (lhsFunc->getNumParams() != rhsFunc->getNumParams())
         return fail();
+
+      auto result = rec(lhsFunc->getResult(), rhsFunc->getResult());
+
+      SmallVector<AnyFunctionType::Param, 4> params;
 
       for (unsigned i : indices(lhsFunc->getParams())) {
         auto lhsParam = lhsFunc->getParams()[i];
@@ -1235,7 +1238,6 @@ static Type subtypeJoinMeetImpl(Operation op, Type lhs, Type rhs,
 
         Type paramType;
         if (lhsParam.isInOut() || lhsParam.isVariadic()) {
-          ASSERT(rhsParam.isInOut());
           auto result = isLikelyExactMatch(lhsParam.getPlainType(),
                                            rhsParam.getPlainType());
           if (!result)

--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -501,6 +501,39 @@ bool swift::constraints::canConvertTo(ConformanceCache &cache,
   return !checkConversion(cache, lhs, rhs, sig);
 }
 
+static ConflictReason
+checkExtInfoConversion(ConformanceCache &cache,
+                       FunctionType *lhsFunc,
+                       FunctionType *rhsFunc,
+                       AnyFunctionType::ExtInfo lhsInfo,
+                       AnyFunctionType::ExtInfo rhsInfo,
+                       GenericSignature sig) {
+  if (lhsInfo.isNoEscape() && !rhsInfo.isNoEscape())
+    return ConflictFlag::FunctionNoEscape;
+
+  if (lhsInfo.isAsync() && !rhsInfo.isAsync())
+    return ConflictFlag::FunctionAsync;
+
+  auto lhsThrows = lhsFunc->getEffectiveThrownErrorType();
+  auto rhsThrows = rhsFunc->getEffectiveThrownErrorType();
+  if (lhsThrows.has_value() && !rhsThrows.has_value()) {
+    auto result = isLikelyExactMatch(*lhsThrows,
+                                     lhsFunc->getASTContext().getNeverType());
+    if (result.has_value() && *result)
+      return ConflictFlag::FunctionThrows;
+  }
+
+  if (lhsThrows.has_value() && rhsThrows.has_value()) {
+    auto reason = checkConversion(cache, *lhsThrows, *rhsThrows, sig);
+    if (reason)
+      return reason | ConflictFlag::FunctionThrows;
+  }
+
+  // FIXME: We can't usefully handle isolation (too complex) or Sendable
+  // (depends on preconcurrency context) here.
+  return std::nullopt;
+}
+
 ConflictReason swift::constraints::checkConversion(ConformanceCache &cache,
                                                    Type lhs, Type rhs,
                                                    GenericSignature sig) {
@@ -632,9 +665,60 @@ ConflictReason swift::constraints::checkConversion(ConformanceCache &cache,
         return result | ConflictFlag::Metatype;
       break;
     }
-    case ConversionBehavior::Function:
-      // FIXME: Implement.
+    case ConversionBehavior::Function: {
+      auto *lhsFunc = lhs->castTo<FunctionType>();
+      auto *rhsFunc = rhs->castTo<FunctionType>();
+
+      // Note: getConversionBehavior() guarantees the function types don't
+      // contain any parameter packs, so we may assume their lengths are
+      // known.
+      if (lhsFunc->getNumParams() != rhsFunc->getNumParams())
+        return ConflictReason(ConflictFlag::FunctionParamCount);
+
+      auto result = checkConversion(cache,
+                                    lhsFunc->getResult(),
+                                    rhsFunc->getResult(),
+                                    sig);
+      if (result)
+        return result | ConflictFlag::FunctionResult;
+
+      for (unsigned i : indices(lhsFunc->getParams())) {
+        auto lhsParam = lhsFunc->getParams()[i];
+        auto rhsParam = rhsFunc->getParams()[i];
+
+        if (lhsParam.isInOut() != rhsParam.isInOut())
+          return ConflictReason(ConflictFlag::FunctionParamFlags);
+
+        if (lhsParam.isVariadic() != rhsParam.isVariadic())
+          return ConflictReason(ConflictFlag::FunctionParamFlags);
+
+        Type paramType;
+        if (lhsParam.isInOut() || lhsParam.isVariadic()) {
+          auto result = isLikelyExactMatch(lhsParam.getPlainType(),
+                                           rhsParam.getPlainType());
+          if (result.has_value() && !*result)
+            return ConflictReason(ConflictFlag::FunctionParamType);
+        } else {
+          auto result = checkConversion(cache,
+                                        rhsParam.getPlainType(),
+                                        lhsParam.getPlainType(),
+                                        sig);
+          if (result)
+            return result | ConflictFlag::FunctionParamType;
+        }
+      }
+
+      auto lhsInfo = lhsFunc->getExtInfo();
+      auto rhsInfo = rhsFunc->getExtInfo();
+      auto reason = checkExtInfoConversion(cache,
+                                           lhsFunc, rhsFunc,
+                                           lhsInfo, rhsInfo, sig);
+      if (reason)
+        return reason;
+
       break;
+    }
+
     case ConversionBehavior::InOut:
     case ConversionBehavior::LValue: {
       // InOut-to-InOut and LValue-to-LValue conversions are invariant.
@@ -1639,4 +1723,20 @@ void swift::constraints::simple_display(llvm::raw_ostream &out,
     out << " tuple_element";
   if (reason.contains(ConflictFlag::Existential))
     out << " existential";
+  if (reason.contains(ConflictFlag::FunctionResult))
+    out << " function_result";
+  if (reason.contains(ConflictFlag::FunctionParamCount))
+    out << " function_param_count";
+  if (reason.contains(ConflictFlag::FunctionParamFlags))
+    out << " function_param_flags";
+  if (reason.contains(ConflictFlag::FunctionParamType))
+    out << " function_param_type";
+  if (reason.contains(ConflictFlag::FunctionNoEscape))
+    out << " function_no_escape";
+  if (reason.contains(ConflictFlag::FunctionAsync))
+    out << " function_async";
+  if (reason.contains(ConflictFlag::FunctionThrows))
+    out << " function_throws";
+  if (reason.contains(ConflictFlag::FunctionSendable))
+    out << " function_sendable";
 }

--- a/test/Sema/common_supertype.swift
+++ b/test/Sema/common_supertype.swift
@@ -139,6 +139,21 @@ func testFunction6(x: @escaping () -> Int, y: @escaping @Sendable () -> Int) -> 
   return result
 }
 
+func testFunction7(x: @escaping () async -> Int, y: @escaping () throws -> Any) -> Exactly<() async throws -> Any> {
+  let result = test(x, y)
+  return result
+}
+
+func testFunction8(x: @escaping () throws -> Int, y: @escaping () async -> Any) -> Exactly<() async throws -> Any> {
+  let result = test(x, y)
+  return result
+}
+
+func testFunction9(x: @escaping (Int...) throws -> (), y: @escaping (Int...) async -> ()) -> Exactly<(Int...) async throws -> ()> {
+  let result = test(x, y)
+  return result
+}
+
 func testExistential1(x: any Q, y: any R) -> Exactly<any P> {
   let result = test(x, y)
   return result


### PR DESCRIPTION
Fix a couple of unimplemented cases: type joins didn't handle sync vs async differences, conversion check didn't handle function types at all. I'm planning on replacing more calls to `typesSatisfyConstraint()` with the new check in upcoming PRs.