### PR TITLE
[Demangling] Bound the substitution hashing and comparison walks.

### DIFF
--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -58,13 +58,17 @@ bool SubstitutionEntry::identifierEquals(Node *lhs, Node *rhs) {
   return true;
 }
 
-bool SubstitutionEntry::deepEquals(Node *lhs, Node *rhs) const {
+bool SubstitutionEntry::deepEquals(Node *lhs, Node *rhs,
+                                   unsigned depth) const {
+  if (depth > MaxSubstitutionEntryDepth)
+    return false;
+
   if (!lhs->isSimilarTo(rhs))
     return false;
 
   for (auto li = lhs->begin(), ri = rhs->begin(), le = lhs->end();
        li != le; ++li, ++ri) {
-    if (!deepEquals(*li, *ri))
+    if (!deepEquals(*li, *ri, depth + 1))
       return false;
   }
 
@@ -76,8 +80,8 @@ static inline size_t combineHash(size_t currentHash, size_t newValue) {
 }
 
 /// Calculate the hash for a node.
-size_t RemanglerBase::hashForNode(Node *node,
-                                  bool treatAsIdentifier) {
+size_t RemanglerBase::hashForNode(Node *node, bool treatAsIdentifier,
+                                  unsigned depth) {
   size_t hash = 0;
 
   if (treatAsIdentifier) {
@@ -104,9 +108,12 @@ size_t RemanglerBase::hashForNode(Node *node,
       hash = combineHash(hash, (unsigned char) c);
     }
   }
-  for (Node *child : *node) {
-    SubstitutionEntry entry = entryForNode(child, treatAsIdentifier);
-    hash = combineHash(hash, entry.hash());
+  if (depth < MaxSubstitutionEntryDepth) {
+    for (Node *child : *node) {
+      SubstitutionEntry entry =
+          entryForNode(child, treatAsIdentifier, depth + 1);
+      hash = combineHash(hash, entry.hash());
+    }
   }
 
   return hash;
@@ -143,7 +150,8 @@ static inline size_t nodeHash(Node *node) {
 /// This will look in the HashHash to see if we already know the hash
 /// (which avoids recursive hashing on the Node tree).
 SubstitutionEntry RemanglerBase::entryForNode(Node *node,
-                                              bool treatAsIdentifier) {
+                                              bool treatAsIdentifier,
+                                              unsigned depth) {
   const size_t ident = treatAsIdentifier ? 4 : 0;
   const size_t hash = nodeHash(node) + ident;
 
@@ -153,7 +161,7 @@ SubstitutionEntry RemanglerBase::entryForNode(Node *node,
     SubstitutionEntry entry = HashHash[ndx];
 
     if (entry.isEmpty()) {
-      size_t entryHash = hashForNode(node, treatAsIdentifier);
+      size_t entryHash = hashForNode(node, treatAsIdentifier, depth);
       entry.setNode(node, treatAsIdentifier, entryHash);
       HashHash[ndx] = entry;
       return entry;
@@ -164,7 +172,7 @@ SubstitutionEntry RemanglerBase::entryForNode(Node *node,
 
   // Hash table is full at this hash value
   SubstitutionEntry entry;
-  size_t entryHash = hashForNode(node, treatAsIdentifier);
+  size_t entryHash = hashForNode(node, treatAsIdentifier, depth);
   entry.setNode(node, treatAsIdentifier, entryHash);
   return entry;
 }

--- a/lib/Demangling/RemanglerBase.h
+++ b/lib/Demangling/RemanglerBase.h
@@ -83,8 +83,18 @@ private:
 
   static bool identifierEquals(Node *lhs, Node *rhs);
 
-  bool deepEquals(Node *lhs, Node *rhs) const;
+  /// Compare two subtrees for equality.
+  ///
+  /// \p depth bounds the walk, as in RemanglerBase::hashForNode. A pair deeper
+  /// than the bound compares unequal, so an over-deep node is never used as a
+  /// substitution; the mangler's own depth limit then fails the mangling with
+  /// ManglingError::TooComplex.
+  bool deepEquals(Node *lhs, Node *rhs, unsigned depth = 0) const;
 };
+
+/// The limit on the depth of a node subtree walked while hashing or comparing
+/// substitution entries, to avoid stack exhaustion.
+constexpr unsigned MaxSubstitutionEntryDepth = 1024;
 
 /// The output string for the Remangler.
 ///
@@ -167,12 +177,19 @@ protected:
     : Factory(Factory), Buffer(Factory) { }
 
   /// Compute the hash for a node.
-  size_t hashForNode(Node *node, bool treatAsIdentifier = false);
+  ///
+  /// \p depth bounds the walk over \p node's subtree, which for an untrusted
+  /// mangled name can be deep enough to exhaust the stack. A subtree deeper
+  /// than the bound hashes as though it were truncated there, which costs
+  /// nothing: equality is decided by deepEquals, not by the hash.
+  size_t hashForNode(Node *node, bool treatAsIdentifier = false,
+                     unsigned depth = 0);
 
   /// Construct a SubstitutionEntry for a given node.
   /// This will look in the HashHash to see if we already know the hash,
   /// to avoid having to walk the entire subtree.
-  SubstitutionEntry entryForNode(Node *node, bool treatAsIdentifier = false);
+  SubstitutionEntry entryForNode(Node *node, bool treatAsIdentifier = false,
+                                 unsigned depth = 0);
 
   /// Find a substitution and return its index.
   /// Returns -1 if no substitution is found.

--- a/test/Demangle/recursion-limit.swift
+++ b/test/Demangle/recursion-limit.swift
@@ -1,6 +1,6 @@
 ; This is not really a Swift source file: -*- Text -*-
 
-; We need sed, so Windows is out
+; We need sed and awk, so Windows is out
 UNSUPPORTED: OS=windows-msvc
 
 RUN: swift-demangle < %S/Inputs/bigtype.txt 2>&1 > %t.check
@@ -11,4 +11,14 @@ RUN: %diff -u %S/Inputs/bigtype-remangle.txt %t.check
 
 RUN: swift-demangle -remangle-objc-rt < %S/Inputs/bigtype.txt 2>&1 | sed 's/([0-9]*:[0-9]*)/(pos)/g' > %t.check || true
 RUN: %diff -u %S/Inputs/bigtype-objcrt.txt %t.check
+
+; The names above trip mangle()'s own depth limit. A long class context chain
+; reaches the substitution hashing and comparison walks, which have their own
+; depth limit. limit does not cover. The trailing Protocol node keeps
+; TypeDecoder's depth cap from rejecting the chain first.
+
+RUN: awk 'BEGIN{ ORS=""; print "$s1M"; for (i = 0; i < 300000; i++) print "1aC"; print "4ProtP\n" }' > %t.deep
+RUN: swift-demangle -remangle-new < %t.deep > %t.deep.check 2>&1 || true
+RUN: %FileCheck %s < %t.deep.check
+CHECK: unable to re-mangle
 


### PR DESCRIPTION
Thread a depth through RemanglerBase::hashForNode, RemanglerBase::entryForNode, and SubstitutionEntry::deepEquals, and stop the walk at MaxSubstitutionEntryDepth rather than crashing due to stack exhaustion.

rdar://185782570