### PR TITLE
[cxx-interop] Fix crash using rvalue references in function pointers

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -828,8 +828,27 @@ bool isCxxStdModule(StringRef moduleName, bool IsSystem);
 std::optional<clang::QualType>
 getCxxReferencePointeeTypeOrNone(const clang::Type *type);
 
-/// Returns true if the given type is a C++ `const` reference type.
-bool isCxxConstReferenceType(const clang::Type *type);
+/// How a C++ reference parameter is represented in Swift.
+enum class CxxReferenceParameterKind {
+  /// `const T&` / `const T&&`: `borrowing T`.
+  Borrowed,
+  /// `T&`: `inout T`. Where `inout` is not expressible (inside
+  /// `@convention(c)`) it stays an `UnsafeMutablePointer`.
+  Mutating,
+  /// `T&&`: `consuming T`.
+  Consuming,
+};
+
+struct CxxReferenceParameter {
+  clang::QualType pointeeType;
+  CxxReferenceParameterKind kind;
+};
+
+/// Classifies a C++ reference parameter type, or `None` if \p type is not a
+/// C++ reference type. Every kind but `Mutating` is lowered indirectly, so
+/// those must be imported as the pointee rather than as a pointer.
+std::optional<CxxReferenceParameter>
+classifyCxxReferenceParameter(clang::QualType type);
 
 /// Determine whether the given Clang record declaration has an attribute that
 /// makes it import as a reference types. Does not check its bases, if any.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -9163,9 +9163,18 @@ importer::getCxxReferencePointeeTypeOrNone(const clang::Type *type) {
   return {};
 }
 
