### PR TITLE
Revert "[rebranch] Adjust to "[Passes] Remove Os and Oz optimization pipelines (#191363)""

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -389,12 +389,7 @@ void swift::performLLVMOptimizations(
     PTO.MergeFunctions = !Opts.DisableLLVMMergeFunctions;
     // Splitting trades code size to enhance memory locality, avoid in -Osize.
     DoHotColdSplit = Opts.EnableHotColdSplit && !Opts.optimizeForSize();
-    // The dedicated Os/Oz size-optimization pipelines were removed upstream in
-    // favor of running the O2 pipeline together with the optsize/minsize
-    // function attributes. Swift already attaches those attributes based on the
-    // optimization mode (see IRGenModule::constructInitialFnAttributes), so the
-    // size preference is preserved at the function level.
-    level = llvm::OptimizationLevel::O2;
+    level = llvm::OptimizationLevel::Os;
   } else {
     level = llvm::OptimizationLevel::O0;
   }


### PR DESCRIPTION
This reverts commit 6ddd9c7730c72932e2cbecfac8fcf0e53270d677 from `rebranch` in favor of https://github.com/swiftlang/swift/pull/91500 (committed on `main`).