### PR TITLE
ClangImporter: load macro API notes from CAS include trees

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -53,6 +53,8 @@
 #include "swift/Parse/ParseVersion.h"
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
+#include "clang/APINotes/APINotesManager.h"
+#include "clang/APINotes/APINotesReader.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
@@ -2652,6 +2654,79 @@ ModuleDecl *ClangImporter::Implementation::loadModule(
   return MD;
 }
 
+llvm::Error
+ClangImporter::Implementation::loadAPINotes(const clang::Module *M) {
+  auto *TopLevelModule = M->getTopLevelModule();
+  auto ASTFile = TopLevelModule->getASTFile();
+  if (!ASTFile)
+    return llvm::Error::success();
+
+  auto *MF = Instance->getASTReader()->getModuleManager().lookup(*ASTFile);
+  if (!MF || MF->IncludeTreeID.empty())
+    return llvm::Error::success();
+
+  auto ID = CAS->parseID(MF->IncludeTreeID);
+  if (!ID)
+    return ID.takeError();
+
+  auto Ref = CAS->getReference(*ID);
+  if (!Ref)
+    return CAS->createUnknownObjectError(*ID);
+
+  auto Root = clang::cas::IncludeTreeRoot::get(*CAS, *Ref);
+  if (!Root)
+    return Root.takeError();
+
+  auto Notes = Root->getAPINotes();
+  if (!Notes)
+    return Notes.takeError();
+
+  llvm::SmallVector<llvm::StringRef, 2> Buffers;
+  if (*Notes)
+    if (auto Err = (*Notes)->forEachAPINotes([&](llvm::StringRef Buffer) {
+      Buffers.push_back(Buffer);
+      return llvm::Error::success();
+    }))
+      return Err;
+
+  auto &SM = Instance->getSourceManager();
+  auto &LangOpts = Instance->getLangOpts();
+  auto Manager =
+      std::make_unique<clang::api_notes::APINotesManager>(SM, LangOpts);
+  Manager->setSwiftVersion(Instance->getAPINotesOpts().SwiftVersion);
+  if (!Buffers.empty() &&
+      !Manager->loadCurrentModuleAPINotesFromBuffer(Buffers))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "failed to load attach APINotes for %s",
+                                   TopLevelModule->Name.c_str());
+
+  CASModuleAPINotes.try_emplace(TopLevelModule, std::move(Manager));
+  return llvm::Error::success();
+}
+
+std::optional<clang::api_notes::GlobalVariableInfo>
+ClangImporter::Implementation::lookupAPINotes(clang::Sema &S,
+                                              const clang::Module *M,
+                                              const clang::IdentifierInfo *II,
+                                              clang::SourceLocation Loc) {
+  if (!II || Loc.isInvalid())
+    return std::nullopt;
+
+  if (M) {
+    M = M->getTopLevelModule();
+    if (auto it = CASModuleAPINotes.find(M); it != CASModuleAPINotes.end()) {
+      for (auto *Reader : it->second->getCurrentModuleReaders()) {
+        auto Info = Reader->lookupGlobalVariable(II->getName());
+        if (auto Selected = Info.getSelected())
+          return Info[*Selected].second;
+      }
+      return std::nullopt;
+    }
+  }
+
+  return S.ProcessAPINotes(M, II, Loc);
+}
+
 ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     const clang::Module *clangModule, SourceLoc importLoc) {
   assert(clangModule);
@@ -2666,6 +2741,10 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
   ModuleDecl *result = wrapperUnit->getParentModule();
   auto &moduleWrapper = ModuleWrappers[clangModule];
   if (!moduleWrapper.getInt()) {
+    if (CAS)
+      if (auto Err = loadAPINotes(clangModule))
+        llvm::report_fatal_error(std::move(Err));
+
     moduleWrapper.setInt(true);
     (void) namelookup::getAllImports(result);
   }

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -50,8 +50,8 @@ static Type importMacroTypeOverride(ClangImporter::Implementation &Impl,
     return Type();
 
   clang::Sema &S = Impl.getClangSema();
-  auto Info = S.ProcessAPINotes(ClangN.getOwningClangModule(), II,
-                                macro->getDefinitionLoc());
+  auto Info = Impl.lookupAPINotes(S, ClangN.getOwningClangModule(), II,
+                                  macro->getDefinitionLoc());
   if (!Info || Info->getType().empty())
     return Type();
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2625,7 +2625,9 @@ NameImporter::importMacroName(const clang::IdentifierInfo *II,
   // Honor an APINotes 'SwiftName:' override, if one applies. A macro constant
   // can only be renamed to a simple identifier, so reject function, operator,
   // and member names, which are meaningless here.
-  if (auto notes = getClangSema().ProcessAPINotes(M, II, MI->getDefinitionLoc())) {
+  clang::Sema &S = getClangSema();
+  if (auto notes =
+          importerImpl->lookupAPINotes(S, M, II, MI->getDefinitionLoc())) {
     if (!notes->SwiftName.empty()) {
       ParsedDeclName ident = parseDeclName(notes->SwiftName);
       if (ident && !ident.isOperator() && !ident.IsFunctionName &&

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -36,6 +36,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "clang/APINotes/Types.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -73,6 +74,9 @@ class ParmVarDecl;
 class Parser;
 class QualType;
 class TypedefNameDecl;
+namespace api_notes {
+class APINotesManager;
+}
 namespace serialization {
 class ModuleFile;
 } // namespace serialization
@@ -557,6 +561,13 @@ private:
   /// modules.
   std::unique_ptr<clang::CompilerInstance> Instance;
 
+  /// Per-module API Notes loaded from an imported PCM's CAS include tree.
+  /// Presence in this map makes the include tree authoritative, including when
+  /// it contains no API Notes.
+  llvm::DenseMap<const clang::Module *,
+                 std::unique_ptr<clang::api_notes::APINotesManager>>
+      CASModuleAPINotes;
+
   /// Clang compiler action, which is used to actually run the
   /// parser.
   std::unique_ptr<clang::FrontendAction> Action;
@@ -662,6 +673,8 @@ public:
   /// mangling, such as Windows) of \p clangDecl to \p os.
   static void getItaniumMangledName(const clang::NamedDecl *clangDecl,
                                     raw_ostream &os);
+
+  llvm::Error loadAPINotes(const clang::Module *module);
 
 private:
   /// The Importer may be configured to load modules of a different OS Version
@@ -1082,6 +1095,10 @@ public:
   clang::Sema &getClangSema() const {
     return Instance->getSema();
   }
+
+  std::optional<clang::api_notes::GlobalVariableInfo>
+  lookupAPINotes(clang::Sema &S, const clang::Module *M,
+                 const clang::IdentifierInfo *II, clang::SourceLocation Loc);
 
   /// Retrieve the Clang AST context.
   clang::Preprocessor &getClangPreprocessor() const {

--- a/test/CAS/apinotes-macros.swift
+++ b/test/CAS/apinotes-macros.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test \
+// RUN:   -module-cache-path %t/clang-module-cache -I %t \
+// RUN:   -disable-implicit-string-processing-module-import \
+// RUN:   -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift -o %t/deps.json -swift-version 5 \
+// RUN:   -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json \
+// RUN:   clang:CASAPINotes clangIncludeTree > %t/CASAPINotes.tree
+// RUN: clang-cas-test --cas %t/cas --print-include-tree \
+// RUN:   @%t/CASAPINotes.tree | %FileCheck %s --check-prefix=INCLUDE-TREE
+// RUN: rm %t/CASAPINotes.apinotes
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py --cas %t/cas \
+// RUN:   %swift_frontend_plain %t/deps.json -o %t/Test.cmd
+// RUN: %target-swift-frontend-plain -typecheck -module-name Test \
+// RUN:   -cache-compile-job -cas-path %t/cas \
+// RUN:   -disable-implicit-string-processing-module-import \
+// RUN:   -disable-implicit-concurrency-module-import \
+// RUN:   %t/main.swift @%t/Test.cmd
+
+// INCLUDE-TREE: APINotes:
+// INCLUDE-TREE: Name: CASAPINotes
+// INCLUDE-TREE: Name: TYPED_CONSTANT
+// INCLUDE-TREE: Type: DWORD
+
+//--- module.modulemap
+module CASAPINotes {
+  header "CASAPINotes.h"
+  export *
+}
+
+//--- CASAPINotes.h
+typedef unsigned int DWORD;
+#define TYPED_CONSTANT 2
+
+//--- CASAPINotes.apinotes
+Name: CASAPINotes
+Globals:
+  - Name: TYPED_CONSTANT
+    Type: DWORD
+
+//--- main.swift
+import CASAPINotes
+
+let _: DWORD = TYPED_CONSTANT
+


### PR DESCRIPTION
Explicit clang module builds store API notes in the CAS include tree attached to the PCM. Macro import currently uses
`Sema::ProcessAPINotes`, which searches the raw filesystem. When the original API notes path is not available, APINotes for macros are lost.

When loading a clang module from CAS, recover its serialized include tree and load the attached API notes into a per-module manager. Use that manager for macro type and name lookup, while preserving the existing filesystem lookup for modules not loaded from CAS.