### PR TITLE
[test] Delete `Package.resolved` copy in `swift-dev-utils` test

### DIFF
--- a/validation-test/BuildSystem/swift-dev-utils.test
+++ b/validation-test/BuildSystem/swift-dev-utils.test
@@ -15,6 +15,9 @@
 # RUN: cp -R "%swift_src_root/utils/swift-dev-utils" "%t/src/swift/utils/swift-dev-utils"
 # RUN: rm -rf "%t/src/swift/utils/swift-dev-utils/.build"
 
+# 'Package.resolved' may lead to networking. See https://github.com/swiftlang/swift/pull/91938.
+# RUN: rm -f "%t/src/swift/utils/swift-dev-utils/Package.resolved"
+
 # Add symlinks for local dependencies
 # RUN: ln -s "%swift_src_root/../swift-"* "%t/src"
 # RUN: ln -s "%swift_src_root/../llbuild" "%t/src"


### PR DESCRIPTION
1. `Package.resolved` is copied with the sources, listing 11 remote pins.
2. `swift-test` hands the resolver both the manifests and those 11 pins.
3. The resolver collects the local path dependencies first. Each overrides any other reference to the same package.
4. It then prefetches every pin that is not overridden. Four are overridden and skipped — `swift-driver`, `swift-argument-parser`, `swift-tools-support-core`, `swift-toolchain-sqlite`. The other seven are cloned: six have no local dependency under `SWIFTCI_USE_LOCAL_DEPS=1`, and `swift-llbuild` is local but its dependency is named for its directory, `llbuild`, while the pin is named for its repository, `swift-llbuild`, so the override misses.
5. `SWIFTCI_USE_LOCAL_DEPS=1` (which means no networking) is defeated.