### PR TITLE
Fix LoadableByAddress for stores of closures involving large loadable types

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2435,22 +2435,6 @@ static void rewriteFunction(StructLoweringState &pass,
     }
   }
 
-  for (StoreInst *instr : pass.storeInstsToMod) {
-    SILValue src = instr->getSrc();
-    SILValue tgt = instr->getDest();
-    SILType srcType = src->getType();
-    SILType tgtType = tgt->getType();
-    assert(srcType && "Expected an address-type source");
-    assert(tgtType.isAddress() && "Expected an address-type target");
-    assert(srcType == tgtType && "Source and target type do not match");
-    (void)srcType;
-    (void)tgtType;
-
-    SILBuilderWithScope copyBuilder(instr);
-    createOutlinedCopyCall(copyBuilder, src, tgt, pass);
-    instr->getParent()->erase(instr);
-  }
-
   for (RetainValueInst *instr : pass.retainInstsToMod) {
     SILBuilderWithScope retainBuilder(instr);
     retainBuilder.createRetainValueAddr(
@@ -2558,6 +2542,24 @@ static void rewriteFunction(StructLoweringState &pass,
     }
     instr->replaceAllUsesWith(newInstr);
     instr->eraseFromParent();
+  }
+
+  // Rewrite stores of large-loadable types after the aggregate-projection
+  // instructions above have been recreated with their new SIL types.
+  for (StoreInst *instr : pass.storeInstsToMod) {
+    SILValue src = instr->getSrc();
+    SILValue tgt = instr->getDest();
+    SILType srcType = src->getType();
+    SILType tgtType = tgt->getType();
+    assert(srcType && "Expected an address-type source");
+    assert(tgtType.isAddress() && "Expected an address-type target");
+    assert(srcType == tgtType && "Source and target type do not match");
+    (void)srcType;
+    (void)tgtType;
+
+    SILBuilderWithScope copyBuilder(instr);
+    createOutlinedCopyCall(copyBuilder, src, tgt, pass);
+    instr->getParent()->erase(instr);
   }
 
   for (MethodInst *instr : pass.methodInstsToMod) {

--- a/test/IRGen/loadable_by_address.sil
+++ b/test/IRGen/loadable_by_address.sil
@@ -107,3 +107,29 @@ bb0(%0 : $Cond):
   retain_value %0 : $Cond
   return %6 : $Cond
 }
+
+struct Region { var a: Int, b: Int, c: Int }
+
+struct Event { var a: Int, b: Int, c: Int, d: Int, e: Int }
+
+class Box {
+  var pending: (region: Region, handler: (Event) -> Bool)?
+  init()
+}
+
+sil_vtable Box {}
+
+// CHECK-LABEL: sil hidden [transparent] @box_pending_setter :
+// CHECK: bb0(%0 : $*Optional<(region: Region, handler: @callee_guaranteed (@in_guaranteed Event) -> Bool)>, %1 : $Box):
+// CHECK: [[REF:%.*]] = ref_element_addr %1, #Box.pending
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF]]
+// CHECK: copy_addr [take] %0 to [init] [[ACCESS]]
+sil hidden [transparent] @box_pending_setter : $@convention(method) (@owned Optional<(region: Region, handler: @callee_guaranteed (Event) -> Bool)>, @guaranteed Box) -> () {
+bb0(%0 : $Optional<(region: Region, handler: @callee_guaranteed (Event) -> Bool)>, %1 : $Box):
+  %2 = ref_element_addr %1 : $Box, #Box.pending
+  %3 = begin_access [modify] [dynamic] %2 : $*Optional<(region: Region, handler: @callee_guaranteed (Event) -> Bool)>
+  store %0 to %3 : $*Optional<(region: Region, handler: @callee_guaranteed (Event) -> Bool)>
+  end_access %3 : $*Optional<(region: Region, handler: @callee_guaranteed (Event) -> Bool)>
+  %5 = tuple ()
+  return %5 : $()
+}


### PR DESCRIPTION
Run the store-rewriting loop after projections are rewritten so both the operands already have their new types when the store is lowered to a copy_addr.

Resolves rdar://186307228 and https://github.com/swiftlang/swift/pull/91927 
