### PR TITLE
[SILOptimizer] RegionAnalysis: Implement `sending` inference for captures of non-escaping `@called(once)` closures

### DIFF
--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -630,6 +630,16 @@ public:
 
   bool isClosureCaptured(SILValue value, Operand *op);
 
+  /// Returns true if \p value's underlying tracked value is ever the target
+  /// of a `send` operation anywhere in this function's body.
+  ///
+  /// This replays the partition-op evaluation over every live block,
+  /// so "sent" here matches what SendNonSendable would report, as
+  /// opposed to a purely syntactic search for `Send` operation,
+  /// which would not account for elision (e.g. `nonisolated(unsafe)`,
+  /// same-actor sends).
+  bool wasValueEverSent(SILValue value);
+
   SILValue getUnderlyingTrackedValue(SILValue value) {
     return getValueMap().getRepresentative(value);
   }

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -519,6 +519,10 @@ class RegionAnalysisFunctionInfo {
 
   SendingOperandToStateMap sendingOperandToStateMap;
 
+  // This is a cache for \c wasValueEverSent(SILValue), memoizing both
+  // positive and negative results.
+  llvm::DenseMap<SILValue, bool> sentValuesCache;
+
   // We make this optional to prevent an issue that we have seen on windows when
   // capturing a field in a closure that is used to initialize a different
   // field.
@@ -637,7 +641,7 @@ public:
   /// so "sent" here matches what SendNonSendable would report, as
   /// opposed to a purely syntactic search for `Send` operation,
   /// which would not account for elision (e.g. `nonisolated(unsafe)`,
-  /// same-actor sends).
+  /// same-actor sends). The result is cached in \c sentValuesCache.
   bool wasValueEverSent(SILValue value);
 
   SILValue getUnderlyingTrackedValue(SILValue value) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -616,12 +616,21 @@ static bool canFunctionArgumentBeSent(SILFunctionArgument *arg) {
 
   // If we have a closure capture...
   if (arg->isClosureCapture()) {
-    // And that closure capture is from an async let, treat it as sending. This
-    // is because we allow for disconnected values to be sent into async let
-    // closures.
-    if (auto declRef = arg->getFunction()->getDeclRef();
-        declRef && declRef.isAsyncLetClosure) {
-      return true;
+    if (auto declRef = arg->getFunction()->getDeclRef()) {
+      // And that closure capture is from an async let, treat it as sending.
+      // This is because we allow for disconnected values to be sent into async
+      // let closures.
+      if (declRef.isAsyncLetClosure)
+        return true;
+
+      // All of the non-Sendable captures of non-escaping @called(once) closures
+      // that aren't explicitly `sending` can be sent.
+      if (auto *closure = declRef.getClosureExpr();
+          closure && closure->isCalledOnce()) {
+        auto *closureTy = closure->getType()->castTo<FunctionType>();
+        if (closureTy->getExtInfo().isNoEscape())
+          return true;
+      }
     }
   }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2307,6 +2307,71 @@ class PartitionOpTranslator {
     partialApplyReachabilityDataflow.propagateReachability();
   }
 
+  /// The argument is a non-escaping `@called(once)` value,
+  /// if it's a closure, attempt to undo send of it's implicitly
+  /// sending captures if the values weren't actually sent in the
+  /// body of the closure.
+  void tryUndoSendOfValuesCapturedByNonescapingCalledOnceClosure(
+      Operand *calledOnceArgument) {
+    auto closure = calledOnceArgument->get();
+
+    // Dig up partial_apply that represents the closure.
+    while (true) {
+      SILValue tmp = closure;
+
+      // Look through conversions
+      if (isa<ConvertEscapeToNoEscapeInst>(tmp) ||
+          isa<ConvertFunctionInst>(tmp)) {
+        tmp = cast<SingleValueInstruction>(tmp)->getOperand(0);
+      }
+
+      // Look through re-abstraction thunks
+      if (auto *pai = dyn_cast<PartialApplyInst>(tmp)) {
+        if (auto *calleeFn = pai->getCalleeFunction()) {
+          if (calleeFn->isThunk())
+            tmp = pai->getArgument(0);
+        }
+      }
+
+      if (closure == tmp)
+        break;
+
+      closure = tmp;
+    }
+
+    auto *pai = dyn_cast<PartialApplyInst>(closure);
+    if (!pai || !pai->isCalledOnce())
+      return;
+
+    auto *calleeFn = pai->getCalleeFunction();
+    if (!calleeFn)
+      return;
+
+    PostOrderFunctionInfo calleePOFI(calleeFn);
+    RegionAnalysisFunctionInfo calleeInfo(calleeFn, &calleePOFI);
+
+    if (!calleeInfo.isSupportedFunction())
+      return;
+
+    ApplySite callSite(pai);
+    for (auto &op : pai->getArgumentOperands()) {
+      auto trackedValue = tryToTrackValue(op.get());
+      if (!trackedValue)
+        continue;
+
+      // Skip explicitly `sending` captures.
+      if (callSite.getParamInfoForOperand(op).hasOption(
+              SILParameterInfo::Sending))
+        continue;
+
+      unsigned argIndex = callSite.getSubstCalleeArgIndex(op);
+      assert(argIndex < calleeFn->getArguments().size());
+
+      if (!calleeInfo.wasValueEverSent(calleeFn->getArgument(argIndex)))
+        builder.addUndoSend(trackedValue->value, calledOnceArgument->getUser());
+    }
+  }
+
 public:
   PartitionOpTranslator(SILFunction *function, PostOrderFunctionInfo *pofi,
                         RegionAnalysisValueMap &valueMap,
@@ -2905,6 +2970,9 @@ public:
     // For non-self parameters, gather all of the sending parameters and
     // gather our non-sending parameters.
     SmallVector<Operand *, 8> nonSendingParameters;
+    // Non-escaping `@called(once)` closures require a post-call undo
+    // of their un-sent captures.
+    SmallVector<Operand *, 2> nonescapingCalledOnceArguments;
     SmallVector<Operand *, 8> sendingIndirectResults;
 
     // NOTE: We want to process indirect parameters as if they are
@@ -2924,6 +2992,16 @@ public:
       // If our parameter is not sending, just add it to the non-sending
       // parameters array and continue.
       if (!fas.isSending(op)) {
+        auto argumentType = op.get()->getType();
+
+        // Non-escaping @called(once) closures require special
+        // handling to undo send of non-Sendable captures that
+        // weren't sent in the body.
+        if (argumentType.isCalledOnce() &&
+            argumentType.containsNoEscapeFunction()) {
+          nonescapingCalledOnceArguments.push_back(&op);
+        }
+
         nonSendingParameters.push_back(&op);
         continue;
       }
@@ -2950,6 +3028,12 @@ public:
         if (auto lookupResult = tryToTrackValue(op.get())) {
           builder.addUndoSend(lookupResult->value, op.getUser());
         }
+      }
+
+      // Attempt to undo send of captures that weren't sent in the body of
+      // a non-escaping `@called(once)` closure.
+      for (Operand *op : nonescapingCalledOnceArguments) {
+        tryUndoSendOfValuesCapturedByNonescapingCalledOnceClosure(op);
       }
     };
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4051,6 +4051,13 @@ CONSTANT_TRANSLATION(DereferenceBorrowAddrInst, LookThrough)
 // the src value and tgt addr
 CONSTANT_TRANSLATION(CopyAddrInst, Store)
 CONSTANT_TRANSLATION(ExplicitCopyAddrInst, Store)
+// `assign` is ordinarily lowered away by DI before this pass but
+// non-escaping `@called(once)` and `async let` bodies require analysis
+// as part of the use (calls for `@called(once)` and `await` for
+// `async let`) to determine whether sends of captures have to be undone
+// and that can happen before DI run on the closure and so `assign` has
+// to be treated as a `store`.
+CONSTANT_TRANSLATION(AssignInst, Store)
 CONSTANT_TRANSLATION(StoreInst, Store)
 CONSTANT_TRANSLATION(StoreWeakInst, Store)
 CONSTANT_TRANSLATION(MarkUnresolvedMoveAddrInst, Store)
@@ -4230,9 +4237,7 @@ CONSTANT_TRANSLATION(UnownedRetainInst, Asserting)
 CONSTANT_TRANSLATION(AllocPackMetadataInst, Asserting)
 CONSTANT_TRANSLATION(DeallocPackMetadataInst, Asserting)
 
-// All of these instructions should be removed by DI which runs before us in the
-// pass pipeline.
-CONSTANT_TRANSLATION(AssignInst, Asserting)
+// This should be removed by DI which runs before us in the pass pipeline.
 CONSTANT_TRANSLATION(AssignOrInitInst, Asserting)
 
 // We should never hit this since it can only appear as a final instruction in a

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -605,32 +605,83 @@ static bool isAsyncLetBeginPartialApply(PartialApplyInst *pai) {
   return *kind == BuiltinValueKind::StartAsyncLetWithLocalBuffer;
 }
 
+// The different kinds of instructions that use a closure value without
+// changing which closure it represents, e.g. as part of converting an
+// escaping closure to a non-escaping one, or adjusting its abstraction
+// level.
+enum class ClosureUseKind {
+  /// Not a closure use instruction that we look through.
+  Unsupported,
+  /// A thunk partial_apply that just forwards its single captured
+  /// argument.
+  Thunk,
+  /// A `convert_function`.
+  FunctionConversion,
+  /// A `convert_escape_to_noescape`.
+  EscapeToNoEscape,
+};
+
+static ClosureUseKind classifyClosureWrapper(SILInstruction *inst) {
+  if (!inst)
+    return ClosureUseKind::Unsupported;
+
+  if (auto *pai = dyn_cast<PartialApplyInst>(inst)) {
+    auto *calleeFn = pai->getCalleeFunction();
+    if (calleeFn && calleeFn->isThunk())
+      return ClosureUseKind::Thunk;
+    return ClosureUseKind::Unsupported;
+  }
+
+  if (isa<ConvertFunctionInst>(inst))
+    return ClosureUseKind::FunctionConversion;
+
+  if (isa<ConvertEscapeToNoEscapeInst>(inst))
+    return ClosureUseKind::EscapeToNoEscape;
+
+  return ClosureUseKind::Unsupported;
+}
+
 // Determine whether this partial application is only used as a non-escaping
 // value i.e. a closure that is passed to a non-escaping parameter.
 static bool isNoEscapePartialApply(PartialApplyInst *pai) {
   SILValue value = pai;
-  while (true) {
-    // Look through re-abstraction and other thunks
-    if (auto *use = value->getSingleUse()) {
-      if (auto *maybeThunk = dyn_cast<PartialApplyInst>(use->getUser())) {
-        if (auto *fas = maybeThunk->getCalleeFunction();
-            fas && fas->isThunk()) {
-          value = maybeThunk;
-          continue;
-        }
-      }
-
-      // Look through function conversions
-      if (auto *cfi = dyn_cast<ConvertFunctionInst>(use->getUser())) {
-        value = cfi;
-        continue;
-      }
-
-      return isa<ConvertEscapeToNoEscapeInst>(use->getUser());
+  while (auto *use = value->getSingleUse()) {
+    auto *user = use->getUser();
+    switch (classifyClosureWrapper(user)) {
+    case ClosureUseKind::Thunk:
+    case ClosureUseKind::FunctionConversion:
+      value = cast<SingleValueInstruction>(user);
+      continue;
+    case ClosureUseKind::EscapeToNoEscape:
+      return true;
+    case ClosureUseKind::Unsupported:
+      return false;
     }
-
-    return false;
   }
+
+  return false;
+}
+
+/// Given a value that could be a closure, attempt to walk up through its
+/// uses and get a `partial_apply` that forms it.
+static PartialApplyInst *getUnderlyingPartialApply(SILValue closure) {
+  auto tryLookthroughClosureUse = [](SILValue value) {
+    auto *inst = value->getDefiningInstruction();
+    switch (classifyClosureWrapper(inst)) {
+    case ClosureUseKind::Thunk:
+      return cast<PartialApplyInst>(inst)->getArgument(0);
+    case ClosureUseKind::FunctionConversion:
+    case ClosureUseKind::EscapeToNoEscape:
+      return cast<SingleValueInstruction>(inst)->getOperand(0);
+    case ClosureUseKind::Unsupported:
+      return SILValue();
+    }
+  };
+
+  while (SILValue unwrapped = tryLookthroughClosureUse(closure))
+    closure = unwrapped;
+
+  return dyn_cast<PartialApplyInst>(closure);
 }
 
 /// Returns true if this is a function argument that is able to be sent in the
@@ -2313,33 +2364,8 @@ class PartitionOpTranslator {
   /// body of the closure.
   void tryUndoSendOfValuesCapturedByNonescapingCalledOnceClosure(
       Operand *calledOnceArgument) {
-    auto closure = calledOnceArgument->get();
-
     // Dig up partial_apply that represents the closure.
-    while (true) {
-      SILValue tmp = closure;
-
-      // Look through conversions
-      if (isa<ConvertEscapeToNoEscapeInst>(tmp) ||
-          isa<ConvertFunctionInst>(tmp)) {
-        tmp = cast<SingleValueInstruction>(tmp)->getOperand(0);
-      }
-
-      // Look through re-abstraction thunks
-      if (auto *pai = dyn_cast<PartialApplyInst>(tmp)) {
-        if (auto *calleeFn = pai->getCalleeFunction()) {
-          if (calleeFn->isThunk())
-            tmp = pai->getArgument(0);
-        }
-      }
-
-      if (closure == tmp)
-        break;
-
-      closure = tmp;
-    }
-
-    auto *pai = dyn_cast<PartialApplyInst>(closure);
+    auto *pai = getUnderlyingPartialApply(calledOnceArgument->get());
     if (!pai || !pai->isCalledOnce())
       return;
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -5098,6 +5098,10 @@ struct SendQueryEvaluator final
 bool RegionAnalysisFunctionInfo::wasValueEverSent(SILValue value) {
   assert(supportedFunction && "Unsupported Function?!");
 
+  // First, check if the answer is already known for this value.
+  if (auto iter = sentValuesCache.find(value); iter != sentValuesCache.end())
+    return iter->second;
+
   auto trackableValue = getValueMap().getTrackableValue(value);
   if (trackableValue.value.isSendable())
     return false;
@@ -5114,12 +5118,13 @@ bool RegionAnalysisFunctionInfo::wasValueEverSent(SILValue value) {
 
     for (auto &partitionOp : blockState.getPartitionOps()) {
       eval.apply(partitionOp);
-      if (workingPartition.isSent(elt))
-        return true;
+      if (workingPartition.isSent(elt)) {
+        return sentValuesCache[value] = true;
+      }
     }
   }
 
-  return false;
+  return sentValuesCache[value] = false;
 }
 
 void RegionAnalysisFunctionInfo::runDataflow() {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -605,6 +605,34 @@ static bool isAsyncLetBeginPartialApply(PartialApplyInst *pai) {
   return *kind == BuiltinValueKind::StartAsyncLetWithLocalBuffer;
 }
 
+// Determine whether this partial application is only used as a non-escaping
+// value i.e. a closure that is passed to a non-escaping parameter.
+static bool isNoEscapePartialApply(PartialApplyInst *pai) {
+  SILValue value = pai;
+  while (true) {
+    // Look through re-abstraction and other thunks
+    if (auto *use = value->getSingleUse()) {
+      if (auto *maybeThunk = dyn_cast<PartialApplyInst>(use->getUser())) {
+        if (auto *fas = maybeThunk->getCalleeFunction();
+            fas && fas->isThunk()) {
+          value = maybeThunk;
+          continue;
+        }
+      }
+
+      // Look through function conversions
+      if (auto *cfi = dyn_cast<ConvertFunctionInst>(use->getUser())) {
+        value = cfi;
+        continue;
+      }
+
+      return isa<ConvertEscapeToNoEscapeInst>(use->getUser());
+    }
+
+    return false;
+  }
+}
+
 /// Returns true if this is a function argument that is able to be sent in the
 /// body of our function.
 ///
@@ -2697,6 +2725,26 @@ public:
       builder.addAssignFresh(lookupResult->value);
   }
 
+  void translateSILNoEscapeCalledOncePartialApply(PartialApplyInst *pai) {
+    REGIONBASEDISOLATION_LOG(
+        llvm::dbgs()
+        << "Translating non-escaping `@called(once)` Partial Apply!\n");
+
+    for (auto &op : ApplySite(pai).getArgumentOperands()) {
+      // All of the non-Sendable captures are sent by default. This would
+      // be undone after the call if the value is not actually sent in the
+      // body.
+      if (auto lookupResult = tryToTrackValue(op.get())) {
+        builder.addRequire(*lookupResult);
+        builder.addSend(lookupResult->value, &op);
+      }
+    }
+
+    // Mark our partial_apply result as being returned fresh.
+    if (auto lookupResult = tryToTrackValue(pai))
+      builder.addAssignFresh(lookupResult->value);
+  }
+
   void translateSILCalledOncePartialApply(PartialApplyInst *pai) {
     ApplySite applySite(pai);
     REGIONBASEDISOLATION_LOG(llvm::dbgs()
@@ -2804,6 +2852,13 @@ public:
     // `@called(once)` closures are allowed to have `sending` captures which
     // need special handling.
     if (pai->isCalledOnce()) {
+      // no-escaping closures treat non-Sendable captures that aren't explicitly
+      // `sending` as individually sent and undo if the values were never
+      // actually sent in the body.
+      if (isNoEscapePartialApply(pai)) {
+        return translateSILNoEscapeCalledOncePartialApply(pai);
+      }
+
       return translateSILCalledOncePartialApply(pai);
     }
 
@@ -4934,7 +4989,7 @@ bool RegionAnalysisFunctionInfo::wasValueEverSent(SILValue value) {
 
   Element elt = trackableValue.value.getID();
 
-  for (auto [block, blockState] : getRange()) {
+  for (const auto &[block, blockState] : getRange()) {
     if (!blockState.getLiveness())
       continue;
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -4856,6 +4856,93 @@ bool RegionAnalysisFunctionInfo::isClosureCaptured(SILValue value,
   return translator->isClosureCaptured(value, op->getUser());
 }
 
+namespace {
+
+/// A minimal evaluator used only to answer whole-function summary queries
+/// like RegionAnalysisFunctionInfo::wasValueEverSent. It mirrors the real
+/// isolation/closure-capture callbacks used by SendNonSendable's
+/// DiagnosticEvaluator (so "sent" here matches what diagnostics would
+/// report, including elision), but never emits errors.
+struct SendQueryEvaluator final
+    : PartitionOpEvaluatorBaseImpl<SendQueryEvaluator> {
+  RegionAnalysisFunctionInfo *info;
+
+  SendQueryEvaluator(Partition &workingPartition,
+                     RegionAnalysisFunctionInfo *info,
+                     SendingOperandToStateMap &operandToStateMap)
+      : PartitionOpEvaluatorBaseImpl(
+            workingPartition, info->getOperandSetFactory(), operandToStateMap),
+        info(info) {}
+
+  void handleError(PartitionOpError &&error) const {}
+
+  bool isActorDerived(Element element) const {
+    return info->getValueMap().getIsolationRegion(element).isActorIsolated();
+  }
+
+  bool isTaskIsolatedDerived(Element element) const {
+    return info->getValueMap().getIsolationRegion(element).isTaskIsolated();
+  }
+
+  SILIsolationInfo getIsolationRegionInfo(Element element) const {
+    return info->getValueMap().getIsolationRegion(element);
+  }
+
+  std::optional<Element> getElement(SILValue value) const {
+    auto trackableValue = info->getValueMap().getTrackableValue(value);
+    if (trackableValue.value.isSendable())
+      return {};
+    return trackableValue.value.getID();
+  }
+
+  SILValue getRepresentative(SILValue value) const {
+    return info->getValueMap()
+        .getTrackableValue(value)
+        .value.getRepresentative()
+        .maybeGetValue();
+  }
+
+  RepresentativeValue getRepresentativeValue(Element element) const {
+    return info->getValueMap().getRepresentativeValue(element);
+  }
+
+  bool isClosureCaptured(Element element, Operand *op) const {
+    auto value = info->getValueMap().maybeGetRepresentative(element);
+    if (!value)
+      return false;
+    return info->isClosureCaptured(value, op);
+  }
+};
+
+} // end anonymous namespace
+
+bool RegionAnalysisFunctionInfo::wasValueEverSent(SILValue value) {
+  assert(supportedFunction && "Unsupported Function?!");
+
+  auto trackableValue = getValueMap().getTrackableValue(value);
+  if (trackableValue.value.isSendable())
+    return false;
+
+  Element elt = trackableValue.value.getID();
+
+  for (auto [block, blockState] : getRange()) {
+    if (!blockState.getLiveness())
+      continue;
+
+    Partition workingPartition = blockState.getEntryPartition();
+    SendQueryEvaluator eval(workingPartition, this,
+                            getSendingOperandToStateMap());
+
+    for (auto &partitionOp : blockState.getPartitionOps()) {
+      eval.apply(partitionOp);
+      if (workingPartition.isSent(elt))
+        return true;
+    }
+  }
+
+  return false;
+}
+
 void RegionAnalysisFunctionInfo::runDataflow() {
   assert(!solved && "solve should only be called once");
   solved = true;

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -2756,9 +2756,8 @@ void UseAfterSendDiagnosticInferrer::infer() {
   }
 
   if (auto *pai = dyn_cast<PartialApplyInst>(sendingOp->getUser())) {
-    if (pai->isCalledOnce() && ApplySite(pai)
-                                   .getParamInfoForOperand(*sendingOp)
-                                   .hasOption(SILParameterInfo::Sending)) {
+    // @called(once) closures can have both implicit and explicit `sending` captures.
+    if (pai->isCalledOnce()) {
       if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
         return diagnosticEmitter.emitNamedUseofStronglySentValue(
             baseLoc, rootValueAndName->first);
@@ -3721,24 +3720,21 @@ bool SentNeverSendableDiagnosticEmitter::emit() {
       }
     }
 
-    // A `sending` capture of an non-isolated `@called(once)` closure is
-    // translated by `translateSILCalledOncePartialApply` as a send of
-    // that specific operand -- so reaching this operand here means the
-    // capture itself crossed isolation, independent of whether the closure
-    // as a whole is isolated. Let's use the captured value's tracked
-    // isolation (when it is actor-isolated) as the caller isolation.
+    // Reaching this operand here means it was individually sent as a capture
+    // of a non-isolated `@called(once)` closure -- either because it was
+    // explicitly `sending`, or because it's an ordinary capture of a
+    // non-escaping closure (every non-Sendable capture of those is sent
+    // individually, independent of whether the closure as a whole is isolated.
+    // Let's use the captured value's tracked isolation (when it is
+    // actor-isolated) as the caller isolation.
     if (auto *pai = dyn_cast<PartialApplyInst>(op->getUser());
         pai && pai->isCalledOnce()) {
-      ApplySite apply(pai);
-      if (apply.getParamInfoForOperand(*op).hasOption(
-              SILParameterInfo::Sending)) {
-        std::optional<ActorIsolation> callerIsolation;
-        if (diagnosticEmitter.getIsolationRegionInfo()->hasActorIsolation())
-          callerIsolation =
-              diagnosticEmitter.getIsolationRegionInfo()->getActorIsolation();
-        if (initForIsolatedPartialApply(op, ace, callerIsolation))
-          return true;
-      }
+      std::optional<ActorIsolation> callerIsolation;
+      if (diagnosticEmitter.getIsolationRegionInfo()->hasActorIsolation())
+        callerIsolation =
+            diagnosticEmitter.getIsolationRegionInfo()->getActorIsolation();
+      if (initForIsolatedPartialApply(op, ace, callerIsolation))
+        return true;
     }
   }
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1011,10 +1011,21 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   // sync with that code.
   if (!fArg->isIndirectResult() && !fArg->isIndirectErrorResult() &&
       fArg->isClosureCapture()) {
-    if (auto declRef = func->getDeclRef();
-        declRef && declRef.isAsyncLetClosure) {
-      return SILIsolationInfo::getDisconnected(
-          isClosureCapturedNonisolatedUnsafe);
+    if (auto declRef = func->getDeclRef()) {
+      if (declRef.isAsyncLetClosure) {
+        return SILIsolationInfo::getDisconnected(
+            isClosureCapturedNonisolatedUnsafe);
+      }
+
+      // All of the non-Sendable captures of non-escaping @called(once) closures
+      // that aren't explicitly `sending` are disconnected.
+      if (auto *closure = declRef.getClosureExpr();
+          closure && closure->isCalledOnce()) {
+        auto *closureTy = closure->getType()->castTo<FunctionType>();
+        if (closureTy->getExtInfo().isNoEscape())
+          return SILIsolationInfo::getDisconnected(
+              isClosureCapturedNonisolatedUnsafe);
+      }
     }
   }
 

--- a/test/SIL/called_once_nonescaping_sending_captures.swift
+++ b/test/SIL/called_once_nonescaping_sending_captures.swift
@@ -1,0 +1,121 @@
+// RUN: %target-swift-frontend %s \
+// RUN:   -target %target-swift-5.1-abi-triple \
+// RUN:   -emit-sil \
+// RUN:   -enable-experimental-feature CalledAttribute \
+// RUN:   -swift-version 6 \
+// RUN:   -verify
+
+// REQUIRES: swift_feature_CalledAttribute
+// REQUIRES: concurrency
+
+class NS {}
+
+func useValue(_ ns: NS) {}
+
+func calledOnce(_: @called(once) () -> Void) {}
+
+func testNeverSentUsableAfter() {
+  let ns1 = NS()
+
+  calledOnce { [ns1] in
+    useValue(ns1)
+  }
+
+  useValue(ns1) // Ok
+
+  let ns2 = NS()
+  calledOnce {
+    useValue(ns2)
+  }
+
+  useValue(ns2) // Ok
+}
+
+func testPassingToTask() {
+  let ns = NS()
+
+  calledOnce { // expected-error {{sending 'ns' risks causing data races}} expected-note {{'ns' used after being passed as a 'sending' parameter; Later uses could race}}
+    Task { _ = ns }
+  }
+
+  useValue(ns) // expected-note {{access can happen concurrently}}
+}
+
+@MainActor func take(_ ns: NS) {}
+
+func calledOnceAsync(_: @called(once) () async -> Void) async {}
+
+func testSentInsideBodyRemainsSent() async {
+  let ns = NS()
+  await calledOnceAsync { [ns] in // expected-error {{sending 'ns' risks causing data races}} expected-note {{'ns' used after being passed as a 'sending' parameter; Later uses could race}}
+    await take(ns) // crosses an isolation boundary
+  }
+  useValue(ns) // expected-note {{access can happen concurrently}}
+}
+
+// Explicitly `sending` captures are always sent and never undone.
+func testSendingCaptureAlwaysPermanent(_ ns: sending NS) {
+  calledOnce { [sending ns] in // expected-error {{sending 'ns' risks causing data races}} expected-note {{'ns' used after being passed as a 'sending' parameter; Later uses could race}}
+    useValue(ns)
+  }
+  useValue(ns) // expected-note {{access can happen concurrently}}
+}
+
+func testIndependentCapturesDoNotEntangle() async {
+  let ns1 = NS()
+  let ns2 = NS()
+
+  await calledOnceAsync { [ns1, ns2] in // expected-error {{sending 'ns1' risks causing data races}} expected-note {{'ns1' used after being passed as a 'sending' parameter; Later uses could race}}
+    await take(ns1)
+    useValue(ns2)
+  }
+
+  useValue(ns1) // expected-note {{access can happen concurrently}}
+  useValue(ns2) // Ok
+
+  func merge<T>(_: T, _: T) {}
+  func send(_: sending NS) {}
+
+  let ns3 = NS()
+  let ns4 = NS()
+
+  calledOnce {
+    merge(ns3, ns4)
+  }
+
+  // FIXME: The following code shouldn't be valid. `ns3` and `ns4` are merged together in the closure and shouldn't be allowed to be sent separately later.
+  send(ns3)
+  send(ns4)
+}
+
+actor A {
+  func run(_: @called(once) () -> Void) {}
+}
+
+func testIsolationCrossingCallAlwaysSends(_ a: A) async {
+  let ns = NS()
+  await a.run { [ns] in // expected-error {{sending 'ns' risks causing data races}} expected-note {{'ns' used after being passed as a 'sending' parameter; Later uses could race}}
+    useValue(ns) // never sent
+  }
+
+  // but `a.run(...)` crosses isolation which also sends `ns`
+  useValue(ns) // expected-note {{access can happen concurrently}}
+}
+
+func testReabstractedEscapingClosure() {
+  func identity<T>(_ f: @escaping (T) -> Void) -> (T) -> Void { f }
+
+  func callOnce(_ f: @called(once) (NS) -> Void) {
+    f(NS())
+  }
+
+  let ns = NS()
+
+  let closure: (NS) -> Void = { x in
+    useValue(ns)
+    useValue(x)
+  }
+
+  callOnce(identity(closure))
+  useValue(ns) // Ok (nothing is sent in the closure)
+}

--- a/test/SIL/called_once_nonescaping_sending_captures.swift
+++ b/test/SIL/called_once_nonescaping_sending_captures.swift
@@ -162,3 +162,14 @@ func testNoncopyableRefAndUndo() {
 
   _ = v // expected-note {{used here}}
 }
+
+func testVarMutatedInClosure() {
+  var value = NS()
+
+  calledOnce {
+    value = NS()
+    useValue(value)
+  }
+
+  useValue(value) // Ok
+}

--- a/test/SIL/called_once_nonescaping_sending_captures.swift
+++ b/test/SIL/called_once_nonescaping_sending_captures.swift
@@ -12,6 +12,8 @@ class NS {}
 
 func useValue(_ ns: NS) {}
 
+func useGeneric<T>(_ t: T) {}
+
 func calledOnce(_: @called(once) () -> Void) {}
 
 func testNeverSentUsableAfter() {
@@ -118,4 +120,45 @@ func testReabstractedEscapingClosure() {
 
   callOnce(identity(closure))
   useValue(ns) // Ok (nothing is sent in the closure)
+}
+
+func testGenericParameterCapture<T>(_ value: T) {
+  calledOnce {
+    useGeneric(value) // expected-error {{sending 'value' risks causing data races}} expected-note {{'value' is captured by a nonisolated closure. nonisolated uses in closure may race against code in the current isolation context}}
+  }
+
+  useGeneric(value)
+}
+
+func testGenericSendingParameterCapture<T>(_ value: sending T) {
+  calledOnce {
+    useGeneric(value)
+  }
+
+  useGeneric(value) // Ok
+}
+
+func testVarCapturedNotMutated() {
+  var value = NS()
+  value = NS()
+  calledOnce {
+    useValue(value)
+  }
+  useValue(value) // Ok
+}
+
+func testNoncopyableRefAndUndo() {
+  struct NCS: ~Copyable, ~Sendable {
+    func test() {}
+  }
+
+  // FIXME: There should be no errors here. This is currently considered to be
+  // a consuming use of `v` because `@called(once)` is never marked as `[on_stack]`.
+  // The move-only checker needs to be tought about non-escaping `@called(once)`.
+  let v = NCS() // expected-error {{'v' used after consume}}
+  calledOnce { // expected-note {{consumed here}}
+    v.test()
+  }
+
+  _ = v // expected-note {{used here}}
 }

--- a/test/SIL/called_once_sending_captures.swift
+++ b/test/SIL/called_once_sending_captures.swift
@@ -135,7 +135,7 @@ extension CalledOnceActor {
 
 // AssignNeverSendableIntoSendingResult: a `@called(once)` closure with a
 // `sending` result, returning a captured value that was never itself sent.
-func calledOnceResult(_ f: @called(once) () -> sending NS) {}
+func calledOnceResult(_ f: @escaping @called(once) () -> sending NS) {}
 
 func testAssignNeverSendableIntoSendingResult(ns: NS) {
   calledOnceResult { ns } // expected-error {{sending 'ns' risks causing data races}} expected-note {{'ns' cannot be a 'sending' result. Code in the current task may race with caller uses}}
@@ -225,7 +225,7 @@ func testInOutSendingCaptureAliasedWithReturnValue(_ x: inout sending NS) -> sen
 actor CustomActorInstance {}
 @globalActor struct CustomActor { static let shared = CustomActorInstance() }
 
-struct CalledOnceAsyncTask { init(_ ns: @called(once) () async -> Void) {} }
+struct CalledOnceAsyncTask { init(_ ns: @escaping @called(once) () async -> Void) {} }
 
 @MainActor
 struct MergeAcrossGlobalActors {


### PR DESCRIPTION
Implements an inference rule that treats all non-Sendable captures
of non-escaping `@called(once)` closures as individually `sending`
and if there were no sending operations in the body the send is
un-done after the call.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
