### PR TITLE
Sema: don't warn about missing inherited init in @objc @implementation when the interface marks it unavailable

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1286,17 +1286,27 @@ static void addImplicitInheritedConstructorsToClass(ClassDecl *decl) {
       continue;
 
     bool alreadyDeclared = false;
+    bool interfaceMarksInitUnavailable = false;
+    auto superSelector = superclassCtor->getObjCRuntimeName();
 
     auto results = decl->lookupDirect(DeclBaseName::createConstructor());
     for (auto *member : results) {
-      if (!isInMainBody(member, decl))
-        continue;
-
       auto *ctor = cast<ConstructorDecl>(member);
 
       // Skip any invalid constructors.
       if (ctor->isInvalid())
         continue;
+
+      // Detect an init from the imported Objective-C interface (not the
+      // extension's main body) that marks the superclass selector unavailable,
+      // e.g. 'NS_UNAVAILABLE'.
+      if (!isInMainBody(member, decl)) {
+        if (ctor->hasClangNode() && superSelector &&
+            ctor->getObjCRuntimeName() == superSelector &&
+            ctor->isUnavailable())
+          interfaceMarksInitUnavailable = true;
+        continue;
+      }
 
       auto type = swift::getMemberTypeForComparison(ctor, nullptr);
       if (isOverrideBasedOnType(ctor, type, superclassCtor)) {
@@ -1323,9 +1333,12 @@ static void addImplicitInheritedConstructorsToClass(ClassDecl *decl) {
       // reachable from Objective-C (e.g. '[Class new]') and traps at runtime if
       // it's invoked, so warn the author to implement it. (Non-required
       // designated inits; required ones are handled by
-      // diagnoseMissingRequiredInitializer above.)
+      // diagnoseMissingRequiredInitializer above.) Skip the warning when the
+      // interface marks that initializer unavailable (e.g. 'NS_UNAVAILABLE'):
+      // its stub is unreachable from Objective-C.
       if (kind == DesignatedInitKind::Stub &&
-          implCtx->getDecl()->isObjCImplementation())
+          implCtx->getDecl()->isObjCImplementation() &&
+          !interfaceMarksInitUnavailable)
         ctx.Diags.diagnose(implCtx->getDecl(),
                            diag::objc_implementation_missing_inherited_init,
                            superclassCtor);

--- a/test/decl/ext/Inputs/objc_implementation_inherited_init.h
+++ b/test/decl/ext/Inputs/objc_implementation_inherited_init.h
@@ -10,4 +10,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithValue:(int)value;
 @end
 
+@interface ImplsUnavailableInit : NSObject
+- (instancetype)initWithValue:(int)value;
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/test/decl/ext/objc_implementation_inherited_init.swift
+++ b/test/decl/ext/objc_implementation_inherited_init.swift
@@ -21,3 +21,11 @@
     super.init()
   }
 }
+
+// The interface marks 'init'/'new' unavailable (NS_UNAVAILABLE), so the stub
+// can't be invoked from Objective-C and won't trap: no diagnostic.
+@objc @implementation extension ImplsUnavailableInit {
+  init(value: Int32) {
+    super.init()
+  }
+}


### PR DESCRIPTION
Resolves: rdar://185699507
