### PR TITLE
Fix @warn_unqualified_access with actor isolation

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -99,6 +99,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
   class DiagnoseWalker : public BaseDiagnosticWalker {
     SmallPtrSet<Expr*, 4> AlreadyDiagnosedMetatypes;
     SmallPtrSet<DeclRefExpr*, 4> AlreadyDiagnosedBitCasts;
+    SmallPtrSet<const DeclRefExpr *, 4> AlreadyCheckedUnqualifiedAccessUses;
 
     bool IsExprStmt;
 
@@ -874,6 +875,9 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     void checkUnqualifiedAccessUse(const DeclRefExpr *DRE) {
       const Decl *D = DRE->getDecl();
       if (!D->getAttrs().hasAttribute<WarnUnqualifiedAccessAttr>())
+        return;
+
+      if (!AlreadyCheckedUnqualifiedAccessUses.insert(DRE).second)
         return;
 
       if (auto *parentExpr = Parent.getAsExpr()) {

--- a/test/attr/warn_unqualified_access.swift
+++ b/test/attr/warn_unqualified_access.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/Other1.swiftmodule -module-name Other1 %S/Inputs/warn_unqualified_access_other.swift
 // RUN: %target-swift-frontend -emit-module-path %t/Other2.swiftmodule -module-name Other2 %S/Inputs/warn_unqualified_access_other.swift
-// RUN: %target-swift-frontend -I %t -typecheck %s -verify
+// RUN: %target-swift-frontend -I %t -typecheck %s -verify -swift-version 5
+// RUN: %target-swift-frontend -I %t -typecheck %s -verify -swift-version 6
 
 import Other1
 import Other2
@@ -80,4 +81,23 @@ class Recovery {
     // expected-note@-2 {{use 'Other1.' to reference the global function in module 'Other1'}} {{5-5=Other1.}}
     // expected-note@-3 {{use 'Other2.' to reference the global function in module 'Other2'}} {{5-5=Other2.}}
   }
+}
+
+@MainActor
+protocol WarnUnqualifiedActorProtocol {}
+
+extension WarnUnqualifiedActorProtocol {
+  @warn_unqualified_access
+  func actorIsolatedMethod() -> some WarnUnqualifiedActorProtocol { self } // expected-note {{declared here}}
+}
+
+struct WarnUnqualifiedActorConformance: WarnUnqualifiedActorProtocol {
+  func testUnqualifiedAccess() {
+    _ = actorIsolatedMethod() // expected-warning {{use of 'actorIsolatedMethod' treated as a reference to instance method in protocol 'WarnUnqualifiedActorProtocol'}} expected-note {{use 'self.' to silence this warning}} {{9-9=self.}}
+  }
+}
+
+@MainActor
+func testQualifiedActorAccess() {
+  _ = WarnUnqualifiedActorConformance().actorIsolatedMethod()
 }


### PR DESCRIPTION
Actor isolation adds an implicit function conversion around method references. The warn_unqualified_access diagnostic walker then checks the same declaration reference twice. On the second visit it has lost the qualified-call context, so qualified calls warn and genuine unqualified calls warn twice.

Check each declaration reference once, preserving the syntactic context from the first visit.

The existing attribute test now covers qualified and unqualified actor-isolated calls in Swift 5 and Swift 6.

Fixes #81869