### PR TITLE
[Sema] Avoid inference cycles through protocol typealiases

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1374,32 +1374,61 @@ namespace {
 class TypeReprCycleCheckWalker : private ASTWalker {
   ASTContext &ctx;
   llvm::SmallDenseSet<Identifier, 2> circularNames;
+  llvm::SmallDenseSet<Identifier, 2> circularTypeAliasNames;
   ValueDecl *witness;
   bool found;
 
 public:
   TypeReprCycleCheckWalker(
       ASTContext &ctx,
-      const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved)
-    : ctx(ctx), witness(nullptr), found(false) {
+      const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
+      ValueDecl *requirement)
+      : ctx(ctx), witness(nullptr), found(false) {
     for (auto *assocType : allUnresolved) {
       circularNames.insert(assocType->getName());
     }
+
+    // A protocol type alias can indirectly refer to an unresolved associated
+    // type even when the alias itself has an unrelated name.
+    requirement->getInterfaceType().findIf([&](Type type) {
+      auto *typeAlias = dyn_cast<TypeAliasType>(type.getPointer());
+      if (!typeAlias ||
+          !typeAlias->getDecl()->getDeclContext()->getExtendedProtocolDecl())
+        return false;
+
+      if (typeAlias->getDecl()->getUnderlyingType().findIf([&](Type type) {
+            auto *dependentMember = type->getAs<DependentMemberType>();
+            auto *assocType =
+                dependentMember ? dependentMember->getAssocType() : nullptr;
+            return assocType && circularNames.count(assocType->getName());
+          })) {
+        circularTypeAliasNames.insert(typeAlias->getDecl()->getName());
+      }
+
+      return false;
+    });
   }
 
 private:
+  bool isCircularName(Identifier name) const {
+    return circularNames.count(name) || circularTypeAliasNames.count(name);
+  }
+
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     auto *declRefTyR = dyn_cast<DeclRefTypeRepr>(T);
-    if (!declRefTyR || declRefTyR->hasGenericArgList()) {
+    if (!declRefTyR) {
       return Action::Continue();
     }
+
+    auto name = declRefTyR->getNameRef().getBaseIdentifier();
+    if (declRefTyR->hasGenericArgList() && !circularTypeAliasNames.count(name))
+      return Action::Continue();
 
     auto *qualIdentTR = dyn_cast<QualifiedIdentTypeRepr>(T);
 
     // If we're inferring `Foo`, don't look at a witness mentioning `Foo`.
     if (!qualIdentTR) {
-      if (circularNames.count(declRefTyR->getNameRef().getBaseIdentifier()) >
-          0) {
+      if (isCircularName(name)) {
         // If unqualified lookup can find a type with this name without looking
         // into protocol members, don't skip the witness, since this type might
         // be a candidate witness.
@@ -1407,8 +1436,8 @@ private:
             declRefTyR->getNameRef(), witness->getDeclContext(),
             declRefTyR->getLoc(), UnqualifiedLookupOptions());
 
-        auto results =
-            evaluateOrDefault(ctx.evaluator, UnqualifiedLookupRequest{desc}, {});
+        auto results = evaluateOrDefault(ctx.evaluator,
+                                         UnqualifiedLookupRequest{desc}, {});
 
         // Ok, resolving this name would trigger associated type inference
         // recursively. We're going to skip this witness.
@@ -1426,7 +1455,7 @@ private:
       return Action::Continue();
     }
 
-    if (circularNames.count(declRefTyR->getNameRef().getBaseIdentifier()) > 0) {
+    if (isCircularName(name)) {
       // But if qualified lookup can find a type with this name without looking
       // into protocol members, don't skip the witness, since this type might
       // be a candidate witness.
@@ -1779,7 +1808,7 @@ AssociatedTypeInference::getPotentialTypeWitnessesFromRequirement(
     }
   }
 
-  TypeReprCycleCheckWalker cycleCheck(dc->getASTContext(), allUnresolved);
+  TypeReprCycleCheckWalker cycleCheck(dc->getASTContext(), allUnresolved, req);
 
   InferredAssociatedTypesByWitnesses result;
 

--- a/test/AssociatedTypeInference/cross_file_protocol_typealias_witness_inference.swift
+++ b/test/AssociatedTypeInference/cross_file_protocol_typealias_witness_inference.swift
@@ -1,0 +1,70 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -module-name Library %t/Library.swift -emit-module-path %t/Library.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name Client %t/Use.swift %t/Conformer.swift -I %t -emit-module-path %t/Client.swiftmodule
+
+// Keep Use.swift before Conformer.swift. Resolving ConcreteView.Value from the
+// earlier file must not invalidate the imported typealias in the later
+// conformance witness.
+
+//--- Library.swift
+
+public protocol View {
+  associatedtype Value
+
+  func withValue<Result>(_ body: Binding<Result>) -> Result
+}
+
+extension View {
+  public typealias Binding<Result> = (Value) -> Result
+}
+
+public struct RequiresValue<V: View, Expected> where V.Value == Expected {}
+
+public protocol InferredView {
+  associatedtype Value
+
+  func withValue<Result>(_ body: InferredBinding<Result>) -> Result
+  func accept(_: Value)
+}
+
+extension InferredView {
+  public typealias InferredBinding<Result> = (Value) -> Result
+}
+
+public struct RequiresInferredValue<V: InferredView, Expected>
+where V.Value == Expected {}
+
+//--- Use.swift
+
+import Library
+
+struct Model {}
+
+func use(_: RequiresValue<ConcreteView<Model>, Model>) {}
+func use(_: RequiresValue<QualifiedConcreteView<Model>, Model>) {}
+func use(_: RequiresInferredValue<ConcreteInferredView<String>, Int>) {}
+
+//--- Conformer.swift
+
+import Library
+
+struct ConcreteView<Value>: View {
+  func withValue<Result>(_ body: Binding<Result>) -> Result {
+    fatalError()
+  }
+}
+
+struct QualifiedConcreteView<Value>: View {
+  func withValue<Result>(_ body: Self.Binding<Result>) -> Result {
+    fatalError()
+  }
+}
+
+struct ConcreteInferredView<Unused>: InferredView {
+  func withValue<Result>(_ body: InferredBinding<Result>) -> Result {
+    fatalError()
+  }
+
+  func accept(_: Int) {}
+}


### PR DESCRIPTION
Protocol extension typealiases can hide references to unresolved associated types from the cycle check used during associated type inference. If a conformance witness uses one of those aliases, checking the witness can recursively start inference again. In a cross file client of an imported protocol, that cycle can surface later as an unhelpful module serialization failure.

This PR teaches `TypeReprCycleCheckWalker` to recognize aliases in the requirement's interface type whose underlying type mentions an unresolved associated type. References to those aliases are then handled like direct references to the associated type. The existing lookup checks still allow a real, independently resolvable type with the same name to participate in inference.