### PR TITLE
[Test] Validate that using string interpolation in OSLog calls does not cause heap allocation

### DIFF
--- a/validation-test/SILOptimizer/oslog.swift
+++ b/validation-test/SILOptimizer/oslog.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -swift-version 6 -verify %s -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -swift-version 6 -O -verify %s -emit-ir -module-name=test | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 6 -Osize -verify %s -emit-ir -module-name=test | %FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
@@ -7,8 +8,23 @@ import os.log
 
 let logger = Logger(subsystem: "x.y.z", category: "c")
 
-// Check that this compiles without errors
+// Check that this compiles without errors or object allocations under -O and
+// -Osize.
+
+// rdar://186404026
+// CHECK-NOT: @swift_allocObject
+// CHECK-NOT: @swift_deallocObject
 
 func testit(buffer: UnsafeRawBufferPointer) {
   logger.fault("buffer \(buffer, privacy: .sensitive)")
 }  
+
+@inline(never)
+public func interpolate1(_ log: Logger, _ x: Int) {
+  log.log("value \(x)")
+}
+
+@inline(never)
+public func interpolate3(_ log: Logger, _ x: Int, _ y: Int, _ z: Int) {
+  log.log("\(x) \(y) \(z)")
+}


### PR DESCRIPTION
This was fixed by a change between 6.4 and current main, most likely the new DeadObjectElimination pass: https://github.com/swiftlang/swift/pull/90456.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
