### PR TITLE
[RemoteMirror] Test the error, not the zeroed result, in swift_reflection_asyncTaskSlabAllocations.

### DIFF
--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -1030,7 +1030,7 @@ swift_reflection_asyncTaskSlabAllocations(SwiftReflectionContextRef ContextRef,
     auto [Error, Info] = Context->asyncTaskSlabAllocations(SlabPtr);
 
     swift_async_task_slab_allocations_return_t Result = {};
-    if (Result.Error) {
+    if (Error) {
       Result.Error = returnableCString(ContextRef, Error);
       return Result;
     }


### PR DESCRIPTION
The guard tested Result.Error, which the line above set to null. Test Error instead.

rdar://186318037