### PR TITLE
Linux LSAN: Use the Gold linker

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1336,7 +1336,9 @@ extra-cmake-options=
    -DCMAKE_C_FLAGS="-gline-tables-only"
    -DCMAKE_CXX_FLAGS="-gline-tables-only"
 
-llvm-cmake-options=-DLLVM_PARALLEL_LINK_JOBS=12
+llvm-cmake-options=
+  -DLLVM_PARALLEL_LINK_JOBS=12
+  -DCLANG_DEFAULT_LINKER=gold
 swift-cmake-options=-DSWIFT_PARALLEL_LINK_JOBS=12
 
 release-debuginfo


### PR DESCRIPTION
The LSAN jobs are running on Ubuntu 22.04 which has an older bfd version which can't handle the relocations generated by Swift.

rdar://185529426