### PR TITLE
[wasi] Build Concurrency C++ sources with -fno-exceptions

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -90,6 +90,12 @@ endif()
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
   "-D__STDC_WANT_LIB_EXT1__=1")
 
+# Sysroot libc++abi has no exception runtime; the -static target misses the
+# -fno-exceptions that llvm_update_compile_flags gives the shared one.
+if("WASI" IN_LIST SWIFT_SDKS)
+  list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fno-exceptions")
+endif()
+
 set(SWIFT_RUNTIME_CONCURRENCY_C_SOURCES
   ../CompatibilityOverride/CompatibilityOverride.cpp
   Actor.cpp


### PR DESCRIPTION
The WASI sysroot's libc++/libc++abi are built with -fno-exceptions (see wasisysroot.py), so libc++abi defines no __cxa_throw or __cxa_allocate_exception.

The Concurrency runtime uses C++ STL data structures, which can throw if not compiled with the right flags.

The cmake helper `add_swift_target_library_single` runs `llvm_update_compile_flags`, which supplies `-fno-exceptions` on the shared target. 

The -static target is only created later, so it never receives those flags.

That has always been true, but it was masked until llvm/llvm-project@54faa755bc36 ("[LLVM][CMake][NFC] Use generator expression to separate CXXFLAGS"). 

The old `llvm_update_compile_flags` applied `COMPILE_FLAGS` as directory-scoped *source* properties for targets mixing C and C++ sources, which swift_Concurrency does. The -static target compiles the same sources in the same directory, so it inherited the flags for free. That commit switched to per-target `target_compile_options`, which does not leak; it is NFC in tree but not for downstream trees that relied on the old behavior.

Setting the flag through C_COMPILE_FLAGS reaches both variants.

Fixes around 300 failures in check-swift-wasi-wasm32-custom, which used to fail with:

  wasm-ld: error: libswift_Concurrency.a(Task.cpp.o):
  undefined symbol: __cxa_allocate_exception
  wasm-ld: error: libswift_Concurrency.a(Task.cpp.o):
  undefined symbol: __cxa_throw

(assisted by claude)
