### PR TITLE
Revert "XFAIL CAS/sanitize-ignorelist.swift"

### DIFF
--- a/test/CAS/sanitize-ignorelist.swift
+++ b/test/CAS/sanitize-ignorelist.swift
@@ -5,8 +5,6 @@
 
 // REQUIRES: OS=macosx
 
-// REQUIRES: rdar185826684
-
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
Reverts swiftlang/swift#91900

This test was failing on downstream CI but has since been fixed.