-bool importer::isCxxConstReferenceType(const clang::Type *type) {
-  auto pointeeType = getCxxReferencePointeeTypeOrNone(type);
-  return pointeeType && pointeeType->isConstQualified();
+std::optional<importer::CxxReferenceParameter>
+importer::classifyCxxReferenceParameter(clang::QualType type) {
+  auto pointeeType = getCxxReferencePointeeTypeOrNone(type.getTypePtr());
+  if (!pointeeType)
+    return std::nullopt;
+
+  auto kind = CxxReferenceParameterKind::Borrowed;
+  if (!pointeeType->isConstQualified())
+    kind = type->isRValueReferenceType()
+               ? CxxReferenceParameterKind::Consuming
+               : CxxReferenceParameterKind::Mutating;
+  return CxxReferenceParameter{*pointeeType, kind};
 }
 
 AccessLevel importer::convertClangAccess(clang::AccessSpecifier access) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -778,9 +778,13 @@ namespace {
         }
 
         auto paramQualType = *param;
-        if (paramQualType->isReferenceType() &&
-            paramQualType->getPointeeType().isConstQualified())
-          paramQualType = paramQualType->getPointeeType();
+        // `inout` is not expressible in `@convention(c)`, so a mutable lvalue
+        // reference stays a pointer; SIL passes it directly to match. Every
+        // other reference kind is lowered indirectly, so it has to be
+        // flattened to the pointee here.
+        if (auto ref = classifyCxxReferenceParameter(paramQualType))
+          if (ref->kind != CxxReferenceParameterKind::Mutating)
+            paramQualType = ref->pointeeType;
 
         // Mark any `sending` parameters if need be.
         ImportTypeAttrs paramAttributes;
@@ -2644,25 +2648,16 @@ ClangImporter::Implementation::importParameterType(
   if (!swiftParamTy) {
     // C++ reference types are brought in as direct
     // types most commonly.
-    if (auto refPointeeType =
-            getCxxReferencePointeeTypeOrNone(paramTy.getTypePtr())) {
+    if (auto ref = classifyCxxReferenceParameter(paramTy)) {
       // We don't support reference type to a dependent type, just bail.
-      if ((*refPointeeType)->isDependentType()) {
+      if (ref->pointeeType->isDependentType())
         return std::nullopt;
-      }
 
-      bool isRvalueRef = paramTy->isRValueReferenceType();
-      // A C++ parameter of type `const <type> &` or `<type> &` becomes `<type>`
-      // or `inout <type>`. Moreover, `const <type> &&` or `<type> &&`
-      // becomes `<type>` or `consuming <type>`. Note that SILGen will use the
-      // indirect parameter convention for such a type.
-      paramTy = *refPointeeType;
-      if (!paramTy.isConstQualified()) {
-        if (isRvalueRef)
-          isConsuming = true;
-        else
-          isInOut = true;
-      }
+      // Note that SILGen will use the indirect parameter convention for such
+      // a type.
+      paramTy = ref->pointeeType;
+      isInOut |= ref->kind == CxxReferenceParameterKind::Mutating;
+      isConsuming |= ref->kind == CxxReferenceParameterKind::Consuming;
       bridging = Bridgeability::None;
     }
   }
@@ -2718,14 +2713,17 @@ ClangImporter::Implementation::importParameterType(
     swiftParamTy = importedType.getType();
   }
 
-  // `isInOut` is set above if we stripped off a mutable `&` before importing
-  // the type. Normally, we want to use an `inout` parameter in this situation.
-  // However, if the parameter belongs to a foreign reference type *and* the
-  // reference we stripped out was directly to that type (rather than to a
-  // pointer to that type), the foreign reference type should "eat" the
-  // indirection of the `&`, so we *don't* want to use an `inout` parameter.
-  if (isInOut && isDirectUseOfForeignReferenceType(paramTy, swiftParamTy))
+  // `isInOut`/`isConsuming` is set above if we stripped off a mutable `&` or an
+  // `&&` before importing the type. Normally, we want an `inout`/`consuming`
+  // parameter in that situation. However, if the parameter belongs to a foreign
+  // reference type *and* the reference we stripped out was directly to that type
+  // (rather than to a pointer to that type), the foreign reference type should
+  // "eat" the indirection of the reference, so we don't want either.
+  if ((isInOut || isConsuming) &&
+      isDirectUseOfForeignReferenceType(paramTy, swiftParamTy)) {
     isInOut = false;
+    isConsuming = false;
+  }
 
   return ImportParameterTypeResult{swiftParamTy, isInOut, isConsuming,
                                    isParamTypeImplicitlyUnwrapped};

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1786,19 +1786,19 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
     return true;
   }
 
-  // Pass C++ const reference types indirectly. Right now there's no way to
-  // express immutable borrowed params, so we have to have this hack.
+  // Every C++ reference kind but a mutable lvalue reference is imported as the
+  // pointee and passed indirectly. Right now there's no way to express
+  // immutable borrowed params, so we have to have this hack.
   // Eventually, we should just express these correctly: rdar://89647503
-  // If this is a const reference to a foreign reference type (const FRT&), this
-  // is equivalent to a pointer to the foreign reference type, which are passed
-  // directly.
-  if (importer::isCxxConstReferenceType(clangTy) &&
-      !(clangTy->getPointeeType()->getAs<clang::RecordType>() &&
-        substTy->isForeignReferenceType()))
-    return true;
-
-  if (clangTy->isRValueReferenceType())
-    return true;
+  // A reference to a foreign reference type is equivalent to a pointer to it,
+  // which is passed directly.
+  if (auto ref = importer::classifyCxxReferenceParameter(
+          clang::QualType(clangTy, 0))) {
+    if (ref->kind == importer::CxxReferenceParameterKind::Mutating)
+      return false;
+    return !(clangTy->getPointeeType()->getAs<clang::RecordType>() &&
+             substTy->isForeignReferenceType());
+  }
 
   return false;
 }
@@ -3917,10 +3917,17 @@ static bool isCFTypedef(const TypeLowering &tl, clang::QualType type) {
 static ParameterConvention getIndirectCParameterConvention(clang::QualType type) {
   // Non-trivial C++ types would be Indirect_Inout (at least in Itanium).
   // A trivial const * parameter in C should be considered @in.
-  if (importer::isCxxConstReferenceType(type.getTypePtr()))
-    return ParameterConvention::Indirect_In_Guaranteed;
-  if (type->isRValueReferenceType())
-    return ParameterConvention::Indirect_In_CXX;
+  if (auto ref = importer::classifyCxxReferenceParameter(type)) {
+    switch (ref->kind) {
+    case importer::CxxReferenceParameterKind::Borrowed:
+      return ParameterConvention::Indirect_In_Guaranteed;
+    case importer::CxxReferenceParameterKind::Consuming:
+      return ParameterConvention::Indirect_In_CXX;
+    case importer::CxxReferenceParameterKind::Mutating:
+      // Imported as a pointer or as `inout`; fall through to the record cases.
+      break;
+    }
+  }
   if (auto *decl = type->getAsRecordDecl()) {
     if (!decl->isParamDestroyedInCallee())
       return ParameterConvention::Indirect_In_CXX;

--- a/test/Interop/Cxx/foreign-reference/Inputs/pass-as-parameter.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/pass-as-parameter.h
@@ -10,6 +10,13 @@ __attribute__((swift_attr("release:immortal"))) IntBox {
 inline int extractValueFromPtr(IntBox *b) { return b->value; }
 inline int extractValueFromRef(IntBox &b) { return b.value; }
 inline int extractValueFromConstRef(const IntBox &b) { return b.value; }
+inline int extractValueFromRvalueRef(IntBox &&b) { return b.value; }
+inline int extractValueFromConstRvalueRef(const IntBox &&b) { return b.value; }
+
+// Both import as '(IntBox) -> CInt'; only the 'consuming' argument label tells
+// them apart.
+inline int overloadedOnRefKind(IntBox &b) { return b.value; }
+inline int overloadedOnRefKind(IntBox &&b) { return b.value + 1; }
 inline int extractValueFromRefToPtr(IntBox *&b) { return b->value; }
 inline int extractValueFromRefToConstPtr(IntBox const *&b) { return b->value; }
 inline int extractValueFromConstRefToPtr(IntBox *const &b) { return b->value; }

--- a/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
@@ -70,6 +70,8 @@ __attribute__((swift_attr("release:immortal"))) DeletedSpecialMembers {
 
 void mutateIt(DeletedSpecialMembers &x) { x.value = 32; }
 
+int readItConstRvalueRef(const DeletedSpecialMembers &&x) { return x.value; }
+
 struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:immortal")))
 __attribute__((swift_attr("release:immortal"))) PrivateSpecialMembers {

--- a/test/Interop/Cxx/foreign-reference/pass-as-parameter.swift
+++ b/test/Interop/Cxx/foreign-reference/pass-as-parameter.swift
@@ -29,6 +29,24 @@ PassAsParameterTestSuite.test("pass as const reference") {
   expectEqual(aValue, 321)
 }
 
+PassAsParameterTestSuite.test("pass as rvalue reference") {
+  let a = IntBox.create(456)!
+  let aValue = extractValueFromRvalueRef(consuming: a)
+  expectEqual(aValue, 456)
+}
+
+PassAsParameterTestSuite.test("pass as const rvalue reference") {
+  let a = IntBox.create(654)!
+  let aValue = extractValueFromConstRvalueRef(consuming: a)
+  expectEqual(aValue, 654)
+}
+
+PassAsParameterTestSuite.test("overloaded on reference kind") {
+  let a = IntBox.create(100)!
+  expectEqual(overloadedOnRefKind(a), 100)
+  expectEqual(overloadedOnRefKind(consuming: a), 101)
+}
+
 PassAsParameterTestSuite.test("pass as reference to pointer") {
   var a = IntBox.create(123)
   let aValue = extractValueFromRefToPtr(&a)

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -22,3 +22,10 @@ public func test() {
   _ = x.test()
   mutateIt(x)
 }
+
+// CHECK-LABEL: define {{.*}}swiftcc {{.*}}@"$s4main18testConstRvalueRefyySo21DeletedSpecialMembersVF"
+// CHECK: call i32 @{{.*}}readItConstRvalueRef{{.*}}(ptr %0)
+
+public func testConstRvalueRef(_ x: DeletedSpecialMembers) {
+  _ = readItConstRvalueRef(consuming: x)
+}

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -63,4 +63,25 @@ inline unsigned firstByteOfArrayRefTypealias(const ByteArray16Typealias &a) {
   return a[0];
 }
 
+inline void callWithIntRef(void (*callback)(int &)) {
+  int value = 42;
+  callback(value);
+  setStaticInt(value);
+}
+
+inline void callWithConstIntRef(void (*callback)(const int &)) {
+  int value = 43;
+  callback(value);
+}
+
+inline void callWithIntRvalueRef(void (*callback)(int &&)) {
+  int value = 44;
+  callback(static_cast<int &&>(value));
+}
+
+inline void callWithConstIntRvalueRef(void (*callback)(const int &&)) {
+  int value = 45;
+  callback(static_cast<const int &&>(value));
+}
+
 #endif // TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -15,6 +15,11 @@
 // CHECK: func refToTemplate<T>(_ t: inout T) -> UnsafeMutablePointer<T>
 // CHECK: func constRefToTemplate<T>(_ t: T) -> UnsafePointer<T>
 
+// CHECK: func callWithIntRef(_ callback: (@convention(c) (UnsafeMutablePointer<CInt>) -> Void)!)
+// CHECK: func callWithConstIntRef(_ callback: (@convention(c) (CInt) -> Void)!)
+// CHECK: func callWithIntRvalueRef(_ callback: (@convention(c) (CInt) -> Void)!)
+// CHECK: func callWithConstIntRvalueRef(_ callback: (@convention(c) (CInt) -> Void)!)
+
 // CHECK-NOT: refToDependent
 // CHECK-NOT: refToDependentParam
 // CHECK-NOT: dontImportAtomicRef

--- a/test/Interop/Cxx/reference/reference-silgen.swift
+++ b/test/Interop/Cxx/reference/reference-silgen.swift
@@ -69,3 +69,15 @@ func setStaticIntRefTypealias() {
 // CHECK: sil hidden @$s4main24setStaticIntRefTypealiasyyF : $@convention(thin) () -> ()
 // CHECK: [[REF:%.*]] = function_ref @$sSo24setStaticIntRefTypealiasyys5Int32VzFTo : $@convention(c) (@inout Int32) -> ()
 // CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
+
+func passCallbacks() {
+  callWithIntRef { $0.pointee = 99 }
+  callWithConstIntRef { _ = $0 }
+  callWithIntRvalueRef { _ = $0 }
+  callWithConstIntRvalueRef { _ = $0 }
+}
+
+// CHECK: sil {{.*}}[clang callWithIntRef] @{{.*}} : $@convention(c) (Optional<@convention(c) (UnsafeMutablePointer<Int32>) -> ()>) -> ()
+// CHECK: sil {{.*}}[clang callWithConstIntRef] @{{.*}} : $@convention(c) (Optional<@convention(c) (@in_guaranteed Int32) -> ()>) -> ()
+// CHECK: sil {{.*}}[clang callWithIntRvalueRef] @{{.*}} : $@convention(c) (Optional<@convention(c) (@in_cxx Int32) -> ()>) -> ()
+// CHECK: sil {{.*}}[clang callWithConstIntRvalueRef] @{{.*}} : $@convention(c) (Optional<@convention(c) (@in_guaranteed Int32) -> ()>) -> ()

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -133,4 +133,13 @@ ReferenceTestSuite.test("const reference to array typealias") {
   expectEqual(7, firstByteOfArrayRefTypealias(bytes))
 }
 
+ReferenceTestSuite.test("reference parameter of a C function pointer") {
+  callWithIntRef { $0.pointee = 99 }
+  expectEqual(99, getStaticInt())
+
+  callWithConstIntRef { expectEqual(43, $0) }
+  callWithIntRvalueRef { expectEqual(44, $0) }
+  callWithConstIntRvalueRef { expectEqual(45, $0) }
+}
+
 runAllTests()


### PR DESCRIPTION
There were multiple places in the codebase that tried to figure out how to map references to Swift types. This PR unifies all of them to use a common helper so every caller remains in sync. This also fixes a miscompilation where we had an extra level of indirection for 'const FRT&&' parameters.

rdar://185650126

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
