### PR TITLE
[Diagnostics] Fix missing type annotation fix-it in computed properties

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8914,8 +8914,7 @@ Parser::parseDeclVarGetSet(PatternBindingEntry &entry, ParseDeclOptions Flags,
   if (!typedPattern) {
     if (accessors.Get || accessors.Set || accessors.Address ||
         accessors.MutableAddress) {
-      SourceLoc locAfterPattern = pattern->getLoc().getAdvancedLoc(
-        pattern->getBoundName().getLength());
+      SourceLoc locAfterPattern = Lexer::getLocForEndOfToken(Context.SourceMgr, pattern->getEndLoc());
       diagnose(pattern->getLoc(), diag::computed_property_missing_type)
         .fixItInsert(locAfterPattern, ": <# Type #>");
       Invalid = true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2204,8 +2204,16 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   }
 
   attr->setInvalid();
-  if (!diagnosed)
-    diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+  if (!diagnosed) {
+    auto diag = diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+    auto braces = decl->getBraces();
+    if (braces.Start.isValid()) {
+      diag.fixItInsertAfter(braces.Start,
+          "\n  subscript(dynamicMember member: String) -> <#Value#> {\n"
+          "    <#code#>\n"
+          "  }");
+    }
+  }
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/test/Parse/computed_property_missing_type_fixit.swift
+++ b/test/Parse/computed_property_missing_type_fixit.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+func foo() {
+  var int {} // expected-error {{computed property must have an explicit type}} {{10-10=: <# Type #>}}
+}
+
+func bar() {
+  var (a, b) {} // expected-error {{computed property must have an explicit type}} {{13-13=: <# Type #>}}
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1382,3 +1382,17 @@ struct InaccessibleAndInvalidCandidate {
   // expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
   // expected-error@-2 {{'@dynamicMemberLookup' requires parameter to have a default value}}
 }
+
+// https://github.com/swiftlang/swift/issues/83344
+// Fix-it to add subscript(dynamicMember:) stub when no subscript exists.
+
+@dynamicMemberLookup struct EmptyStruct_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyStruct_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{48-48=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup class EmptyClass_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyClass_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{46-46=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup enum EmptyEnum_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyEnum_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{44-44=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup struct StructWithUnrelatedMembers_83344 { // expected-error {{'@dynamicMemberLookup' requires 'StructWithUnrelatedMembers_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{63-63=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+  var x: Int = 0
+  func foo() {}
+}


### PR DESCRIPTION
Resolves #87324.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>
-->

This PR fixes an issue where the fix-it for missing type annotations in computed properties was either misplaced or dropped entirely. 
Previously, the fix-it relied on \pattern->getBoundName().getLength()\ to determine the insertion location. For non-trivial patterns (like \BindingPattern\), this resulted in an empty string and a length of 0, which caused the fix-it to be incorrectly located at the start of the pattern.

By utilizing \Lexer::getLocForEndOfToken(Context.SourceMgr, pattern->getEndLoc())\, the fix-it is robustly inserted at the end of the parsed pattern, fixing issue #87324.