### PR TITLE
[Demangling] Check the payload kinds in keyPathSourceString.

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3803,10 +3803,17 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
           if (node->getKind() == Node::Kind::Identifier) {
             return std::string(node->getText());
           }
-          if (node->getKind() == Node::Kind::LocalDeclName) {
-            auto text = node->getChild(1)->getText();
-            auto index = node->getChild(0)->getIndex() + 1;
-            return std::string(text) + " #" + std::to_string(index);
+          if (node->getKind() == Node::Kind::LocalDeclName &&
+              node->getNumChildren() >= 2) {
+            // Only attempt to generate a string if the child nodes are an index
+            // (discriminator) followed by text (name).
+            NodePointer discriminator = node->getChild(0);
+            NodePointer name = node->getChild(1);
+            if (name->hasText() && discriminator->hasIndex()) {
+              auto index = discriminator->getIndex() + 1;
+              return std::string(name->getText()) + " #" +
+                     std::to_string(index);
+            }
           }
           return std::string("<unknown>");
         };

--- a/unittests/Basic/DemangleTest.cpp
+++ b/unittests/Basic/DemangleTest.cpp
@@ -159,3 +159,14 @@ TEST(Demangle, OldFunctionTypeManglingFlagSavedAcrossDemangle) {
       << "IsOldFunctionTypeMangling leaked across DemangleInitRAII";
 }
 
+// A LocalDeclName whose name child is itself a LocalDeclName carries children
+// rather than text, so reading text off it reads the children as a StringRef.
+TEST(Demangle, KeyPathSourceStringNestedLocalDeclName) {
+  static const char nested[] = "$s4main1SVySiAA3fooL_L_VcipACTK";
+  EXPECT_EQ("subscript(_: <unknown>)",
+            keyPathSourceString(nested, sizeof(nested) - 1));
+
+  static const char local[] = "$s4main1SVySiAA3fooL_VcipACTK";
+  EXPECT_EQ("subscript(_: foo #1)",
+            keyPathSourceString(local, sizeof(local) - 1));
+}


### PR DESCRIPTION
Return `"<unknown>"` for a LocalDeclName whose discriminator does not hold an index or whose name child does not hold text.

rdar://185742726