### PR TITLE
[Runtime] Look up function type metadata in the prespecializations library.

### DIFF
--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -43,11 +43,19 @@ struct LibPrespecializedData {
   /// conforming-type Metadata *). Values are the corresponding witness table.
   TargetPointer<Runtime, const void> pointerKeyedWitnessTableMap;
 
+  /// Function type metadata map. Keys are (result metadata, parameter metadata
+  /// ...). Values are a TargetPrespecializedMetadataCandidates listing every
+  /// prespecialized function type sharing that key. Candidates under one key
+  /// differ in data the key does not carry: function flags, parameter flags,
+  /// global actor, and thrown error. The caller must check each candidate
+  /// against those.
+  TargetPointer<Runtime, const void> functionMetadataMap;
+
   // Existing fields are above, add new fields below this point.
 
   // The major/minor version numbers for this version of the struct.
   static constexpr uint32_t currentMajorVersion = 1;
-  static constexpr uint32_t currentMinorVersion = 5;
+  static constexpr uint32_t currentMinorVersion = 6;
 
   // Version numbers where various fields were introduced.
   static constexpr uint32_t minorVersionWithDisabledProcessesTable = 2;
@@ -55,6 +63,7 @@ struct LibPrespecializedData {
   static constexpr uint32_t minorVersionWithOptionFlags = 3;
   static constexpr uint32_t minorVersionWithDescriptorMap = 4;
   static constexpr uint32_t minorVersionWithPointerKeyedWitnessTableMap = 5;
+  static constexpr uint32_t minorVersionWithFunctionMetadataMap = 6;
 
   // Option flags values.
   enum : typename Runtime::StoredSize {
@@ -115,7 +124,24 @@ struct LibPrespecializedData {
       return nullptr;
     return pointerKeyedWitnessTableMap;
   }
+
+  const void *getFunctionMetadataMap() const {
+    if (minorVersion < minorVersionWithFunctionMetadataMap)
+      return nullptr;
+    return functionMetadataMap;
+  }
 };
+
+/// The value of an entry in a prespecialized metadata table whose key does not
+/// fully determine the type. Every prespecialized metadata sharing the key is
+/// listed, and the caller picks the one matching the rest of the request.
+template <typename Runtime>
+struct TargetPrespecializedMetadataCandidates {
+  typename Runtime::StoredSize count;
+  ConstTargetMetadataPointer<Runtime, TargetMetadata> metadata[];
+};
+using PrespecializedMetadataCandidates =
+    TargetPrespecializedMetadataCandidates<InProcess>;
 
 enum class LibPrespecializedLookupResult {
   // We found something.
@@ -139,6 +165,15 @@ void libPrespecializedImageLoaded();
 /// nullptr on failure. Failure is never definitive.
 const WitnessTable *getLibPrespecializedWitnessTable(
     const ProtocolConformanceDescriptor *conformance, const Metadata *type);
+
+/// Look up the prespecialized function type metadata sharing the key
+/// (result, parameters...). The key does not capture function flags, parameter
+/// flags, the global actor, or the thrown error, so the caller must check the
+/// returned candidates against those. Returns nullptr when there are none.
+const PrespecializedMetadataCandidates *
+getLibPrespecializedFunctionTypeMetadata(const Metadata *result,
+                                         const Metadata *const *parameters,
+                                         unsigned numParameters);
 
 std::pair<LibPrespecializedLookupResult, const TypeContextDescriptor *>
 getLibPrespecializedTypeDescriptor(Demangle::NodePointer node);

--- a/stdlib/public/runtime/LibPrespecialized.cpp
+++ b/stdlib/public/runtime/LibPrespecialized.cpp
@@ -348,6 +348,7 @@ struct LibPrespecializedState {
     LOG("  descriptorMap=%p", data->getDescriptorMap());
     LOG("  pointerKeyedWitnessTableMap=%p",
         data->getPointerKeyedWitnessTableMap());
+    LOG("  functionMetadataMap=%p", data->getFunctionMetadataMap());
 
     return data;
   }
@@ -615,6 +616,40 @@ swift::getLibPrespecializedWitnessTable(
         (const void *)conformance, (const void *)type, result);
     return reinterpret_cast<const WitnessTable *>(
         const_cast<void *>(result));
+  }
+#endif
+  return nullptr;
+}
+
+const PrespecializedMetadataCandidates *
+swift::getLibPrespecializedFunctionTypeMetadata(
+    const Metadata *result, const Metadata *const *parameters,
+    unsigned numParameters) {
+#if DYLD_FIND_POINTER_HASH_TABLE_ENTRY_DEFINED
+  auto &state = LibPrespecialized.get();
+
+  auto *data = state.data;
+  if (!data)
+    return nullptr;
+
+  if (state.mapConfiguration ==
+      LibPrespecializedState::MapConfiguration::Disabled)
+    return nullptr;
+
+  auto *map = data->getFunctionMetadataMap();
+  if (!map)
+    return nullptr;
+
+  if (SWIFT_RUNTIME_WEAK_CHECK(_dyld_find_pointer_hash_table_entry)) {
+    // The dyld call takes the first pointer of the key separately from the
+    // rest. Our keys are the result type followed by the parameter types.
+    auto value = SWIFT_RUNTIME_WEAK_USE(_dyld_find_pointer_hash_table_entry(
+        map, result, numParameters,
+        const_cast<const void **>(
+            reinterpret_cast<const void *const *>(parameters))));
+    LOG("Function type lookup (result=%p, %u parameters) -> %p.",
+        (const void *)result, numParameters, value);
+    return reinterpret_cast<const PrespecializedMetadataCandidates *>(value);
   }
 #endif
   return nullptr;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1306,7 +1306,11 @@ public:
     return 0; // No single meaningful value here.
   }
 
-  bool matchesKey(const Key &key) const {
+  /// Does the given function type metadata describe exactly the type `key`
+  /// asks for? Split out from matchesKey so the same comparison can be applied
+  /// to prespecialized function metadata, which lives outside any cache entry.
+  static bool metadataMatchesKey(const FunctionTypeMetadata &Data,
+                                 const Key &key) {
     if (key.getFlags().getIntValue() != Data.Flags.getIntValue())
       return false;
     if (key.getDifferentiabilityKind().Value !=
@@ -1328,6 +1332,10 @@ public:
         return false;
     }
     return true;
+  }
+
+  bool matchesKey(const Key &key) const {
+    return metadataMatchesKey(Data, key);
   }
 
   friend llvm::hash_code hash_value(const FunctionCacheEntry &value) {
@@ -1365,6 +1373,26 @@ public:
 
 /// The uniquing structure for function type metadata.
 static SimpleGlobalCache<FunctionCacheEntry, FunctionTypesTag> FunctionTypes;
+
+/// Get the unique function type metadata for a key, preferring a
+/// prespecialized one from the prespecializations library. Prespecialized
+/// function types never go into the dynamic cache.
+static const FunctionTypeMetadata *
+getFunctionTypeMetadataForKey(const FunctionCacheEntry::Key &key) {
+  auto numParameters = key.getFlags().getNumParameters();
+  if (auto *candidates = getLibPrespecializedFunctionTypeMetadata(
+          key.getResult(), key.Parameters, numParameters)) {
+    // The table's key is only (result, parameters...), so several function
+    // types can share an entry. Find the one that matches the whole request.
+    for (size_t i = 0; i < candidates->count; i++) {
+      auto *metadata = cast<FunctionTypeMetadata>(candidates->metadata[i]);
+      if (FunctionCacheEntry::metadataMatchesKey(*metadata, key))
+        return metadata;
+    }
+  }
+
+  return &FunctionTypes.getOrInsert(key).first->Data;
+}
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata0(FunctionTypeFlags flags,
@@ -1426,7 +1454,7 @@ swift::swift_getFunctionTypeMetadata(FunctionTypeFlags flags,
     reinterpret_cast<const ParameterFlags *>(parameterFlags), result, nullptr,
     ExtendedFunctionTypeFlags(), nullptr
   };
-  return &FunctionTypes.getOrInsert(key).first->Data;
+  return getFunctionTypeMetadataForKey(key);
 }
 
 const FunctionTypeMetadata *
@@ -1447,7 +1475,7 @@ swift::swift_getFunctionTypeMetadataDifferentiable(
     reinterpret_cast<const ParameterFlags *>(parameterFlags), result, nullptr,
     ExtendedFunctionTypeFlags(), nullptr
   };
-  return &FunctionTypes.getOrInsert(key).first->Data;
+  return getFunctionTypeMetadataForKey(key);
 }
 
 const FunctionTypeMetadata *
@@ -1463,7 +1491,7 @@ swift::swift_getFunctionTypeMetadataGlobalActor(
     reinterpret_cast<const ParameterFlags *>(parameterFlags), result,
     globalActor, ExtendedFunctionTypeFlags(), nullptr
   };
-  return &FunctionTypes.getOrInsert(key).first->Data;
+  return getFunctionTypeMetadataForKey(key);
 }
 
 extern "C" const EnumDescriptor NOMINAL_TYPE_DESCR_SYM(s5NeverO);
@@ -1537,7 +1565,7 @@ swift::swift_getExtendedFunctionTypeMetadata(
     reinterpret_cast<const ParameterFlags *>(parameterFlags), result,
     globalActor, extFlags, thrownError
   };
-  return &FunctionTypes.getOrInsert(key).first->Data;
+  return getFunctionTypeMetadataForKey(key);
 }
 
 FunctionCacheEntry::FunctionCacheEntry(const Key &key) {


### PR DESCRIPTION
A new table maps (result type, parameter types) to function type metadata. The key is limited to pointer identity, so it doesn't distinguish function flags, parameter flags, global actor, or thrown error. The lookup thus may provide multiple values, and the runtime searches those for an exact match.

Prespecialized function metadata is returned directly and never enters the dynamic cache.