### PR TITLE
XFAIL CAS/sanitize-ignorelist.swift

### DIFF
--- a/test/CAS/sanitize-ignorelist.swift
+++ b/test/CAS/sanitize-ignorelist.swift
@@ -5,6 +5,8 @@
 
 // REQUIRES: OS=macosx
 
+// REQUIRES: rdar185826684
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
REQUIRES: 185826684

root cause:
commit 486d3ad0bd8f6cd199d636ddb003b86208141217
Date:   Tue Aug 25 09:56:12 2026 -0700

    Add sanitizer ignorelists from clang driver to ModuleDependencyScanner (#91085)

From PR: https://github.com/swiftlang/swift/pull/91085

Note: I always xfail on the main branch even if the failure is platform dependent