### PR TITLE
[Diagnostics] Add fix-it for missing subscript in @dynamicMemberLookup

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2204,8 +2204,16 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   }
 
   attr->setInvalid();
-  if (!diagnosed)
-    diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+  if (!diagnosed) {
+    auto diag = diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+    auto braces = decl->getBraces();
+    if (braces.Start.isValid()) {
+      diag.fixItInsertAfter(braces.Start,
+          "\n  subscript(dynamicMember member: String) -> <#Value#> {\n"
+          "    <#code#>\n"
+          "  }");
+    }
+  }
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1382,3 +1382,17 @@ struct InaccessibleAndInvalidCandidate {
   // expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
   // expected-error@-2 {{'@dynamicMemberLookup' requires parameter to have a default value}}
 }
+
+// https://github.com/swiftlang/swift/issues/83344
+// Fix-it to add subscript(dynamicMember:) stub when no subscript exists.
+
+@dynamicMemberLookup struct EmptyStruct_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyStruct_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{48-48=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup class EmptyClass_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyClass_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{46-46=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup enum EmptyEnum_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyEnum_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{44-44=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup struct StructWithUnrelatedMembers_83344 { // expected-error {{'@dynamicMemberLookup' requires 'StructWithUnrelatedMembers_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{63-63=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+  var x: Int = 0
+  func foo() {}
+}


### PR DESCRIPTION
### Summary

This PR provides a helpful fix-it to automatically add the `subscript(dynamicMember:)` method stub when applying the `@dynamicMemberLookup` attribute to a type that doesn't define it.

### Motivation

Previously, the compiler emitted a diagnostic error but no actionable fix-it. This improves the developer experience by letting IDEs generate the required method stub automatically.

### Implementation

Updated the logic inside `AttributeChecker::visitDynamicMemberLookupAttr` in `lib/Sema/TypeCheckAttr.cpp`. It locates the starting brace of the nominal type declaration and inserts a `fixItInsertAfter` stub for the subscript method.

### Testing

Added test cases in `test/attr/attr_dynamic_member_lookup.swift` to cover structs, classes, enums, and structs with existing members. Verified the exact fix-it replacement logic against the frontend diagnostic verifier. Tested locally via `utils/run-test` with `swift-frontend`.

### Issue
Fixes #83344
