### PR TITLE
build-script: Verify and print installed CMake version

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -222,6 +222,7 @@ class CMake(object):
                                 echo=True, optional=True)
         (c_major, c_minor, c_patch) = (0, 0, 0)
         if version is not None:
+            print(version)
             x = re.findall(r'cmake version (\d+)\.(\d+)\.(\d+)',
                            version.rstrip())
             if len(x) == 1:

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -54,6 +54,8 @@ class NinjaBuilder(product.ProductBuilder):
     def build(self):
         if os.path.exists(self.ninja_bin_path):
             return
+        if self.toolchain.cmake is None:
+            raise ValueError(f"CMake not installed")
 
         print("--- Local Ninja Build ---")
         with log_time_in_scope('local ninja'):


### PR DESCRIPTION
If CMake isn't installed at all, the ninja build would try to execute a `None`, which didn't work very well and would emit a pretty unhelpful error message about an unexpected `NoneType`. Changing the error to make it a little clearer.

When CMake is installed, build-script gets the version of CMake to ensure that it's new enough, but it doesn't print the version. There are different supported versions of CMake with varying degrees of integrated Swift support, so it's useful to see which version was used in the log when something fails.
