### PR TITLE
[cxx-interop] Fix a test on rebranch

### DIFF
--- a/test/Interop/Cxx/foreign-reference/witness-table-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -cxx-interoperability-mode=default -disable-availability-checking -I %S/Inputs
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -cxx-interoperability-mode=default -disable-availability-checking -I %S/Inputs
 
 import WitnessTable
 


### PR DESCRIPTION
`witness-table-typechecker.swift` is failing on rebranch because it triggers unrelated modularization warnings coming from the SDK. Let's suppress them.

rdar://186556136

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
