### PR TITLE
[Concurrency] AsyncStream; next must not drop error from termination handler

### DIFF
--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -75,13 +75,13 @@ fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, @unchecked Sendabl
 /// States:
 ///
 ///   - `idle`:  The stream is active with **no consumers present**,
-///   and may accept new elements (depending on the `BufferingPolicy`).
+///      and may accept new elements (depending on the `BufferingPolicy`).
 ///   - `waiting`: The stream is active with **at least one consumer present**,
-///   and new elements are directly delivered to the next consumer.
+///      and new elements are directly delivered to the next consumer.
 ///   - `draining`: The stream **no longer accepts new elements**,
-///   new consumers drain the buffered elements.
+///      new consumers drain the buffered elements.
 ///   - `terminating`: The stream is terminating,
-///   and is currently running the termination handler, before moving on to terminated.
+///      and is currently running the termination handler, before moving on to terminated.
 ///   - `terminated`: The stream is in a terminal state,
 ///   **no new elements are accepted**, and **new consumers return immediately**.
 ///
@@ -110,7 +110,7 @@ fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, @unchecked Sendabl
 ///
 /// - `TerminateAction`:
 ///   - `callAndResume`: The `TerminationHandler` is invoked, and all consumers are resumed afterward.
-///   - `call`: Only the `TerminationHandler` is invoked.
+///   - `call`: The `TerminationHandler` is invoked; any consumer parked during termination is resumed afterward.
 ///   - `none`: No action is taken.
 ///
 /// Behavior:
@@ -182,23 +182,25 @@ internal final class _AsyncStreamStorage<
       // The stream is terminating but the outcome is not yet finalized:
       // the termination handler still has to run and may call `finish(throwing:)`
       // to set a failure.
