### PR TITLE
XFAIL test/embedded/avr/testIRGenFunctioning.swift

### DIFF
--- a/test/embedded/avr/testIRGenFunctioning.swift
+++ b/test/embedded/avr/testIRGenFunctioning.swift
@@ -3,6 +3,7 @@
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: CODEGENERATOR=AVR
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: optimized_stdlib
 // UNSUPPORTED: CPU=wasm32
 
 // IRGen needs various patches to work with program address space 1 on AVR.


### PR DESCRIPTION
Add
// REQUIRES optimized_stdlib

rdar://186396835 (🟠 OSS Swift CI: oss-swift_tools-RA_stdlib-DA_test-simulators-apple-silicon failed: test: embedded/avr/testIRGenFunctioning.swift (exit code 2))

assertion failed: (CastInst::castIsValid(opc, C, Ty) && "Invalid constantexpr cast!"),
  function getCast, file Constants.cpp, line 2220.
3. While evaluating request IRGenRequest(IR Generation for module testIRGenFunctioning)
4. While emitting IR SIL function "@$es31_ensureErrorMetadataInitialized33_...LLyyF"
   for <<debugloc at ".../stdlib/public/core/EmbeddedRuntime.swift":562:14>>
  llvm::IRBuilderBase::CreateCast(...)
