### PR TITLE
XFAIL test/ClangImporter/cf_redeclared_tag.swift

### DIFF
--- a/test/ClangImporter/cf_redeclared_tag.swift
+++ b/test/ClangImporter/cf_redeclared_tag.swift
@@ -2,6 +2,8 @@
 
 // REQUIRES: objc_interop
 
+// REQUIRES: rdar186401993
+
 import CFRedeclaredTag
 
 // Equivalent, since CFRedeclaredTagRef should be imported as OpaquePointer


### PR DESCRIPTION
REQUIRES: rdar186401993

Fail a test from https://github.com/swiftlang/swift/pull/91868

note: I always xfail on the main branch even if the failures is platform dependent