### PR TITLE
[doc] expand the definition of "deinit barrier"

### DIFF
--- a/docs/SIL/Ownership.md
+++ b/docs/SIL/Ownership.md
@@ -825,11 +825,12 @@ Deinit barriers (see Instruction.isDeinitBarrier(_:)) are instructions
 which would be affected by the side effects of deinitializers. To
 maintain the order of effects that is visible to the programmer,
 destroys of lexical values cannot be reordered with respect to them.
-There are three kinds:
+There are four kinds:
 
 1.  synchronization points (locks, memory barriers, syscalls, etc.)
 2.  loads of weak or unowned values
 3.  accesses of pointers
+4.  accesses of exclusive variables defined globally or as a class member
 
 Examples:
 
@@ -852,6 +853,9 @@ Examples:
     instance is defined behavior. Hoisting the destroy of the instance
     above the access to the memory would result in accessing a freed
     pointer.
+4.  Given an instance (`a`) of a class which references another class instance (`b`). A destroy of `a` cannot be hoisted
+    above an access to a property of `b` via a potentially aliasing reference to `b`. Such accesses to aliasable state are
+    protected by dynamic exclusivity checks.
 
 ## Dead End Blocks
 


### PR DESCRIPTION
Add a new kind of deinit barrier: global variables and class members.

This expands the concept of a deinit barrier to include access to
regular variables. Previously, deinit barriers were only meant to
handle special cases related to unsafe or "unpredictable" code
patterns. With this much more conservative definition, programmers are
protected from any kind of "action at a distance" behavior relative to
invoking a deinitializer.

In particular, this now allows a class that contains references to
internal class data, such as a linked list of nodes, to manually
cleanup its data structure during deinitialization without simply
relying on the regular reference counting mechanism.

For example:
```
final class ManualLinkedList {
  var head: Node?
  var tail: Node?

  deinit {
    // Unlink the nodes to avoid a deep recursive deallocation.
    var current = head
    while let c = current {
      let n = c.next
      c.next = nil
      current = n
    }
  }
}
```

Now, with the stronger deinit barrier, a user of `ManualLinkedList`
does not need to manually extend the lifetime of the list across any
references to its internal nodes.

This change was implemented here:

```
commit 611e7c630b51ded70beb3aead6e79977b67c06ed
Author: Erik Eckstein <eeckstein@apple.com>
Date:   Fri Aug 7 16:28:15 2026 +0200

    SIL: make dynamic access scopes a deinit barrier

    A deinitializer can read and write class properties, global variables or boxes - which are
    protected by dynamic access scopes: the deinit could modify the memory which the access
    scope is reading, or vice versa.

    Fixes a mis-compile
    rdar://183126067
```
