### PR TITLE
ClangImporter: Adjust to "[clang] Extract in-memory module cache writ…

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -566,8 +566,13 @@ public:
   /// content. Delegates to clang for everything except construction of the
   /// replica.
   ///
+  /// \param cached If true, the emitted PCH is also published in the in-memory
+  /// module cache shared with the ClangImporter's CompilerInstance. This is
+  /// required whenever that instance is going to import the PCH afterwards.
+  ///
   /// \sa clang::GeneratePCHAction
-  bool emitBridgingPCH(StringRef headerPath, StringRef outputPCHPath);
+  bool emitBridgingPCH(StringRef headerPath, StringRef outputPCHPath,
+                       bool cached);
 
   /// Returns true if a clang CompilerInstance can successfully read in a PCH,
   /// assuming it exists, with the current options. This can be used to find out
@@ -740,7 +745,7 @@ public:
 
   std::optional<std::string>
   getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
-                 StringRef SwiftPCHHash);
+                 StringRef SwiftPCHHash, bool Cached);
   std::optional<std::string>
   /// \param isExplicit true if the PCH filename was passed directly
   /// with -import-objc-header option.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -95,6 +95,8 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Serialization/ASTReader.h"
 #include "clang/Serialization/ASTWriter.h"
+#include "clang/Serialization/InMemoryModuleCache.h"
+#include "clang/Serialization/ModuleCache.h"
 #include "clang/Serialization/ObjectFilePCHContainerReader.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -243,7 +245,8 @@ namespace {
       return std::make_unique<HeaderParsingASTConsumer>(Impl);
     }
     bool BeginSourceFileAction(clang::CompilerInstance &CI) override {
-      auto PCH = Importer.getOrCreatePCH(ImporterOpts, SwiftPCHHash);
+      auto PCH =
+          Importer.getOrCreatePCH(ImporterOpts, SwiftPCHHash, /*Cached=*/true);
       if (PCH.has_value()) {
         Impl.getClangInstance()->getPreprocessorOpts().ImplicitPCHInclude =
             PCH.value();
@@ -1227,7 +1230,7 @@ ClangImporter::getPCHFilename(const ClangImporterOptions &ImporterOptions,
 
 std::optional<std::string>
 ClangImporter::getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
-                              StringRef SwiftPCHHash) {
+                              StringRef SwiftPCHHash, bool Cached) {
   bool isExplicit;
   auto PCHFilename = getPCHFilename(ImporterOptions, SwiftPCHHash,
                                     isExplicit);
@@ -1244,7 +1247,7 @@ ClangImporter::getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
       return std::nullopt;
     }
     auto FailedToEmit = emitBridgingPCH(ImporterOptions.BridgingHeader,
-                                        PCHFilename.value());
+                                        PCHFilename.value(), Cached);
     if (FailedToEmit) {
       return std::nullopt;
     }
@@ -2292,8 +2295,41 @@ ClangImporter::cloneCompilerInstanceForPrecompiling() {
   return clonedInstance;
 }
 
+/// Publishes the precompiled header just written to \p pchPath in the
+/// in-memory module cache of \p instance, marking it as final.
+///
+/// Clang used to do this from \c clang::ASTWriter::WriteAST whenever
+/// \c clang::LangOptions::CacheGeneratedPCH was set. That option is gone;
+/// \c clang::GeneratePCHAction no longer touches the module cache at all, so
+/// the client that asked for the PCH has to publish it itself, the way
+/// \c clang::CompilerInstance does for implicitly built modules.
+///
+/// This is not merely an optimization that saves a read from the file system.
+/// \c ClangImporter::canReadPCH probes an existing PCH with a throwaway
+/// \c clang::ASTReader that shares this module cache. A failed probe leaves
+/// the entry for \p pchPath in the \c clang::InMemoryModuleCache::ToBuild
+/// state, and \c clang::ModuleManager::addModule reports any later load of a
+/// \c ToBuild path as out of date without even looking at the file on disk.
+/// Publishing the rebuilt PCH supersedes that entry.
+static void publishBuiltPCH(clang::CompilerInstance &instance,
+                            StringRef pchPath) {
+  auto &fs = instance.getVirtualFileSystem();
+  auto status = fs.status(pchPath);
+  if (!status)
+    return;
+  auto buffer = fs.getBufferForFile(pchPath, /*FileSize=*/-1,
+                                    /*RequiresNullTerminator=*/false,
+                                    /*IsVolatile=*/false, /*IsText=*/false);
+  if (!buffer)
+    return;
+
+  instance.getModuleCache().getInMemoryModuleCache().addBuiltPCM(
+      pchPath, std::move(*buffer), status->getSize(),
+      llvm::sys::toTimeT(status->getLastModificationTime()));
+}
+
 bool ClangImporter::emitBridgingPCH(
-    StringRef headerPath, StringRef outputPCHPath) {
+    StringRef headerPath, StringRef outputPCHPath, bool cached) {
   auto emitInstance = cloneCompilerInstanceForPrecompiling();
   auto &invocation = emitInstance->getInvocation();
 
@@ -2319,6 +2355,10 @@ bool ClangImporter::emitBridgingPCH(
                   outputPCHPath, headerPath);
     return true;
   }
+
+  if (cached)
+    publishBuiltPCH(*emitInstance, outputPCHPath);
+
   return false;
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -406,12 +406,13 @@ static bool precompileBridgingHeader(const CompilerInstance &Instance) {
   if (!PCHOutDir.empty()) {
     // Create or validate a persistent PCH.
     auto SwiftPCHHash = Invocation.getPCHHash();
-    auto PCH = clangImporter->getOrCreatePCH(ImporterOpts, SwiftPCHHash);
+    auto PCH = clangImporter->getOrCreatePCH(ImporterOpts, SwiftPCHHash,
+                                             /*cached=*/false);
     return !PCH.has_value();
   }
   return clangImporter->emitBridgingPCH(
       opts.InputsAndOutputs.getFilenameOfFirstInput(),
-      opts.InputsAndOutputs.getSingleOutputFilename());
+      opts.InputsAndOutputs.getSingleOutputFilename(), /*cached=*/false);
 }
 
 static bool precompileClangModule(const CompilerInstance &Instance) {

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -92,7 +92,7 @@ TEST(ClangImporterTest, emitPCHInMemory) {
 
   std::string PCH = createFilename(cache, "bridging.h.pch");
   ASSERT_FALSE(importer->canReadPCH(PCH));
-  ASSERT_FALSE(importer->emitBridgingPCH(options.BridgingHeader, PCH));
+  ASSERT_FALSE(importer->emitBridgingPCH(options.BridgingHeader, PCH, true));
   ASSERT_TRUE(importer->canReadPCH(PCH));
 
   // Overwrite the PCH with garbage.  We should still be able to read it from


### PR DESCRIPTION
…es from `ASTWriter` (#190062)"

```
<unknown>:0: error: PCH file '[...].pch' is out of date and needs to be rebuilt
<unknown>:0: note: earlier input file validation was not performed
<unknown>:0: error: clang importer creation failed
```

`ASTWriter::WriteAST` no longer publishes the PCH it writes into the in-memory module cache, and `LangOptions::CacheGeneratedPCH`, which used to request that, is gone. `clang::CompilerInstance` compensates by calling `addBuiltPCM` itself after building a module, so the client that asked for a PCH must now do the same.

This is load bearing. `canReadPCH` probes a stale PCH with a throwaway `ASTReader` sharing that cache; the failed probe drops the buffer, leaving the path in the `ToBuild` state. `ModuleManager::addModule` then reports any later load of a `ToBuild` path as out of date without consulting the file on disk. Publishing the rebuilt PCH supersedes that entry.

See https://github.com/llvm/llvm-project/commit/7f9e4fe70872f926c1f88830ce9656645b949d51 (https://github.com/llvm/llvm-project/pull/190062).