### PR TITLE
Opaque Values: add support for ObjC async completion handlers

### DIFF
--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -927,6 +927,10 @@ public:
             SGF.B.createProjectBlockStorage(loc, blockStorage);
 
         ManagedValue continuation;
+        // Set when the continuation had to be loaded as an owned value; this
+        // block is emitted out of line, so it cannot rely on a scope cleanup
+        // and destroys the value explicitly after the resume call below.
+        SILValue continuationToDestroy;
         {
           FormalEvaluationScope scope(SGF);
 
@@ -942,9 +946,17 @@ public:
               SILType::getPrimitiveAddressType(continuationTy));
 
           // If we are calling the unsafe variant, we always pass the value in
-          // registers.
-          if (!checkedBridging)
+          // registers. A checked continuation is passed indirectly, but only
+          // in lowered-address mode; with opaque values the intrinsic takes it
+          // as a value too.
+          if (!checkedBridging) {
             continuation = SGF.B.createLoadTrivial(loc, continuation);
+          } else if (!SGF.silConv.useLoweredAddresses()) {
+            continuationToDestroy = SGF.B.emitLoadValueOperation(
+                loc, continuation.getValue(), LoadOwnershipQualifier::Copy);
+            continuation = ManagedValue::forOwnedRValue(
+                continuationToDestroy, CleanupHandle::invalid());
+          }
         }
 
         auto mappedOutContinuationTy =
@@ -969,6 +981,9 @@ public:
              SGF.B.copyOwnedObjectRValue(loc, bridgedForeignError,
                                          ManagedValue::ScopeKind::Lexical)},
             SGFContext());
