### PR TITLE
Derive `CodingKey` via macro

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -274,6 +274,7 @@ enum class BuiltinDerivedConformanceMacroKind : uint8_t {
   DeriveCaseIterable,
   DeriveEncodable,
   DeriveDecodable,
+  DeriveCodingKey,
 
   NumKinds,
 };

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1611,6 +1611,13 @@ MacroDecl *ASTContext::getBuiltinDerivedConformanceMacroDecl(
                       {stringParam("", "infos")},
                       MacroIntroducedDeclName::getArbitrary());
     break;
+  case BuiltinDerivedConformanceMacroKind::DeriveCodingKey:
+    macro = makeMacro("_deriveCodingKey", "DeriveCodingKeyMacro",
+                      {stringParam("", "infos"), stringParam("", "witness"),
+                       stringParam("", "rawType"), boolParam("", "usingRaw")},
+                      MacroIntroducedDeclName::getArbitrary());
+    break;
+
   case BuiltinDerivedConformanceMacroKind::NumKinds:
     llvm_unreachable("not a real kind");
   }

--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -21,6 +21,7 @@ add_swift_macro_library(SwiftMacros
   DerivedConformances/DeriveCaseIterable.swift
   DerivedConformances/DeriveEquatable.swift
   DerivedConformances/DeriveHashable.swift
+  DerivedConformances/DeriveCodingKey.swift
   SWIFT_DEPENDENCIES
     SwiftDiagnostics
     SwiftSyntax

--- a/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveCodingKey.swift
+++ b/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveCodingKey.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// The type the `CodingKey` witness is centered around (either `String` or `Int`)
+enum CodingKeyType: TypeInfoProtocol {
+  case int
+  case string
+
+  static func fromSyntax(node: ExprSyntax) throws -> Self {
+    switch node.trimmedDescription {
+    case "int": return .int
+    case "string": return .string
+    default: fatalError("expected `int` or `string` but got `\(node.trimmedDescription)`")
+    }
+  }
+
+  var syntax: ExprSyntax {
+    "\(raw: self.prefix)"
+  }
+
+  var typeName: String {
+    switch self {
+    case .int: return "Swift::Int"
+    case .string: return "Swift::String"
+    }
+  }
+
+  var prefix: String {
+    switch self {
+    case .int: return "int"
+    case .string: return "string"
+    }
+  }
+}
+
+/// The kind of witness we want to derive, either `init?` or `var ...Value`
+enum CodingKeyWitness: TypeInfoProtocol {
+
+  /// `init?((int|string)Value:)`
+  case `init`
+
+  /// `var (int|string)Value`
+  case valueVar
+
+  static func fromSyntax(node: ExprSyntax) throws -> CodingKeyWitness {
+    switch node.trimmedDescription {
+    case "`init`", "init": return .`init`
+    case "valueVar": return .valueVar
+    default:
+      fatalError(
+        "Expected `init`, `valueVar` but got `\(node.trimmedDescription)`"
+      )
+    }
+  }
+
+  var syntax: ExprSyntax {
+    switch self {
+    case .`init`: return "init"
+    case .valueVar: return "valueVar"
+    }
+  }
+}
+
+/// Deriving macro for `CodingKey`
+public struct DeriveCodingKeyMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let (typeInfo, witnessKind, rawType, usingRaw) = try node.arguments.expect(
+      .init(parser: NominalTypeInfo.fromStringLit),
+      .init(parser: CodingKeyWitness.fromStringLit),
+      .init(parser: CodingKeyType.fromStringLit),
+      .boolArg(nil)
+    )
+
+    // If `usingRaw` is true, then we use the raw value of the enum to derive the
+    // witnesses
+
+    let enumInfo: EnumTypeInfo
+
+    switch typeInfo.kind {
+    case .enumLike(let info):
+      enumInfo = info
+    default: fatalError("Expected an enum")
+    }
+
+    let witness: DeclSyntax
+
+    switch witnessKind {
+    case .`init`: witness = expandInit(enumInfo, rawType, usingRaw)
+    case .valueVar: witness = expandValueVar(enumInfo, rawType, usingRaw)
+    }
+
+    return [witness]
+  }
+
+  static func expandInit(_ enumInfo: EnumTypeInfo, _ ty: CodingKeyType, _ usingRaw: Bool)
+    -> DeclSyntax
+  {
+    if usingRaw {
+      return
+        """
+        init?(\(raw: ty.prefix)Value: \(raw: ty.typeName)) {
+          self.init(rawValue: \(raw: ty.prefix)Value)
+        }
+        """
+    }
+
+    switch ty {
+    case .int:
+      // Can't init with an int value if we can't use the raw value path, so we return
+      // nil.
+      return
+        """
+        init?(intValue: Int) {
+            return nil
+        }
+        """
+    case .string:
+      // If we can't use the raw value path for a string argument, then we match against
+      // the enum elements names.
+      let cases = enumInfo.cases.compactMap { c -> String? in
+        guard let guards = c.constructionGuards() else { return nil }
+        let body = (guards + ["self = .\(c.name)"]).joined(separator: "\n  ")
+        return
+          """
+          case "\(c.rawName)":
+            \(body)
+          """
+      }.joined(separator: "\n")
+      return
+        """
+        init?(stringValue: Swift::String) {
+          switch stringValue {
+            \(raw: cases)
+            default: return nil
+          }
+        }
+        """
+    }
+
+  }
+
+  static func expandValueVar(_ enumInfo: EnumTypeInfo, _ ty: CodingKeyType, _ usingRaw: Bool)
+    -> DeclSyntax
+  {
+    let body: String
+    let retType: String
+    switch ty {
+    case .int:
+      retType = "\(ty.typeName)?"
+    case .string:
+      retType = ty.typeName
+    }
+
+    if usingRaw {
+      // use the raw value directly
+      body = "return self.rawValue"
+    } else {
+      switch ty {
+      // We always return nil for `intValue` if there is no raw value.
+      case .int:
+        body = "return nil"
+
+      // Return the (escaped) name of the element
+      case .string:
+        let cases = enumInfo.cases.map { c in
+          """
+          case .\(c.name): return "\(c.rawName)"
+          """
+        }.joined(separator: "\n")
+
+        if enumInfo.cases.isEmpty {
+          body =
+            """
+            return ""
+            """
+        } else {
+          body = """
+            switch self {
+              \(cases)
+            }
+            """
+        }
+      }
+    }
+
+    return
+      """
+      var \(raw: ty.prefix)Value: \(raw: retType) {
+        \(raw: body)
+      }
+      """
+  }
+}

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -80,6 +80,45 @@ public struct AvailabilityQuery {
   var constantResult: Bool?
 }
 
