### PR TITLE
CopyToBorrowOptimization: extend the borrow scope of the load's base reference

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
@@ -104,11 +104,33 @@ private func optimize(load: LoadInst, _ context: FunctionPassContext) -> Bool {
     return false
   }
 
-  if mayWrite(toAddressOf: load, within: collectedUses.destroys, context) {
-    return false
+  // If the loaded address is a projection of a borrowed reference, the borrow scope of that reference
+  // must enclose the whole lifetime of the new `load_borrow`.
+  if let baseReference = load.address.accessBase.reference,
+     let baseBorrow = BeginBorrowValue(baseReference.lookThroughForwardingInstructions)
+  {
+    // The `end_borrow`s of `baseBorrow` are not considered to be writes here, because that borrow scope is
+    // extended beyond the load's liverange below. If it cannot be extended, this function bails out.
+    if mayWrite(toAddressOf: load, within: collectedUses.destroys, ignoreEndBorrowsOf: baseBorrow, context) {
+      return false
+    }
+
+    var liverange = InstructionRange(begin: load, context)
+    defer { liverange.deinitialize() }
+    liverange.insert(contentsOf: collectedUses.destroys.lazy.map { $0.next! })
+
+    guard extendBorrowScope(of: baseBorrow.value, toOverlap: liverange, context) else {
+      return false
+    }
+    load.replaceWithLoadBorrow(collectedUses: collectedUses, enclosingBorrow: baseBorrow.value)
+  } else {
+    // The address is not derived from a borrowed reference.
+    if mayWrite(toAddressOf: load, within: collectedUses.destroys, context) {
+      return false
+    }
+    load.replaceWithLoadBorrow(collectedUses: collectedUses)
   }
 
-  load.replaceWithLoadBorrow(collectedUses: collectedUses)
   return true
 }
 