+      @unsafe
       struct Terminating: ~Copyable {
         var buffer: Buffer
+        var consumers: Consumers
         private(set) var failure: Failure?
         var terminationHandler: TerminationHandler?
 
         /// Returns true if the value was set, false otherwise.
         @export(implementation)
         mutating func setFailureOnce(_ failure: Failure?) -> Bool {
-          guard self.failure == nil else {
+          guard unsafe self.failure == nil else {
             return false
           }
-          self.failure = failure
+          unsafe self.failure = failure
           return true
         }
         @export(implementation)
         mutating func takeFailure() -> Failure? {
-          self.failure.take()
+          unsafe self.failure.take()
         }
       }
 
@@ -323,7 +325,7 @@ extension _AsyncStreamStorage.StateMachine {
       return draining.terminationHandler
 
     case .terminating(let terminating):
-      return terminating.terminationHandler
+      return unsafe terminating.terminationHandler
 
     case .terminated(let terminated):
       return terminated.terminationHandler
@@ -350,8 +352,8 @@ extension _AsyncStreamStorage.StateMachine {
       unsafe self = .init(state: .draining(draining))
 
     case .terminating(var terminating):
-      previous = terminating.terminationHandler
-      terminating.terminationHandler = newValue
+      previous = unsafe terminating.terminationHandler
+      unsafe terminating.terminationHandler = newValue
       unsafe self = .init(state: .terminating(terminating))
 
     case .terminated(var terminated):
@@ -480,9 +482,7 @@ extension _AsyncStreamStorage.StateMachine {
       return unsafe .suspend
 
     case .draining(var draining):
-      guard
-        let element = draining.buffer.popFirst()
-      else {
+      guard let element = draining.buffer.popFirst() else {
         unsafe self = .init(state: .terminated(.init(
           terminationHandler: draining.terminationHandler.take()
         )))
@@ -525,24 +525,14 @@ extension _AsyncStreamStorage.StateMachine {
       // Deliver any remaining buffered elements just like `draining`; the failure thrown
       // once the buffer empties is finalized by the caller of `terminate` after
       // the handler returns
-      guard let element = terminating.buffer.popFirst() else {
-        unsafe self = .init(state: .terminated(.init(
-          terminationHandler: terminating.terminationHandler.take()
-        )))
-
-        switch terminating.failure {
-        case .some(let failure):
-          return unsafe .throw(
-            consumer: consumer,
-            failure: failure
-          )
-
-        case .none:
-          return unsafe .resume(
-            consumer: consumer,
-            element: nil
-          )
-        }
+      guard let element = unsafe terminating.buffer.popFirst() else {
+        // The buffer is empty but we have not reached the terminal state yet:
+        // the termination handler is still running and may call `finish(throwing:)`
+        // to set a failure we must deliver to the consumer. Park it until the
+        // outcome is finalized rather than resuming it with a premature `nil`.
+        unsafe terminating.consumers.append(consumer)
+        unsafe self = .init(state: .terminating(terminating))
+        return unsafe .suspend
       }
 
       unsafe self = .init(state: .terminating(terminating))
@@ -605,7 +595,7 @@ extension _AsyncStreamStorage.StateMachine {
     case .terminating(var terminating):
       // A re-entrant `finish(throwing:)` from within the termination handler,
       // while the cancellation outcome is not yet final.
-      _ = terminating.setFailureOnce(failure)
+      _ = unsafe terminating.setFailureOnce(failure)
       unsafe self = .init(state: .terminating(terminating))
       return unsafe .none
 
@@ -625,6 +615,7 @@ extension _AsyncStreamStorage.StateMachine {
     case .idle(var idle):
       unsafe self = .init(state: .terminating(.init(
         buffer: idle.buffer,
+        consumers: [],
         failure: nil,
       )))
       return unsafe .call(
@@ -634,6 +625,7 @@ extension _AsyncStreamStorage.StateMachine {
     case .waiting(var waiting):
       unsafe self = .init(state: .terminating(.init(
         buffer: [],
+        consumers: [],
         failure: nil
       )))
       return unsafe .callAndResume(.init(
@@ -661,7 +653,10 @@ extension _AsyncStreamStorage.StateMachine {
 
   /// Reads the failure recorded in the terminal state after the termination
   /// handler has run, and finalizes to `terminated`.
-  mutating func takeTerminalFailure() -> Failure? {
+  ///
+  /// Returns the recorded failure together with any consumers that were parked
+  /// while the stream was `terminating`. The caller must resume these after releasing the lock.
+  mutating func takeTerminalFailure() -> (failure: Failure?, consumers: Consumers) {
     switch unsafe consume self.state {
     case .idle:
       preconditionFailure("takeTerminalFailure() called in a non-terminal state")
@@ -673,21 +668,25 @@ extension _AsyncStreamStorage.StateMachine {
       preconditionFailure("takeTerminalFailure() called in a non-terminal state")
 
     case .terminating(var terminating):
-      let failure = terminating.takeFailure()
+      let failure = unsafe terminating.takeFailure()
+      let consumers = unsafe terminating.consumers
       unsafe self = .init(state: .terminated(.init(
         terminationHandler: terminating.terminationHandler.take()
       )))
-      return failure
+      return unsafe (failure, consumers)
 
     case .terminated(var terminated):
       let failure = terminated.failure.take()
       unsafe self = .init(state: .terminated(terminated))
-      return failure
+      return unsafe (failure, [])
     }
   }
 
   /// Finalizes the `terminating` state to `terminated` preserving any recorded failure.
-  mutating func finalizeTermination() {
+  ///
+  /// Returns any consumers parked while `terminating`, together with
+  /// the failure to deliver to them; the caller must resume these after releasing the lock.
+  mutating func finalizeTermination() -> (failure: Failure?, consumers: Consumers) {
     switch unsafe consume self.state {
     case .idle:
       preconditionFailure("finalizeTermination() called in a non-terminal state")
@@ -698,23 +697,37 @@ extension _AsyncStreamStorage.StateMachine {
     case .draining(let draining):
       // `finish` with buffered elements left us draining
       unsafe self = .init(state: .draining(draining))
+      return unsafe (nil, [])
 
     case .terminating(var terminating):
-      if terminating.buffer.isEmpty {
-        unsafe self = .init(state: .terminated(.init(
-          failure: terminating.failure,
-          terminationHandler: terminating.terminationHandler.take()
-        )))
+      if unsafe terminating.consumers.isEmpty {
+        // No consumers, store the outcome for a future `next()`
+        if unsafe terminating.buffer.isEmpty {
+          unsafe self = .init(state: .terminated(.init(
+            failure: terminating.failure,
+            terminationHandler: terminating.terminationHandler.take()
+          )))
+        } else {
+          unsafe self = .init(state: .draining(.init(
+            buffer: terminating.buffer,
+            failure: terminating.failure,
+            terminationHandler: terminating.terminationHandler.take()
+          )))
+        }
+        return unsafe (nil, [])
       } else {
-        unsafe self = .init(state: .draining(.init(
-          buffer: terminating.buffer,
-          failure: terminating.failure,
+        // Consumers waiting for the outcome
+        let failure = unsafe terminating.takeFailure()
+        let consumers = unsafe terminating.consumers
+        unsafe self = .init(state: .terminated(.init(
           terminationHandler: terminating.terminationHandler.take()
         )))
+        return unsafe (failure, consumers)
       }
 
     case .terminated(let terminated):
       unsafe self = .init(state: .terminated(terminated))
+      return unsafe (nil, [])
     }
   }
 }
@@ -799,9 +812,17 @@ extension _AsyncStreamStorage {
     case .callAndResume(var callAndResume):
       unsafe callAndResume.terminationHandler?.invoke(terminationReason)
 
-      let failure = withLock { state in
-        // Reload the failure, in case the termination handler has set one using `finish(throwing:)`.
-        return state.takeTerminalFailure()
+      let outcome = withLock { state in
+        // Reload the failure, in case the termination handler has set one using `finish(throwing:)`,
+        // and collect any consumers parked by a `next()` that raced the termination.
+        return unsafe state.takeTerminalFailure()
+      }
+      let failure = unsafe outcome.failure
+      var parked = unsafe outcome.consumers
+
+      // Carry along any consumers from the parked state so that triggered the termination still receives the failure first.
+      while let consumer = unsafe parked.popFirst() {
+        unsafe callAndResume.consumers.append(consumer)
       }
 
       if let failure {
@@ -815,8 +836,19 @@ extension _AsyncStreamStorage {
 
     case .call(let terminationHandler):
       terminationHandler?.invoke(terminationReason)
-      withLock { state in
-        state.finalizeTermination()
+      let outcome = withLock { state in
+        return unsafe state.finalizeTermination()
+      }
+      let failure = unsafe outcome.failure
+      var parked = unsafe outcome.consumers
+
+      if let failure {
+        let consumer = unsafe parked.removeFirst()
+        unsafe consumer.resume(returning: .failure(failure))
+      }
+
+      while let consumer = unsafe parked.popFirst() {
+        unsafe consumer.resume(returning: .success(nil))
       }
 
     case .none:

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -1,11 +1,12 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking -parse-as-library
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library)
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature NonisolatedNonsendingByDefault)
+// RUN: %target-typecheck-verify-swift %import-libdispatch -strict-concurrency=complete -disable-availability-checking -parse-as-library
+// RUN: %target-run-simple-swift( %import-libdispatch -Xfrontend -disable-availability-checking -parse-as-library)
+// RUN: %target-run-simple-swift( %import-libdispatch -Xfrontend -disable-availability-checking -parse-as-library -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature NonisolatedNonsendingByDefault)
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
+// REQUIRES: libdispatch
 
 // rdar://78109470
 // UNSUPPORTED: back_deployment_runtime
@@ -14,6 +15,7 @@
 
 import _Concurrency
 import StdlibUnittest
+import Dispatch
 
 struct SomeError: Error, Equatable {
   var value: Int = 0
@@ -506,6 +508,54 @@ class NotSendable {}
           expectEqual(failure, firstError)
         } else {
           expectUnreachable("expected SomeError, got \(String(describing: caught))")
+        }
+      }
+
+      // A `next()` that arrives while the stream is in the `.terminating` state,
+      // but before the `onTermination` handler has called `finish(throwing:)`
+      // must not finalize the termination as it would drop the handler-supplied failure.
+      tests.test("finish(throwing:) from onTermination is not lost to a concurrent next() during termination") {
+        let thrownError = SomeError()
+
+        let (controlStream, controlContinuation) = AsyncStream<Int>.makeStream()
+        var controlIterator = controlStream.makeAsyncIterator()
+
+        let (stream, continuation) = AsyncThrowingStream<Int, Error>.makeStream()
+
+        continuation.onTermination = { @Sendable termination in
+          guard case .cancelled = termination else { return }
+
+          // Start an unstructured task consuming next() which we'll race with the finish() call below.
+          let nextSemaphore = DispatchSemaphore(value: 0)
+          Task.detached {
+            var iterator = stream.makeAsyncIterator()
+            nextSemaphore.signal()
+            _ = try? await iterator.next()
+          }
+          nextSemaphore.wait()
+
+          continuation.finish(throwing: thrownError) // We must consistently see the error thrown from the handler
+        }
+
+        let task = Task { () -> Error? in
+          controlContinuation.yield(1)
+          do {
+            for try await _ in stream {}
+            return nil
+          } catch {
+            return error
+          }
+        }
+
+        expectEqual(await controlIterator.next(), 1)
+        task.cancel()
+
+        let caught = await task.value
+        if let failure = caught as? SomeError {
+          expectEqual(failure, thrownError)
+        } else {
+          expectUnreachable(
+            "cancelled consumer lost the onTermination finish(throwing:) error to a concurrent next(); got \(String(describing: caught))")
         }
       }
 


### PR DESCRIPTION
Under certain conditions, when racing the next with a termination handler, the next could accidentally cause dropping of the error if the termination handler was going to set one.

This corrects this edge-case to properly surface the error if it was set in a termination handler

Follow up to https://github.com/swiftlang/swift/pull/91529/
Resolves rdar://186212463