+extension AvailabilityQuery {
+  /// The `#available` or `#unavailable` condition that this query spells in
+  /// source.
+  var condition: String {
+    var spec = domain
+    if let primaryRange {
+      spec += " \(primaryRange)"
+    }
+    var specs = [spec]
+    if !isUnavailability && primaryRange != nil {
+      specs.append("*")
+    }
+
+    let keyword = isUnavailability ? "#unavailable" : "#available"
+    return "\(keyword)(\(specs.joined(separator: ", ")))"
+  }
+}
+
+extension EnumCaseInfo {
+  /// The `guard` statements that must precede a reference constructing this
+  /// case, each returning `nil` when its condition fails, or `nil` if the case
+  /// can never be constructed and must be left out of the initializer.
+  func constructionGuards() -> [String]? {
+    guard isConstructible else { return nil }
+
+    var guards: [String] = []
+    for query in runtimeAvailabilityQueries {
+      if let constantResult = query.constantResult {
+        if !constantResult {
+          return nil
+        }
+        continue
+      }
+      guards.append("guard \(query.condition) else { return nil }")
+    }
+    return guards
+  }
+}
+
 public struct StructTypeInfo {
   /// Information on all the struct's properties
   var properties: [StoredProperty]
@@ -558,6 +597,15 @@ extension EnumCaseInfo: TypeInfoProtocol {
     """
     EnumCaseInfo(name: \(stringlit(name)), associatedValueLabels: \(arraySyntax(associatedValueLabels, {optionalSyntax($0, stringlit)})), isReachable: \(boollit(isReachable)), isConstructible: \(boollit(isConstructible)), runtimeAvailabilityQueries: \(arraySyntax(runtimeAvailabilityQueries, \.syntax)))
     """
+  }
+}
+
+extension EnumCaseInfo {
+  public var rawName: String {
+    if name.starts(with: "`") {
+        return String(name.dropFirst().dropLast(1))
+    }
+    return name
   }
 }
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodingKey.cpp
@@ -21,8 +21,11 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Feature.h"
+#include "swift/Basic/QuotedString.h"
 
 using namespace swift;
 
@@ -333,6 +336,76 @@ static bool canSynthesizeCodingKey(DerivedConformance &derived) {
   return true;
 }
 
+static ValueDecl *deriveCodingKeyViaMacros(DerivedConformance &derived,
+                                           ValueDecl *requirement) {
+
+  // We can only synthesize CodingKey for enums.
+  auto *enumDecl = dyn_cast<EnumDecl>(derived.Nominal);
+  if (!enumDecl)
+    return nullptr;
+
+  // Check other preconditions for synthesized conformance.
+  if (!canSynthesizeCodingKey(derived))
+    return nullptr;
+
+  auto rawType = enumDecl->getRawType();
+  auto name = requirement->getBaseName();
+
+  bool isInit, isString, usingRaw;
+
+  auto computeRequirement = [&]() {
+    if (name == derived.Context.Id_stringValue) {
+      isInit = false;
+      isString = true;
+      usingRaw = rawType && rawType->isString();
+      return true;
+    }
+    if (name == derived.Context.Id_intValue) {
+      isInit = false;
+      isString = false;
+      usingRaw = rawType && rawType->isInt();
+      return true;
+    }
+    if (!name.isConstructor())
+      return false;
+
+    auto argumentNames = requirement->getName().getArgumentNames();
+
+    if (argumentNames.size() != 1)
+      return false;
+    if (argumentNames[0] == derived.Context.Id_stringValue) {
+      isInit = true;
+      isString = true;
+      usingRaw = rawType && rawType->isString();
+      return true;
+    }
+    if (argumentNames[0] == derived.Context.Id_intValue) {
+      isInit = true;
+      isString = false;
+      usingRaw = rawType && rawType->isInt();
+      return true;
+    }
+    return false;
+  };
+
+  if (!computeRequirement()) {
+    derived.Context.Diags.diagnose(requirement->getLoc(),
+                                   diag::broken_coding_key_requirement);
+    return nullptr;
+  }
+
+  std::string macro;
+  auto os = llvm::raw_string_ostream(macro);
+  os << "#_deriveCodingKey(" << QuotedString(getNominalTypeInfoString(derived))
+     << ", " << QuotedString(isInit ? "init" : "valueVar") << ", "
+     << QuotedString(isString ? "string" : "int") << ", "
+     << (usingRaw ? "true" : "false") << ")";
+  os.flush();
+  return deriveRequirementViaMacro(
+      derived, requirement, macro,
+      BuiltinDerivedConformanceMacroKind::DeriveCodingKey);
+}
+
 ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
 
   // We can only synthesize CodingKey for enums.
