### PR TITLE
[Distributed] Synthesize DistributedProtocolStub typealias

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -678,6 +678,10 @@ EXPERIMENTAL_FEATURE(LibkernOwnershipConventions, true)
 /// Emit `resignRemoteID` calls in remote distributed actor deinits.
 EXPERIMENTAL_FEATURE(DistributedActorResignRemoteID, false)
 
+/// The `@Resolvable` macro will synthesize a `DistributedProtocolStub` typealias
+/// linking a distributed-actor protocol to its generated `$`-prefixed stub.
+EXPERIMENTAL_FEATURE(DistributedProtocolStubTypealias, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -494,6 +494,7 @@ UNINTERESTING_FEATURE(CxxImplementation)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 UNINTERESTING_FEATURE(DistributedActorResignRemoteID)
+UNINTERESTING_FEATURE(DistributedProtocolStubTypealias)
 
 static bool usesFeatureCoroutineAccessors(Decl *decl) {
   auto accessorDeclUsesFeatureCoroutineAccessors = [](AccessorDecl *accessor) {

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -66,7 +66,119 @@ extension DistributedResolvableMacro {
         \(raw: requirementStubs)
       }
       """
-    return [extensionDecl.cast(ExtensionDeclSyntax.self)]
+
+    var extensions: [ExtensionDeclSyntax] = [
+      extensionDecl.cast(ExtensionDeclSyntax.self),
+    ]
+    if shouldEmitStubTypealias(node) {
+      extensions.append(stubTypealiasExtension(proto))
+    }
+    return extensions
+  }
+
+  /// Reads the `_emitStubTypealias:` argument from the `@Resolvable(...)` attribute.
+  /// Default value: true
+  static func shouldEmitStubTypealias(_ node: AttributeSyntax) -> Bool {
+    guard case let .argumentList(arguments)? = node.arguments else {
+      return true
+    }
+    for argument in arguments where argument.label?.text == "_emitStubTypealias" {
+      if let literal = argument.expression.as(BooleanLiteralExprSyntax.self) {
+        return literal.literal.tokenKind == .keyword(.true)
+      }
+    }
+    return true
+  }
+
+  static func stubTypealiasExtension(_ proto: ProtocolDeclSyntax) -> ExtensionDeclSyntax {
+    let attributes = proto.attributes.filter { attr in
+      Self.attributesToCopy.contains(
+        attr.as(AttributeSyntax.self)?.attributeName.trimmed.description ?? ""
+      )
+    }
+    let access = proto.accessControlModifiers
+    let stubConstraint = actorSystemConstraint(proto)
+    let stubReference = stubType(proto)
+    // The synthesized typealias is gated behind the 'DistributedProtocolStubTypealias' feature.
+    // The '#if' is evaluated in the client's build.
+    let decl: DeclSyntax =
+      """
+      \(attributes)
+      extension \(proto.name.trimmed) where \(raw: stubConstraint) {
+        #if $DistributedProtocolStubTypealias
+        \(access)typealias DistributedProtocolStub = \(raw: stubReference)
+        #endif
+      }
+      """
+    return decl.cast(ExtensionDeclSyntax.self)
+  }
+
+  static func actorSystemConstraint(_ proto: ProtocolDeclSyntax) -> String {
+    for req in proto.genericWhereClause?.requirements ?? [] {
+      switch req.requirement {
+      case .conformanceRequirement(let conformanceReq)
+           where conformanceReq.leftType.isActorSystem:
+        return "Self.ActorSystem: \(conformanceReq.rightType.trimmed)"
+      case .sameTypeRequirement(let sameTypeReq):
+        switch sameTypeReq.leftType {
+        case .type(let type) where type.isActorSystem:
+          if case .type(let rightType) = sameTypeReq.rightType.trimmed {
+            return "Self.ActorSystem == \(rightType)"
+          }
+          continue
+        default:
+          continue
+        }
+      default:
+        continue
+      }
+    }
+    return "Self.ActorSystem: DistributedActorSystem"
+  }
+
+  static func stubType(_ proto: ProtocolDeclSyntax) -> String {
+    let stubName = "$\(proto.name.trimmed.text)"
+    let typeParams = stubTypeParameters(proto)
+    if typeParams.isEmpty {
+      return stubName
+    }
+    let args = typeParams.map { "Self.\($0)" }.joined(separator: ", ")
+    return "\(stubName)<\(args)>"
+  }
+
+  static func stubTypeParameters(_ proto: ProtocolDeclSyntax) -> [String] {
+    var isGenericOverActorSystem = false
+    for req in proto.genericWhereClause?.requirements ?? [] {
+      switch req.requirement {
+      case .conformanceRequirement(let conformanceReq) where conformanceReq.leftType.isActorSystem:
+        isGenericOverActorSystem = true
+      case .sameTypeRequirement(let sameTypeReq):
+        switch sameTypeReq.leftType {
+        case .type(let type) where type.isActorSystem:
+          isGenericOverActorSystem = false
+        default:
+          continue
+        }
+      default:
+        continue
+      }
+    }
+
+    var primaryTypeParams: [String] = []
+    if let primaryTypes = proto.primaryAssociatedTypeClause?.primaryAssociatedTypes {
+      primaryTypeParams = primaryTypes.map { $0.name.trimmed.text }
+    }
+
+    let actorSystemTypeParam: [String]
+    if primaryTypeParams.contains("ActorSystem") {
+      actorSystemTypeParam = []
+    } else if isGenericOverActorSystem {
+      actorSystemTypeParam = ["ActorSystem"]
+    } else {
+      actorSystemTypeParam = []
+    }
+
+    return actorSystemTypeParam + primaryTypeParams
   }
 
   /// Returns rendered string with all stub declarations for given members.

--- a/stdlib/public/Distributed/DistributedMacros.swift
+++ b/stdlib/public/Distributed/DistributedMacros.swift
@@ -26,9 +26,54 @@ import _Concurrency
 /// The attached to type must be a protocol that refines the `DistributedActor`
 /// protocol. It must either specify a concrete `ActorSystem` or constrain it
 /// in such way that the system's `SerializationRequirement` is statically known.
+///
+/// ### Resolvable protocol stub type
+///
+/// This macro synthesizes a type with the same name as the protocol, prefixed with a `$` sign, e.g.
+/// `@Resolvable protocol Greeter ... {}` results in a `distributed actor $Greeter {}` type.
+///
+/// This type is referred to as 'resolvable protocol stub' type, and is only interacted with directly when:
+/// - resolving a type on a remote host, without knowing the underlying implementation type, like so:
+///
+/// ```swift
+/// let greeter: some Greeter = try $Greeter.resolve(id: ..., using: system)
+/// ```
+///
+/// Alongside the `$`-prefixed stub, the macro can synthesize a typealias linking
+/// the protocol to its generated stub:
+///
+/// ```swift
+/// typealias DistributedProtocolStub = $Greeter // or $Greeter<Self.ActorSystem>
+/// ```
+///
+/// This typealias lets callers spell the stub type generically, given only the
+/// protocol, e.g. `SomeGreeterProtocol.DistributedProtocolStub`. Its synthesis is
+/// gated behind the experimental `DistributedProtocolStubTypealias` feature, so it
+/// only materializes when a client enables that feature.
+///
+/// Combining multiple resolvable protocols is less common, but possible. An actor
+/// that conforms to two `@Resolvable` protocols `A` and `B` inherits a
+/// `DistributedProtocolStub` typealias from each, which the compiler cannot
+/// disambiguate, so the actor must declare a single `DistributedProtocolStub`
+/// itself to pick a default. A `@Resolvable` protocol that refines another can
+/// avoid contributing a second candidate by opting out of the synthesis with
+/// `@Resolvable(_emitStubTypealias: false)`.
+///
+/// - Parameter _emitStubTypealias: When `true` (the default) the macro synthesizes
+///   the `DistributedProtocolStub` typealias (subject to the experimental feature
+///   above). Pass `false` to suppress it, e.g. on a protocol that refines another
+///   `@Resolvable` protocol and would otherwise introduce a conflicting witness.
 @attached(peer, names: prefixed(`$`)) // provides $Greeter concrete stub type
 @attached(extension, names: arbitrary) // provides extension for Greeter & _DistributedActorStub
 public macro Resolvable() =
   #externalMacro(module: "SwiftMacros", type: "DistributedResolvableMacro")
+
+
+#if $DistributedProtocolStubTypealias
+@attached(peer, names: prefixed(`$`)) // provides $Greeter concrete stub type
+@attached(extension, names: arbitrary) // provides extension for Greeter & _DistributedActorStub
+public macro Resolvable(_emitStubTypealias: Bool) =
+  #externalMacro(module: "SwiftMacros", type: "DistributedResolvableMacro")
+#endif
 
 #endif

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_stub_typealias.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_stub_typealias.swift
@@ -1,0 +1,124 @@
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+//
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-6.0-abi-triple -enable-experimental-feature DistributedProtocolStubTypealias -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s 2>&1 | %FileCheck %s
+
+import Distributed
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+@Resolvable
+protocol Pinned: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
+  distributed func ping() -> String
+}
+// CHECK:      extension Pinned where Self.ActorSystem == LocalTestingDistributedActorSystem {
+// CHECK-NEXT:   #if $DistributedProtocolStubTypealias
+// CHECK-NEXT:   typealias DistributedProtocolStub = $Pinned
+// CHECK-NEXT:   #endif
+// CHECK-NEXT: }
+
+@Resolvable
+protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  distributed func greet(name: String) -> String
+}
+// CHECK:      extension Greeter where Self.ActorSystem: DistributedActorSystem<any Codable> {
+// CHECK-NEXT:   #if $DistributedProtocolStubTypealias
+// CHECK-NEXT:   typealias DistributedProtocolStub = $Greeter<Self.ActorSystem>
+// CHECK-NEXT:   #endif
+// CHECK-NEXT: }
+
+@Resolvable
+protocol WithPrimary<Item>: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  associatedtype Item: Codable
+  distributed func get() -> Item
+}
+// CHECK:      extension WithPrimary where Self.ActorSystem: DistributedActorSystem<any Codable> {
+// CHECK-NEXT:   #if $DistributedProtocolStubTypealias
+// CHECK-NEXT:   typealias DistributedProtocolStub = $WithPrimary<Self.ActorSystem, Self.Item>
+// CHECK-NEXT:   #endif
+// CHECK-NEXT: }
+
+// ==== -----------------------------------------------------------------------
+// MARK: A base protocol that requires a stub type
+
+// A base protocol may make 'DistributedProtocolStub' a hard requirement. Every
+// conforming actor must then resolve it to a single '_DistributedActorStub'.
+protocol Servable: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
+  associatedtype DistributedProtocolStub: Distributed._DistributedActorStub
+}
+
+@Resolvable
+protocol Inherited: Servable {
+  distributed func pong() -> String
+}
+// CHECK:      extension Inherited where Self.ActorSystem: DistributedActorSystem {
+// CHECK-NEXT:   #if $DistributedProtocolStubTypealias
+// CHECK-NEXT:   typealias DistributedProtocolStub = $Inherited
+// CHECK-NEXT:   #endif
+// CHECK-NEXT: }
+
+// ==== -----------------------------------------------------------------------
+// MARK: Refining a @Resolvable protocol with '_emitStubTypealias: false'
+
+// 'Refined' refines 'Servable' and synthesizes 'DistributedProtocolStub = $Refined'
+@Resolvable
+protocol Refined: Servable {
+  distributed func p() -> String
+}
+// CHECK:      extension Refined where Self.ActorSystem: DistributedActorSystem {
+// CHECK-NEXT:   #if $DistributedProtocolStubTypealias
+// CHECK-NEXT:   typealias DistributedProtocolStub = $Refined
+// CHECK-NEXT:   #endif
+// CHECK-NEXT: }
+
+// A plain '@Resolvable' here would make the generated '$RefinedMore' inherit two
+// 'DistributedProtocolStub' witnesses ($Refined via 'Refined' and $RefinedMore
+// via its own synthesized typealias), so neither '$RefinedMore' nor an actor
+// conforming to 'RefinedMore' would satisfy 'Servable'. Opting out of the
+// synthesis with '_emitStubTypealias: false' keeps the single inherited witness
+@Resolvable(_emitStubTypealias: false)
+protocol RefinedMore: Refined {
+  distributed func q() -> String
+}
+
+// Compiles: 'DistributedProtocolStub' resolves to the inherited '$Refined'
+distributed actor RefinedActor: RefinedMore {
+  distributed func p() -> String { "p" }
+  distributed func q() -> String { "q" }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Two independent @Resolvable protocols
+
+@Resolvable
+protocol IndepA: Servable {
+  distributed func a() -> String
+}
+// CHECK:      extension IndepA where Self.ActorSystem: DistributedActorSystem {
+// CHECK-NEXT:   #if $DistributedProtocolStubTypealias
+// CHECK-NEXT:   typealias DistributedProtocolStub = $IndepA
+// CHECK-NEXT:   #endif
+// CHECK-NEXT: }
+
+@Resolvable
+protocol IndepB: Servable {
+  distributed func b() -> String
+}
+// CHECK:      extension IndepB where Self.ActorSystem: DistributedActorSystem {
+// CHECK-NEXT:   #if $DistributedProtocolStubTypealias
+// CHECK-NEXT:   typealias DistributedProtocolStub = $IndepB
+// CHECK-NEXT:   #endif
+// CHECK-NEXT: }
+
+// An actor conforming to both inherits two 'DistributedProtocolStub' witnesses
+// ($IndepA and $IndepB), so it must pick one explicitly to satisfy 'Servable'.
+distributed actor CombinedPick: IndepA, IndepB {
+  typealias DistributedProtocolStub = $IndepB
+  distributed func a() -> String { "a" }
+  distributed func b() -> String { "b" }
+}


### PR DESCRIPTION
This is an idea to help system authors provide nicer APIs. Today they're forced to ask end-users to spell out `as: $TheProtocol.self` when exposing an "impl" to external clients using a concrete protocol.

Instead, most types only ever implement a single resolvable protocol, so as long as we offer a way to get from `A: MySystemResolvableProtoco` to the stub type, they can offer APIs without the explicit `as:` which is a MUCH better user experience.

For the rare cases when a type implements multiple protocols, you'd have to pick a default but then in APIs you could expose it as either of them. This isn't ideal but it is workable.

Resolves rdar://186327941