### PR TITLE
utils: drop CAS version check

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -610,9 +610,6 @@ $PinnedToolchain = [IO.Path]::GetFileNameWithoutExtension($PinnedBuild)
 $ToolchainVersionIdentifier = $PinnedToolchain -replace 'swift-(.+?)-windows10.*', '$1'
 
 if ($EnableCaching) {
-  if ($PinnedVersion -ne "0.0.0") {
-    throw "CAS currently requires using a main-branch pinned toolchain."
-  }
   $UseHostToolchain = $false
 }
 


### PR DESCRIPTION
We restricted the use of CAS to 0.0.0 as the snapshots did not have the necessary support at the time. We now require 6.4.x as a baseline for the bootstrap toolchain, which has the required support, remove this check.