@@ -343,6 +416,9 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
   // Check other preconditions for synthesized conformance.
   if (!canSynthesizeCodingKey(*this))
     return nullptr;
+
+  if (Context.LangOpts.hasFeature(Feature::DeriveConformancesViaMacros))
+    return deriveCodingKeyViaMacros(*this, requirement);
 
   auto rawType = enumDecl->getRawType();
   auto name = requirement->getBaseName();

--- a/test/SILGen/derived_coding_key.swift
+++ b/test/SILGen/derived_coding_key.swift
@@ -1,0 +1,200 @@
+// RUN: %target-swift-frontend -emit-silgen -emit-sorted-sil %s -swift-version 4 -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
+// RUN: %target-swift-frontend -emit-silgen -emit-sorted-sil %s -swift-version 4 -enable-library-evolution -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
+// RUN: %target-swift-frontend -emit-silgen -emit-sorted-sil %s -swift-version 4 | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
+// RUN: %target-swift-frontend -emit-silgen -emit-sorted-sil %s -swift-version 4 -enable-library-evolution | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
+
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+// CHECK-LABEL: enum PlainEnum {
+enum PlainEnum {
+  // CHECK: case a
+  case a
+  // CHECK: case b
+  case b
+  // CHECK: case c
+  case c
+  // CHECK-DAG: init?(stringValue: String)
+  // CHECK-DAG: init?(intValue: Int)
+  // CHECK-DAG: var stringValue: String { get }
+  // CHECK-DAG: var intValue: Int? { get }
+}
+// CHECK: }
+
+extension PlainEnum: CodingKey {}
+
+// CHECK-LABEL: enum StringRawEnum : String {
+enum StringRawEnum: String {
+  // CHECK: case alpha
+  case alpha = "a"
+  // CHECK: case beta
+  case beta = "b"
+  // CHECK: case gamma
+  case gamma = "c"
+  // CHECK-DAG: init?(stringValue: String)
+  // CHECK-DAG: init?(intValue: Int)
+  // CHECK-DAG: var stringValue: String { get }
+  // CHECK-DAG: var intValue: Int? { get }
+}
+// CHECK: }
+
+extension StringRawEnum: CodingKey {}
+
+// CHECK-LABEL: enum IntRawEnum : Int {
+enum IntRawEnum: Int {
+  // CHECK: case one
+  case one = 1
+  // CHECK: case two
+  case two = 2
+  // CHECK: case three
+  case three = 3
+  // CHECK-DAG: init?(stringValue: String)
+  // CHECK-DAG: init?(intValue: Int)
+  // CHECK-DAG: var stringValue: String { get }
+  // CHECK-DAG: var intValue: Int? { get }
+}
+// CHECK: }
+
+extension IntRawEnum: CodingKey {}
+
+// CHECK-LABEL: enum EmptyEnum {
+enum EmptyEnum {
+  // CHECK-DAG: init?(stringValue: String)
+  // CHECK-DAG: init?(intValue: Int)
+  // CHECK-DAG: var stringValue: String { get }
+  // CHECK-DAG: var intValue: Int? { get }
+}
+// CHECK: }
+
+extension EmptyEnum: CodingKey {}
+
+// CHECK-LABEL: enum ManyEnum {
+enum ManyEnum {
+  // CHECK: case first
+  case first
+  // CHECK: case second
+  case second
+  // CHECK: case third
+  case third
+  // CHECK: case fourth
+  case fourth
+  // CHECK: case fifth
+  case fifth
+  // CHECK-DAG: init?(stringValue: String)
+  // CHECK-DAG: init?(intValue: Int)
+  // CHECK-DAG: var stringValue: String { get }
+  // CHECK-DAG: var intValue: Int? { get }
+}
+// CHECK: }
+
+extension ManyEnum: CodingKey {}
+
+// MARK: - Enum with unavailable cases
+
+@available(macOS 10.15, *)
+// CHECK-LABEL: enum AvailableEnum {
+enum AvailableEnum {
+  // CHECK: case old
+  case old
+  @available(macOS 11.0, *)
+  // CHECK: case new
+  case new
+  // CHECK-DAG: init?(stringValue: String)
+  // CHECK-DAG: init?(intValue: Int)
+  // CHECK-DAG: var stringValue: String { get }
+  // CHECK-DAG: var intValue: Int? { get }
+}
+// CHECK: }
+
+extension AvailableEnum: CodingKey {}
+
+// IntRawEnum
+
+// CHECK-LABEL: // IntRawEnum.init(stringValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}10IntRawEnumO11stringValueACSgSS_tcfC
+
+// CHECK-LABEL: // IntRawEnum.stringValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}10IntRawEnumO11stringValueSSvg
+
+// CHECK-LABEL: // IntRawEnum.init(intValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}10IntRawEnumO8intValueACSgSi_tcfC
+
+// CHECK-LABEL: // IntRawEnum.intValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}10IntRawEnumO8intValueSiSgvg
+
+// AvailableEnum
+
+// CHECK-LABEL: // AvailableEnum.init(stringValue:)
+// CHECK-NEXT: // Isolation: unspecified
+// CHECK-NEXT: sil hidden{{.*}}[ossa] @$s{{.*}}13AvailableEnumO11stringValueACSgSS_tcfC
+
+// CHECK-LABEL: // AvailableEnum.stringValue.getter
+// CHECK-NEXT: // Isolation: unspecified
+// CHECK-NEXT: sil hidden{{.*}}[ossa] @$s{{.*}}13AvailableEnumO11stringValueSSvg
+
+// StringRawEnum
+
+// CHECK-LABEL: // StringRawEnum.init(stringValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}13StringRawEnumO11stringValueACSgSS_tcfC
+
+// CHECK-LABEL: // StringRawEnum.stringValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}13StringRawEnumO11stringValueSSvg
+
+// CHECK-LABEL: // StringRawEnum.init(intValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}13StringRawEnumO8intValueACSgSi_tcfC
+
+// CHECK-LABEL: // StringRawEnum.intValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}13StringRawEnumO8intValueSiSgvg
+
+// EmptyEnum
+
+// CHECK-LABEL: // EmptyEnum.init(stringValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}9EmptyEnumO11stringValueACSgSS_tcfC
+
+// CHECK-LABEL: // EmptyEnum.stringValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}9EmptyEnumO11stringValueSSvg
+
+// CHECK-LABEL: // EmptyEnum.init(intValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}9EmptyEnumO8intValueACSgSi_tcfC
+
+// CHECK-LABEL: // EmptyEnum.intValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}9EmptyEnumO8intValueSiSgvg
+
+// PlainEnum
+
+// CHECK-LABEL: // PlainEnum.init(stringValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}9PlainEnumO11stringValueACSgSS_tcfC
+
+// CHECK-LABEL: // PlainEnum.stringValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}9PlainEnumO11stringValueSSvg
+
+// CHECK-LABEL: // PlainEnum.init(intValue:)
+// CHECK: sil hidden [ossa] @$s{{.*}}9PlainEnumO8intValueACSgSi_tcfC
+
+// CHECK-LABEL: // PlainEnum.intValue.getter
+// CHECK: sil hidden [ossa] @$s{{.*}}9PlainEnumO8intValueSiSgvg
+
+// Witness tables
+
+// CHECK-LABEL: sil_witness_table hidden IntRawEnum: CodingKey module {{.*}} {
+// CHECK: method #CodingKey.stringValue!getter
+// CHECK: method #CodingKey.init!allocator
+// CHECK: method #CodingKey.intValue!getter
+// CHECK: }
+
+// CHECK-LABEL: sil_witness_table hidden StringRawEnum: CodingKey module {{.*}} {
+// CHECK: method #CodingKey.stringValue!getter
+// CHECK: method #CodingKey.init!allocator
+// CHECK: method #CodingKey.intValue!getter
+// CHECK: }
+
+// CHECK-LABEL: sil_witness_table hidden EmptyEnum: CodingKey module {{.*}} {
+// CHECK: method #CodingKey.stringValue!getter
+// CHECK: method #CodingKey.init!allocator
+// CHECK: method #CodingKey.intValue!getter
+// CHECK: }
+
+// CHECK-LABEL: sil_witness_table hidden PlainEnum: CodingKey module {{.*}} {
+// CHECK: method #CodingKey.stringValue!getter
+// CHECK: method #CodingKey.init!allocator
+// CHECK: method #CodingKey.intValue!getter
+// CHECK: }

