### PR TITLE
[ConstraintSystem] Mark consuming methods as `@called(once)` when base is non-Copyable

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -789,6 +789,13 @@ public:
                              sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
+  [[nodiscard]] ASTExtInfoBuilder
+  withCalledOnceDependentType(Type calledOnceDependentType) const {
+    return ASTExtInfoBuilder(bits, clangTypeInfo, globalActor, thrownError,
+                             sendableDependentType, calledOnceDependentType,
+                             lifetimeDependencies);
+  }
+
   [[nodiscard]]
   ASTExtInfoBuilder withThrows() const {
     return withThrows(true, Type());
@@ -1034,6 +1041,11 @@ public:
   [[nodiscard]]
   ASTExtInfo withSendableDependentType(Type sendableDependentType) const {
     return builder.withSendableDependentType(sendableDependentType).build();
+  }
+
+  [[nodiscard]] ASTExtInfo
+  withCalledOnceDependentType(Type calledOnceDependentType) const {
+    return builder.withCalledOnceDependentType(calledOnceDependentType).build();
   }
 
   [[nodiscard]] ASTExtInfo withSendingResult(bool sending = true) const {

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -583,16 +583,22 @@ class ASTExtInfoBuilder {
   /// a concrete dependent type should set the Sendable bit instead.
   Type sendableDependentType;
 
+  /// A dependent type that determines whether the function is @called(once).
+  /// Only used within the constraint system, and must contain type variables,
+  /// a concrete dependent type should set the Sendable bit instead.
+  Type calledOnceDependentType;
+
   ArrayRef<LifetimeDependenceInfo> lifetimeDependencies;
 
   using Representation = FunctionTypeRepresentation;
 
   ASTExtInfoBuilder(unsigned bits, ClangTypeInfo clangTypeInfo,
                     Type globalActor, Type thrownError,
-                    Type sendableDependentType,
+                    Type sendableDependentType, Type calledOnceDependentType,
                     ArrayRef<LifetimeDependenceInfo> lifetimeDependencies)
       : bits(bits), clangTypeInfo(clangTypeInfo), globalActor(globalActor),
         thrownError(thrownError), sendableDependentType(sendableDependentType),
+        calledOnceDependentType(calledOnceDependentType),
         lifetimeDependencies(lifetimeDependencies) {
     assert(isThrowing() || !thrownError);
     assert(hasGlobalActorFromBits(bits) == !globalActor.isNull());
@@ -633,7 +639,7 @@ public:
             (sendingResult ? SendingResultMask : 0) |
             (calledOnce ? CalledOnceMask : 0),
             ClangTypeInfo(type), isolation.getOpaqueType(), thrownError,
-            /*sendableDependentType*/ Type(), lifetimeDependencies) {}
+            /*sendableDependentType*/ Type(), /*calledOnceDependentType*/Type(), lifetimeDependencies) {}
 
   void checkInvariants() const;
 
@@ -681,6 +687,11 @@ public:
   /// is only used within the constraint system, and will contain type
   /// variables if present.
   Type getSendableDependentType() const { return sendableDependentType; }
+
+  /// A dependent type that determines whether the function is @called(once). This
+  /// is only used within the constraint system, and will contain type
+  /// variables if present.
+  Type getCalledOnceDependentType() const { return calledOnceDependentType; }
 
   ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {
     return lifetimeDependencies;
@@ -741,41 +752,41 @@ public:
     return ASTExtInfoBuilder(
         (bits & ~RepresentationMask) | (unsigned)rep,
         shouldStoreClangType(rep) ? clangTypeInfo : ClangTypeInfo(),
-        globalActor, thrownError, sendableDependentType, lifetimeDependencies);
+        globalActor, thrownError, sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withNoEscape(bool noEscape = true) const {
     return ASTExtInfoBuilder(noEscape ? (bits | NoEscapeMask)
                                       : (bits & ~NoEscapeMask),
                              clangTypeInfo, globalActor, thrownError,
-                             sendableDependentType, lifetimeDependencies);
+                             sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withSendable(bool concurrent = true) const {
     return ASTExtInfoBuilder(concurrent ? (bits | SendableMask)
                                         : (bits & ~SendableMask),
                              clangTypeInfo, globalActor, thrownError,
-                             sendableDependentType, lifetimeDependencies);
+                             sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withAsync(bool async = true) const {
     return ASTExtInfoBuilder(async ? (bits | AsyncMask) : (bits & ~AsyncMask),
                              clangTypeInfo, globalActor, thrownError,
-                             sendableDependentType, lifetimeDependencies);
+                             sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withThrows(bool throws, Type thrownError) const {
     assert(throws || !thrownError);
     return ASTExtInfoBuilder(
         throws ? (bits | ThrowsMask) : (bits & ~ThrowsMask), clangTypeInfo,
-        globalActor, thrownError, sendableDependentType, lifetimeDependencies);
+        globalActor, thrownError, sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
   [[nodiscard]]
   ASTExtInfoBuilder
   withSendableDependentType(Type sendableDependentType) const {
     return ASTExtInfoBuilder(bits, clangTypeInfo, globalActor, thrownError,
-                             sendableDependentType, lifetimeDependencies);
+                             sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
   [[nodiscard]]
@@ -787,7 +798,7 @@ public:
     return ASTExtInfoBuilder(sending ? (bits | SendingResultMask)
                                      : (bits & ~SendingResultMask),
                              clangTypeInfo, globalActor, thrownError,
-                             sendableDependentType, lifetimeDependencies);
+                             sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
   [[nodiscard]]
@@ -797,13 +808,13 @@ public:
         (bits & ~DifferentiabilityMask) |
             ((unsigned)differentiability << DifferentiabilityMaskOffset),
         clangTypeInfo, globalActor, thrownError, sendableDependentType,
-        lifetimeDependencies);
+        calledOnceDependentType, lifetimeDependencies);
   }
   [[nodiscard]]
   ASTExtInfoBuilder withClangFunctionType(const clang::Type *type) const {
     return ASTExtInfoBuilder(bits, ClangTypeInfo(type), globalActor,
                              thrownError, sendableDependentType,
-                             lifetimeDependencies);
+                             calledOnceDependentType, lifetimeDependencies);
   }
 
   /// Put a SIL representation in the ExtInfo.
@@ -817,7 +828,7 @@ public:
     return ASTExtInfoBuilder(
         (bits & ~RepresentationMask) | (unsigned)rep,
         shouldStoreClangType(rep) ? clangTypeInfo : ClangTypeInfo(),
-        globalActor, thrownError, sendableDependentType, lifetimeDependencies);
+        globalActor, thrownError, sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
   /// \p lifetimeDependencies should be arena allocated and not a temporary
@@ -826,7 +837,7 @@ public:
   [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
       llvm::ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return ASTExtInfoBuilder(bits, clangTypeInfo, globalActor, thrownError,
-                             sendableDependentType, lifetimeDependencies);
+                             sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
   [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
@@ -839,20 +850,20 @@ public:
         (bits & ~IsolationMask) |
             (unsigned(isolation.getKind()) << IsolationMaskOffset),
         clangTypeInfo, isolation.getOpaqueType(), thrownError,
-        sendableDependentType, lifetimeDependencies);
+        sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
   [[nodiscard]] ASTExtInfoBuilder withHasInOutResult() const {
     return ASTExtInfoBuilder((bits | InOutResultMask), clangTypeInfo,
                              globalActor, thrownError, sendableDependentType,
-                             lifetimeDependencies);
+                             calledOnceDependentType, lifetimeDependencies);
   }
 
   [[nodiscard]] ASTExtInfoBuilder withCalledOnce(bool enabled = true) const {
     return ASTExtInfoBuilder(enabled ? (bits | CalledOnceMask)
                                      : (bits & ~CalledOnceMask),
                              clangTypeInfo, globalActor, thrownError,
-                             sendableDependentType, lifetimeDependencies);
+                             sendableDependentType, calledOnceDependentType, lifetimeDependencies);
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
@@ -861,6 +872,7 @@ public:
     ID.AddPointer(globalActor.getPointer());
     ID.AddPointer(thrownError.getPointer());
     ID.AddPointer(sendableDependentType.getPointer());
+    ID.AddPointer(calledOnceDependentType.getPointer());
     for (auto info : lifetimeDependencies) {
       info.Profile(ID);
     }
@@ -894,9 +906,11 @@ class ASTExtInfo {
 
   ASTExtInfo(unsigned bits, ClangTypeInfo clangTypeInfo, Type globalActor,
              Type thrownError, Type sendableDependentType,
+             Type calledOnceDependentType,
              llvm::ArrayRef<LifetimeDependenceInfo> lifetimeDependenceInfo)
       : builder(bits, clangTypeInfo, globalActor, thrownError,
-                sendableDependentType, lifetimeDependenceInfo) {
+                sendableDependentType, calledOnceDependentType,
+                lifetimeDependenceInfo) {
     builder.checkInvariants();
   };
 
@@ -950,6 +964,13 @@ public:
   /// variables if present.
   Type getSendableDependentType() const {
     return builder.getSendableDependentType();
+  }
+
+  /// A dependent type that determines whether the function is @called(once). This
+  /// is only used within the constraint system, and will contain type
+  /// variables if present.
+  Type getCalledOnceDependentType() const {
+    return builder.getCalledOnceDependentType();
   }
 
   ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const {

--- a/include/swift/AST/TypeTransform.h
+++ b/include/swift/AST/TypeTransform.h
@@ -910,6 +910,21 @@ case TypeKind::Id:
             isUnchanged = false;
           }
         }
+
+        // Transform the @called(once) dependent type if present.
+        if (auto calledOnceDep = origExtInfo.getCalledOnceDependentType()) {
+          auto [newCalledOnceDep, isCalledOnce] =
+              asDerived().transformCalledOnceDependentType(calledOnceDep);
+          if (!newCalledOnceDep) {
+            // If we're no longer @called(once) dependent, update the @called(once) bit.
+            extInfo = extInfo->withCalledOnceDependentType(Type());
+            extInfo = extInfo->withCalledOnce(isCalledOnce);
+            isUnchanged = false;
+          } else if (newCalledOnceDep.getPointer() != calledOnceDep.getPointer()) {
+            extInfo = extInfo->withCalledOnceDependentType(newCalledOnceDep);
+            isUnchanged = false;
+          }
+        }
       }
 
       if (auto genericFnType = dyn_cast<GenericFunctionType>(base)) {
@@ -1167,6 +1182,10 @@ case TypeKind::Id:
   bool shouldDesugarTypeAliases() const { return false; }
 
   std::pair<Type, /*sendable*/ bool> transformSendableDependentType(Type ty) {
+    return std::make_pair(ty, false);
+  }
+
+  std::pair<Type, /*calledOnce*/ bool> transformCalledOnceDependentType(Type ty) {
     return std::make_pair(ty, false);
   }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -443,7 +443,7 @@ protected:
     HasCachedType : 1
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(AnyFunctionType, TypeBase, NumAFTExtInfoBits+1+1+1+1+1+16,
+  SWIFT_INLINE_BITFIELD_FULL(AnyFunctionType, TypeBase, NumAFTExtInfoBits+1+1+1+1+1+1+16,
     /// Extra information which affects how the function is called, like
     /// regparm and the calling convention.
     ExtInfoBits : NumAFTExtInfoBits,
@@ -451,7 +451,8 @@ protected:
     HasClangTypeInfo : 1,
     HasThrownError : 1,
     HasLifetimeDependencies : 1,
-    HasSendableDependence : 1
+    HasSendableDependence : 1,
+    HasCalledOnceDependence : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(ArchetypeType, TypeBase, 1+1+16,
@@ -3745,6 +3746,8 @@ protected:
           !Info.value().getLifetimeDependencies().empty();
       Bits.AnyFunctionType.HasSendableDependence =
           !Info->getSendableDependentType().isNull();
+      Bits.AnyFunctionType.HasCalledOnceDependence =
+          !Info->getCalledOnceDependentType().isNull();
       // The use of both assert() and static_assert() is intentional.
       assert(Bits.AnyFunctionType.ExtInfoBits == Info.value().getBits() &&
              "Bits were dropped!");
@@ -3758,6 +3761,7 @@ protected:
       Bits.AnyFunctionType.HasThrownError = false;
       Bits.AnyFunctionType.HasLifetimeDependencies = false;
       Bits.AnyFunctionType.HasSendableDependence = false;
+      Bits.AnyFunctionType.HasCalledOnceDependence = false;
     }
     this->NumParams = NumParams;
     assert(this->NumParams == NumParams && "Params dropped!");
@@ -3818,6 +3822,10 @@ public:
     return Bits.AnyFunctionType.HasSendableDependence;
   }
 
+  bool hasCalledOnceDependentType() const {
+    return Bits.AnyFunctionType.HasCalledOnceDependence;
+  }
+
   bool hasLifetimeDependencies() const {
     return Bits.AnyFunctionType.HasLifetimeDependencies;
   }
@@ -3836,6 +3844,11 @@ public:
   /// is only used within the constraint system, and will contain type
   /// variables if present.
   Type getSendableDependentType() const;
+
+  /// A dependent type that determines whether the function is @called(once).
+  /// This is only used within the constraint system, and will contain type
+  /// variables if present.
+  Type getCalledOnceDependentType() const;
 
   ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const;
 
@@ -3889,7 +3902,8 @@ public:
     assert(hasExtInfo());
     return ExtInfo(Bits.AnyFunctionType.ExtInfoBits, getClangTypeInfo(),
                    getGlobalActor(), getThrownError(),
-                   getSendableDependentType(), getLifetimeDependencies());
+                   getSendableDependentType(), getCalledOnceDependentType(),
+                   getLifetimeDependencies());
   }
 
   /// Get the canonical ExtInfo for the function type.
@@ -4058,7 +4072,7 @@ public:
     return getExtInfo().getDifferentiabilityKind();
   }
 
-  bool isCalledOnce() const { return getExtInfo().isCalledOnce(); }
+  bool isCalledOnce() const;
 
   /// Returns a new function type exactly like this one but with the ExtInfo
   /// replaced.
@@ -4140,7 +4154,8 @@ class FunctionType final
   }
 
   size_t numTrailingObjects(OverloadToken<Type>) const {
-    return hasGlobalActor() + hasThrownError() + hasSendableDependentType();
+    return hasGlobalActor() + hasThrownError() + hasSendableDependentType() +
+           hasCalledOnceDependentType();
   }
 
   size_t numTrailingObjects(OverloadToken<size_t>) const {
@@ -4189,6 +4204,16 @@ public:
     if (!hasSendableDependentType())
       return Type();
     return getTrailingObjects<Type>()[hasGlobalActor() + hasThrownError()];
+  }
+
+  /// A dependent type that determines whether the function is @called(once).
+  /// This is only used within the constraint system, and will contain type
+  /// variables if present.
+  Type getCalledOnceDependentType() const {
+    if (!hasCalledOnceDependentType())
+      return Type();
+    return getTrailingObjects<Type>()[hasGlobalActor() + hasThrownError() +
+                                      hasSendableDependentType()];
   }
 
   inline size_t getNumLifetimeDependencies() const {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4051,6 +4051,9 @@ public:
   /// Return the function type setting sendable to \p newValue.
   AnyFunctionType *withSendable(bool newValue) const;
 
+  /// Return the function type setting @called(once) to \p newValue.
+  AnyFunctionType *withCalledOnce(bool newValue) const;
+
   /// True if the parameter declaration it is attached to is guaranteed
   /// to not persist the closure for longer than the duration of the call.
   bool isNoEscape() const {

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -278,6 +278,9 @@ SIMPLE_LOCATOR_PATH_ELT(ThrownErrorType)
 /// The sendable dependence of a function type.
 SIMPLE_LOCATOR_PATH_ELT(FunctionSendability)
 
+/// The execution semantics dependence of a function type.
+SIMPLE_LOCATOR_PATH_ELT(FunctionExecutionSemantics)
+
 /// A type coercion operand.
 SIMPLE_LOCATOR_PATH_ELT(CoercionOperand)
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3156,6 +3156,13 @@ public:
                                         TypeMatchOptions flags,
                                         ConstraintLocatorBuilder locator);
 
+  /// Match the execution semantics between two functions currently
+  /// represented by `@called(once)` bit.
+  SolutionKind
+  matchFunctionExecutionSemantics(FunctionType *func1, FunctionType *func2,
+                                  ConstraintKind kind, TypeMatchOptions flags,
+                                  ConstraintLocatorBuilder locator);
+
   /// Subroutine of \c matchTypes(), which matches up two function
   /// types.
   SolutionKind matchFunctionTypes(FunctionType *func1, FunctionType *func2,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5092,7 +5092,8 @@ DynamicSelfType *DynamicSelfType::get(Type selfType, const ASTContext &ctx) {
 static RecursiveTypeProperties
 getFunctionRecursiveProperties(ArrayRef<AnyFunctionType::Param> params,
                                Type result, Type globalActor, Type thrownError,
-                               Type sendableDependentType) {
+                               Type sendableDependentType,
+                               Type calledOnceDependentType) {
   RecursiveTypeProperties properties;
   for (auto param : params)
     properties |= param.getPlainType()->getRecursiveProperties();
@@ -5103,6 +5104,11 @@ getFunctionRecursiveProperties(ArrayRef<AnyFunctionType::Param> params,
     properties |= thrownError->getRecursiveProperties();
   if (sendableDependentType) {
     ASSERT(sendableDependentType->hasTypeVariable());
+    properties |= RecursiveTypeProperties::SolverAllocated;
+    properties |= RecursiveTypeProperties::HasTypeVariable;
+  }
+  if (calledOnceDependentType) {
+    ASSERT(calledOnceDependentType->hasTypeVariable());
     properties |= RecursiveTypeProperties::SolverAllocated;
     properties |= RecursiveTypeProperties::HasTypeVariable;
   }
@@ -5289,14 +5295,17 @@ FunctionType *FunctionType::get(ArrayRef<AnyFunctionType::Param> params,
   Type thrownError;
   Type globalActor;
   Type sendableDependentType;
+  Type calledOnceDependentType;
   if (info.has_value()) {
     thrownError = info->getThrownError();
     globalActor = info->getGlobalActor();
     sendableDependentType = info->getSendableDependentType();
+    calledOnceDependentType = info->getCalledOnceDependentType();
   }
 
   auto properties = getFunctionRecursiveProperties(
-      params, result, globalActor, thrownError, sendableDependentType);
+      params, result, globalActor, thrownError, sendableDependentType,
+      calledOnceDependentType);
   auto arena = getArena(properties);
 
   if (info.has_value()) {
@@ -5329,7 +5338,8 @@ FunctionType *FunctionType::get(ArrayRef<AnyFunctionType::Param> params,
       info.has_value() && !info.value().getClangTypeInfo().empty();
 
   unsigned numTypes = (globalActor ? 1 : 0) + (thrownError ? 1 : 0) +
-                      (sendableDependentType ? 1 : 0);
+                      (sendableDependentType ? 1 : 0) +
+                      (calledOnceDependentType ? 1 : 0);
 
   bool hasLifetimeDependenceInfo =
       info.has_value() ? !info->getLifetimeDependencies().empty() : false;
@@ -5402,6 +5412,10 @@ FunctionType::FunctionType(ArrayRef<AnyFunctionType::Param> params, Type output,
       getTrailingObjects<Type>()[typeIdx] = sendableDependentType;
       typeIdx += 1;
     }
+    if (Type calledOnceDependentType = info->getCalledOnceDependentType()) {
+      getTrailingObjects<Type>()[typeIdx] = calledOnceDependentType;
+      typeIdx += 1;
+    }
     auto lifetimeDependenceInfo = info->getLifetimeDependencies();
     if (!lifetimeDependenceInfo.empty()) {
       *getTrailingObjects<size_t>() = lifetimeDependenceInfo.size();
@@ -5470,8 +5484,10 @@ GenericFunctionType *GenericFunctionType::get(GenericSignature sig,
     thrownError = info->getThrownError();
     globalActor = info->getGlobalActor();
 
-    // Generic functions can't currently have Sendable dependence.
+    // Generic functions can't currently have Sendable or @called(once)
+    // dependence.
     ASSERT(!info->getSendableDependentType());
+    ASSERT(!info->getCalledOnceDependentType());
   }
 
   if (thrownError) {

--- a/lib/AST/ExtInfo.cpp
+++ b/lib/AST/ExtInfo.cpp
@@ -158,6 +158,9 @@ void ASTExtInfoBuilder::checkInvariants() const {
   }
   if (sendableDependentType)
     ASSERT(!isSendable() && sendableDependentType->hasTypeVariable());
+
+  if (calledOnceDependentType)
+    ASSERT(!isCalledOnce() && calledOnceDependentType->hasTypeVariable());
 }
 
 // MARK: - ASTExtInfo

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5074,6 +5074,11 @@ AnyFunctionType *AnyFunctionType::withSendable(bool newValue) const {
   return withExtInfo(info);
 }
 
+AnyFunctionType *AnyFunctionType::withCalledOnce(bool newValue) const {
+  auto info = getExtInfo().intoBuilder().withCalledOnce(newValue).build();
+  return withExtInfo(info);
+}
+
 std::optional<Type> AnyFunctionType::getEffectiveThrownErrorType() const {
   // A non-throwing function... has no thrown interface type.
   if (!isThrowing())

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1640,6 +1640,11 @@ Type TypeBase::replaceTypeVariablesAndPlaceholdersWithErrors() {
       // just become non-Sendable.
       return std::make_pair(Type(), false);
     }
+    std::pair<Type, /*calledOnce*/ bool> transformCalledOnceDependentType(Type ty) {
+      // Fold away the @called(once) dependence if present, the function type will
+      // just become non-@called(once).
+      return std::make_pair(Type(), false);
+    }
   };
   return Transform(getASTContext()).doIt(this, TypePosition::Invariant);
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4523,6 +4523,17 @@ Type AnyFunctionType::getSendableDependentType() const {
   }
 }
 
+Type AnyFunctionType::getCalledOnceDependentType() const {
+  switch (getKind()) {
+  case TypeKind::Function:
+    return cast<FunctionType>(this)->getCalledOnceDependentType();
+  case TypeKind::GenericFunction:
+    return Type();
+  default:
+    llvm_unreachable("Illegal type kind for AnyFunctionType.");
+  }
+}
+
 bool AnyFunctionType::isSendable() const {
   ASSERT(!hasSendableDependentType() && "Query Sendable dependence first");
   return getExtInfo().isSendable();
@@ -4573,6 +4584,11 @@ AnyFunctionType::getLifetimeDependenceForResult(const ValueDecl *decl) const {
   return getLifetimeDependenceFor(resultIndex);
 }
 
+bool AnyFunctionType::isCalledOnce() const {
+  ASSERT(!hasCalledOnceDependentType() && "Query CalledOnce dependence first");
+  return getExtInfo().isCalledOnce();
+}
+
 ClangTypeInfo AnyFunctionType::getCanonicalClangTypeInfo() const {
   return getClangTypeInfo().getCanonical();
 }
@@ -4613,11 +4629,15 @@ AnyFunctionType::getCanonicalExtInfo(bool useClangFunctionType) const {
   if (sendableDependentType)
     sendableDependentType = sendableDependentType->getCanonicalType();
 
+  Type calledOnceDependentType = getCalledOnceDependentType();
+  if (calledOnceDependentType)
+    calledOnceDependentType = calledOnceDependentType->getCanonicalType();
+
   return ExtInfo(bits,
                  useClangFunctionType ? getCanonicalClangTypeInfo()
                                       : ClangTypeInfo(),
                  globalActor, thrownError, sendableDependentType,
-                 getLifetimeDependencies());
+                 calledOnceDependentType, getLifetimeDependencies());
 }
 
 bool AnyFunctionType::hasNonDerivableClangType() {

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -132,6 +132,11 @@ class Traversal : public TypeVisitor<Traversal, bool>
         return true;
     }
 
+    if (auto calledOnceDep = ty->getCalledOnceDependentType()) {
+      if (doIt(calledOnceDep))
+        return true;
+    }
+
     return doIt(ty->getResult());
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12632,6 +12632,15 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         closureExtInfo = closureExtInfo.withSendable();
       }
     }
+
+    // Infer `@called(once)` from the contextual type.
+    if (!closureExtInfo.isCalledOnce()) {
+      if (auto calledOnceTy = contextualFnType->getCalledOnceDependentType()) {
+        closureExtInfo = closureExtInfo.withCalledOnceDependentType(calledOnceTy);
+      } else if (contextualFnType->isCalledOnce()) {
+        closureExtInfo = closureExtInfo.withCalledOnce();
+      }
+    }
   }
 
   // Propagate sending result from the contextual type to the closure.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2965,6 +2965,59 @@ ConstraintSystem::SolutionKind ConstraintSystem::matchFunctionSendability(
   return SolutionKind::Solved;
 }
 
+ConstraintSystem::SolutionKind
+ConstraintSystem::matchFunctionExecutionSemantics(
+    FunctionType *func1, FunctionType *func2, ConstraintKind kind,
+    TypeMatchOptions flags, ConstraintLocatorBuilder locator) {
+  auto formUnsolved = [&]() {
+    // If we're supposed to generate constraints, do so.
+    if (flags.contains(TMF_GenerateConstraints)) {
+      auto *constraint = Constraint::create(*this, kind, func1, func2,
+                                            getConstraintLocator(locator));
+      addUnsolvedConstraint(constraint);
+      return SolutionKind::Solved;
+    }
+    return SolutionKind::Unsolved;
+  };
+
+  // First check to see if we have any @called(once) dependent function types,
+  // if any of them still have unresolved type variables we need to wait until
+  // they're fully resolved.
+  auto dep1 = func1->getCalledOnceDependentType();
+  if (dep1) {
+    dep1 = simplifyType(dep1);
+    if (dep1->hasTypeVariable())
+      return formUnsolved();
+  }
+  auto dep2 = func2->getCalledOnceDependentType();
+  if (dep2) {
+    dep2 = simplifyType(dep2);
+    if (dep2->hasTypeVariable())
+      return formUnsolved();
+  }
+
+  // Sendability is given by either the sendability of the dependent type if
+  // present, otherwise it's given by the function itself.
+  auto func1CalledOnce = dep1 ? dep1->isNoncopyable() : func1->isCalledOnce();
+  auto func2CalledOnce = dep2 ? dep2->isNoncopyable() : func2->isCalledOnce();
+
+  if (func1CalledOnce != func2CalledOnce) {
+    if (func1CalledOnce || kind < ConstraintKind::Subtype) {
+      if (!shouldAttemptFixes())
+        return SolutionKind::Error;
+
+      auto *fix = ExecutionSemanticsMismatch::create(
+          *this, func1, func2, getConstraintLocator(locator));
+      if (recordFix(fix, FixImpact::FunctionTypeMismatch))
+        return SolutionKind::Error;
+    }
+
+    increaseScore(SK_FunctionConversion, locator);
+  }
+
+  return SolutionKind::Solved;
+}
+
 static bool isWitnessMatching(ConstraintLocatorBuilder locator) {
   SmallVector<LocatorPathElt, 4> path;
   (void) locator.getLocatorParts(path);
@@ -3223,10 +3276,15 @@ ConstraintSystem::SolutionKind
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,
                                      ConstraintLocatorBuilder locator) {
-  // If the locator is for a @Sendable match, that's all we want to do.
+  // If the locator is for a @Sendable or execution semantics match, that's all
+  // we want to do.
   if (auto last = locator.last()) {
     if (last->is<LocatorPathElt::FunctionSendability>())
       return matchFunctionSendability(func1, func2, kind, flags, locator);
+
+    if (last->is<LocatorPathElt::FunctionExecutionSemantics>())
+      return matchFunctionExecutionSemantics(func1, func2, kind, flags,
+                                             locator);
   }
 
   // Match the 'throws' effect.
@@ -3261,19 +3319,11 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       increaseScore(SK_SyncInAsync, locator);
   }
 
-  if (func1->isCalledOnce() != func2->isCalledOnce()) {
-    if (func1->isCalledOnce() || kind < ConstraintKind::Subtype) {
-      if (!shouldAttemptFixes())
-        return SolutionKind::Error;
-
-      auto *fix = ExecutionSemanticsMismatch::create(
-          *this, func1, func2, getConstraintLocator(locator));
-      if (recordFix(fix, FixImpact::FunctionTypeMismatch))
-        return SolutionKind::Error;
-    }
-
-    increaseScore(SK_FunctionConversion, locator);
-  }
+  auto execResult = matchFunctionExecutionSemantics(
+      func1, func2, kind, TMF_GenerateConstraints,
+      locator.withPathElement(ConstraintLocator::FunctionExecutionSemantics));
+  if (execResult == SolutionKind::Error)
+    return execResult;
 
   // Match @Sendable.
   auto sendableResult = matchFunctionSendability(

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -109,6 +109,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PackExpansionType:
   case ConstraintLocator::ThrownErrorType:
   case ConstraintLocator::FunctionSendability:
+  case ConstraintLocator::FunctionExecutionSemantics:
   case ConstraintLocator::FallbackType:
   case ConstraintLocator::KeyPathSubscriptIndex:
   case ConstraintLocator::ExistentialMemberAccessConversion:
@@ -517,6 +518,10 @@ void LocatorPathElt::dump(raw_ostream &out) const {
   }
   case ConstraintLocator::FunctionSendability: {
     out << "function sendability";
+    break;
+  }
+  case ConstraintLocator::FunctionExecutionSemantics: {
+    out << "function execution semantics";
     break;
   }
   case ConstraintLocator::FallbackType: {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3714,7 +3714,8 @@ void constraints::simplifyLocator(ASTNode &anchor,
 
     case ConstraintLocator::GlobalActorType:
     case ConstraintLocator::ContextualType:
-    case ConstraintLocator::FunctionSendability: {
+    case ConstraintLocator::FunctionSendability:
+    case ConstraintLocator::FunctionExecutionSemantics: {
       // This was just for identifying purposes, strip it off.
       path = path.slice(1);
       continue;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1774,6 +1774,17 @@ struct TypeSimplifier : public TypeTransform<TypeSimplifier> {
     // Otherwise we've flattened the dependence, evaluate Sendable.
     return std::make_pair(Type(), isSendableCapture(ty));
   }
+
+  std::pair<Type, /*calledOnce*/ bool> transformCalledOnceDependentType(Type ty) {
+    ty = simplify(ty);
+
+    // If we still have type variables, we keep the dependence.
+    if (ty->hasTypeVariable())
+      return std::pair(ty, false);
+
+    // Otherwise we've flattened the dependence, evaluate @called(once).
+    return std::make_pair(Type(), ty->isNoncopyable());
+  }
 };
 
 } // end anonymous namespace

--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -1087,8 +1087,9 @@ static std::optional<AnyFunctionType::ExtInfo>
 extInfoJoinMeetImpl(Operation op,
                     AnyFunctionType::ExtInfo lhsInfo,
                     AnyFunctionType::ExtInfo rhsInfo) {
-  bool noEscape, sendable, throwing, async;
+  bool noEscape, sendable, calledOnce, throwing, async;
   Type sendableDep;
+  Type calledOnceDep;
   Type thrownError;
 
   // Concurrency is too hard to reason about here.
@@ -1097,6 +1098,9 @@ extInfoJoinMeetImpl(Operation op,
 
   auto lhsSendableDep = lhsInfo.getSendableDependentType();
   auto rhsSendableDep = rhsInfo.getSendableDependentType();
+
+  auto lhsCalledOnceDep = lhsInfo.getCalledOnceDependentType();
+  auto rhsCalledOnceDep = rhsInfo.getCalledOnceDependentType();
 
   if (op == Operation::Join) {
     noEscape = lhsInfo.isNoEscape() || rhsInfo.isNoEscape();
@@ -1119,6 +1123,25 @@ extInfoJoinMeetImpl(Operation op,
       sendable = false;
     } else {
       sendable = lhsInfo.isSendable() && rhsInfo.isSendable();
+    }
+
+    if (lhsCalledOnceDep && rhsCalledOnceDep) {
+      // Form a tuple; its @called(once) iff both components are @called(once).
+      SmallVector<TupleTypeElt, 2> elts;
+      elts.push_back(lhsCalledOnceDep);
+      elts.push_back(rhsCalledOnceDep);
+      calledOnceDep = TupleType::get(elts, lhsSendableDep->getASTContext());
+      calledOnce = false;
+    } else if (lhsCalledOnceDep && !rhsCalledOnceDep) {
+      if (rhsInfo.isCalledOnce())
+        calledOnceDep = lhsCalledOnceDep;
+      calledOnce = false;
+    } else if (!lhsCalledOnceDep && rhsCalledOnceDep) {
+      if (lhsInfo.isCalledOnce())
+        calledOnceDep = rhsCalledOnceDep;
+      calledOnce = false;
+    } else {
+      calledOnce = lhsInfo.isCalledOnce() && rhsInfo.isCalledOnce();
     }
 
     throwing = lhsInfo.isThrowing() || rhsInfo.isThrowing();
@@ -1158,6 +1181,27 @@ extInfoJoinMeetImpl(Operation op,
       sendable = lhsInfo.isSendable() || rhsInfo.isSendable();
     }
 
+    if (lhsCalledOnceDep && rhsCalledOnceDep) {
+      // We cannot represent the meet of two @called(once)-dependent types.
+      return std::nullopt;
+    } else if (lhsCalledOnceDep && !rhsCalledOnceDep) {
+      if (rhsInfo.isCalledOnce()) {
+        calledOnce = true;
+      } else {
+        calledOnce = false;
+        calledOnceDep = lhsCalledOnceDep;
+      }
+    } else if (!lhsCalledOnceDep && rhsCalledOnceDep) {
+      if (lhsInfo.isCalledOnce()) {
+        calledOnce = true;
+      } else {
+        calledOnce = false;
+        calledOnceDep = rhsCalledOnceDep;
+      }
+    } else {
+      calledOnce = lhsInfo.isCalledOnce() || rhsInfo.isCalledOnce();
+    }
+
     throwing = lhsInfo.isThrowing() && rhsInfo.isThrowing();
     Type thrownError;
     if (throwing) {
@@ -1182,6 +1226,8 @@ extInfoJoinMeetImpl(Operation op,
       .withAsync(async)
       .withSendable(sendable)
       .withSendableDependentType(sendableDep)
+      .withCalledOnce(calledOnce)
+      .withCalledOnceDependentType(calledOnceDep)
       .build();
 }
 

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -22,6 +22,7 @@
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/Effects.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/MacroDefinition.h"
@@ -2083,6 +2084,29 @@ ConstraintSystem::getTypeOfMemberReferencePre(
       openedType =
           FunctionType::get(fullFunctionType->getParams(), functionType,
                             fullFunctionType->getExtInfo());
+    }
+  }
+
+  // Member type could be `@called(once)` if the method is consuming and base is
+  // non-Copyable.
+  if (Context.LangOpts.hasFeature(Feature::CalledAttribute)) {
+    if (auto *method = dyn_cast<FuncDecl>(value);
+        method && method->isInstanceMethod() && method->getSelfAccessKind() == SelfAccessKind::Consuming) {
+      auto *fullTy = openedType->castTo<FunctionType>();
+      auto *methodTy = fullTy->getResult()->castTo<FunctionType>();
+
+      std::optional<AnyFunctionType::ExtInfo> newExtInfo;
+      if (baseObjTy->hasTypeVariable())
+        newExtInfo =
+            methodTy->getExtInfo().withCalledOnceDependentType(baseObjTy);
+      else if (baseObjTy->isNoncopyable())
+        newExtInfo = methodTy->getExtInfo().withCalledOnce();
+
+      if (newExtInfo) {
+        auto *newMethodTy = methodTy->withExtInfo(*newExtInfo);
+        openedType = FunctionType::get(fullTy->getParams(), newMethodTy,
+                                       fullTy->getExtInfo());
+      }
     }
   }
 

--- a/test/SILGen/called_once_consuming_method.swift
+++ b/test/SILGen/called_once_consuming_method.swift
@@ -1,0 +1,138 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -enable-experimental-feature CalledAttribute %s | %FileCheck %s
+
+// REQUIRES: swift_feature_CalledAttribute
+
+struct Resource: ~Copyable {
+  deinit {}
+  consuming func use() {}
+}
+
+struct Box<Wrapped: ~Copyable>: ~Copyable {
+  var value: Wrapped? = nil
+  consuming func take() -> Wrapped { value! }
+}
+
+extension Box: Copyable where Wrapped: Copyable {
+}
+
+protocol Usable: ~Copyable {
+  consuming func use()
+}
+
+func runOnce(_ f: @called(once) () -> Void) {
+  f()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_consuming_method10testSimpleyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: alloc_box ${ let @called(once) @callee_owned () -> () }, let, name "f1"
+// CHECK: [[F1_VALUE:%.*]] = load [take] {{%.*}} : $*Resource
+// CHECK: [[F1_REF:%.*]] = function_ref @$s28called_once_consuming_method10testSimpleyyAA8ResourceVnFyyXOADncfu_ : $@convention(thin) (@owned Resource) -> @owned @called(once) @callee_owned () -> ()
+// CHECK: apply [[F1_REF]]([[F1_VALUE]]) : $@convention(thin) (@owned Resource) -> @owned @called(once) @callee_owned () -> ()
+// CHECK: [[F2_REF:%.*]] = function_ref @$s28called_once_consuming_method10testSimpleyyAA8ResourceVnFyyXOADncfu1_ : $@convention(thin) (@owned Resource) -> @owned @called(once) @callee_owned () -> ()
+// CHECK: [[F2_THICK:%.*]] = thin_to_thick_function [[F2_REF]] : $@convention(thin) (@owned Resource) -> @owned @called(once) @callee_owned () -> () to $@callee_guaranteed (@owned Resource) -> @owned @called(once) @callee_owned () -> ()
+// CHECK: move_value [lexical] [var_decl] [[F2_THICK]] : $@callee_guaranteed (@owned Resource) -> @owned @called(once) @callee_owned () -> ()
+// CHECK: } // end sil function '$s28called_once_consuming_method10testSimpleyyAA8ResourceVnF'
+
+// CHECK-LABEL: sil private [ossa] @$s28called_once_consuming_method10testSimpleyyAA8ResourceVnFyyXOADncfu_ : $@convention(thin) (@owned Resource) -> @owned @called(once) @callee_owned () -> () {
+// CHECK: [[THUNK:%.*]] = function_ref @$s28called_once_consuming_method10testSimpleyyAA8ResourceVnFyyXOADncfu_yyXOfu0_ : $@convention(thin) (@owned Resource) -> ()
+// CHECK: [[VALUE:%.*]] = load [take] {{%.*}} : $*Resource
+// CHECK: [[CLOSURE:%.*]] = partial_apply [called_once] [[THUNK]]([[VALUE]]) : $@convention(thin) (@owned Resource) -> ()
+// CHECK: return [[CLOSURE]] : $@called(once) @callee_owned () -> ()
+// CHECK: } // end sil function '$s28called_once_consuming_method10testSimpleyyAA8ResourceVnFyyXOADncfu_'
+func testSimple(_ r: consuming Resource) {
+  let f1 = r.use
+  f1()
+
+  let f2 = Resource.use
+  _ = f2
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_consuming_method31testCopyableViaGenericParameteryyAA3BoxVySiGnF : $@convention(thin) (Box<Int>) -> () {
+// CHECK-NOT: @called(once)
+// CHECK: } // end sil function '$s28called_once_consuming_method31testCopyableViaGenericParameteryyAA3BoxVySiGnF'
+func testCopyableViaGenericParameter(_ b: consuming Box<Int>) {
+  let f = b.take
+  _ = f()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_consuming_method34testNonCopyableViaGenericParameter_2b2yAA3BoxVyxGn_AFntRi_zlF : $@convention(thin) <T where T : ~Copyable> (@in Box<T>, @in Box<T>) -> () {
+// CHECK: alloc_box $<τ_0_0 where τ_0_0 : ~Copyable> { let @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0> } <T>, let, name "f1"
+// CHECK: [[F1_REF:%.*]] = function_ref @$s28called_once_consuming_method34testNonCopyableViaGenericParameter_2b2yAA3BoxVyxGn_AFntRi_zlFxyXOAFncfu_ : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<τ_0_0>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>
+// CHECK: apply [[F1_REF]]<T>({{%.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<τ_0_0>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>
+// CHECK: [[UNAPPLIED_REF:%.*]] = function_ref @$s28called_once_consuming_method34testNonCopyableViaGenericParameter_2b2yAA3BoxVyxGn_AFntRi_zlFxyXOAFncfu1_ : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<τ_0_0>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>
+// CHECK: [[UNAPPLIED_PARTIAL:%.*]] = partial_apply [callee_guaranteed] [[UNAPPLIED_REF]]<T>() : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<τ_0_0>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>
+// CHECK: [[UNAPPLIED:%.*]] = convert_function [[UNAPPLIED_PARTIAL]] : $@callee_guaranteed (@in Box<T>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <T> to $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in Box<τ_0_0>) -> (@owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_1>) for <T, T>
+// CHECK: [[UNAPPLIED_MOVED:%.*]] = move_value [lexical] [var_decl] [[UNAPPLIED]] : $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in Box<τ_0_0>) -> (@owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_1>) for <T, T>
+// CHECK: debug_value [[UNAPPLIED_MOVED]] : $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in Box<τ_0_0>) -> (@owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_1>) for <T, T>, let, name "unapplied"
+// CHECK: alloc_box $<τ_0_0 where τ_0_0 : ~Copyable> { let @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0> } <T>, let, name "f2"
+// CHECK: [[F2_VALUE:%.*]] = apply {{%.*}}({{%.*}}) : $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in Box<τ_0_0>) -> (@owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_1>) for <T, T>
+// CHECK: store [[F2_VALUE]] to [init] {{%.*}} : $*@called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <T>
+// CHECK: } // end sil function '$s28called_once_consuming_method34testNonCopyableViaGenericParameter_2b2yAA3BoxVyxGn_AFntRi_zlF'
+
+// CHECK-LABEL: sil private [ossa] @$s28called_once_consuming_method34testNonCopyableViaGenericParameter_2b2yAA3BoxVyxGn_AFntRi_zlFxyXOAFncfu_ : $@convention(thin) <T where T : ~Copyable> (@in Box<T>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <T> {
+// CHECK: [[THUNK:%.*]] = function_ref @$s28called_once_consuming_method34testNonCopyableViaGenericParameter_2b2yAA3BoxVyxGn_AFntRi_zlFxyXOAFncfu_xyXOfu0_ : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<τ_0_0>) -> @out τ_0_0
+// CHECK: [[CLOSURE:%.*]] = partial_apply [called_once] [[THUNK]]<T>({{%.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<τ_0_0>) -> @out τ_0_0
+// CHECK: [[SUBSTITUTED:%.*]] = convert_function [[CLOSURE]] : $@called(once) @callee_owned () -> @out T to $@called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <T>
+// CHECK: return [[SUBSTITUTED]] : $@called(once) @callee_owned @substituted <τ_0_0> () -> @out τ_0_0 for <T>
+// CHECK: } // end sil function '$s28called_once_consuming_method34testNonCopyableViaGenericParameter_2b2yAA3BoxVyxGn_AFntRi_zlFxyXOAFncfu_'
+func testNonCopyableViaGenericParameter<T: ~Copyable>(_ b1: consuming Box<T>, b2: consuming Box<T>) {
+  let f1 = b1.take
+  _ = f1()
+
+  let unapplied = Box<T>.take
+  let f2 = unapplied(b2)
+  _ = f2()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_consuming_method23testProtocolRequirementyyxnAA6UsableRzRi_zlF : $@convention(thin) <T where T : Usable, T : ~Copyable> (@in T) -> () {
+// CHECK: alloc_box ${ let @called(once) @callee_owned () -> () }, let, name "f"
+// CHECK: } // end sil function '$s28called_once_consuming_method23testProtocolRequirementyyxnAA6UsableRzRi_zlF'
+
+// CHECK-LABEL: sil private [ossa] @$s28called_once_consuming_method23testProtocolRequirementyyxnAA6UsableRzRi_zlFyyXOxncfu_yyXOfu0_ : $@convention(thin) <T where T : Usable, T : ~Copyable> (@in T) -> () {
+// CHECK: witness_method $T, #Usable.use : <Self where Self : Usable, Self : ~Copyable> (consuming Self) -> () -> ()
+// CHECK: } // end sil function '$s28called_once_consuming_method23testProtocolRequirementyyxnAA6UsableRzRi_zlFyyXOxncfu_yyXOfu0_'
+func testProtocolRequirement<T: Usable & ~Copyable>(_ x: consuming T) {
+  let f = x.use
+  f()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_consuming_method25testUseOfCalledOnceMethodyyAA8ResourceVnF : $@convention(thin) (@owned Resource) -> () {
+// CHECK: [[CLOSURE_REF:%.*]] = function_ref @$s28called_once_consuming_method25testUseOfCalledOnceMethodyyAA8ResourceVnFyyXOADncfu_ : $@convention(thin) (@owned Resource) -> @owned @called(once) @callee_owned () -> ()
+// CHECK: [[CLOSURE:%.*]] = apply [[CLOSURE_REF]]({{%.*}}) : $@convention(thin) (@owned Resource) -> @owned @called(once) @callee_owned () -> ()
+// CHECK: [[NOESCAPE:%.*]] = convert_escape_to_noescape [[CLOSURE]] : $@called(once) @callee_owned () -> () to $@noescape @called(once) @callee_owned () -> ()
+// CHECK: function_ref @$s28called_once_consuming_method7runOnceyyyyXEnF
+// CHECK: apply {{%.*}}([[NOESCAPE]]) : $@convention(thin) (@owned @noescape @called(once) @callee_owned () -> ()) -> ()
+// CHECK: } // end sil function '$s28called_once_consuming_method25testUseOfCalledOnceMethodyyAA8ResourceVnF'
+func testUseOfCalledOnceMethod(_ r: consuming Resource) {
+  runOnce(r.use)
+}
+
+func pick<T: ~Copyable>(_ b: Bool) -> Box<T> {
+  .init()
+}
+func pick(_: String) -> String { "" }
+
+// CHECK-LABEL: sil hidden [ossa] @$s28called_once_consuming_method26testJoinWithDependentTypesyxSbRi_zlF : $@convention(thin) <T where T : ~Copyable> (Bool) -> @out T {
+// CHECK: alloc_box $<τ_0_0 where τ_0_0 : ~Copyable> { let Box<τ_0_0> } <T>, let, name "f"
+// CHECK: cond_br {{%.*}}, [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+//
+// CHECK: [[TRUE_BB]]:
+// CHECK: [[PICK_REF:%.*]] = function_ref @$s28called_once_consuming_method4pickyAA3BoxVyxGSbRi_zlF : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (Bool) -> @out Box<τ_0_0>
+// CHECK: apply [[PICK_REF]]<Box<T>>({{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (Bool) -> @out Box<τ_0_0>
+// CHECK: [[TRUE_REF:%.*]] = function_ref @$s28called_once_consuming_method26testJoinWithDependentTypesyxSbRi_zlFAA3BoxVyxGyXOADyAEGncfu_ : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<Box<τ_0_0>>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out Box<τ_0_0> for <τ_0_0>
+// CHECK: [[TRUE_VALUE:%.*]] = apply [[TRUE_REF]]<T>({{%.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> (@in Box<Box<τ_0_0>>) -> @owned @called(once) @callee_owned @substituted <τ_0_0> () -> @out Box<τ_0_0> for <τ_0_0>
+// CHECK: br [[JOIN_BB:bb[0-9]+]]([[TRUE_VALUE]] : $@called(once) @callee_owned @substituted <τ_0_0> () -> @out Box<τ_0_0> for <T>)
+//
+// CHECK: [[FALSE_BB]]:
+// CHECK: [[FALSE_REF:%.*]] = function_ref @$s28called_once_consuming_method26testJoinWithDependentTypesyxSbRi_zlFAA3BoxVyxGyXOfU_ : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> () -> @out Box<τ_0_0>
+// CHECK: [[FALSE_CLOSURE:%.*]] = partial_apply [called_once] [[FALSE_REF]]<T>() : $@convention(thin) <τ_0_0 where τ_0_0 : ~Copyable> () -> @out Box<τ_0_0>
+// CHECK: [[FALSE_VALUE:%.*]] = convert_function [[FALSE_CLOSURE]] : $@called(once) @callee_owned () -> @out Box<T> to $@called(once) @callee_owned @substituted <τ_0_0> () -> @out Box<τ_0_0> for <T>
+// CHECK: br [[JOIN_BB]]([[FALSE_VALUE]] : $@called(once) @callee_owned @substituted <τ_0_0> () -> @out Box<τ_0_0> for <T>)
+//
+// CHECK: [[JOIN_BB]]([[JOINED:%.*]] : @owned $@called(once) @callee_owned @substituted <τ_0_0> () -> @out Box<τ_0_0> for <T>):
+// CHECK: apply [[JOINED]]({{%.*}}) : $@called(once) @callee_owned @substituted <τ_0_0> () -> @out Box<τ_0_0> for <T>
+// CHECK: } // end sil function '$s28called_once_consuming_method26testJoinWithDependentTypesyxSbRi_zlF'
+func testJoinWithDependentTypes<T: ~Copyable>(_ b: Bool) -> T {
+  let f: Box<T> = (b ? pick(b).take : { @called(once) in .init() })()
+  _ = f
+}


### PR DESCRIPTION
This is modeled the same was as `@Sendable`. If the base type is not yet resolved enough to
determine whether it's non-Copyable or not - the dependence is recorded in the function type
and later simplified out and replaced with an actual bit flit in `ExtInfo`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
