### PR TITLE
[Concurrency][SILGen] Don't split async @out tuple results across suspensions

### DIFF
--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -223,9 +223,13 @@ private:
 /// initializations that have an addressable memory object to be stored into.
 class SingleBufferInitialization : virtual public Initialization {
   llvm::TinyPtrVector<CleanupHandle::AsPointer> SplitCleanups;
+
+  /// Whether this buffer may be initialized element-by-element via splitIntoTupleElements().
+  bool CanSplitIntoTupleElements = true;
+
 public:
   SingleBufferInitialization() {}
-  
+
   bool canPerformInPlaceInitialization() const override {
     return true;
   }
@@ -235,9 +239,13 @@ public:
                                               SILLocation loc) override = 0;
 
   bool isInPlaceInitializationOfGlobal() const override = 0;
-  
+
   bool canSplitIntoTupleElements() const override {
-    return true;
+    return CanSplitIntoTupleElements;
+  }
+
+  void setCanSplitIntoTupleElements(bool canSplit) {
+    CanSplitIntoTupleElements = canSplit;
   }
   
   MutableArrayRef<InitializationPtr>

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -487,6 +487,17 @@ createIndirectResultInit(SILGenFunction &SGF, SILValue addr,
   auto &resultTL = SGF.getTypeLowering(addr->getType());
   auto temporary = SGF.useBufferAsTemporary(addr, resultTL);
 
+  // A tuple result stored into an @out buffer must not be initialized
+  // element-by-element across a suspension point. This could result in
+  // a partial write happening before the suspension, and only the part of the write
+  // happening after the suspension point would survive, leaving the earlier part corrupt.
+  // Only a tuple with more than one element can be left partially written
+  if (SGF.F.isAsync()) {
+    if (auto tupleTy = addr->getType().getAs<TupleType>())
+      if (tupleTy->getNumElements() > 1)
+        temporary->setCanSplitIntoTupleElements(false);
+  }
+
   // Remember the cleanup that will be activated.
   auto cleanup = temporary->getInitializedCleanup();
   if (cleanup.isValid())

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_pending.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_pending.swift
@@ -1,5 +1,7 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library) | %FileCheck %s --dump-input=always
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature NonisolatedNonsendingByDefault)  | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library) | %FileCheck %s
+// Also run with -O, which is where the tuple-return-across-suspension miscompile appeared.
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library -O) | %FileCheck %s
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library -swift-version 5 -strict-concurrency=complete -enable-upcoming-feature NonisolatedNonsendingByDefault) | %FileCheck %s
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // REQUIRES: executable_test
@@ -54,8 +56,44 @@ func test_sum_nextOnPending() async {
   assert(sum == expected, "Expected: \(expected), got: \(sum)")
 }
 
+enum ReproError: Error { case boom }
+
+func echoIndex(_ index: Int) async throws -> Int {
+  await Task.yield()
+  if index < 0 { throw ReproError.boom }
+  return index
+}
+
+func test_tuple_result_across_suspend() async {
+  var results: [Int: Int] = [:]
+  await withTaskGroup(of: (Int, Result<Int, any Error>).self) { group in
+    for index in 0..<6 {
+      group.addTask {
+        // Note that the index is readily available, and would previously be attempted to
+        // be written before suspending for the echoIndex call. This would result in corrupting
+        // the tuple value when the write completes after the suspension.
+        do {
+          return (index, .success(try await echoIndex(index)))
+        } catch {
+          return (index, .failure(error))
+        }
+      }
+    }
+    while let (index, result) = await group.next() {
+      if case .success(let value) = result {
+        results[index] = value
+      }
+    }
+  }
+
+  // Check values returned through tuples were not corrupted:
+  // CHECK: tuple-result keys=[0, 1, 2, 3, 4, 5]
+  print("tuple-result keys=\(results.keys.sorted())")
+}
+
 @main struct Main {
   static func main() async {
     await test_sum_nextOnPending()
+    await test_tuple_result_across_suspend()
   }
 }

--- a/test/SILGen/async_tuple_indirect_result_across_suspend.swift
+++ b/test/SILGen/async_tuple_indirect_result_across_suspend.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -disable-availability-checking | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Regression test for a -O miscompile of an async function that returns a tuple
+// literal (into an @out indirect result) whose *later* element awaits.
+//
+// SILGen used to initialize the @out result buffer element-by-element, in
+// source order, storing an earlier element into the @out buffer *before* the
+// suspension caused by a later element:
+//
+//   // INCORRECT SIL (before the fix):
+//   %2 = tuple_element_addr %0 : $*(Int, Int), 0
+//   %3 = tuple_element_addr %0 : $*(Int, Int), 1
+//   store %1 to [trivial] %2 : $*Int                     // elt 0, BEFORE the suspend
+//   %4 = function_ref @echo : $@convention(thin) @async (Int) -> Int
+//   %5 = apply %4(%1) : $@convention(thin) @async (Int) -> Int  // suspension point
+//   hop_to_executor %e
+//   store %5 to [trivial] %3 : $*Int                     // elt 1, after resuming
+
+func echo(_ i: Int) async -> Int { i }
+
+@inline(never)
+func sink<T>(_ body: @Sendable () async -> T) async -> T { await body() }
+
+func twoInts(_ index: Int) async -> (Int, Int) {
+  await sink {
+    (index, await echo(index))
+  }
+}
+
+// The already-available first element (index, %1) must not be written into the
+// @out buffer before the suspension; the whole tuple is built and stored once,
+// after resuming.
+// CHECK-LABEL: sil {{.*}}twoInts{{.*}}yYaYbXEfU_ : $@convention(thin) @Sendable @async @substituted <τ_0_0> (Int) -> @out τ_0_0 for <(Int, Int)> {
+// CHECK:         bb0(%0 : $*(Int, Int), %1 : @closureCapture $Int):
+// CHECK-NOT:     tuple_element_addr
+// CHECK-NOT:     store %1 to
+// CHECK:         [[R:%[0-9]+]] = apply {{%[0-9]+}}(%1)
+// CHECK:         [[T:%[0-9]+]] = tuple (%1, [[R]])
+// CHECK:         store [[T]] to [trivial] %0


### PR DESCRIPTION
The bug was about tuples returned from task group tasks being corrupted in -O mode. Turns out this was an outright miscompile related to tuples themselves when part of it is synchronously known and another is only after a suspension.

We must not allow part of the tuple being written before the suspension and the rest after it. The result would be corrupted data of the parts that were written before suspending but were "lost". The fix is to prevent splitting tuple writes.

Resolves rdar://186012395

