### PR TITLE
[cxx-interop] Lower @cxx @implementation functions to their C++ entry points

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2397,6 +2397,9 @@ bool Decl::hasOnlyCEntryPoint() const {
       return true;
   }
 
+  if (getAttrs().hasAttribute<CxxDeclAttr>())
+    return true;
+
   return false;
 }
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1251,8 +1251,9 @@ bool SILDeclRef::hasNonUniqueDefinition() const {
 }
 
 bool SILDeclRef::declExposedToForeignLanguage(const ValueDecl *decl) {
-  // @c / @_cdecl / @objc.
+  // @c / @_cdecl / @cxx / @objc.
   if (decl->getAttrs().hasAttribute<CDeclAttr>() ||
+      decl->getAttrs().hasAttribute<CxxDeclAttr>() ||
       (decl->getAttrs().hasAttribute<ObjCAttr>() &&
        decl->getDeclContext()->isModuleScopeContext())) {
     return true;
@@ -1585,8 +1586,9 @@ std::optional<std::string> SILDeclRef::getAsmName() const {
       if (auto VD = dyn_cast<ValueDecl>(decl))
         return std::string(EA->getCName(VD));
 
-    // @c/@_cdecl
-    if (decl->getAttrs().hasAttribute<CDeclAttr>())
+    // @c/@_cdecl/@cxx.
+    if (decl->getAttrs().hasAttribute<CDeclAttr>() ||
+        decl->getAttrs().hasAttribute<CxxDeclAttr>())
       return std::string(decl->getCDeclName());
   }
 

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -173,7 +173,8 @@ void SILFunctionBuilder::addFunctionAttributes(
   }
 
   // @_silgen_name and @_cdecl functions may be called from C code somewhere.
-  if (Attrs.hasAttribute<SILGenNameAttr>() || Attrs.hasAttribute<CDeclAttr>())
+  if (Attrs.hasAttribute<SILGenNameAttr>() || Attrs.hasAttribute<CDeclAttr>() ||
+      Attrs.hasAttribute<CxxDeclAttr>())
     F->setHasCReferences(true);
 
   for (auto *EA : Attrs.getAttributes<ExposeAttr>()) {

--- a/test/Interop/Cxx/cxx-impl/Inputs/functions-execution.swift
+++ b/test/Interop/Cxx/cxx-impl/Inputs/functions-execution.swift
@@ -1,0 +1,47 @@
+import Functions
+
+// int returnsInt();
+@cxx @implementation
+public func returnsInt() -> CInt { return 42 }
+
+// int64_t takesInt64(int64_t x);
+@cxx @implementation
+public func takesInt64(_ x: Int64) -> Int64 { return x }
+
+// int *returnsPtrToInt();
+@cxx @implementation
+public func returnsPtrToInt() -> UnsafeMutablePointer<CInt>? { return nil }
+
+// void swapInts(int *p, int *q);
+@cxx @implementation
+public func swapInts(_ p: UnsafeMutablePointer<CInt>?, _ q: UnsafeMutablePointer<CInt>?) {
+  let tmp = p!.pointee
+  p!.pointee = q!.pointee
+  q!.pointee = tmp
+}
+
+// TrivialStruct returnsTrivialStruct();
+@cxx @implementation
+public func returnsTrivialStruct() -> TrivialStruct {
+  return TrivialStruct(x: 7, y: 9)
+}
+
+// int overloadedByArity(int x);
+@cxx @implementation
+public func overloadedByArity(_ x: CInt) -> CInt { return x + 1 }
+
+// int overloadedByArity(int x, int y);
+@cxx @implementation
+public func overloadedByArity(_ x: CInt, _ y: CInt) -> CInt { return x + y }
+
+// int withDefaultArg(int a, int b = 10);
+@cxx @implementation
+public func withDefaultArg(_ a: CInt, _ b: CInt) -> CInt { return a + b }
+
+// extern "C" int externCFunc(int x);
+@cxx @implementation
+public func externCFunc(_ x: CInt) -> CInt { return -x }
+
+// int foo(int x);
+@cxx(foo) @implementation
+public func swiftRenamedFoo(_ x: CInt) -> CInt { return x * 2 }

--- a/test/Interop/Cxx/cxx-impl/Inputs/functions.h
+++ b/test/Interop/Cxx/cxx-impl/Inputs/functions.h
@@ -1,6 +1,8 @@
 #ifndef TEST_INTEROP_CXX_CXX_IMPL_FUNCTIONS_H
 #define TEST_INTEROP_CXX_CXX_IMPL_FUNCTIONS_H
 
+#include <stdint.h>
+
 struct TrivialStruct {
   int x;
   int y;
@@ -27,6 +29,8 @@ int defer(int x);
 void takesPrimitives(int i, long l, char c, float f, double d, bool b);
 int returnsInt();
 
+int64_t takesInt64(int64_t x);
+
 // Pointers
 
 void takesPtrToInt(int *p);
@@ -49,9 +53,24 @@ int *returnsPtrToInt();
 int *_Nullable returnsNullablePtrToInt();
 int *_Nonnull returnsNonnullPtrToInt();
 
+void swapInts(int *p, int *q);
+
 // Trivial struct
 
 void takesTrivialStruct(TrivialStruct s);
 TrivialStruct returnsTrivialStruct();
+
+// Overloads
+
+int overloadedByArity(int x);
+int overloadedByArity(int x, int y);
+
+// Default arg
+
+int withDefaultArg(int a, int b = 10);
+
+// Linkage
+
+extern "C" int externCFunc(int x);
 
 #endif // !TEST_INTEROP_CXX_CXX_IMPL_FUNCTIONS_H

--- a/test/Interop/Cxx/cxx-impl/dead-function-elimination-irgen.swift
+++ b/test/Interop/Cxx/cxx-impl/dead-function-elimination-irgen.swift
@@ -1,0 +1,24 @@
+// A `@cxx @implementation` function provides the body of a C++ function. Its
+// only callers are in C++, which the Swift compiler cannot see. If the Swift
+// function is not `public`, it has hidden linkage, and at -O the SIL
+// optimizer's dead-function elimination would delete it as unused, unless we
+// mark it as referenced from a foreign language.
+//
+// This test ensures that a non-public @cxx @implementation function is not
+// removed by dead-function elimination.
+
+// RUN: %target-swift-emit-ir \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -I %S/Inputs \
+// RUN:   -O \
+// RUN:   %s | %FileCheck %s --check-prefix=CHECK-%target-abi
+
+// REQUIRES: swift_feature_CxxImplementation
+
+import Functions
+
+// CHECK-SYSV: define {{.*}}@_Z10returnsIntv
+// CHECK-WIN: define {{.*}}@"?returnsInt@@YAHXZ"
+@cxx @implementation
+func returnsInt() -> CInt { return 42 }

--- a/test/Interop/Cxx/cxx-impl/functions-execution.cpp
+++ b/test/Interop/Cxx/cxx-impl/functions-execution.cpp
@@ -1,0 +1,67 @@
+// Executable end-to-end test: a C++ program calls functions declared in
+// functions.h whose bodies are provided in Swift via `@cxx @implementation`.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-interop-build-clangxx \
+// RUN:   -c %s \
+// RUN:   -Wno-nullability-completeness \
+// RUN:   -I %S/Inputs \
+// RUN:   -o %t/functions-execution-main.o
+// RUN: %target-interop-build-swift \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -module-name FunctionsExecutionMain \
+// RUN:   -parse-as-library \
+// RUN:   -Xcc -Wno-nullability-completeness \
+// RUN:   -I %S/Inputs \
+// RUN:   -Xlinker %t/functions-execution-main.o \
+// RUN:   %S/Inputs/functions-execution.swift \
+// RUN:   -o %t/functions-execution
+// RUN: %target-codesign %t/functions-execution
+// RUN: %target-run %t/functions-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_CxxImplementation
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "functions.h"
+
+int main() {
+  printf("returnsInt=%d\n", returnsInt());
+  // CHECK: returnsInt=42
+
+  printf("takesInt64=%d\n", (int)takesInt64(64));
+  // CHECK: takesInt64=64
+
+  unsigned p = (unsigned)(uintptr_t)returnsPtrToInt();
+  printf("returnsPtrToInt=%u\n", p);
+  // CHECK: returnsPtrToInt=0
+
+  int a = 1, b = 2;
+  swapInts(&a, &b);
+  printf("swapInts=%d,%d\n", a, b);
+  // CHECK: swapInts=2,1
+
+  TrivialStruct s = returnsTrivialStruct();
+  printf("returnsTrivialStruct=%d,%d\n", s.x, s.y);
+  // CHECK: returnsTrivialStruct=7,9
+
+  printf("overloadedByArity1=%d\n", overloadedByArity(41));
+  // CHECK: overloadedByArity1=42
+  printf("overloadedByArity2=%d\n", overloadedByArity(67, 2));
+  // CHECK: overloadedByArity2=69
+
+  printf("withDefaultArg=%d\n", withDefaultArg(32));
+  // CHECK: withDefaultArg=42
+  printf("withDefaultArg=%d\n", withDefaultArg(67, 2));
+  // CHECK: withDefaultArg=69
+
+  printf("externCFunc=%d\n", externCFunc(42));
+  // CHECK: externCFunc=-42
+
+  printf("foo=%d\n", foo(21));
+  // CHECK: foo=42
+
+  return 0;
+}

--- a/test/Interop/Cxx/cxx-impl/functions-irgen.swift
+++ b/test/Interop/Cxx/cxx-impl/functions-irgen.swift
@@ -1,0 +1,206 @@
+// Verifies that each `@cxx @implementation` function body is emitted under the
+// matched C++ declaration's mangled symbol, and that Swift-side calls target
+// the same foreign entry points.
+
+// RUN: %target-swift-emit-ir \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -Xcc -Wno-nullability-completeness \
+// RUN:   -I %S/Inputs \
+// RUN:   %s | %FileCheck %s --check-prefixes=CHECK,CHECK-%target-abi
+
+// REQUIRES: swift_feature_CxxImplementation
+
+import Functions
+
+
+// Primitives
+
+// void takesPrimitives(int i, long l, char c, float f, double d, bool b);
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z15takesPrimitivesilcfdb
+// CHECK-WIN-LABEL: define{{.*}} void @"?takesPrimitives@@YAXHJDMN_N@Z"
+@cxx @implementation
+public func takesPrimitives(_ i: CInt, _ l: CLong, _ c: CChar, _ f: CFloat, _ d: CDouble, _ b: CBool) {}
+
+// int returnsInt();
+// CHECK-SYSV-LABEL: define{{.*}} i32 @_Z10returnsIntv
+// CHECK-WIN-LABEL: define{{.*}} i32 @"?returnsInt@@YAHXZ"
+@cxx @implementation
+public func returnsInt() -> CInt { return 42 }
+
+// int64_t takesInt64(int64_t x);
+// int64_t is long on LP64 Linux but long long elsewhere, so allow either
+// Itanium mangling; MSVC spells both _J.
+// CHECK-SYSV-LABEL: define{{.*}} i64 @_Z10takesInt64{{[lx]}}
+// CHECK-WIN-LABEL: define{{.*}} i64 @"?takesInt64@@YA_J_J@Z"
+@cxx @implementation
+public func takesInt64(_ x: Int64) -> Int64 { return x }
+
+
+// Pointers
+
+// void takesPtrToInt(int *p);
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z13takesPtrToIntPi
+// CHECK-WIN-LABEL: define{{.*}} void @"?takesPtrToInt@@YAXPEAH@Z"
+@cxx @implementation
+public func takesPtrToInt(_ p: UnsafeMutablePointer<CInt>?) {}
+
+// void takesPtrToConstInt(const int *p);
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z18takesPtrToConstIntPKi
+// CHECK-WIN-LABEL: define{{.*}} void @"?takesPtrToConstInt@@YAXPEBH@Z"
+@cxx @implementation
+public func takesPtrToConstInt(_ p: UnsafePointer<CInt>?) {}
+
+// void takesPtrToVoid(void *p);
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z14takesPtrToVoidPv
+// CHECK-WIN-LABEL: define{{.*}} void @"?takesPtrToVoid@@YAXPEAX@Z"
+@cxx @implementation
+public func takesPtrToVoid(_ p: UnsafeMutableRawPointer?) {}
+
+// void takesFuncPtr(int (*fn)(int));
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z12takesFuncPtrPFiiE
+// CHECK-WIN-LABEL: define{{.*}} void @"?takesFuncPtr@@YAXP6AHH@Z@Z"
+@cxx @implementation
+public func takesFuncPtr(_ fn: (@convention(c) (CInt) -> CInt)?) {}
+
+// int *returnsPtrToInt();
+// CHECK-SYSV-LABEL: define{{.*}} ptr @_Z15returnsPtrToIntv
+// CHECK-WIN-LABEL: define{{.*}} ptr @"?returnsPtrToInt@@YAPEAHXZ"
+@cxx @implementation
+public func returnsPtrToInt() -> UnsafeMutablePointer<CInt>? { return nil }
+
+// void takesNonnullPtrToInt(int *_Nonnull p);
+// The nullability annotation changes the imported Swift type (non-optional
+// pointer) but not the mangled symbol.
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z20takesNonnullPtrToIntPi
+// CHECK-WIN-LABEL: define{{.*}} void @"?takesNonnullPtrToInt@@YAXPEAH@Z"
+@cxx @implementation
+public func takesNonnullPtrToInt(_ p: UnsafeMutablePointer<CInt>) {}
+
+// void swapInts(int *p, int *q);
+// Two pointer parameters of the same type exercise substitution compression
+// in the mangled name: Itanium's S_ and MSVC's 0 back-reference.
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z8swapIntsPiS_
+// CHECK-WIN-LABEL: define{{.*}} void @"?swapInts@@YAXPEAH0@Z"
+@cxx @implementation
+public func swapInts(_ p: UnsafeMutablePointer<CInt>?, _ q: UnsafeMutablePointer<CInt>?) {
+  let tmp = p!.pointee
+  p!.pointee = q!.pointee
+  q!.pointee = tmp
+}
+
+
+// Trivial struct
+
+// void takesTrivialStruct(TrivialStruct s);
+// CHECK-SYSV-LABEL: define{{.*}} void @_Z18takesTrivialStruct13TrivialStruct
+// CHECK-WIN-LABEL: define{{.*}} void @"?takesTrivialStruct@@YAXUTrivialStruct@@@Z"
+@cxx @implementation
+public func takesTrivialStruct(_ s: TrivialStruct) {}
+
+// TrivialStruct returnsTrivialStruct();
+// The struct-return ABI differs by target (direct vs. sret), so don't pin the
+// return type.
+// CHECK-SYSV-LABEL: define{{.*}} @_Z20returnsTrivialStructv
+// CHECK-WIN-LABEL: define{{.*}} @"?returnsTrivialStruct@@YA?AUTrivialStruct@@XZ"
+@cxx @implementation
+public func returnsTrivialStruct() -> TrivialStruct {
+  return TrivialStruct(x: 1, y: 2)
+}
+
+
+// Overloads
+
+// int overloadedByArity(int x);
+// CHECK-SYSV-LABEL: define{{.*}} i32 @_Z17overloadedByArityi
+// CHECK-WIN-LABEL: define{{.*}} i32 @"?overloadedByArity@@YAHH@Z"
+@cxx @implementation
+public func overloadedByArity(_ x: CInt) -> CInt { return x }
+
+// int overloadedByArity(int x, int y);
+// CHECK-SYSV-LABEL: define{{.*}} i32 @_Z17overloadedByArityii
+// CHECK-WIN-LABEL: define{{.*}} i32 @"?overloadedByArity@@YAHHH@Z"
+@cxx @implementation
+public func overloadedByArity(_ x: CInt, _ y: CInt) -> CInt { return x + y }
+
+
+// Default arg
+
+// int withDefaultArg(int a, int b = 10);
+// C++ default arguments are substituted at C++ call sites and don't affect the
+// definition. The implementation matches the full two-parameter signature.
+// CHECK-SYSV-LABEL: define{{.*}} i32 @_Z14withDefaultArgii
+// CHECK-WIN-LABEL: define{{.*}} i32 @"?withDefaultArg@@YAHHH@Z"
+@cxx @implementation
+public func withDefaultArg(_ a: CInt, _ b: CInt) -> CInt { return a + b }
+
+
+// Linkage
+
+// extern "C" int externCFunc(int x);
+// We need to respect the C language linkage of a function declared in a C++
+// header, so the implementation is emitted under the unmangled name.
+// CHECK-LABEL: define{{.*}} i32 @externCFunc(
+@cxx @implementation
+public func externCFunc(_ x: CInt) -> CInt { return x }
+
+
+// Renamed function
+
+// int foo(int x);
+// `@cxx(foo)` matches `int foo(int)` by that C++ name even though the Swift
+// function is named differently. The body is still emitted under the matched
+// declaration's mangled symbol.
+// CHECK-SYSV-LABEL: define{{.*}} i32 @_Z3fooi
+// CHECK-WIN-LABEL: define{{.*}} i32 @"?foo@@YAHH@Z"
+@cxx(foo) @implementation
+public func swiftRenamedFoo(_ x: CInt) -> CInt { return x }
+
+
+// Swift-side calls
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s{{.*}}12callCxxFuncsyyF"
+// CHECK-SYSV:   invoke void @_Z15takesPrimitivesilcfdb
+// CHECK-SYSV:   invoke i32 @_Z10returnsIntv
+// CHECK-SYSV:   invoke i64 @_Z10takesInt64{{[lx]}}
+// CHECK-SYSV:   invoke void @_Z13takesPtrToIntPi
+// CHECK-SYSV:   invoke void @_Z18takesPtrToConstIntPKi
+// CHECK-SYSV:   invoke void @_Z14takesPtrToVoidPv
+// CHECK-SYSV:   invoke void @_Z12takesFuncPtrPFiiE
+// CHECK-SYSV:   invoke ptr @_Z15returnsPtrToIntv
+// CHECK-SYSV:   invoke void @_Z20takesNonnullPtrToIntPi
+// CHECK-SYSV:   invoke void @_Z8swapIntsPiS_
+// CHECK-SYSV:   invoke void @_Z18takesTrivialStruct13TrivialStruct
+// CHECK-SYSV:   invoke {{.*}} @_Z20returnsTrivialStructv
+// CHECK-SYSV:   invoke i32 @_Z17overloadedByArityi
+// CHECK-SYSV:   invoke i32 @_Z17overloadedByArityii
+// CHECK-SYSV:   invoke i32 @_Z14withDefaultArgii
+// CHECK-SYSV:   invoke i32 @externCFunc
+// CHECK-SYSV:   invoke i32 @_Z3fooi
+public func callCxxFuncs() {
+  takesPrimitives(1, 2, 3, 4, 5, true)
+  _ = returnsInt()
+  _ = takesInt64(42)
+
+  var x: CInt = 42
+  var y: CInt = 67
+  takesPtrToInt(&x)
+  takesPtrToConstInt(&x)
+  takesPtrToVoid(&x)
+  takesFuncPtr(foo)
+  _ = returnsPtrToInt()
+  takesNonnullPtrToInt(&x)
+  swapInts(&x, &y)
+
+  takesTrivialStruct(TrivialStruct(x: 1, y: 2))
+  _ = returnsTrivialStruct()
+
+  _ = overloadedByArity(42)
+  _ = overloadedByArity(42, 67)
+
+  _ = withDefaultArg(42, 67)
+
+  _ = externCFunc(42)
+
+  _ = foo(42)
+}

--- a/test/Serialization/Inputs/cxx-attr/cxx_attr.h
+++ b/test/Serialization/Inputs/cxx-attr/cxx_attr.h
@@ -1,0 +1,6 @@
+#ifndef TEST_SERIALIZATION_CXX_ATTR_H
+#define TEST_SERIALIZATION_CXX_ATTR_H
+
+int foo(int x);
+
+#endif

--- a/test/Serialization/Inputs/cxx-attr/module.modulemap
+++ b/test/Serialization/Inputs/cxx-attr/module.modulemap
@@ -1,0 +1,4 @@
+module CxxAttr {
+  header "cxx_attr.h"
+  requires cplusplus
+}

--- a/test/Serialization/cxx_attr.swift
+++ b/test/Serialization/cxx_attr.swift
@@ -1,0 +1,35 @@
+// The @cxx attribute (and the @implementation match it drives) must survive
+// serialization: compiling from a .sib must produce the same C++ entry point
+// as compiling from source.
+
+// RUN: %empty-directory(%t)
+
+// Ensure .swift -> .ll
+// RUN: %target-swift-frontend \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -I %S/Inputs/cxx-attr \
+// RUN:   -emit-ir %s | %FileCheck %s
+
+// Ensure .swift -> .sib -> .ll
+// RUN: %target-swift-frontend \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -I %S/Inputs/cxx-attr \
+// RUN:   -emit-sib %s -o %t/cxx_attr.sib
+// RUN: %target-swift-frontend \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature CxxImplementation \
+// RUN:   -I %S/Inputs/cxx-attr \
+// RUN:   -emit-sil %t/cxx_attr.sib | %FileCheck --check-prefix=SIL %s
+
+// REQUIRES: swift_feature_CxxImplementation
+
+import CxxAttr
+
+// CHECK: define {{.*}}@{{_Z3fooi|"\?foo@@YAHH@Z"}}
+
+// SIL: [asmname "{{_Z3fooi|\?foo@@YAHH@Z}}"]
+
+@cxx @implementation
+func foo(_ x: Int32) -> Int32 { return x }


### PR DESCRIPTION
Emit a matched `@cxx @implementation` function's body under the matched C++ declaration's mangled symbol so C++ callers link against the Swift definition directly.

A @cxx function's only callers are in C++, which the SIL optimizer cannot see; mark it as having foreign references so dead-function elimination does not delete a non-public implementation, and suppress the native Swift entry point.

rdar://185906680