### PR TITLE
tests: require an optimized stdlib for AutoDiff/SILGen/throw.swift

### DIFF
--- a/test/AutoDiff/SILGen/throw.swift
+++ b/test/AutoDiff/SILGen/throw.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil %s | %FileCheck %s
 
+// REQUIRES: optimized_stdlib
+
 import _Differentiation
 
 // Nothing special for throwing functions


### PR DESCRIPTION
This test started failing when the stdlib is built in Debug configuration (https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators-apple-silicon)

rdar://185992087
