### PR TITLE
[cxx-interop] Skip CxxOptional conformance for ~Copyable wrapped values

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -906,6 +906,13 @@ static void conformToCxxOptional(ClangImporter::Implementation &impl,
 
   auto valueType = clangCtx.getTypeDeclType(value_type);
 
+  if (getCxxValueSemanticsKind(valueType.getTypePtr(), impl) !=
+      CxxValueSemanticsKind::Copyable) {
+    // CxxOptional doesn't support ~Copyable elements, so skip the constructor
+    // synthesis and the conformance, if the wrapped value is move-only.
+    return;
+  }
+
   auto constRefValueType =
       clangCtx.getLValueReferenceType(valueType.withConst());
   // Create a fake variable with type of the wrapped value.

--- a/test/Interop/Cxx/stdlib/Inputs/std-optional.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-optional.h
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 using StdOptionalInt = std::optional<int>;
 using StdOptionalBool = std::optional<bool>;
@@ -24,6 +25,8 @@ struct HasDeletedCopyCtor {
   HasDeletedCopyCtor(HasDeletedCopyCtor &&other) = default;
 };
 using StdOptionalHasDeletedCopyCtor = std::optional<HasDeletedCopyCtor>;
+using StdOptionalMoveOnlyVector =
+    std::optional<std::vector<HasDeletedCopyCtor>>;
 
 struct HasDeletedMoveCtor {
   int value;
@@ -39,6 +42,13 @@ inline StdOptionalInt getNilOptional() { return {std::nullopt}; }
 
 inline StdOptionalHasDeletedCopyCtor getNonNilOptionalHasDeletedCopyCtor() {
   return StdOptionalHasDeletedCopyCtor(HasDeletedCopyCtor(654));
+}
+
+inline StdOptionalMoveOnlyVector getNonNilOptionalMoveOnlyVector() {
+  std::vector<HasDeletedCopyCtor> vec;
+  vec.emplace_back(789);
+  vec.emplace_back(987);
+  return StdOptionalMoveOnlyVector(std::move(vec));
 }
 
 inline bool takesOptionalInt(std::optional<int> arg) { return (bool)arg; }

--- a/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
@@ -3,7 +3,7 @@
 import StdOptional
 import CxxStdlib
 
-func takeCopyable<T: Copyable>(_ x: T) {} // expected-note {{'where T: Copyable' is implicit here}}
+func takeCopyable<T: Copyable>(_ x: T) {} // expected-note* {{'where T: Copyable' is implicit here}}
 
 func takeCxxOptional<T: CxxOptional>(_ x: T) {
   _ = x.hasValue
@@ -18,6 +18,11 @@ var _ = nonNilCopyable.pointee // expected-warning {{'pointee' is deprecated: us
 let nonNilOptNonCopyable = getNonNilOptionalHasDeletedCopyCtor()
 takeCopyable(nonNilOptNonCopyable) // expected-error {{conform to 'Copyable'}}
 var _ = nonNilOptNonCopyable.pointee
+
+let optVectorNonCopyable = getNonNilOptionalMoveOnlyVector()
+takeCopyable(optVectorNonCopyable) // expected-error {{conform to 'Copyable'}}
+var _ = optVectorNonCopyable.pointee
+var _ = optVectorNonCopyable.pointee[0].value
 
 let _ = returnsConvertsToTemplated() // shouldn't crash the compiler
 

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -96,4 +96,11 @@ StdOptionalTestSuite.test("std::optional init(_:Wrapped)") {
   expectEqual(321, optConstexprCtor.pointee.value)
 }
 
+StdOptionalTestSuite.test("std::optional of move-only std::vector") {
+  let optVectorNonCopyable = getNonNilOptionalMoveOnlyVector()
+  expectEqual(2, optVectorNonCopyable.pointee.size())
+  expectEqual(789, optVectorNonCopyable.pointee[0].value)
+  expectEqual(987, optVectorNonCopyable.pointee[1].value)
+}
+
 runAllTests()


### PR DESCRIPTION
The synthesized conformance to CxxOptional requires explicitly instantiating the constructor of `std::optional`, which then tries to instantiate the wrapped value's copy constructor. For most types, the compiler relies on `is_copy_constructible<value_type>` to decide whether to instantiate the copy constructor of the wrapped value. 

However, `is_copy_constructible<std::vector<MoveOnly>>` returns true even though the copy constructor's body is ill-formed for `MoveOnly`. The copy constructor is therefore instantiated, which fails with a hard error instead of a substitution failure.

rdar://186112333

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