+
+        if (continuationToDestroy)
+          SGF.B.createDestroyValue(loc, continuationToDestroy);
 
         // Second, emit a branch from the end of the foreign error block to the
         // await block, to await the continuation which was just fulfilled.

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -872,7 +872,9 @@ static void buildBlockToFuncThunkBody(SILGenFunction &SGF,
   SILValue indirectResult;
   if (funcTy->getNumResults() != 0) {
     auto result = funcTy->getSingleResult();
-    if (result.getConvention() == ResultConvention::Indirect) {
+    // A formally indirect result only occupies an indirect SIL argument in
+    // lowered-address mode; with opaque values it is returned as a value.
+    if (fnConv.isSILIndirect(result)) {
       SILType resultTy =
           fnConv.getSILType(result, SGF.getTypeExpansionContext());
       indirectResult = entry->createFunctionArgument(resultTy);

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -388,6 +388,7 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
     SILGenFunction SGF(*this, *F, SwiftModule);
     {
       Scope scope(SGF, loc);
+      bool useLoweredAddresses = SGF.silConv.useLoweredAddresses();
       SmallVector<ManagedValue, 4> params;
       SGF.collectThunkParams(loc, params);
 
@@ -415,9 +416,16 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
 
         // If we are not using checked bridging, we load the continuation from
         // memory since we are going to pass it in registers, not in memory to
-        // the intrinsic.
-        if (!checkedBridging)
+        // the intrinsic. A checked continuation is passed indirectly, but only
+        // in lowered-address mode; with opaque values the intrinsic takes it as
+        // a value too.
+        if (!checkedBridging) {
           continuation = SGF.B.createLoadTrivial(loc, continuation);
+        } else if (!useLoweredAddresses) {
+          auto loaded = SGF.B.emitLoadValueOperation(
+              loc, continuation.getValue(), LoadOwnershipQualifier::Copy);
+          continuation = SGF.emitManagedRValueWithCleanup(loaded);
+        }
       }
 
       // Check for an error if the convention includes one.
@@ -525,25 +533,38 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       // arguments to the callback.
       {
         Scope resumeScope(SGF, loc);
-        auto resumeArgBuf = SGF.emitTemporaryAllocation(loc,
-                                              loweredResumeTy.getAddressType());
 
-        auto prepareArgument = [&](SILValue destBuf, CanType destFormalType,
-                                   ManagedValue arg, CanType argFormalType) {
+        // In lowered-address mode the intrinsic takes the resume value
+        // indirectly, so compose it in a temporary buffer. With opaque values
+        // it takes a value, so collect the bridged components and compose them
+        // into a tuple instead.
+        SILValue resumeArgBuf;
+        if (useLoweredAddresses) {
+          resumeArgBuf = SGF.emitTemporaryAllocation(
+              loc, loweredResumeTy.getAddressType());
+        }
+        SmallVector<ManagedValue, 4> resumeArgValues;
+
+        auto prepareArgument = [&](SILType destTy, SILValue destBuf,
+                                   CanType destFormalType, ManagedValue arg,
+                                   CanType argFormalType) {
           // Convert the ObjC argument to the bridged Swift representation we
           // want.
           ManagedValue bridgedArg = SGF.emitBridgedToNativeValue(
               loc, arg.copy(SGF, loc), argFormalType, destFormalType,
-              destBuf->getType().getObjectType());
+              destTy.getObjectType());
           // Force-unwrap an argument that comes to us as Optional if it's
           // formally non-optional in the return.
-          if (bridgedArg.getType().getOptionalObjectType()
-              && !destBuf->getType().getOptionalObjectType()) {
+          if (bridgedArg.getType().getOptionalObjectType() &&
+              !destTy.getOptionalObjectType()) {
             bridgedArg = SGF.emitPreconditionOptionalHasValue(loc,
                                                              bridgedArg,
                                                              /*implicit*/ true);
           }
-          bridgedArg.forwardInto(SGF, loc, destBuf);
+          if (destBuf)
+            bridgedArg.forwardInto(SGF, loc, destBuf);
+          else
+            resumeArgValues.push_back(bridgedArg);
         };
 
         // Collect the indices which correspond to the values to be returned.
@@ -567,14 +588,17 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
           // does not.
           return paramIndices[i] - 1;
         };
-        if (auto resumeTuple = dyn_cast<TupleType>(resumeType)) {
+        auto resumeTuple = dyn_cast<TupleType>(resumeType);
+        if (resumeTuple) {
           assert(paramIndices.size() == resumeTuple->getNumElements());
           assert(params.size() == resumeTuple->getNumElements()
                                    + 1 + (bool)errorIndex + (bool)flagIndex);
           for (unsigned i : indices(resumeTuple.getElementTypes())) {
-            auto resumeEltBuf = SGF.B.createTupleElementAddr(loc,
-                                                             resumeArgBuf, i);
+            SILValue resumeEltBuf;
+            if (resumeArgBuf)
+              resumeEltBuf = SGF.B.createTupleElementAddr(loc, resumeArgBuf, i);
             prepareArgument(
+                /*destTy*/ loweredResumeTy.getTupleElementType(i),
                 /*destBuf*/ resumeEltBuf,
                 /*destFormalType*/
                 F->mapTypeIntoEnvironment(resumeTuple.getElementTypes()[i])
@@ -586,16 +610,25 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
         } else {
           assert(paramIndices.size() == 1);
           assert(params.size() == 2 + (bool)errorIndex + (bool)flagIndex);
-          prepareArgument(/*destBuf*/ resumeArgBuf,
-                          /*destFormalType*/
-                          F->mapTypeIntoEnvironment(resumeType)->getCanonicalType(),
-                          /*arg*/ params[paramIndices[0]],
-                          /*argFormalType*/
-                          blockParams[blockParamIndex(0)].getParameterType());
+          prepareArgument(
+              /*destTy*/ loweredResumeTy,
+              /*destBuf*/ resumeArgBuf,
+              /*destFormalType*/
+              F->mapTypeIntoEnvironment(resumeType)->getCanonicalType(),
+              /*arg*/ params[paramIndices[0]],
+              /*argFormalType*/
+              blockParams[blockParamIndex(0)].getParameterType());
         }
-        
+
         // Resume the continuation with the composed bridged result.
-        ManagedValue resumeArg = SGF.emitManagedBufferWithCleanup(resumeArgBuf);
+        ManagedValue resumeArg;
+        if (useLoweredAddresses) {
+          resumeArg = SGF.emitManagedBufferWithCleanup(resumeArgBuf);
+        } else if (resumeTuple) {
+          resumeArg = SGF.B.createTuple(loc, loweredResumeTy, resumeArgValues);
+        } else {
+          resumeArg = resumeArgValues[0];
+        }
         Type replacementTypes[]
           = {F->mapTypeIntoEnvironment(resumeType)->getCanonicalType()};
         auto subs = SubstitutionMap::get(resumeIntrinsic->getGenericSignature(),

--- a/test/Interop/Cxx/objc-correctness/objc-async-completion-handler-non-trivial-cxx-execution.swift
+++ b/test/Interop/Cxx/objc-correctness/objc-async-completion-handler-non-trivial-cxx-execution.swift
@@ -10,12 +10,6 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 
-// The ObjC async completion handler thunk builds the continuation's resume
-// argument in an alloc_stack, which is not valid with opaque values, where an
-// @in parameter is lowered to a direct value. This is unrelated to what is
-// tested here and reproduces without the @in_cxx fix as well.
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
-
 // The argument of the completion handler block is passed with the Itanium C++
 // ABI convention: the caller destroys it.
 

--- a/test/Interpreter/SDK/objc_dynamic_lookup.swift
+++ b/test/Interpreter/SDK/objc_dynamic_lookup.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 import Foundation
 

--- a/test/Interpreter/rdar80847020.swift
+++ b/test/Interpreter/rdar80847020.swift
@@ -10,7 +10,6 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(_ s: Clazz) async throws {
     let res: (String, String) = try await s.doSomethingMultiResultFlaggy()

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -1,7 +1,7 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -sil-verify-all -enable-sil-opaque-values -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-OPAQUE --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-sil -o /dev/null -sil-verify-all -enable-sil-opaque-values -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen -checked-async-objc-bridging=off -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-ADDR --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 
@@ -111,10 +111,11 @@ func testGeneric2<T: AnyObject, U>(x: GenericObject<T>, y: U) async throws {
 // CHECK:   [[CONT_OPEN_EXT:%.*]] = open_existential_addr immutable_access [[CONT_ADDR]]
 // CHECK:   [[CONT_CAST:%.*]] = unchecked_addr_cast [[CONT_OPEN_EXT]]
 // CHECK:   [[CONT:%.*]] = load [trivial] [[CONT_CAST]]
-// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $Int
-// CHECK:   store %1 to [trivial] [[RESULT_BUF]]
+// CHECK-ADDR:   [[RESULT_BUF:%.*]] = alloc_stack $Int
+// CHECK-ADDR:   store %1 to [trivial] [[RESULT_BUF]]
 // CHECK:   [[RESUME:%.*]] = function_ref @{{.*}}resumeUnsafeContinuation
-// CHECK:   apply [[RESUME]]<Int>([[CONT]], [[RESULT_BUF]])
+// CHECK-ADDR:   apply [[RESUME]]<Int>([[CONT]], [[RESULT_BUF]])
+// CHECK-OPAQUE: apply [[RESUME]]<Int>([[CONT]], %1)
 
 // CHECK: sil{{.*}}@[[STRING_COMPLETION_THROW_BLOCK]]
 // CHECK:   [[RESUME_IN:%.*]] = copy_value %1
@@ -126,13 +127,14 @@ func testGeneric2<T: AnyObject, U>(x: GenericObject<T>, y: U) async throws {
 // CHECK:   [[ERROR_IN_B:%.*]] = begin_borrow [[ERROR_IN]]
 // CHECK:   switch_enum [[ERROR_IN_B]] : {{.*}}, case #Optional.some!enumelt: [[ERROR_BB:bb[0-9]+]], case #Optional.none!enumelt: [[RESUME_BB:bb[0-9]+]]
 // CHECK: [[RESUME_BB]]:
-// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $String
+// CHECK-ADDR:   [[RESULT_BUF:%.*]] = alloc_stack $String
 // CHECK:   [[RESUME_CP:%.*]] = copy_value [[RESUME_IN]]
 // CHECK:   [[BRIDGE:%.*]] = function_ref @{{.*}}unconditionallyBridgeFromObjectiveC
 // CHECK:   [[BRIDGED_RESULT:%.*]] = apply [[BRIDGE]]([[RESUME_CP]]
-// CHECK:   store [[BRIDGED_RESULT]] to [init] [[RESULT_BUF]]
+// CHECK-ADDR:   store [[BRIDGED_RESULT]] to [init] [[RESULT_BUF]]
 // CHECK:   [[RESUME:%.*]] = function_ref @{{.*}}resumeUnsafeThrowingContinuation
-// CHECK:   apply [[RESUME]]<String>([[CONT]], [[RESULT_BUF]])
+// CHECK-ADDR:   apply [[RESUME]]<String>([[CONT]], [[RESULT_BUF]])
+// CHECK-OPAQUE: apply [[RESUME]]<String>([[CONT]], [[BRIDGED_RESULT]])
 // CHECK:   br [[END_BB:bb[0-9]+]]
 // CHECK: [[END_BB]]:
 // CHECK:   return
@@ -148,7 +150,8 @@ func testGeneric2<T: AnyObject, U>(x: GenericObject<T>, y: U) async throws {
 // CHECK:   [[CONT_OPEN:%.*]] = open_existential_addr immutable_access [[CONT_ADDR]]
 // CHECK:   [[CONT_CAST:%.*]] = unchecked_addr_cast [[CONT_OPEN]]
 // CHECK:   [[CONT:%.*]] = load [trivial] [[CONT_CAST]]
-// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $()
+// CHECK-ADDR:   [[RESULT_BUF:%.*]] = alloc_stack $()
+// CHECK-OPAQUE: [[RESULT_BUF:%.*]] = tuple ()
 // CHECK:   [[RESUME:%.*]] = function_ref @{{.*}}resumeUnsafeContinuation
 // CHECK:   apply [[RESUME]]<()>([[CONT]], [[RESULT_BUF]])
 
@@ -177,13 +180,14 @@ func testGeneric2<T: AnyObject, U>(x: GenericObject<T>, y: U) async throws {
 // CHECK:   function_ref{{.*}}42_resumeUnsafeThrowingContinuationWithError
 
 // CHECK: sil{{.*}}@[[NSSTRING_INT_THROW_COMPLETION_BLOCK]]
-// CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $(String, Int)
-// CHECK:   [[RESULT_0_BUF:%.*]] = tuple_element_addr [[RESULT_BUF]] {{.*}}, 0
+// CHECK-ADDR:   [[RESULT_BUF:%.*]] = alloc_stack $(String, Int)
+// CHECK-ADDR:   [[RESULT_0_BUF:%.*]] = tuple_element_addr [[RESULT_BUF]] {{.*}}, 0
 // CHECK:   [[BRIDGE:%.*]] = function_ref @{{.*}}unconditionallyBridgeFromObjectiveC
 // CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE]]
-// CHECK:   store [[BRIDGED]] to [init] [[RESULT_0_BUF]]
-// CHECK:   [[RESULT_1_BUF:%.*]] = tuple_element_addr [[RESULT_BUF]] {{.*}}, 1
-// CHECK:   store %2 to [trivial] [[RESULT_1_BUF]]
+// CHECK-ADDR:   store [[BRIDGED]] to [init] [[RESULT_0_BUF]]
+// CHECK-ADDR:   [[RESULT_1_BUF:%.*]] = tuple_element_addr [[RESULT_BUF]] {{.*}}, 1
+// CHECK-ADDR:   store %2 to [trivial] [[RESULT_1_BUF]]
+// CHECK-OPAQUE: {{%.*}} = tuple ([[BRIDGED]] : $String, %2 : $Int)
 
 // CHECK-LABEL: sil {{.*}}@${{.*}}22testSlowServerFromMain
 @MainActor
@@ -256,7 +260,7 @@ func testThrowingMethodFromMain(slowServer: SlowServer) async -> String {
 }
 
 // rdar://91502776
-// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}21checkCostcoMembershipSbyYaF : $@convention(thin) @async () -> Bool {
+// CHECK-LABEL: sil hidden [ossa] {{.*}}@$s{{.*}}21checkCostcoMembershipSbyYaF : $@convention(thin) @async () -> Bool {
 // CHECK:    bb0:
 // CHECK:        hop_to_executor {{%.*}} : $Optional<any Actor>
 // CHECK:        [[FINAL_BUF:%.*]] = alloc_stack $Bool
@@ -297,10 +301,11 @@ func checkCostcoMembership() async -> Bool {
 }
 
 extension OptionalMemberLookups {
-  // CHECK-LABEL: sil hidden [ossa] @$s10objc_async21OptionalMemberLookupsPAAE19testForceDirectCallyyYaF
+  // CHECK-LABEL: sil hidden [ossa] {{.*}}@$s10objc_async21OptionalMemberLookupsPAAE19testForceDirectCallyyYaF
   // CHECK:         [[SELF:%[0-9]+]] = copy_value {{.*}} : $Self
   // CHECK:         [[METH:%[0-9]+]] = objc_method {{.*}} : $Self, #OptionalMemberLookups.generateMaybe!foreign : <Self where Self : OptionalMemberLookups> (Self) -> () async -> (), $@convention(objc_method) (@convention(block) () -> (), Self) -> ()
-  // CHECK:         [[CONT:%.*]] = struct $UnsafeContinuation<(), Never> (%10 : $Builtin.RawUnsafeContinuation)
+  // CHECK:         [[RAW_CONT:%.*]] = get_async_continuation_addr ()
+  // CHECK:         [[CONT:%.*]] = struct $UnsafeContinuation<(), Never> ([[RAW_CONT]] : $Builtin.RawUnsafeContinuation)
   // CHECK:         [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage
   // CHECK:         [[PROJECTED:%.*]] = project_block_storage [[BLOCK_STORAGE]] : $*@block_storage
   // CHECK:         [[PROJECTED_ANY:%.*]] = init_existential_addr [[PROJECTED]]
@@ -328,7 +333,7 @@ extension OptionalMemberLookups {
 // CHECK: [[RETAINED_OPTIONAL:%.*]] = copy_value [[MANAGED_OPTIONAL]] : $Optional<NSError>
 // CHECK: [[MARKED:%.*]] = mark_dependence [[RETAINED_OPTIONAL]] : $Optional<NSError> on {{.*}} : $*Optional<NSError>
 // CHECK: assign [[MARKED]] to {{.*}} : $*Optional<NSError>
-// CHECK: dealloc_stack {{.*}} : $*AutoreleasingUnsafeMutablePointer<Optional<NSError>>
+// CHECK-ADDR: dealloc_stack {{.*}} : $*AutoreleasingUnsafeMutablePointer<Optional<NSError>>
 // CHECK: dealloc_stack {{.*}} : $*@sil_unmanaged Optional<NSError>
 // CHECK: destroy_value {{.*}} : $MainActor
 // CHECK: hop_to_executor {{.*}} : $Optional<any Actor>
@@ -344,30 +349,32 @@ extension SlowServer: @retroactive FailableFloatLoader {
     return 0
   }
 }
-// CHECK-LABEL: sil [ossa] @$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKF : $@convention(method) @async (@guaranteed SlowServer) -> (Float, @error any Error)
+// CHECK-LABEL: sil [ossa] {{.*}}@$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKF : $@convention(method) @async (@guaranteed SlowServer) -> (Float, @error any Error)
 
-// CHECK-LABEL: sil private [thunk] [ossa] @$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKFTo : $@convention(objc_method) (@convention(block) @Sendable (Float, Optional<NSError>) -> (), SlowServer) -> () {
+// CHECK-LABEL: sil private [thunk] [ossa] {{.*}}@$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKFTo : $@convention(objc_method) (@convention(block) @Sendable (Float, Optional<NSError>) -> (), SlowServer) -> () {
 // CHECK:         function_ref @$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKFyyYacfU_To
 
-// CHECK-LABEL: sil shared [thunk] [ossa] @$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Float, Optional<NSError>) -> (), SlowServer) -> ()
+// CHECK-LABEL: sil shared [thunk] [ossa] {{.*}}@$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Float, Optional<NSError>) -> (), SlowServer) -> ()
 // CHECK:         [[BLOCK:%.*]] = copy_block
 // CHECK:         [[METHOD:%.*]] = function_ref @$sSo10SlowServerC10objc_asyncE16loadFloatOrThrowSfyYaKF :
 // CHECK:         try_apply [[METHOD]]({{%.*}}) : {{.*}}, normal bb1, error bb2
 // CHECK:       bb1([[NORMAL_RESULT:%.*]] : $Float):
-// CHECK-NEXT:    [[BORROWED_BLOCK:%.*]] = begin_borrow [[BLOCK]] :
+// CHECK-ADDR-NEXT:    [[BORROWED_BLOCK:%.*]] = begin_borrow [[BLOCK]] :
 // CHECK-NEXT:    [[NIL_NSERROR:%.*]] = enum $Optional<NSError>, #Optional.none
-// CHECK-NEXT:    apply [[BORROWED_BLOCK]]([[NORMAL_RESULT]], [[NIL_NSERROR]])
+// CHECK-ADDR-NEXT:    apply [[BORROWED_BLOCK]]([[NORMAL_RESULT]], [[NIL_NSERROR]])
+// CHECK-OPAQUE-NEXT:  apply [[BLOCK]]([[NORMAL_RESULT]], [[NIL_NSERROR]])
 // CHECK:       bb2([[ERROR_RESULT:%.*]] : @owned $any Error):
-// CHECK-NEXT:    [[BORROWED_BLOCK:%.*]] = begin_borrow [[BLOCK]] :
+// CHECK-ADDR-NEXT:    [[BORROWED_BLOCK:%.*]] = begin_borrow [[BLOCK]] :
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[CONVERT_FN:%.*]] = function_ref
 // CHECK-NEXT:    [[NSERROR:%.*]] = apply [[CONVERT_FN]]([[ERROR_RESULT]])
 // CHECK-NEXT:    [[SOME_NSERROR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt, [[NSERROR]] : $NSError
 // CHECK-NEXT:    [[ZERO_FLOAT:%.*]] = builtin "zeroInitializer"() : $Float
-// CHECK-NEXT:    [[BORROWED_SOME_NSERROR:%.*]] = begin_borrow [[SOME_NSERROR]] :
-// CHECK-NEXT:    apply [[BORROWED_BLOCK]]([[ZERO_FLOAT]], [[BORROWED_SOME_NSERROR]])
+// CHECK-ADDR-NEXT:    [[BORROWED_SOME_NSERROR:%.*]] = begin_borrow [[SOME_NSERROR]] :
+// CHECK-ADDR-NEXT:    apply [[BORROWED_BLOCK]]([[ZERO_FLOAT]], [[BORROWED_SOME_NSERROR]])
+// CHECK-OPAQUE-NEXT:  apply [[BLOCK]]([[ZERO_FLOAT]], [[SOME_NSERROR]])
 
-// CHECK-LABEL: sil hidden [ossa] @$s10objc_async13testAnyObjectyySo10SlowServerCYaF : $@convention(thin) @async (@guaranteed SlowServer) -> () {
+// CHECK-LABEL: sil hidden [ossa] {{.*}}@$s10objc_async13testAnyObjectyySo10SlowServerCYaF : $@convention(thin) @async (@guaranteed SlowServer) -> () {
 // CHECK: bb0([[SLOWSERVER:%.*]] : @guaranteed $SlowServer):
 // CHECK: [[SLOWSERVER_C:%.*]] = copy_value [[SLOWSERVER]]
 // CHECK: [[SLOWSERVER_ANYOBJECT:%.*]] = init_existential_ref [[SLOWSERVER_C]]

--- a/test/SILGen/objc_async_checked.swift
+++ b/test/SILGen/objc_async_checked.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -swift-version 6 -I %S/Inputs/custom-modules -target %target-swift-5.1-abi-triple %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -swift-version 6 -I %S/Inputs/custom-modules -target %target-swift-5.1-abi-triple %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-sil -o /dev/null -sil-verify-all -enable-sil-opaque-values -swift-version 6 -I %S/Inputs/custom-modules -target %target-swift-5.1-abi-triple %s -verify
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen -swift-version 6 -I %S/Inputs/custom-modules -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 

--- a/test/SILGen/objc_async_defined_in_swift_any.swift
+++ b/test/SILGen/objc_async_defined_in_swift_any.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-emit-silgen-ossa(mock-sdk: %clang-importer-sdk) -o /dev/null -enable-sil-opaque-values -target %target-swift-5.1-abi-triple -verify %s
+// RUN: %target-swift-emit-silgen-ossa(mock-sdk: %clang-importer-sdk) -o /dev/null -enable-sil-opaque-values -target %target-swift-5.1-abi-triple -verify %s
+// RUN: %target-swift-emit-sil(mock-sdk: %clang-importer-sdk) -sil-verify-all -o /dev/null -enable-sil-opaque-values -target %target-swift-5.1-abi-triple -verify %s
 
 // RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -target %target-swift-5.1-abi-triple -verify %s
 // REQUIRES: concurrency

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-sil -o /dev/null -sil-verify-all -enable-sil-opaque-values -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen -I %S/Inputs/custom-modules  -target %target-swift-5.1-abi-triple %s -verify | %FileCheck --implicit-check-not=hop_to_executor --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix CHECK-C %s
 

--- a/test/SILGen/objc_async_sendable_completion_handlers.swift
+++ b/test/SILGen/objc_async_sendable_completion_handlers.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t/src)
 // RUN: split-file %s %t/src
 
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values %t/src/main.swift -import-objc-header %t/src/Test.h -swift-version 6 -module-name main -I %t -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values %t/src/main.swift -import-objc-header %t/src/Test.h -swift-version 6 -module-name main -I %t -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -o /dev/null -sil-verify-all -enable-sil-opaque-values %t/src/main.swift -import-objc-header %t/src/Test.h -swift-version 6 -module-name main -I %t -verify
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %t/src/main.swift \
 // RUN:   -import-objc-header %t/src/Test.h \

--- a/test/SILGen/objc_effectful_properties.swift
+++ b/test/SILGen/objc_effectful_properties.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -checked-async-objc-bridging=off -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -checked-async-objc-bridging=off -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-sil -o /dev/null -sil-verify-all -enable-sil-opaque-values -checked-async-objc-bridging=off -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen -checked-async-objc-bridging=off -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency

--- a/test/SILGen/objc_effectful_properties_checked.swift
+++ b/test/SILGen/objc_effectful_properties_checked.swift
@@ -1,5 +1,5 @@
-// FIXME: crashes under opaque values
-// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -swift-version 6 -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen-ossa -o /dev/null -sil-verify-all -enable-sil-opaque-values -swift-version 6 -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-sil -o /dev/null -sil-verify-all -enable-sil-opaque-values -swift-version 6 -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-silgen -swift-version 6 -target %target-swift-5.1-abi-triple -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency

--- a/test/Sanitizers/tsan/objc_async.swift
+++ b/test/Sanitizers/tsan/objc_async.swift
@@ -11,7 +11,6 @@
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 @main struct Main {
   static func main() async {

--- a/validation-test/SILGen/rdar85526916.swift
+++ b/validation-test/SILGen/rdar85526916.swift
@@ -9,7 +9,6 @@
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: howdy

--- a/validation-test/compiler_crashers_fixed/rdar80704382.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704382.swift
@@ -10,7 +10,6 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run() async throws {
   // CHECK: item_id

--- a/validation-test/compiler_crashers_fixed/rdar80704984.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704984.swift
@@ -10,7 +10,6 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run1(on object: PFXObject) async throws {
   do {

--- a/validation-test/compiler_crashers_fixed/rdar80704984_2.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704984_2.swift
@@ -10,7 +10,6 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run1(on object: PFXObject) async throws {
   do {

--- a/validation-test/compiler_crashers_fixed/rdar80704984_3.swift
+++ b/validation-test/compiler_crashers_fixed/rdar80704984_3.swift
@@ -10,7 +10,6 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run1(on object: PFXObject) async throws {
   do {

--- a/validation-test/compiler_crashers_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_fixed/rdar81590807.swift
@@ -16,7 +16,6 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: passSync

--- a/validation-test/compiler_crashers_fixed/rdar81590807_2.swift
+++ b/validation-test/compiler_crashers_fixed/rdar81590807_2.swift
@@ -10,7 +10,6 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: syncSuccess

--- a/validation-test/compiler_crashers_fixed/rdar81617749.swift
+++ b/validation-test/compiler_crashers_fixed/rdar81617749.swift
@@ -10,7 +10,6 @@
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 func run(on object: PFXObject) async throws {
   // CHECK: performSingleFlaggy1


### PR DESCRIPTION
With `-enable-sil-opaque-values`, SILGen cannot emit the thunks that bridge an
imported Objective-C async method's completion handler. Three independent sites
hardcode the lowered-address representation, so as soon as the resume value or
the continuation is materialised they produce ill-formed SIL or trip an
assertion.

Under opaque values a formally indirect (`@in`, `@in_guaranteed`, `@out`)
parameter or result is represented as a value, not an address. Each of the
three sites builds an address anyway — an `alloc_stack` temporary, an
`unchecked_addr_cast` to an address type, or an indirect-result function
argument — and hands it to a callee whose SIL type is now object-typed.

Resolves rdar://186458608.