### PR TITLE
test: Fix ModuleInterface/synthesized-conformances.swift on visionOS.

### DIFF
--- a/test/ModuleInterface/synthesized-conformances.swift
+++ b/test/ModuleInterface/synthesized-conformances.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name synthesized -disable-objc-attr-requires-foundation-module -enable-objc-interop
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name synthesized
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name synthesized -application-extension
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftinterface
 
@@ -70,18 +71,22 @@ public struct HasNestedTypesAndAvailability {
   }
 }
 
-// CHECK-LABEL: @available(visionOS, unavailable)
-// CHECK-NEXT: public struct UnavailableOnVisionOS {
-@available(visionOS, unavailable)
-public struct UnavailableOnVisionOS {
-  // CHECK-LABEL: @available(iOS 18, *)
-  // CHECK-NEXT: public enum HasRawValueAndRefinediOSAvailability : Swift::Int {
-  @available(iOS 18, *)
-  public enum HasRawValueAndRefinediOSAvailability: Int {
-    // CHECK-NEXT: case a
-    case a
-  }
-}
+// FIXME: [availability] These declarations produce synthesized conformances with rejected availability
+//@available(visionOS, unavailable)
+//public struct UnavailableOnVisionOS {
+//  @available(iOS 18, *)
+//  public enum HasRawValueAndRefinediOSAvailability: Int {
+//    case a
+//  }
+//}
+
+//@available(macOSApplicationExtension, unavailable)
+//public struct UnavailableInMacOSAppExtensions {
+//  @available(macOS 99, *)
+//  public enum HasRawValueAndRefinedMacOSAvailability: Int {
+//    case a
+//  }
+//}
 
 @objc public enum ObjCEnum: Int32 {
   case a, b = 5, c
@@ -162,16 +167,6 @@ extension NoRawValueWithExplicitHashable : Hashable {
 // CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 // CHECK-NEXT: @available(*, deprecated, message: "Use something else")
 // CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueUniversallyDeprecated : Swift::RawRepresentable {}
-
-// CHECK: @available(iOS 18, *)
-// CHECK-NEXT: @available(visionOS, unavailable)
-// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::Equatable {}
-// CHECK: @available(iOS 18, *)
-// CHECK-NEXT: @available(visionOS, unavailable)
-// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::Hashable {}
-// CHECK: @available(iOS 18, *)
-// CHECK-NEXT: @available(visionOS, unavailable)
-// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::RawRepresentable {}
 
 // CHECK: extension synthesized::ObjCEnum : Swift::Equatable {}
 // CHECK: extension synthesized::ObjCEnum : Swift::Hashable {}


### PR DESCRIPTION
Remove a test case that is causing synthesized-conformances.swift to fail when run on visionOS after https://github.com/swiftlang/swift/pull/91747. The following test case now fails:

    @available(visionOS, unavailable)
    public struct Outer {
      @available(iOS 18, *)
      public enum Inner: Int {
        case a
      }
    }

    // Implies this Equatable conformance:
    @available(visionOS, unavailable)
    @available(iOS 18, *)
    extension Outer.Inner : Swift::Equatable {}

References to declarations that were introduced in a later version of iOS in contexts that are unavailable on visionOS because that is unsound (apps built for iOS may run unmodified on visionOS). However, the synthesized conformance above ought to be considered valid since it is also annotated `@available(iOS 18, *)`. Unfortunately, the availability checker doesn't track independent iOS availability when compiling for visionOS, though, so the conformance is rejected.

This is expected fallout from https://github.com/swiftlang/swift/pull/91747 so for now just comment out the test case with a FIXME to reintroduce it later.

Resolves rdar://186150610.
