### PR TITLE
Add experimental @_target attribute for per-function CPU overrides

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1366,6 +1366,11 @@ BridgedSemanticsAttr BridgedSemanticsAttr_createParsed(
     BridgedASTContext cContext, swift::SourceLoc atLoc,
     swift::SourceRange range, BridgedStringRef cValue);
 
+SWIFT_NAME("BridgedTargetAttr.createParsed(_:atLoc:range:value:)")
+BridgedTargetAttr BridgedTargetAttr_createParsed(
+    BridgedASTContext cContext, swift::SourceLoc atLoc,
+    swift::SourceRange range, BridgedStringRef cValue);
+
 SWIFT_NAME("BridgedSetterAccessAttr.createParsed(_:range:accessLevel:)")
 BridgedSetterAccessAttr
 BridgedSetterAccessAttr_createParsed(BridgedASTContext cContext,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -850,6 +850,32 @@ public:
   }
 };
 
+/// The `@_target` attribute, overriding the target CPU/features for functions.
+class TargetAttr : public DeclAttribute {
+public:
+  TargetAttr(StringRef Value, SourceLoc AtLoc, SourceRange Range,
+             bool Implicit)
+      : DeclAttribute(DeclAttrKind::Target, AtLoc, Range, Implicit),
+        Value(Value) {}
+
+  TargetAttr(StringRef Value, bool Implicit)
+      : TargetAttr(Value, SourceLoc(), SourceRange(), Implicit) {}
+
+  const StringRef Value;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DeclAttrKind::Target;
+  }
+
+  TargetAttr *clone(ASTContext &ctx) const {
+    return new (ctx) TargetAttr(Value, AtLoc, Range, isImplicit());
+  }
+
+  bool isEquivalent(const TargetAttr *other, Decl *attachedTo) const {
+    return Value == other->Value;
+  }
+};
+
 /// Defines the @_alignment attribute.
 class AlignmentAttr : public DeclAttribute {
 public:

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -945,7 +945,13 @@ DECL_ATTR(cxx, CxxDecl,
   178)
 DECL_ATTR_FEATURE_REQUIREMENT(CxxDecl, CxxImplementation)
 
-LAST_DECL_ATTR(CxxDecl)
+DECL_ATTR(_target, Target,
+  OnAbstractFunction,
+  UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | UnconstrainedInABIAttr,
+  179)
+DECL_ATTR_FEATURE_REQUIREMENT(Target, TargetAttribute)
+
+LAST_DECL_ATTR(Target)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4502,6 +4502,22 @@ ERROR(attr_incompatible_with_attr,none,
       "'%0' cannot be used with '%1'",
       (DeclAttribute, DeclAttribute))
 
+ERROR(attr_target_empty_string,none,
+      "'@_target' requires a non-empty target string", ())
+
+ERROR(attr_target_unsupported_feature,none,
+      "unsupported target feature '%0' in '@_target'", (StringRef))
+
+ERROR(attr_target_unsupported_cpu,none,
+      "unsupported CPU '%0' in '@_target'", (StringRef))
+
+ERROR(attr_target_duplicate_option,none,
+      "duplicate '%0' option in '@_target'", (StringRef))
+
+ERROR(attr_target_invalid_branch_protection,none,
+      "invalid branch protection specification '%0' in '@_target'",
+      (StringRef))
+
 ERROR(attr_incompatible_with_non_final,none,
       "'%0' cannot be applied to a non-final %kindonly1",
       (DeclAttribute, const ValueDecl *))

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -678,6 +678,9 @@ EXPERIMENTAL_FEATURE(LibkernOwnershipConventions, true)
 /// Emit `resignRemoteID` calls in remote distributed actor deinits.
 EXPERIMENTAL_FEATURE(DistributedActorResignRemoteID, false)
 
+/// Enable @_target, a per-function target-features/CPU override.
+EXPERIMENTAL_FEATURE(TargetAttribute, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -333,6 +333,9 @@ private:
   /// Name of a section if @section attribute was used, otherwise empty.
   StringRef Section;
 
+  /// The target string from @_target.
+  StringRef TargetFeatures;
+
   /// Name of a Wasm export if @_expose(wasm) attribute was used, otherwise
   /// empty.
   StringRef WasmExportName;
@@ -1499,6 +1502,9 @@ public:
   /// Return custom section name if @section was used, otherwise empty
   StringRef section() const { return Section; }
   void setSection(StringRef value) { Section = value; }
+
+  StringRef targetFeatures() const { return TargetFeatures; }
+  void setTargetFeatures(StringRef value) { TargetFeatures = value; }
 
   /// Return Wasm export name if @_expose(wasm) was used, otherwise empty
   StringRef wasmExportName() const { return WasmExportName; }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5603,6 +5603,11 @@ public:
     printFieldQuoted(Attr->Value, Label::always("value"));
     printFoot();
   }
+  void visitTargetAttr(TargetAttr *Attr, Label label) {
+    printCommon(Attr, "target_attr", label);
+    printFieldQuoted(Attr->Value, Label::always("value"));
+    printFoot();
+  }
   void visitSetterAccessAttr(SetterAccessAttr *Attr, Label label) {
     printCommon(Attr, "setter_access_attr", label);
     printField(Attr->getAccess(), Label::always("access"));

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1386,6 +1386,12 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DeclAttrKind::Target: {
+    Printer.printAttrName("@_target");
+    Printer << "(\"" << cast<TargetAttr>(this)->Value << "\")";
+    break;
+  }
+
   case DeclAttrKind::Diagnose: {
     auto diagnoseAttr = cast<DiagnoseAttr>(this);
     Printer.printAttrName("@diagnose(");
@@ -2183,6 +2189,8 @@ StringRef DeclAttribute::getAttrName() const {
     case ExecutionSemantics::Once:
       return "called(once)";
     }
+  case DeclAttrKind::Target:
+    return "_target";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -762,6 +762,14 @@ BridgedSemanticsAttr_createParsed(BridgedASTContext cContext, SourceLoc atLoc,
                     /*Implicit=*/false);
 }
 
+BridgedTargetAttr
+BridgedTargetAttr_createParsed(BridgedASTContext cContext, SourceLoc atLoc,
+                               SourceRange range, BridgedStringRef cValue) {
+  return new (cContext.unbridged())
+      TargetAttr(cValue.unbridged(), atLoc, range,
+                /*Implicit=*/false);
+}
+
 BridgedSetterAccessAttr
 BridgedSetterAccessAttr_createParsed(BridgedASTContext cContext,
                                      SourceRange range,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -216,6 +216,10 @@ static bool usesFeatureCAttribute(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureTargetAttribute(Decl *decl) {
+  return decl->getAttrs().hasAttribute<TargetAttr>();
+}
+
 static bool findLifetimeAttr(Decl *decl, bool findUnderscored) {
   auto hasLifetimeAttr = [&](Decl *decl) {
     if (!decl->getAttrs().hasAttribute<LifetimeAttr>()) {

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -206,6 +206,8 @@ extension ASTGenVisitor {
         return handle(self.generateSwiftNativeObjCRuntimeBaseAttr(attribute: node)?.asDeclAttribute)
       case .Diagnose:
         return handle(self.generateDiagnoseAttr(attribute: node)?.asDeclAttribute)
+      case .Target:
+        return handle(self.generateTargetAttr(attribute: node)?.asDeclAttribute)
       case .Transpose:
         return handle(self.generateTransposeAttr(attribute: node)?.asDeclAttribute)
       case .TypeEraser:
@@ -2025,6 +2027,25 @@ extension ASTGenVisitor {
   ///   ```
   ///   @semantics("semantics_name")
   func generateSemanticsAttr(attribute node: AttributeSyntax) -> BridgedSemanticsAttr? {
+    self.generateWithLabeledExprListArguments(attribute: node) { args in
+      guard let value = self.generateConsumingSimpleStringLiteralAttrOption(args: &args) else {
+        return nil
+      }
+
+      return .createParsed(
+        self.ctx,
+        atLoc: self.generateSourceLoc(node.atSign),
+        range: self.generateAttrSourceRange(node),
+        value: value
+      )
+    }
+  }
+
+  /// E.g.:
+  ///   ```
+  ///   @_target("avx2")
+  ///   ```
+  func generateTargetAttr(attribute node: AttributeSyntax) -> BridgedTargetAttr? {
     self.generateWithLabeledExprListArguments(attribute: node) { args in
       guard let value = self.generateConsumingSimpleStringLiteralAttrOption(args: &args) else {
         return nil

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3752,6 +3752,8 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   if (!f->section().empty())
     fn->setSection(f->section());
 
+  addTargetAttrFunctionAttributes(fn, f->targetFeatures());
+
   llvm::AttrBuilder attrBuilder(getLLVMContext());
   if (!f->wasmExportName().empty()) {
     attrBuilder.addAttribute("wasm-export-name", f->wasmExportName());

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -37,6 +37,9 @@
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/CharInfo.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticIDs.h"
+#include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
 #include "clang/CodeGen/ModuleBuilder.h"
@@ -48,6 +51,9 @@
 #include "clang/Lex/PreprocessorOptions.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Frontend/Debug/Options.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
@@ -1690,6 +1696,58 @@ llvm::AttributeList IRGenModule::constructInitialAttributes() {
   llvm::AttrBuilder b(getLLVMContext());
   constructInitialFnAttributes(b);
   return llvm::AttributeList().addFnAttributes(getLLVMContext(), b);
+}
+
+void IRGenModule::addTargetAttrFunctionAttributes(llvm::Function *fn,
+                                                  StringRef targetString) {
+  if (targetString.empty())
+    return;
+  auto *clangImporter =
+      static_cast<ClangImporter *>(Context.getClangModuleLoader());
+  auto &TI = clangImporter->getTargetInfo();
+  clang::ParsedTargetAttr parsed = TI.parseTargetAttr(targetString);
+  StringRef targetCPU = TI.getTargetOpts().CPU;
+  StringRef tuneCPU = TI.getTargetOpts().TuneCPU;
+  if (!parsed.CPU.empty() && TI.isValidCPUName(parsed.CPU)) {
+    targetCPU = parsed.CPU;
+    tuneCPU = ""; // Clear the tune CPU
+  }
+  if (!parsed.Tune.empty() && TI.isValidCPUName(parsed.Tune))
+    tuneCPU = parsed.Tune;
+  llvm::StringMap<bool> featureMap;
+  static clang::DiagnosticOptions diagOpts;
+  clang::DiagnosticsEngine diags(clang::DiagnosticIDs::create(), diagOpts,
+                                 new clang::IgnoringDiagConsumer());
+  TI.initFeatureMap(featureMap, diags, targetCPU, parsed.Features);
+  if (!featureMap.empty()) {
+    std::vector<std::string> features;
+    for (auto &entry : featureMap)
+      features.push_back((entry.getValue() ? "+" : "-") + entry.getKey().str());
+    llvm::sort(features);
+    fn->addFnAttr("target-features", llvm::join(features, ","));
+  }
+  if (!targetCPU.empty())
+    fn->addFnAttr("target-cpu", targetCPU);
+  if (!tuneCPU.empty())
+    fn->addFnAttr("tune-cpu", tuneCPU);
+  if (!parsed.BranchProtection.empty()) {
+    clang::TargetInfo::BranchProtectionInfo BPI;
+    StringRef diagMsg;
+    if (TI.validateBranchProtection(parsed.BranchProtection, parsed.CPU, BPI,
+                                    clangImporter->getClangASTContext().getLangOpts(),
+                                    diagMsg)) {
+      if (BPI.SignReturnAddr != clang::LangOptions::SignReturnAddressScopeKind::None) {
+        fn->addFnAttr("sign-return-address", BPI.getSignReturnAddrStr());
+        fn->addFnAttr("sign-return-address-key", BPI.getSignKeyStr());
+      }
+      if (BPI.BranchTargetEnforcement)
+        fn->addFnAttr("branch-target-enforcement");
+      if (BPI.BranchProtectionPAuthLR)
+        fn->addFnAttr("branch-protection-pauth-lr");
+      if (BPI.GuardedControlStack)
+        fn->addFnAttr("guarded-control-stack");
+    }
+  }
 }
 
 llvm::ConstantInt *IRGenModule::getInt32(uint32_t value) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1733,6 +1733,9 @@ public:
   llvm::AttributeList constructInitialAttributes();
   StackProtectorMode shouldEmitStackProtector(SILFunction *f);
 
+  void addTargetAttrFunctionAttributes(llvm::Function *fn,
+                                       StringRef targetString);
+
   llvm::ConstantInt *getMallocTypeId(llvm::Function *fn);
 
   void emitProtocolDecl(ProtocolDecl *D);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1983,6 +1983,8 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f,
   if (f->hasSemanticsAttr(semantics::USE_FRAME_POINTER))
     CurFn->addFnAttr("frame-pointer", "all");
 
+  IGM.addTargetAttrFunctionAttributes(CurFn, f->targetFeatures());
+
   // Disable inlining of coroutine functions until we split.
   if (f->getLoweredFunctionType()->isCoroutine()) {
     CurFn->addFnAttr(llvm::Attribute::NoInline);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3353,6 +3353,35 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
+  case DeclAttrKind::Target: {
+    if (!consumeIfAttributeLParen()) {
+      diagnose(Loc, diag::attr_expected_lparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return makeParserSuccess();
+    }
+    if (Tok.isNot(tok::string_literal)) {
+      diagnose(Loc, diag::attr_expected_string_literal, AttrName);
+      return makeParserSuccess();
+    }
+    auto Name = getStringLiteralIfNotInterpolated(
+        Loc, ("'" + AttrName + "'").str());
+    consumeToken(tok::string_literal);
+    if (Name.has_value())
+      AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+    else
+      DiscardAttribute = true;
+    if (!consumeIf(tok::r_paren)) {
+      diagnose(Loc, diag::attr_expected_rparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return makeParserSuccess();
+    }
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) TargetAttr(Name.value(), AtLoc,
+                                               AttrRange,
+                                               /*Implicit=*/false));
+    break;
+  }
+
   case DeclAttrKind::Diagnose: {
     // Record that this file carries a syntactic warning control.
     SF.setHasWarningControlAttr();

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -259,6 +259,9 @@ void SILFunctionBuilder::addFunctionAttributes(
       F->setSection(*sectionName);
   }
 
+  if (auto *TA = decl->getAttrs().getAttribute<TargetAttr>())
+    F->setTargetFeatures(TA->Value);
+
   // Only emit replacements for the objc entry point of objc methods.
   // There is one exception: @_dynamicReplacement(for:) of @objc methods in
   // generic classes. In this special case we use native replacement instead of

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -90,6 +90,7 @@ SILFunction *GenericCloner::createDeclaration(
   // A specialization of a function goes into the same section as the original
   // function.
   NewF->setSection(Orig->section());
+  NewF->setTargetFeatures(Orig->targetFeatures());
   NewF->copyEffects(Orig);
   return NewF;
 }

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -826,6 +826,11 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
 
   SILFunction *Caller = AI.getFunction();
 
+  // @_target requires an exact match between caller and callee.
+  if (Caller->targetFeatures() != Callee->targetFeatures()) {
+    return nullptr;
+  }
+
   // We don't support inlining a function that binds dynamic self because we
   // have no mechanism to preserve the original function's local self metadata.
   if (mayBindDynamicSelf(Callee)) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -53,10 +53,12 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/UUID.h"  // for COM
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParseDeclName.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/Basic/CharInfo.h"
+#include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -426,6 +428,7 @@ public:
   void visitExternAttr(ExternAttr *attr);
   void visitUsedAttr(UsedAttr *attr);
   void visitSectionAttr(SectionAttr *attr);
+  void visitTargetAttr(TargetAttr *attr);
 
   void visitDynamicCallableAttr(DynamicCallableAttr *attr);
 
@@ -2833,6 +2836,63 @@ void AttributeChecker::visitSectionAttr(SectionAttr *attr) {
   } else if (!VarD->hasStorageOrWrapsStorage()) {
     diagnose(attr->getLocation(), diag::attr_not_on_computed_properties, attr);
   }
+}
+
+void AttributeChecker::visitTargetAttr(TargetAttr *attr) {
+  if (attr->Value.empty()) {
+    diagnoseAndRemoveAttr(attr, diag::attr_target_empty_string);
+    return;
+  }
+  if (attr->Value.contains("fpmath=")) {
+    diagnoseAndRemoveAttr(attr, diag::attr_target_unsupported_feature,
+                          "fpmath=");
+    return;
+  }
+  auto *clangImporter =
+      static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
+  // This can only be null in unit tests.
+  if (!clangImporter)
+    return;
+  auto *TI = &clangImporter->getTargetInfo();
+  clang::ParsedTargetAttr Parsed = TI->parseTargetAttr(attr->Value);
+  if (!Parsed.Duplicate.empty()) {
+    diagnoseAndRemoveAttr(attr, diag::attr_target_duplicate_option,
+                          Parsed.Duplicate);
+    return;
+  }
+  if (!Parsed.CPU.empty() && !TI->isValidCPUName(Parsed.CPU)) {
+    diagnoseAndRemoveAttr(attr, diag::attr_target_unsupported_cpu, Parsed.CPU);
+    return;
+  }
+  if (!Parsed.Tune.empty() && !TI->isValidCPUName(Parsed.Tune)) {
+    diagnoseAndRemoveAttr(attr, diag::attr_target_unsupported_cpu, Parsed.Tune);
+    return;
+  }
+  for (StringRef feature : Parsed.Features) {
+    StringRef bare = feature.drop_front(); // remove leading + or -
+    if (!TI->isValidFeatureName(bare)) {
+      diagnoseAndRemoveAttr(attr, diag::attr_target_unsupported_feature, bare);
+      return;
+    }
+  }
+  if (!Parsed.BranchProtection.empty()) {
+    clang::TargetInfo::BranchProtectionInfo BPI;
+    StringRef DiagMsg;
+    auto &langOpts = clangImporter->getClangASTContext().getLangOpts();
+    if (!TI->validateBranchProtection(Parsed.BranchProtection, Parsed.CPU,
+                                      BPI, langOpts, DiagMsg)) {
+      diagnoseAndRemoveAttr(
+          attr, diag::attr_target_invalid_branch_protection,
+          DiagMsg.empty() ? Parsed.BranchProtection : DiagMsg);
+      return;
+    }
+  }
+
+  // Need to disallow @_transparent because it bypasses the ordinary
+  // performance-inliner feature compatibility guard.
+  if (auto *transparent = D->getAttrs().getAttribute<TransparentAttr>())
+    diagnoseAndRemoveAttr(attr, diag::attr_incompatible_with_attr, attr,
+                          transparent);
 }
 
 void AttributeChecker::visitUnsafeNoObjCTaggedPointerAttr(

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1673,6 +1673,7 @@ namespace  {
     UNINTERESTING_ATTR(UnsafeNoObjCTaggedPointer)
     UNINTERESTING_ATTR(Used)
     UNINTERESTING_ATTR(Section)
+    UNINTERESTING_ATTR(Target)
     UNINTERESTING_ATTR(SwiftNativeObjCRuntimeBase)
     UNINTERESTING_ATTR(ShowInInterface)
     UNINTERESTING_ATTR(Specialize)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6197,6 +6197,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::Target_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::TargetDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) TargetAttr(blobData, isImplicit);
+        break;
+      }
+
       case decls_block::Inline_DECL_ATTR: {
         unsigned kind;
         serialization::decls_block::InlineDeclAttrLayout::readRecord(

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1117,6 +1117,9 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
       case ExtraStringFlavor::Section:
         fn->setSection(blobData);
         break;
+      case ExtraStringFlavor::TargetFeatures:
+        fn->setTargetFeatures(blobData);
+        break;
       case ExtraStringFlavor::WasmImportModule:
         WasmImportModule = blobData;
         break;
@@ -4537,6 +4540,9 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name,
         break;
       case ExtraStringFlavor::Section:
         v->setSection(blobData);
+        break;
+      case ExtraStringFlavor::TargetFeatures:
+        // @_target is OnAbstractFunction only; never written for globals.
         break;
       case ExtraStringFlavor::WasmImportModule:
       case ExtraStringFlavor::WasmImportName:

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1021; // Hidden type layout placeholder
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1022; // @_target attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2386,6 +2386,12 @@ namespace decls_block {
     Semantics_DECL_ATTR,
     BCFixed<1>, // implicit flag
     BCBlob      // semantics value
+  >;
+
+  using TargetDeclAttrLayout = BCRecordLayout<
+    Target_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCBlob      // target string
   >;
 
   using EffectsDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -90,6 +90,8 @@ enum class ExtraStringFlavor : uint8_t {
   WasmImportModule,
   /// wasm import field/name for @_extern(wasm)
   WasmImportName,
+  /// @_target string
+  TargetFeatures,
 };
 
 enum class IsNestedEncoding : uint8_t {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3606,6 +3606,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DeclAttrKind::Target: {
+      auto *theAttr = cast<TargetAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[TargetDeclAttrLayout::Code];
+      TargetDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                       theAttr->isImplicit(), theAttr->Value);
+      return;
+    }
+
     case DeclAttrKind::Documentation: {
       auto *theAttr = cast<DocumentationAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[DocumentationDeclAttrLayout::Code];

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -662,6 +662,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   // record count above.
   writeExtraStringIfNonEmpty(ExtraStringFlavor::AsmName, F.asmName());
   writeExtraStringIfNonEmpty(ExtraStringFlavor::Section, F.section());
+  writeExtraStringIfNonEmpty(ExtraStringFlavor::TargetFeatures,
+                             F.targetFeatures());
   writeExtraStringIfNonEmpty(ExtraStringFlavor::WasmImportModule,
                              F.wasmImportModuleName());
   writeExtraStringIfNonEmpty(ExtraStringFlavor::WasmImportName,

--- a/test/IRGen/target_attribute_arm64.swift
+++ b/test/IRGen/target_attribute_arm64.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -enable-experimental-feature TargetAttribute -emit-ir -parse-as-library -target arm64-apple-macosx13.0 %s | %FileCheck %s
+
+// REQUIRES: swift_feature_TargetAttribute
+// REQUIRES: OS=macosx && CPU=arm64
+
+// CHECK: define {{.*}}@"$s{{.*}}withFeature{{.*}}"(i64 %0) [[FEATURE_ATTRS:#[0-9]+]]
+@_target("sve2")
+public func withFeature(_ x: Int) -> Int {
+    return x + 1
+}
+
+// CHECK: define {{.*}}@"$s{{.*}}withCPU{{.*}}"(i64 %0) [[CPU_ATTRS:#[0-9]+]]
+@_target("cpu=apple-a10")
+public func withCPU(_ x: Int) -> Int {
+    return x + 1
+}
+
+// CHECK-DAG: attributes [[FEATURE_ATTRS]] = {{.*}}"target-features"="{{[^"]*}}+sve2{{[^"]*}}"
+
+// CHECK-DAG: attributes [[CPU_ATTRS]] = {{.*}}"target-cpu"="apple-a10"{{.*}}"target-features"="{{[^"]*}}"

--- a/test/IRGen/target_attribute_x86_64.swift
+++ b/test/IRGen/target_attribute_x86_64.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -enable-experimental-feature TargetAttribute -emit-ir -parse-as-library -target x86_64-apple-macosx13.0 %s | %FileCheck %s
+
+// REQUIRES: swift_feature_TargetAttribute
+// REQUIRES: OS=macosx && CPU=x86_64
+
+// CHECK: define {{.*}}@"$s{{.*}}withFeature{{.*}}"(i64 %0) [[FEATURE_ATTRS:#[0-9]+]]
+@_target("avx2")
+public func withFeature(_ x: Int) -> Int {
+    return x + 1
+}
+
+// CHECK: define {{.*}}@"$s{{.*}}withArch{{.*}}"(i64 %0) [[ARCH_ATTRS:#[0-9]+]]
+@_target("arch=skylake")
+public func withArch(_ x: Int) -> Int {
+    return x + 1
+}
+
+// CHECK-DAG: attributes [[FEATURE_ATTRS]] = {{.*}}"target-features"="{{[^"]*}}+avx2{{[^"]*}}"
+
+// CHECK-DAG: attributes [[ARCH_ATTRS]] = {{.*}}"target-cpu"="skylake"{{.*}}"target-features"="{{[^"]*}}"

--- a/test/SILOptimizer/generic_specialize_target_attribute.swift
+++ b/test/SILOptimizer/generic_specialize_target_attribute.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -O -emit-ir -parse-as-library -enable-experimental-feature TargetAttribute -target arm64-apple-macosx13.0 %s | %FileCheck %s
+
+// REQUIRES: swift_feature_TargetAttribute
+// REQUIRES: OS=macosx && CPU=arm64
+
+@_target("sve2")
+public func specializedTargetFn<T>(_ x: T) -> T {
+    return x
+}
+
+public func forcesSpecialization(_ x: Int) -> Int {
+    return specializedTargetFn(x)
+}
+
+// CHECK-DAG: define {{.*}}@"$s{{.*}}specializedTargetFn{{.*}}"{{.*}} [[SPECIALIZED_ATTRS:#[0-9]+]]
+// CHECK-DAG: attributes [[SPECIALIZED_ATTRS]] = {{.*}}"target-features"="{{[^"]*}}+sve2{{[^"]*}}"

--- a/test/SILOptimizer/target_attribute_inline.swift
+++ b/test/SILOptimizer/target_attribute_inline.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library -enable-experimental-feature TargetAttribute -target arm64-apple-macosx13.0 %s | %FileCheck %s
+
+// REQUIRES: swift_feature_TargetAttribute
+// REQUIRES: OS=macosx && CPU=arm64
+
+@_target("sve2")
+@inline(__always)
+func sve2_callee(_ x: Int) -> Int {
+    return x + 1
+}
+
+// The callee has @_target but the caller doesn't -- no inlining
+// CHECK-LABEL: sil {{.*}}@{{.*}}none_caller{{.*}} : $@convention(thin) (Int) -> Int
+// CHECK: function_ref {{.*}}sve2_callee
+// CHECK: apply
+// CHECK: end sil function
+public func none_caller(_ x: Int) -> Int {
+    return sve2_callee(x)
+}
+
+// Both caller and callee have @_target, but for different features -- no inlining
+// CHECK-LABEL: sil {{.*}}@{{.*}}dotprod_caller{{.*}} : $@convention(thin) (Int) -> Int
+// CHECK: function_ref {{.*}}sve2_callee
+// CHECK: apply
+// CHECK: end sil function
+@_target("dotprod")
+public func dotprod_caller(_ x: Int) -> Int {
+    return sve2_callee(x)
+}
+
+// Both caller and callee share the same @_target -- inlined
+// CHECK-LABEL: sil {{.*}}@{{.*}}sve2_caller{{.*}} : $@convention(thin) (Int) -> Int
+// CHECK-NOT: function_ref
+// CHECK-NOT: apply
+// CHECK: end sil function
+@_target("sve2")
+public func sve2_caller(_ x: Int) -> Int {
+    return sve2_callee(x)
+}

--- a/test/Serialization/attr-target.swift
+++ b/test/Serialization/attr-target.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature TargetAttribute -parse-as-library -emit-module-path %t/a.swiftmodule -module-name a -emit-module-interface-path %t/a.swiftinterface -enable-library-evolution -swift-version 5 %s
+// RUN: %llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
+// RUN: %target-swift-ide-test -enable-experimental-feature TargetAttribute -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
+// RUN: %FileCheck --check-prefix INTERFACE-CHECK %s < %t/a.swiftinterface
+
+// REQUIRES: swift_feature_TargetAttribute
+
+// BC-CHECK: <Target_DECL_ATTR
+
+// MODULE-CHECK: @_target("default") @inlinable func inlinableWithTarget(_ x: Int) -> Int
+@_target("default")
+@inlinable
+public func inlinableWithTarget(_ x: Int) -> Int {
+    return x + 1
+}
+
+// INTERFACE-CHECK: #if compiler(>=5.3) && $TargetAttribute
+// INTERFACE-CHECK-NEXT: @_target("default") @inlinable public func inlinableWithTarget(_ x: Swift::Int) -> Swift::Int {
+// INTERFACE-CHECK-NEXT: return x + 1
+// INTERFACE-CHECK-NEXT: }
+// INTERFACE-CHECK-NEXT: #endif

--- a/test/attr/attr_target.swift
+++ b/test/attr/attr_target.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TargetAttribute -disable-availability-checking
+
+// REQUIRES: swift_feature_TargetAttribute
+
+@_target("") // expected-error {{'@_target' requires a non-empty target string}}
+func emptyString(_ x: Int) -> Int { return x }
+
+// @_target cannot be combined with @_transparent
+@_target("default") // expected-error {{'@_target' cannot be used with '@_transparent'}}
+@_transparent
+func incompatibleWithTransparent(_ x: Int) -> Int { return x }
+
+@_target("tune=generic,tune=generic") // expected-error {{duplicate 'tune=' option in '@_target'}}
+func duplicateTune(_ x: Int) -> Int { return x }

--- a/test/attr/attr_target_arm64.swift
+++ b/test/attr/attr_target_arm64.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TargetAttribute -disable-availability-checking -target arm64-apple-macosx13.0
+
+// REQUIRES: swift_feature_TargetAttribute
+// REQUIRES: OS=macosx && CPU=arm64
+
+@_target("sve2")
+func validFeature(_ x: Int) -> Int { return x }
+
+@_target("cpu=apple-m1")
+func validCPU(_ x: Int) -> Int { return x }
+
+@_target("cpu=apple-m1+dotprod")
+func validCPUWithSuffix(_ x: Int) -> Int { return x }
+
+@_target("cpu=bogus-cpu-name") // expected-error {{unsupported CPU 'bogus-cpu-name' in '@_target'}}
+func invalidCPU(_ x: Int) -> Int { return x }

--- a/test/attr/attr_target_x86_64.swift
+++ b/test/attr/attr_target_x86_64.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TargetAttribute -disable-availability-checking -target x86_64-apple-macosx13.0
+
+// REQUIRES: swift_feature_TargetAttribute
+// REQUIRES: OS=macosx && CPU=x86_64
+
+@_target("avx2")
+func validFeature(_ x: Int) -> Int { return x }
+
+@_target("no-sse4.2")
+func validNegatedFeature(_ x: Int) -> Int { return x }
+
+@_target("arch=skylake")
+func validArch(_ x: Int) -> Int { return x }
+
+@_target("tune=icelake-client")
+func validTune(_ x: Int) -> Int { return x }
+
+@_target("sve2") // expected-error {{unsupported target feature 'sve2' in '@_target'}}
+func invalidFeature(_ x: Int) -> Int { return x }
+
+@_target("arch=bogus-cpu-name") // expected-error {{unsupported CPU 'bogus-cpu-name' in '@_target'}}
+func invalidCPU(_ x: Int) -> Int { return x }


### PR DESCRIPTION
This lets a single function override baseline CPU/ISA. This is guarded behind an experimental feature flag.