--- a/test/SILGen/synthesized_conformance_class_macros.swift
+++ b/test/SILGen/synthesized_conformance_class_macros.swift
@@ -11,13 +11,14 @@ final class Final<T> {
 // CHECK:   @_hasStorage final var x: T { get set }
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
-// CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var hashValue: Int { get }
-// CHECK:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Final<T>.CodingKeys, _ rhs: Final<T>.CodingKeys) -> Bool
-// CHECK:     init?(stringValue: String)
-// CHECK:     init?(intValue: Int)
-// CHECK:     var intValue: Int? { get }
-// CHECK:     var stringValue: String { get }
+// CHECK-DAG:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Final<T>.CodingKeys, _ rhs: Final<T>.CodingKeys) -> Bool
+// CHECK-DAG:     case x
+// CHECK-DAG:     init?(intValue: Int)
+// CHECK-DAG:     var intValue: Int? { get }
+// CHECK-DAG:     init?(stringValue: String)
+// CHECK-DAG:     var stringValue: String { get }
+// CHECK-DAG:     func hash(into hasher: inout Hasher)
+// CHECK-DAG:     var hashValue: Int { get }
 // CHECK:   }
 // CHECK:   deinit
 // CHECK: }
@@ -30,14 +31,14 @@ class Nonfinal<T> {
 // CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
-// CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var hashValue: Int { get }
-// CHECK:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Nonfinal<T>.CodingKeys, _ rhs: Nonfinal<T>.CodingKeys) -> Bool
-// CHECK:     case x
-// CHECK-DAG: init?(stringValue: String)
-// CHECK-DAG: init?(intValue: Int)
-// CHECK:     var intValue: Int? { get }
-// CHECK:     var stringValue: String { get }
+// CHECK-DAG:     @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Nonfinal<T>.CodingKeys, _ rhs: Nonfinal<T>.CodingKeys) -> Bool
+// CHECK-DAG:     case x
+// CHECK-DAG:     init?(stringValue: String)
+// CHECK-DAG:     init?(intValue: Int)
+// CHECK-DAG:     func hash(into hasher: inout Hasher)
+// CHECK-DAG:     var hashValue: Int { get }
+// CHECK-DAG:     var intValue: Int? { get }
+// CHECK-DAG:     var stringValue: String { get }
 // CHECK:   }
 // CHECK:   deinit
 // CHECK: }

--- a/test/SILGen/synthesized_conformance_struct_macros.swift
+++ b/test/SILGen/synthesized_conformance_struct_macros.swift
@@ -10,15 +10,15 @@ struct Struct<T> {
 // CHECK-LABEL: struct Struct<T> {
 // CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   enum CodingKeys : CodingKey {
-// CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var hashValue: Int { get }
-// CHECK-FRAGILE:   @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Struct<T>.CodingKeys, _ rhs: Struct<T>.CodingKeys) -> Bool
-// CHECK-RESILIENT: static func == (lhs: Struct<T>.CodingKeys, rhs: Struct<T>.CodingKeys) -> Bool
-// CHECK:     case x
+// CHECK-FRAGILE-DAG:   @_semantics("derived_enum_equals") @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ lhs: Struct<T>.CodingKeys, _ rhs: Struct<T>.CodingKeys) -> Bool
+// CHECK-RESILIENT-DAG: static func == (lhs: Struct<T>.CodingKeys, rhs: Struct<T>.CodingKeys) -> Bool
+// CHECK-DAG:     case x
 // CHECK-DAG:     init?(stringValue: String)
 // CHECK-DAG:     init?(intValue: Int)
-// CHECK:     var intValue: Int? { get }
-// CHECK:     var stringValue: String { get }
+// CHECK-DAG:     func hash(into hasher: inout Hasher)
+// CHECK-DAG:     var hashValue: Int { get }
+// CHECK-DAG:     var intValue: Int? { get }
+// CHECK-DAG:     var stringValue: String { get }
 // CHECK:   }
 // CHECK:   init(x: T)
 // CHECK: }

--- a/test/decl/enum/derived_coding_key.swift
+++ b/test/decl/enum/derived_coding_key.swift
@@ -1,0 +1,277 @@
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s
+
+// CHECK-LABEL: internal enum Simple : CodingKey
+enum Simple: CodingKey {
+  // CHECK:        case a
+  case a
+  // CHECK:        case b
+  case b
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "a":
+  // CHECK-NEXT:       self = Simple.a
+  // CHECK-NEXT:     case "b":
+  // CHECK-NEXT:       self = Simple.b
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     return nil
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return "a"
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return "b"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum StringRaw : String, CodingKey
+enum StringRaw: String, CodingKey {
+  // CHECK:        case alpha
+  case alpha = "a"
+  // CHECK:        case beta
+  case beta = "b"
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     self.init(rawValue: stringValue)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     return nil
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return self.rawValue
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum IntRaw : Int, CodingKey
+enum IntRaw: Int, CodingKey {
+  // CHECK:        case one
+  case one = 1
+  // CHECK:        case two
+  case two = 2
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "one":
+  // CHECK-NEXT:       self = IntRaw.one
+  // CHECK-NEXT:     case "two":
+  // CHECK-NEXT:       self = IntRaw.two
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     self.init(rawValue: intValue)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return self.rawValue
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .one:
+  // CHECK-NEXT:         return "one"
+  // CHECK-NEXT:       case .two:
+  // CHECK-NEXT:         return "two"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum Empty : CodingKey
+enum Empty: CodingKey {
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     return nil
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     return nil
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return ""
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum Escaped : CodingKey
+enum Escaped: CodingKey {
+  // CHECK:        case `default`
+  case `default`
+  // CHECK:        case `init`
+  case `init`
+  // CHECK:        case `self`
+  case `self`
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "default":
+  // CHECK-NEXT:       self = Escaped.default
+  // CHECK-NEXT:     case "init":
+  // CHECK-NEXT:       self = Escaped.init
+  // CHECK-NEXT:     case "self":
+  // CHECK-NEXT:       self = Escaped.self
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .default:
+  // CHECK-NEXT:         return "default"
+  // CHECK-NEXT:       case .init:
+  // CHECK-NEXT:         return "init"
+  // CHECK-NEXT:       case .self:
+  // CHECK-NEXT:         return "self"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum EscapedWithStringRaw : String, CodingKey
+enum EscapedWithStringRaw: String, CodingKey {
+  // CHECK:        case `default`
+  case `default` = "def"
+  // CHECK:        case `class`
+  case `class` = "cls"
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     self.init(rawValue: stringValue)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return self.rawValue
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum RawIdentifiers : CodingKey
+enum RawIdentifiers: CodingKey {
+  // CHECK:        case `hello world`
+  case `hello world`
+  // CHECK:        case `if`
+  case `if`
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "hello world":
+  // CHECK-NEXT:       self = RawIdentifiers.hello world
+  // CHECK-NEXT:     case "if":
+  // CHECK-NEXT:       self = RawIdentifiers.if
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .hello world:
+  // CHECK-NEXT:         return "hello world"
+  // CHECK-NEXT:       case .if:
+  // CHECK-NEXT:         return "if"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum HasUnavailableElement : CodingKey
+enum HasUnavailableElement: CodingKey {
+  // CHECK:        case a
+  case a
+  // CHECK:        @available(*, unavailable)
+  // CHECK-NEXT:   case b
+  @available(*, unavailable)
+  case b
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "a":
+  // CHECK-NEXT:       self = HasUnavailableElement.a
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return "a"
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return "b"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL: internal enum UnavailableEnum : CodingKey
+@available(*, unavailable)
+enum UnavailableEnum: CodingKey {
+  // CHECK:        case a
+  case a
+  // CHECK:        case b
+  case b
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "a":
+  // CHECK-NEXT:       self = UnavailableEnum.a
+  // CHECK-NEXT:     case "b":
+  // CHECK-NEXT:       self = UnavailableEnum.b
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return "a"
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return "b"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}

--- a/test/decl/enum/derived_coding_key_macos.swift
+++ b/test/decl/enum/derived_coding_key_macos.swift
@@ -1,0 +1,158 @@
+// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE50,CHECK-NO-APPEXT
+// RUN: %target-swift-frontend -application-extension -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE50,CHECK-APPEXT
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx51 -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-POST50,CHECK-NO-APPEXT
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx14 -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE50,CHECK-NO-APPEXT
+
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL: internal enum HasElementsWithAvailability : CodingKey
+enum HasElementsWithAvailability: CodingKey {
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case neverAvailable
+  @available(*, unavailable)
+  case neverAvailable
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  case unavailableMacOS
+  @available(macOS, unavailable)
+  case unavailableMacOS
+  // CHECK:       @available(macOS, obsoleted: 50)
+  // CHECK-NEXT:  case obsoleted50
+  @available(macOS, obsoleted: 50)
+  case obsoleted50
+  // CHECK:       @available(macOS 50, *)
+  // CHECK-NEXT:  case introduced50
+  @available(macOS, introduced: 50)
+  case introduced50
+  // CHECK:       @available(macOSApplicationExtension, unavailable)
+  // CHECK-NEXT:  case unavailableMacOSAppExtension
+  @available(macOSApplicationExtension, unavailable)
+  case unavailableMacOSAppExtension
+
+  // CHECK:                internal init?(stringValue: String) {
+  // CHECK-NEXT:             switch stringValue {
+  // CHECK-NEXT:             case "alwaysAvailable":
+  // CHECK-NEXT:               self = HasElementsWithAvailability.alwaysAvailable
+  // CHECK-PRE50-NEXT:       case "obsoleted50":
+  // CHECK-PRE50-NEXT:         self = HasElementsWithAvailability.obsoleted50
+  // CHECK-NEXT:             case "introduced50":
+  // CHECK-NEXT:               self = HasElementsWithAvailability.introduced50
+  // CHECK-NO-APPEXT-NEXT:   case "unavailableMacOSAppExtension":
+  // CHECK-NO-APPEXT-NEXT:     self = HasElementsWithAvailability.unavailableMacOSAppExtension
+  // CHECK-NEXT:             default:
+  // CHECK-NEXT:               return nil
+  // CHECK-NEXT:             }
+  // CHECK-NEXT:           }
+
+  // CHECK:       internal init?(intValue: Int) {
+  // CHECK-NEXT:    return nil
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var intValue: Int? {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return nil
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var stringValue: String {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      switch self {
+  // CHECK-NEXT:      case .alwaysAvailable:
+  // CHECK-NEXT:        return "alwaysAvailable"
+  // CHECK-NEXT:      case .neverAvailable:
+  // CHECK-NEXT:        return "neverAvailable"
+  // CHECK-NEXT:      case .unavailableMacOS:
+  // CHECK-NEXT:        return "unavailableMacOS"
+  // CHECK-NEXT:      case .obsoleted50:
+  // CHECK-NEXT:        return "obsoleted50"
+  // CHECK-NEXT:      case .introduced50:
+  // CHECK-NEXT:        return "introduced50"
+  // CHECK-NEXT:      case .unavailableMacOSAppExtension:
+  // CHECK-NEXT:        return "unavailableMacOSAppExtension"
+  // CHECK-NEXT:      }
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+}
+
+// CHECK-LABEL: internal enum StringRawWithAvailability : String, CodingKey
+enum StringRawWithAvailability: String, CodingKey {
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable = "a"
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case neverAvailable
+  @available(*, unavailable)
+  case neverAvailable = "n"
+  // CHECK:       @available(macOS 50, *)
+  // CHECK-NEXT:  case introduced50
+  @available(macOS, introduced: 50)
+  case introduced50 = "i"
+
+  // CHECK:                internal init?(rawValue: String) {
+  // CHECK-NEXT:             switch _findStringSwitchCase(cases: ["a", "i"], string: rawValue) {
+  // CHECK-NEXT:             case 0:
+  // CHECK-NEXT:               self = StringRawWithAvailability.alwaysAvailable
+  // CHECK-NEXT:             case 1:
+  // CHECK-PRE50-NEXT:         guard #available(macOS 50, *) else {
+  // CHECK-PRE50-NEXT:           return nil
+  // CHECK-PRE50-NEXT:         }
+  // CHECK-NEXT:               self = StringRawWithAvailability.introduced50
+  // CHECK-NEXT:             default:
+  // CHECK-NEXT:               return nil
+  // CHECK-NEXT:             }
+  // CHECK-NEXT:           }
+
+  // CHECK:       internal init?(stringValue: String) {
+  // CHECK-NEXT:    self.init(rawValue: stringValue)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal init?(intValue: Int) {
+  // CHECK-NEXT:    return nil
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var stringValue: String {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return self.rawValue
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+}
+
+// CHECK-LABEL: internal enum IntRawWithAvailability : Int, CodingKey
+enum IntRawWithAvailability: Int, CodingKey {
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable = 1
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  case unavailableMacOS
+  @available(macOS, unavailable)
+  case unavailableMacOS = 2
+
+  // CHECK:       internal init?(stringValue: String) {
+  // CHECK-NEXT:    switch stringValue {
+  // CHECK-NEXT:    case "alwaysAvailable":
+  // CHECK-NEXT:      self = IntRawWithAvailability.alwaysAvailable
+  // CHECK-NEXT:    default:
+  // CHECK-NEXT:      return nil
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal init?(intValue: Int) {
+  // CHECK-NEXT:    self.init(rawValue: intValue)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var intValue: Int? {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return self.rawValue
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var stringValue: String {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      switch self {
+  // CHECK-NEXT:      case .alwaysAvailable:
+  // CHECK-NEXT:        return "alwaysAvailable"
+  // CHECK-NEXT:      case .unavailableMacOS:
+  // CHECK-NEXT:        return "unavailableMacOS"
+  // CHECK-NEXT:      }
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+}

--- a/test/decl/enum/derived_coding_key_macos_macros.swift
+++ b/test/decl/enum/derived_coding_key_macos_macros.swift
@@ -1,0 +1,151 @@
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE50,CHECK-NO-APPEXT
+// RUN: %target-swift-frontend -application-extension -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE50,CHECK-APPEXT
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx51 -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-POST50,CHECK-NO-APPEXT
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx14 -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE50,CHECK-NO-APPEXT
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+// CHECK-LABEL: internal enum HasElementsWithAvailability : CodingKey
+enum HasElementsWithAvailability: CodingKey {
+ 
+  // CHECK:       internal init?(intValue: Int) {
+  // CHECK-NEXT:    return nil
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var intValue: Int? {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return nil
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:                internal init?(stringValue: String) {
+  // CHECK-NEXT:             switch stringValue {
+  // CHECK-NEXT:             case "alwaysAvailable":
+  // CHECK-NEXT:               self = .alwaysAvailable
+  // CHECK-PRE50-NEXT:       case "obsoleted50":
+  // CHECK-PRE50-NEXT:         self = .obsoleted50
+  // CHECK-NEXT:             case "introduced50":
+  // CHECK-PRE50-NEXT:               guard #available(macOS 50, *) else {
+  // CHECK-PRE50-NEXT:                 return nil
+  // CHECK-PRE50-NEXT:               }
+  // CHECK-NEXT:               self = .introduced50
+  // CHECK-NO-APPEXT-NEXT:   case "unavailableMacOSAppExtension":
+  // CHECK-NO-APPEXT-NEXT:     self = .unavailableMacOSAppExtension
+  // CHECK-NEXT:             default:
+  // CHECK-NEXT:               return nil
+  // CHECK-NEXT:             }
+  // CHECK-NEXT:           }
+
+  // CHECK:       internal var stringValue: String {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      switch self {
+  // CHECK-NEXT:      case .alwaysAvailable:
+  // CHECK-NEXT:        return "alwaysAvailable"
+  // CHECK-NEXT:      case .neverAvailable:
+  // CHECK-NEXT:        return "neverAvailable"
+  // CHECK-NEXT:      case .unavailableMacOS:
+  // CHECK-NEXT:        return "unavailableMacOS"
+  // CHECK-NEXT:      case .obsoleted50:
+  // CHECK-NEXT:        return "obsoleted50"
+  // CHECK-NEXT:      case .introduced50:
+  // CHECK-NEXT:        return "introduced50"
+  // CHECK-NEXT:      case .unavailableMacOSAppExtension:
+  // CHECK-NEXT:        return "unavailableMacOSAppExtension"
+  // CHECK-NEXT:      }
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+  
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case neverAvailable
+  @available(*, unavailable)
+  case neverAvailable
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  case unavailableMacOS
+  @available(macOS, unavailable)
+  case unavailableMacOS
+  // CHECK:       @available(macOS, obsoleted: 50)
+  // CHECK-NEXT:  case obsoleted50
+  @available(macOS, obsoleted: 50)
+  case obsoleted50
+  // CHECK:       @available(macOS 50, *)
+  // CHECK-NEXT:  case introduced50
+  @available(macOS, introduced: 50)
+  case introduced50
+  // CHECK:       @available(macOSApplicationExtension, unavailable)
+  // CHECK-NEXT:  case unavailableMacOSAppExtension
+  @available(macOSApplicationExtension, unavailable)
+  case unavailableMacOSAppExtension
+}
+
+// CHECK-LABEL: internal enum StringRawWithAvailability : String, CodingKey
+enum StringRawWithAvailability: String, CodingKey {
+  // CHECK:       internal init?(intValue: Int) {
+  // CHECK-NEXT:    return nil
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal init?(stringValue: String) {
+  // CHECK-NEXT:    self.init(rawValue: stringValue)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var stringValue: String {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return self.rawValue
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+ 
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable = "a"
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case neverAvailable
+  @available(*, unavailable)
+  case neverAvailable = "n"
+  // CHECK:       @available(macOS 50, *)
+  // CHECK-NEXT:  case introduced50
+  @available(macOS, introduced: 50)
+  case introduced50 = "i"
+
+}
+
+// CHECK-LABEL: internal enum IntRawWithAvailability : Int, CodingKey
+enum IntRawWithAvailability: Int, CodingKey {
+
+  // CHECK:       internal init?(intValue: Int) {
+  // CHECK-NEXT:    self.init(rawValue: intValue)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var intValue: Int? {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return self.rawValue
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal init?(stringValue: String) {
+  // CHECK-NEXT:    switch stringValue {
+  // CHECK-NEXT:    case "alwaysAvailable":
+  // CHECK-NEXT:      self = .alwaysAvailable
+  // CHECK-NEXT:    default:
+  // CHECK-NEXT:      return nil
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+  
+  // CHECK:       internal var stringValue: String {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      switch self {
+  // CHECK-NEXT:      case .alwaysAvailable:
+  // CHECK-NEXT:        return "alwaysAvailable"
+  // CHECK-NEXT:      case .unavailableMacOS:
+  // CHECK-NEXT:        return "unavailableMacOS"
+  // CHECK-NEXT:      }
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable = 1
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  case unavailableMacOS
+  @available(macOS, unavailable)
+  case unavailableMacOS = 2
+}

--- a/test/decl/enum/derived_coding_key_macros.swift
+++ b/test/decl/enum/derived_coding_key_macros.swift
@@ -1,0 +1,310 @@
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -print-ast %s | %FileCheck %s
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -print-ast %s | %FileCheck %s
+
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+// CHECK-LABEL: internal enum Simple : CodingKey
+enum Simple: CodingKey {
+
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     return nil
+  // CHECK-NEXT:   }
+  
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "a":
+  // CHECK-NEXT:       self = .a
+  // CHECK-NEXT:     case "b":
+  // CHECK-NEXT:       self = .b
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return "a"
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return "b"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case a
+  case a
+  // CHECK:        case b
+  case b
+}
+
+// A String raw type means both string witnesses forward to the raw value.
+
+// CHECK-LABEL: internal enum StringRaw : String, CodingKey
+enum StringRaw: String, CodingKey {
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     return nil
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     self.init(rawValue: stringValue)
+  // CHECK-NEXT:   }
+
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return self.rawValue
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case alpha
+  case alpha = "a"
+  // CHECK:        case beta
+  case beta = "b"
+}
+
+// An Int raw type means the int witnesses forward to the raw value, while the
+// string witnesses are still derived from the element names.
+
+// CHECK-LABEL: internal enum IntRaw : Int, CodingKey
+enum IntRaw: Int, CodingKey {
+
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     self.init(rawValue: intValue)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return self.rawValue
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "one":
+  // CHECK-NEXT:       self = .one
+  // CHECK-NEXT:     case "two":
+  // CHECK-NEXT:       self = .two
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .one:
+  // CHECK-NEXT:         return "one"
+  // CHECK-NEXT:       case .two:
+  // CHECK-NEXT:         return "two"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case one
+  case one = 1
+  // CHECK:        case two
+  case two = 2
+}
+
+// CHECK-LABEL: internal enum Empty : CodingKey
+enum Empty: CodingKey {
+
+  // CHECK:        internal init?(intValue: Int) {
+  // CHECK-NEXT:     return nil
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var intValue: Int? {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return ""
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// The string value of an escaped element is its name without the backticks.
+
+// CHECK-LABEL: internal enum Escaped : CodingKey
+enum Escaped: CodingKey {
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "default":
+  // CHECK-NEXT:       self = .default
+  // CHECK-NEXT:     case "init":
+  // CHECK-NEXT:       self = .init
+  // CHECK-NEXT:     case "self":
+  // CHECK-NEXT:       self = .self
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .default:
+  // CHECK-NEXT:         return "default"
+  // CHECK-NEXT:       case .init:
+  // CHECK-NEXT:         return "init"
+  // CHECK-NEXT:       case .self:
+  // CHECK-NEXT:         return "self"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case `default`
+  case `default`
+  // CHECK:        case `init`
+  case `init`
+  // CHECK:        case `self`
+  case `self`
+}
+
+// CHECK-LABEL: internal enum EscapedWithStringRaw : String, CodingKey
+enum EscapedWithStringRaw: String, CodingKey {
+
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     self.init(rawValue: stringValue)
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return self.rawValue
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case `default`
+  case `default` = "def"
+  // CHECK:        case `class`
+  case `class` = "cls"
+}
+
+// CHECK-LABEL: internal enum RawIdentifiers : CodingKey
+enum RawIdentifiers: CodingKey {
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "hello world":
+  // CHECK-NEXT:       self = .hello world
+  // CHECK-NEXT:     case "if":
+  // CHECK-NEXT:       self = .if
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .hello world:
+  // CHECK-NEXT:         return "hello world"
+  // CHECK-NEXT:       case .if:
+  // CHECK-NEXT:         return "if"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case `hello world`
+  case `hello world`
+  // CHECK:        case `if`
+  case `if`
+
+}
+
+// Unavailable elements can't be produced at runtime, so `init?(stringValue:)`
+// never matches them. `stringValue` still has to handle them, since an
+// unavailable element may still be formed in unavailable code.
+
+// CHECK-LABEL: internal enum HasUnavailableElement : CodingKey
+enum HasUnavailableElement: CodingKey {
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "a":
+  // CHECK-NEXT:       self = .a
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return "a"
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return "b"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case a
+  case a
+  // CHECK:        @available(*, unavailable)
+  // CHECK-NEXT:   case b
+  @available(*, unavailable)
+  case b
+
+}
+
+// An unavailable enum has available elements, so nothing is skipped.
+
+// CHECK-LABEL: internal enum UnavailableEnum : CodingKey
+@available(*, unavailable)
+enum UnavailableEnum: CodingKey {
+
+
+  // CHECK:        internal init?(stringValue: String) {
+  // CHECK-NEXT:     switch stringValue {
+  // CHECK-NEXT:     case "a":
+  // CHECK-NEXT:       self = .a
+  // CHECK-NEXT:     case "b":
+  // CHECK-NEXT:       self = .b
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        internal var stringValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return "a"
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return "b"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK:        case a
+  case a
+  // CHECK:        case b
+  case b
+}


### PR DESCRIPTION
Move `CodingKey` derivation to a macro under a feature flag.

Adds a `DeriveConformancesViaMacros` feature flag path for deriving `CodingKey`'s `init?(stringValue:)`, `init?(intValue:)`, `var stringValue` and `var intValue` on enums. 

When enabled, `DerivedConformance::deriveCodingKey` builds a `#_deriveCodingKey(...)` macro call instead of hand-crafting the AST nodes, and the new `DeriveCodingKeyMacro` (in `SwiftMacros`) expands it.

Type info is encoded the same way as for `Equatable`, reusing `getNominalTypeInfoString`. The witness to derived is described in the two other string arguments passed to the macro.

The non-macro path is untouched. This is opt-in via the feature flag.

Note: This PR is meant to be merged after #91882 as it contains its changes.