### PR TITLE
[cxx-interop] Use a valid point of instantiation in lookupCxxTypeMember

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -96,7 +96,8 @@ lookupCxxTypeMember(clang::Sema &Sema, const clang::CXXRecordDecl *Rec,
     return nullptr; // Was not a clang::TypeDecl
 
   if (mustBeComplete &&
-      !Sema.isCompleteType({}, td->getASTContext().getTypeDeclType(td)))
+      !Sema.isCompleteType(td->getLocation(),
+                           td->getASTContext().getTypeDeclType(td)))
     return nullptr;
 
   return td;

--- a/test/Interop/Cxx/stdlib/Inputs/derived-conformance-uninstantiated-member-type.h
+++ b/test/Interop/Cxx/stdlib/Inputs/derived-conformance-uninstantiated-member-type.h
@@ -1,0 +1,30 @@
+// The member type aliases name specializations of a class template that
+// nothing in this header instantiates. Clang instantiates std::vector<int> for
+// Holder's field, but that does not instantiate the __normal_iterator
+// specializations the aliases refer to.
+//
+// Deliberately no member functions: an eagerly imported member (a constructor,
+// an operator, or a member function template) that mentions const_iterator
+// would instantiate it first and hide the problem.
+
+namespace __gnu_cxx {
+template <class Pointer, class Container>
+struct __normal_iterator {
+  Pointer current;
+};
+} // namespace __gnu_cxx
+
+namespace std {
+template <class T>
+class vector {
+public:
+  typedef T value_type;
+  typedef unsigned long size_type;
+  typedef __gnu_cxx::__normal_iterator<T *, vector> iterator;
+  typedef __gnu_cxx::__normal_iterator<const T *, vector> const_iterator;
+};
+} // namespace std
+
+struct Holder {
+  std::vector<int> v;
+};

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -152,3 +152,9 @@ module StdCoroutine {
   requires cplusplus
   export *
 }
+
+module DerivedConformanceUninstantiatedMemberType {
+  header "derived-conformance-uninstantiated-member-type.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/derived-conformance-uninstantiated-member-type.swift
+++ b/test/Interop/Cxx/stdlib/derived-conformance-uninstantiated-member-type.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test \
+// RUN:   -print-module \
+// RUN:   -module-to-print=DerivedConformanceUninstantiatedMemberType \
+// RUN:   -source-filename=x \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN:   -I %S/Inputs | %FileCheck %s
+
+// REQUIRES: swift_feature_ImportCxxMembersLazily
+
+// CHECK: struct vector<CInt> : CxxVector {
+// CHECK:   typealias const_iterator = __gnu_cxx.__normal_iterator<UnsafePointer<CInt>, std.vector<CInt>>
+// CHECK:   typealias RawIterator = __gnu_cxx.__normal_iterator<UnsafePointer<CInt>, std.vector<CInt>>
+// CHECK: }


### PR DESCRIPTION
Deriving conformances looks up member type aliases such as value_type and const_iterator and asks Sema whether they name complete types. That query passed an empty SourceLocation. When the alias names a class template specialization that nothing has instantiated yet, Sema instantiates it on demand and records the location as its point of instantiation, which trips an assertion:

  Loc.isValid() && "point of instantiation must be valid!"

Eager member import hid this: importing anything that mentions the alias instantiates the specialization first, with a valid location. With ImportCxxMembersLazily nothing else does. For libstdc++'s std::vector the only eagerly imported member that mentions const_iterator is the parameter-pack template emplace(const_iterator, _Args&&...), so a change that stops importing function templates with a parameter pack trips the assertion.

Use the alias's own location as the point of instantiation, as VisitClassTemplateSpecializationDecl already does.

rdar://186539182