@@ -383,6 +405,7 @@ private struct AllocStackUsesWalker : AddressDefUseWalker {
 private func mayWrite(
   toAddressOf load: LoadInst,
   within destroys: Stack<Instruction>,
+  ignoreEndBorrowsOf borrowToIgnore: BeginBorrowValue? = nil,
   _ context: FunctionPassContext
 ) -> Bool {
   let aliasAnalysis = context.aliasAnalysis
@@ -395,7 +418,9 @@ private func mayWrite(
 
   // Visit all instructions starting from the destroys in backward order.
   while let inst = worklist.pop() {
-    if inst.mayWrite(toAddress: load.address, aliasAnalysis) {
+    if inst.mayWrite(toAddress: load.address, aliasAnalysis),
+       !inst.isEndBorrow(ofScope: borrowToIgnore)
+    {
       return true
     }
     worklist.pushPredecessors(of: inst, ignoring: load)
@@ -404,7 +429,7 @@ private func mayWrite(
 }
 
 private extension LoadInst {
-  func replaceWithLoadBorrow(collectedUses: Uses) {
+  func replaceWithLoadBorrow(collectedUses: Uses, enclosingBorrow: Value? = nil) {
     let context = collectedUses.context
     let builder = Builder(before: self, context)
     let loadBorrow = builder.createLoadBorrow(fromAddress: address)
@@ -412,7 +437,8 @@ private extension LoadInst {
     var liverange = InstructionRange(begin: self, ends: collectedUses.destroys, context)
     defer { liverange.deinitialize() }
 
-    createEndBorrows(for: loadBorrow, atEndOf: liverange, collectedUses: collectedUses)
+    createEndBorrows(for: loadBorrow, atEndOf: liverange, collectedUses: collectedUses,
+                     enclosingBorrow: enclosingBorrow)
 
     uses.replaceAll(with: loadBorrow, context)
     context.erase(instruction: self)
@@ -440,7 +466,11 @@ private func remove(copy: CopyValueInst, collectedUses: Uses, liverange: Instruc
   }
 }
 
-private func createEndBorrows(for beginBorrow: Value, atEndOf liverange: InstructionRange, collectedUses: Uses) {
+private func createEndBorrows(for beginBorrow: Value,
+                              atEndOf liverange: InstructionRange,
+                              collectedUses: Uses,
+                              enclosingBorrow: Value? = nil
+) {
   let context = collectedUses.context
 
   // There can be multiple destroys in a row in case of decomposing an aggregate, e.g.
@@ -461,9 +491,28 @@ private func createEndBorrows(for beginBorrow: Value, atEndOf liverange: Instruc
 
   while let endInst = allLifetimeEndingInstructions.pop() {
     if !liverange.contains(endInst) {
-      let builder = Builder(before: endInst, context)
+      var insertionPoint = endInst
+      if let enclosingBorrow {
+        // If we already inserted `end_borrow`s for an enclosing scope - e.g. when the borrow scope of the
+        // load's base was extended - we need to make sure that the `end_borrow`s for this (inner) scope are
+        // inserted before the `end_borrow`s of the enclosing scope.
+        while let prev = insertionPoint.previous as? EndBorrowInst, prev.borrow == enclosingBorrow {
+          insertionPoint = prev
+        }
+      }
+      let builder = Builder(before: insertionPoint, context)
       builder.createEndBorrow(of: beginBorrow)
     }
+  }
+}
+
+private extension Instruction {
+  /// True if this is an `end_borrow` which ends the borrow scope of `beginBorrow`.
+  func isEndBorrow(ofScope beginBorrow: BeginBorrowValue?) -> Bool {
+    guard let beginBorrow, let endBorrow = self as? EndBorrowInst else {
+      return false
+    }
+    return endBorrow.borrow == beginBorrow.value
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
@@ -194,13 +194,22 @@ private struct Uses {
   // Exit blocks of the load/copy_value's liverange which don't have a destroy.
   // Those are successor blocks of terminators, like `switch_enum`, which do _not_ forward the value.
   // E.g. the none-case of a switch_enum of an Optional.
-  private(set) var nonDestroyingLiverangeExits: Stack<Instruction>
+  // Note: we cannot just store the first instruction of a basic block, because that might get deleted
+  //       before we use the results of `nonDestroyingLiverangeExitBlocks`.
+  private(set) var nonDestroyingLiverangeExitBlocks: Stack<BasicBlock>
+
+  // Forwarding instructions which end the lifetime without a destroy, e.g. an `unchecked_enum_data`
+  // which extracts a trivial payload out of a non-trivial enum.
+  // Note: we cannot just store the next instruction after the forwarding instruction (which we eventually
+  //       need) because that might get deleted before we use the results of `nonDestroyingForwardingEnds`.
+  private(set) var nonDestroyingForwardingEnds: Stack<ForwardingInstruction>
 
   init(_ context: FunctionPassContext) {
     self.context = context
     self.forwardingUses = Stack(context)
     self.destroys = Stack(context)
-    self.nonDestroyingLiverangeExits = Stack(context)
+    self.nonDestroyingLiverangeExitBlocks = Stack(context)
+    self.nonDestroyingForwardingEnds = Stack(context)
   }
 
   mutating func collectUses(of initialValue: SingleValueInstruction) -> Bool {
@@ -287,20 +296,21 @@ private struct Uses {
       // A terminator instruction can implicitly end the lifetime of its operand in a success block,
       // e.g. a `switch_enum` with a non-payload case block. Such success blocks need an `end_borrow`, though.
       for succ in termInst.successors where !succ.arguments.contains(where: {$0.ownership == .owned}) {
-        nonDestroyingLiverangeExits.append(succ.instructions.first!)
+        nonDestroyingLiverangeExitBlocks.append(succ)
       }
     } else if !forwardingInst.forwardedResults.contains(where: { $0.ownership == .owned }) {
       // The forwarding instruction has no owned result, which means it ends the lifetime of its owned operand.
       // This can happen with an `unchecked_enum_data` which extracts a trivial payload out of a
       // non-trivial enum.
-      nonDestroyingLiverangeExits.append(forwardingInst.next!)
+      nonDestroyingForwardingEnds.append(forwardingInst)
     }
   }
 
   mutating func deinitialize() {
     forwardingUses.deinitialize()
     destroys.deinitialize()
-    nonDestroyingLiverangeExits.deinitialize()
+    nonDestroyingLiverangeExitBlocks.deinitialize()
+    nonDestroyingForwardingEnds.deinitialize()
   }
 }
 
@@ -483,7 +493,12 @@ private func createEndBorrows(for beginBorrow: Value,
 
   var allLifetimeEndingInstructions = InstructionWorklist(context)
   allLifetimeEndingInstructions.pushIfNotVisited(contentsOf: collectedUses.destroys.lazy.map { $0 })
-  allLifetimeEndingInstructions.pushIfNotVisited(contentsOf: collectedUses.nonDestroyingLiverangeExits)
+  allLifetimeEndingInstructions.pushIfNotVisited(contentsOf: collectedUses.nonDestroyingLiverangeExitBlocks.lazy.map {
+    $0.instructions.first!
+  })
+  allLifetimeEndingInstructions.pushIfNotVisited(contentsOf: collectedUses.nonDestroyingForwardingEnds.lazy.map {
+    $0.next!
+  })
 
   defer {
     allLifetimeEndingInstructions.deinitialize()

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -31,7 +31,7 @@ public struct Builder {
 
   /// Creates a builder which inserts _before_ `insPnt`, using a custom `location`.
   public init(before insPnt: Instruction, location: Location, _ context: some MutatingContext) {
-    context.verifyIsTransforming(function: insPnt.parentFunction)
+    context.verifyModifying(instruction: insPnt)
     self.init(insertAt: .before(insPnt), location: location, context.notifyInstructionChanged, context._bridged)
   }
 
@@ -42,7 +42,7 @@ public struct Builder {
   /// For replacing an existing meta instruction with another, use
   /// ``Builder.init(replacing:_:)``.
   public init(before insPnt: Instruction, _ context: some MutatingContext) {
-    context.verifyIsTransforming(function: insPnt.parentFunction)
+    context.verifyModifying(instruction: insPnt)
     self.init(insertAt: .before(insPnt), location: insPnt.location,
               context.notifyInstructionChanged, context._bridged)
   }
@@ -51,7 +51,7 @@ public struct Builder {
   /// for the purpose of replacing that meta instruction with an equivalent instruction.
   /// This function does not delete `insPnt`.
   public init(replacing insPnt: MetaInstruction, _ context: some MutatingContext) {
-    context.verifyIsTransforming(function: insPnt.parentFunction)
+    context.verifyModifying(instruction: insPnt)
     self.init(insertAt: .before(insPnt), location: insPnt.location, context.notifyInstructionChanged, context._bridged)
   }
 
@@ -60,7 +60,7 @@ public struct Builder {
   /// TODO: this is usually incorrect for terminator instructions. Instead use
   /// `Builder.insert(after:location:_:insertFunc)` from OptUtils.swift. Rename this to afterNonTerminator.
   public init(after insPnt: Instruction, location: Location, _ context: some MutatingContext) {
-    context.verifyIsTransforming(function: insPnt.parentFunction)
+    context.verifyModifying(instruction: insPnt)
     guard let nextInst = insPnt.next else {
       fatalError("cannot insert an instruction after a block terminator.")
     }

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -130,6 +130,14 @@ extension MutatingContext {
     precondition(_bridged.isTransforming(function.bridged), "pass modifies wrong function")
   }
 
+  /// Verifies that:
+  /// - the instruction is not deleted
+  /// - the parent function is the currently transformed function
+  public func verifyModifying(instruction: Instruction) {
+    precondition(!instruction.isDeleted, "trying to modify or use a deleted instruction")
+    verifyIsTransforming(function: instruction.parentFunction)
+  }
+
   public func notifyInstructionsChanged() {
     _bridged.notifyChanges(.Instructions)
   }

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -133,6 +133,8 @@ class ClassLet {
   @_hasStorage var aVar: Klass
   @_hasStorage let aLetTuple: (Klass, Klass)
   @_hasStorage let anOptionalLet: FakeOptional<Klass>
+  @_hasStorage let aTupleWithOptional: (Klass, FakeOptional<Klass>)
+  @_hasStorage let aMultiPayloadTuple: (Klass, MultiPayload)
 
   @_hasStorage let anotherLet: ClassLet
 }
@@ -2735,5 +2737,57 @@ bb0(%0 : @owned $C):
   store %1 to [init] %2
   destroy_value [dead_end] %0
   unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @end_borrow_at_begin_of_non_destroying_liverange_exit :
+// CHECK:         [[OUTER:%.*]] = begin_borrow %0
+// CHECK:         [[INNER:%.*]] = load_borrow
+// CHECK:       bb2:
+// CHECK-NEXT:    end_borrow [[INNER]]
+// CHECK-NEXT:    end_borrow [[OUTER]]
+// CHECK-LABEL: } // end sil function 'end_borrow_at_begin_of_non_destroying_liverange_exit'
+sil [ossa] @end_borrow_at_begin_of_non_destroying_liverange_exit : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%0 : @owned $ClassLet):
+  %1 = begin_borrow %0 : $ClassLet
+  %2 = ref_element_addr [immutable] %1 : $ClassLet, #ClassLet.aTupleWithOptional
+  %3 = load [copy] %2 : $*(Klass, FakeOptional<Klass>)
+  (%4, %5) = destructure_tuple %3 : $(Klass, FakeOptional<Klass>)
+  switch_enum %5 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%6 : @owned $Klass):
+  destroy_value %6 : $Klass
+  destroy_value %4 : $Klass
+  end_borrow %1 : $ClassLet
+  br bb3
+
+bb2:
+  end_borrow %1 : $ClassLet
+  destroy_value %4 : $Klass
+  br bb3
+
+bb3:
+  destroy_value %0 : $ClassLet
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @end_borrow_after_non_destroying_forwarding_end :
+// CHECK:         [[OUTER:%.*]] = begin_borrow %0
+// CHECK:         [[INNER:%.*]] = load_borrow
+// CHECK:         end_borrow [[INNER]]
+// CHECK-NEXT:    end_borrow [[OUTER]]
+// CHECK-LABEL: } // end sil function 'end_borrow_after_non_destroying_forwarding_end'
+sil [ossa] @end_borrow_after_non_destroying_forwarding_end : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%0 : @owned $ClassLet):
+  %1 = begin_borrow %0 : $ClassLet
+  %2 = ref_element_addr [immutable] %1 : $ClassLet, #ClassLet.aMultiPayloadTuple
+  %3 = load [copy] %2 : $*(Klass, MultiPayload)
+  (%4, %5) = destructure_tuple %3 : $(Klass, MultiPayload)
+  %6 = unchecked_enum_data %5 : $MultiPayload, #MultiPayload.b!enumelt
+  end_borrow %1 : $ClassLet
+  destroy_value %4 : $Klass
+  destroy_value %0 : $ClassLet
+  %r = tuple ()
+  return %r : $()
 }
 

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -108,6 +108,7 @@ sil @guaranteed_fakeoptional_klass_user : $@convention(thin) (@guaranteed FakeOp
 sil @guaranteed_fakeoptional_classlet_user : $@convention(thin) (@guaranteed FakeOptional<ClassLet>) -> ()
 sil @closure : $@convention(thin) (@inout_aliasable Klass) -> ()
 sil @lendC : $@yield_once_2 @convention(thin) () -> @yields @guaranteed C
+sil @lendClassLet : $@yield_once @convention(thin) () -> @yields @guaranteed ClassLet
 sil @useC : $@convention(thin) (@guaranteed C) -> () {
 [global:]
 }
@@ -1735,8 +1736,15 @@ bb0(%0 : @guaranteed $C):
   return %retval : $()
 }
 
+// The borrow scope of the load's base is extended to cover the lifetime of the `load_borrow`.
+//
 // CHECK-LABEL: sil [ossa] @load_extends_borrow_scope :
-// CHECK:         load [copy]
+// CHECK:         [[OUTER:%.*]] = begin_borrow %0
+// CHECK-NEXT:    [[ADDR:%.*]] = ref_element_addr [[OUTER]]
+// CHECK-NEXT:    [[INNER:%.*]] = load_borrow [[ADDR]]
+// CHECK-NEXT:    end_borrow [[INNER]]
+// CHECK-NEXT:    end_borrow [[OUTER]]
+// CHECK-NEXT:    return %0
 // CHECK-LABEL: } // end sil function 'load_extends_borrow_scope'
 sil [ossa] @load_extends_borrow_scope : $@convention(thin) (@owned Klass) -> @owned Klass {
 bb0(%0 : @owned $Klass):
@@ -1746,6 +1754,137 @@ bb0(%0 : @owned $Klass):
   end_borrow %1 : $Klass
   destroy_value %3 : $Klass
   return %0 : $Klass
+}
+
+// The borrow scope of the base cannot be extended, because the enclosing owned value is destroyed
+// within the liverange of the load.
+//
+// CHECK-LABEL: sil [ossa] @dont_extend_borrow_scope_beyond_owned_lifetime :
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'dont_extend_borrow_scope_beyond_owned_lifetime'
+sil [ossa] @dont_extend_borrow_scope_beyond_owned_lifetime : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = begin_borrow %0 : $Klass
+  %2 = ref_element_addr [immutable] %1 : $Klass, #Klass.baseLet
+  %3 = load [copy] %2 : $*Klass
+  end_borrow %1 : $Klass
+  destroy_value %0 : $Klass
+  destroy_value %3 : $Klass
+  return undef : $()
+}
+
+// The borrow scope of the base cannot be extended, because it does not end with an `end_borrow`,
+// but with a reborrow.
+//
+// CHECK-LABEL: sil [ossa] @dont_extend_reborrowed_base :
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'dont_extend_reborrowed_base'
+sil [ossa] @dont_extend_reborrowed_base : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%0 : @owned $ClassLet):
+  %1 = begin_borrow %0 : $ClassLet
+  %2 = ref_element_addr [immutable] %1 : $ClassLet, #ClassLet.aLet
+  %3 = load [copy] %2 : $*Klass
+  br bb1(%1 : $ClassLet)
+
+bb1(%4 : @reborrow $ClassLet):
+  %5 = borrowed %4 : $ClassLet from (%0 : $ClassLet)
+  destroy_value %3 : $Klass
+  end_borrow %5 : $ClassLet
+  destroy_value %0 : $ClassLet
+  return undef : $()
+}
+
+// The base is a guaranteed phi with multiple enclosing values, i.e. not a borrow scope introducer.
+//
+// CHECK-LABEL: sil [ossa] @dont_extend_base_with_multiple_enclosing_values :
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'dont_extend_base_with_multiple_enclosing_values'
+sil [ossa] @dont_extend_base_with_multiple_enclosing_values : $@convention(thin) (@owned ClassLet, @owned ClassLet) -> () {
+bb0(%0 : @owned $ClassLet, %1 : @owned $ClassLet):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = begin_borrow %0 : $ClassLet
+  br bb3(%2 : $ClassLet)
+
+bb2:
+  %3 = begin_borrow %1 : $ClassLet
+  br bb3(%3 : $ClassLet)
+
+bb3(%4 : @reborrow $ClassLet):
+  %5 = borrowed %4 : $ClassLet from (%0 : $ClassLet, %1 : $ClassLet)
+  %6 = ref_element_addr [immutable] %5 : $ClassLet, #ClassLet.aLet
+  %7 = load [copy] %6 : $*Klass
+  end_borrow %5 : $ClassLet
+  destroy_value %7 : $Klass
+  destroy_value %0 : $ClassLet
+  destroy_value %1 : $ClassLet
+  return undef : $()
+}
+
+// The base is yielded from a `begin_apply`, i.e. its scope does not end with an `end_borrow`.
+//
+// CHECK-LABEL: sil [ossa] @dont_extend_yielded_base :
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'dont_extend_yielded_base'
+sil [ossa] @dont_extend_yielded_base : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @lendClassLet : $@yield_once @convention(thin) () -> @yields @guaranteed ClassLet
+  (%1, %2) = begin_apply %0() : $@yield_once @convention(thin) () -> @yields @guaranteed ClassLet
+  %3 = ref_element_addr [immutable] %1 : $ClassLet, #ClassLet.aLet
+  %4 = load [copy] %3 : $*Klass
+  end_apply %2 as $()
+  destroy_value %4 : $Klass
+  return undef : $()
+}
+
+// The base is an `unchecked_ownership_conversion`, which `extendBorrowScope` cannot handle.
+//
+// CHECK-LABEL: sil [ossa] @dont_extend_unchecked_conversion_base :
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'dont_extend_unchecked_conversion_base'
+sil [ossa] @dont_extend_unchecked_conversion_base : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%0 : @owned $ClassLet):
+  %1 = unchecked_ownership_conversion %0 : $ClassLet, @owned to @guaranteed
+  %2 = ref_element_addr [immutable] %1 : $ClassLet, #ClassLet.aLet
+  %3 = load [copy] %2 : $*Klass
+  end_borrow %1 : $ClassLet
+  destroy_value %3 : $Klass
+  destroy_value %0 : $ClassLet
+  return undef : $()
+}
+
+// The `end_borrow`s of the extended base scope are created at the exit block of the liverange.
+// The `end_borrow`s of the `load_borrow` must be inserted _before_ them.
+//
+// CHECK-LABEL: sil [ossa] @extend_borrow_scope_into_liverange_exit :
+// CHECK:         [[OUTER:%.*]] = begin_borrow %0
+// CHECK:         [[INNER:%.*]] = load_borrow
+// CHECK:       bb1({{.*}} : @guaranteed $Klass):
+// CHECK-NEXT:    end_borrow [[INNER]]
+// CHECK-NEXT:    end_borrow [[OUTER]]
+// CHECK:       bb2:
+// CHECK-NEXT:    end_borrow [[INNER]]
+// CHECK-NEXT:    end_borrow [[OUTER]]
+// CHECK-LABEL: } // end sil function 'extend_borrow_scope_into_liverange_exit'
+sil [ossa] @extend_borrow_scope_into_liverange_exit : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%0 : @owned $ClassLet):
+  %1 = begin_borrow %0 : $ClassLet
+  %2 = ref_element_addr [immutable] %1 : $ClassLet, #ClassLet.anOptionalLet
+  %3 = load [copy] %2 : $*FakeOptional<Klass>
+  end_borrow %1 : $ClassLet
+  switch_enum %3 : $FakeOptional<Klass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%4 : @owned $Klass):
+  destroy_value %4 : $Klass
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_value %0 : $ClassLet
+  return undef : $()
 }
 
 // CHECK-LABEL: sil [ossa] @write_in_unreachable_block :
@@ -2026,10 +2165,19 @@ bb5:
   return %r : $()
 }
 
-// CHECK-LABEL: sil [ossa] @blocked_by_end_borrow :
-// CHECK:         %7 = load [copy] %6
-// CHECK:       } // end sil function 'blocked_by_end_borrow'
-sil [ossa] @blocked_by_end_borrow : $@convention(thin) (@guaranteed Container) -> () {
+// The base of the load is derived from a `load_borrow` whose scope ends within the liverange of the
+// load. As the `load_borrow`'s address is immutable, its scope can be extended.
+//
+// CHECK-LABEL: sil [ossa] @extend_load_borrow_scope_of_base :
+// CHECK:         [[BASEADDR:%.*]] = ref_element_addr [immutable] %0
+// CHECK-NEXT:    [[OUTER:%.*]] = load_borrow [[BASEADDR]]
+// CHECK:         [[ADDR:%.*]] = ref_element_addr [immutable]
+// CHECK-NEXT:    [[INNER:%.*]] = load_borrow [[ADDR]]
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_borrow [[INNER]]
+// CHECK-NEXT:    end_borrow [[OUTER]]
+// CHECK:       } // end sil function 'extend_load_borrow_scope_of_base'
+sil [ossa] @extend_load_borrow_scope_of_base : $@convention(thin) (@guaranteed Container) -> () {
 bb0(%0 : @guaranteed $Container):
   %1 = function_ref @useC : $@convention(thin) (@guaranteed C) -> ()
   %2 = ref_element_addr [immutable] %0 : $Container, #Container.b
@@ -2042,6 +2190,23 @@ bb0(%0 : @guaranteed $Container):
   %9 = apply %1(%7) : $@convention(thin) (@guaranteed C) -> ()
   destroy_value %7 : $C
   return %9 : $()
+}
+
+// Same as above, but the address of the base `load_borrow` is mutable. The `destroy_value` of the
+// loaded value may write to it, therefore its borrow scope cannot be extended.
+//
+// CHECK-LABEL: sil [ossa] @dont_extend_load_borrow_scope_over_may_write :
+// CHECK:         load [copy]
+// CHECK:       } // end sil function 'dont_extend_load_borrow_scope_over_may_write'
+sil [ossa] @dont_extend_load_borrow_scope_over_may_write : $@convention(thin) (@guaranteed Container) -> () {
+bb0(%0 : @guaranteed $Container):
+  %1 = ref_element_addr %0 : $Container, #Container.b
+  %2 = load_borrow %1 : $*Base
+  %3 = ref_element_addr [immutable] %2 : $Base, #Base.c
+  %4 = load [copy] %3 : $*C
+  end_borrow %2 : $Base
+  destroy_value %4 : $C
+  return undef : $()
 }
 
 // CHECK-LABEL: sil [ossa] @remove_copy_of_guaranteed_arg :


### PR DESCRIPTION
Before replacing a `load [copy]` with a `load_borrow`, extend the borrow scope of the base reference of the load's address, so that it encloses the lifetime of the new `load_borrow`. If the scope cannot be extended, bail out.

This enables the optimization in more cases. It also fixes cases where an invalid `load_borrow` was created, e.g. if the base's borrow scope ends in a reborrow instead of an `end_borrow`.

The `end_borrow`s of the new `load_borrow` are now inserted before the `end_borrow`s of the extended base scope, which matters if both are created at the same liverange exit.
