### PR TITLE
Preserve async-let typed errors

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -8323,9 +8323,16 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
   SILType loweredOpaquePatternType = getLoweredType(AbstractionPattern::getOpaque(),
                                                     formalPatternType);
 
-  auto asyncLetGet = childTask.isThrowing
-      ? SGM.getAsyncLetGetThrowing()
-      : SGM.getAsyncLetGet();
+  auto asyncLetGet = childTask.thrownError.has_value()
+                         ? SGM.getAsyncLetGetThrowing()
+                         : SGM.getAsyncLetGet();
+  std::optional<AsyncLetTypedErrorEmission> typedErrorEmission;
+
+  // If child task throws a typed error, emit it with the declared type
+  if (childTask.thrownError &&
+      !childTask.thrownError->isErrorExistentialType()) {
+    typedErrorEmission.emplace(*this, loc, *childTask.thrownError);
+  }
 
   // The intrinsic returns a pointer to the address of the result value inside
   // the async let task context.
@@ -8334,6 +8341,11 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
       {ManagedValue::forObjectRValueWithoutOwnership(childTask.asyncLet),
        ManagedValue::forObjectRValueWithoutOwnership(childTask.resultBuf)},
       SGFContext());
+
+  // Restore the original error destination.
+  if (typedErrorEmission) {
+    typedErrorEmission.reset();
+  }
 
   auto resultAddr = B.createPointerToAddress(loc, childTask.resultBuf,
                 loweredOpaquePatternType.getAddressType(),

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1718,7 +1718,14 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD, unsigned idx,
       init = tryExpr->getSubExpr();
     init = cast<CallExpr>(init)->getFn();
     auto initClosure = cast<AutoClosureExpr>(init);
-    bool isThrowing = init->getType()->castTo<AnyFunctionType>()->isThrowing();
+    auto functionType = init->getType()->castTo<AnyFunctionType>();
+    std::optional<CanType> thrownErrorType;
+
+    // Record the lowered type of the child task's typed error.
+    if (auto errorType = functionType->getEffectiveThrownErrorType()) {
+      thrownErrorType =
+          getLoweredRValueType(AbstractionPattern::getOpaque(), *errorType);
+    }
 
     // Allocate space to receive the child task's result.
     auto initLoweredTy = getLoweredType(AbstractionPattern::getOpaque(),
@@ -1754,7 +1761,7 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD, unsigned idx,
     enterAsyncLetCleanup(alet, resultBufPtr);
 
     // Save the child task so we can await it as needed.
-    AsyncLetChildTasks[{PBD, idx}] = {alet, resultBufPtr, isThrowing};
+    AsyncLetChildTasks[{PBD, idx}] = {alet, resultBufPtr, thrownErrorType};
     return;
   }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1199,6 +1199,84 @@ manageBufferForExprResult(SILValue buffer, const TypeLowering &bufferTL,
                                              enterDestroyCleanup(buffer));
 }
 
+static ManagedValue emitForcedErrorCast(SILGenFunction &SGF, SILLocation loc,
+                                        ManagedValue erasedError,
+                                        CanType typedErrorType) {
+  auto &typedErrorTL = SGF.getTypeLowering(typedErrorType);
+  auto castOptions = CheckedCastInstOptions();
+  auto erasedErrorType = erasedError.getType().getASTType();
+  bool requiresAddressCast = !canSILUseScalarCheckedCastInstructions(
+      SGF.SGM.M, SGF.F.hasLoweredAddresses(), erasedErrorType, typedErrorType);
+
+  if (requiresAddressCast) {
+    // If an address cast is required, move the erased error into
+    // a temporary buffer and initialize the typed error in a new one.
+    auto erasedErrorAddr = erasedError.materialize(SGF, loc);
+    auto typedErrorAddr =
+        SGF.emitTemporaryAllocation(loc, typedErrorTL.getLoweredType());
+
+    SGF.B.createUnconditionalCheckedCastAddr(
+        loc, castOptions, erasedErrorAddr.forward(SGF), erasedErrorType,
+        typedErrorAddr, typedErrorType);
+
+    ManagedValue typedError =
+        SGF.emitManagedBufferWithCleanup(typedErrorAddr, typedErrorTL);
+    return typedError;
+  }
+
+  // Otherwise, cast the erased error directly to the typed error.
+  ManagedValue typedError = SGF.B.createUnconditionalCheckedCast(
+      loc, castOptions, std::move(erasedError), typedErrorTL.getLoweredType(),
+      typedErrorType);
+  return typedError;
+}
+
+SILGenFunction::AsyncLetTypedErrorEmission::AsyncLetTypedErrorEmission(
+    SILGenFunction &SGF, SILLocation loc, CanType errorType)
+    : SGF(SGF), Loc(loc), ErrorType(errorType), OldThrowDest(SGF.ThrowDest),
+      ErasedErrorBB(SGF.createBasicBlock(FunctionSection::Postmatter)) {
+  assert(loc && "cannot pass a null location");
+
+  // Make the error block receive the erased error as an argument.
+  auto erasedErrorType = SILType::getExceptionType(SGF.getASTContext());
+  ErasedErrorBB->createPhiArgument(erasedErrorType, OwnershipKind::Owned);
+
+  // Route thrown errors to the temporary error block.
+  SGF.ThrowDest = JumpDest(ErasedErrorBB, SGF.Cleanups.getCleanupsDepth(),
+                           CleanupLocation(loc), ThrownErrorInfo(SILValue()));
+}
+
+void SILGenFunction::AsyncLetTypedErrorEmission::finish() {
+  assert(ErasedErrorBB && "emission already finished");
+
+  auto erasedErrorBB = ErasedErrorBB;
+  SGF.ThrowDest = OldThrowDest;
+
+  // If there are no uses of the catch block, just drop it.
+  if (erasedErrorBB->pred_empty()) {
+    SGF.eraseBasicBlock(erasedErrorBB);
+  } else {
+    // Otherwise, we need to emit it.
+    SILGenSavedInsertionPoint scope(SGF, erasedErrorBB,
+                                    FunctionSection::Postmatter);
+    FullExpr catchCleanups(SGF.Cleanups, CleanupLocation(Loc));
+
+    // Cast the captured erased error back to the typed error.
+    assert(erasedErrorBB->getNumArguments() == 1 &&
+           "typed async-let error block must receive one erased error");
+    auto erasedError =
+        ManagedValue::forForwardedRValue(SGF, erasedErrorBB->getArgument(0));
+    auto typedError =
+        emitForcedErrorCast(SGF, Loc, std::move(erasedError), ErrorType);
+
+    // Propagate the typed error to the original throw destination.
+    SGF.emitThrow(Loc, std::move(typedError));
+  }
+
+  // Prevent double-finishing and make the destructor a no-op.
+  ErasedErrorBB = nullptr;
+}
+
 SILGenFunction::ForceTryEmission::ForceTryEmission(SILGenFunction &SGF,
                                                    ForceTryExpr *loc)
     : SGF(SGF), Loc(loc), OldThrowDest(SGF.ThrowDest) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -626,7 +626,7 @@ public:
   struct AsyncLetChildTask {
     SILValue asyncLet; // RawPointer to the async let state
     SILValue resultBuf; // RawPointer to the result buffer
-    bool isThrowing; // true if task can throw
+    std::optional<CanType> thrownError; // Child task's thrown-error type
   };
   
   /// Mapping from each async let clause to the AsyncLet repr that contains the
@@ -3197,6 +3197,29 @@ public:
 
     ~ForceTryEmission() {
       if (Loc) finish();
+    }
+  };
+
+  class AsyncLetTypedErrorEmission {
+    SILGenFunction &SGF;
+    SILLocation Loc;
+    CanType ErrorType;
+    JumpDest OldThrowDest;
+    SILBasicBlock *ErasedErrorBB;
+
+  public:
+    AsyncLetTypedErrorEmission(SILGenFunction &SGF, SILLocation loc,
+                               CanType errorType);
+
+    AsyncLetTypedErrorEmission(const AsyncLetTypedErrorEmission &) = delete;
+    AsyncLetTypedErrorEmission &
+    operator=(const AsyncLetTypedErrorEmission &) = delete;
+
+    void finish();
+
+    ~AsyncLetTypedErrorEmission() {
+      if (ErasedErrorBB)
+        finish();
     }
   };
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9239,9 +9239,11 @@ static Expr *wrapAsyncLetInitializer(
 
   // Form the autoclosure type. It is always 'async', and will be 'throws'.
   Type initializerType = initializer->getType();
-  bool throws = TypeChecker::canThrow(ctx, initializer)
-                  .has_value();
   bool hasSendingeResult = isSendingInitializer(initializer);
+  auto canThrow = TypeChecker::canThrow(ctx, initializer);
+  bool throws = canThrow.has_value();
+  Type thrownError = throws ? std::move(*canThrow) : Type();
+
   bool isSendable =
       !ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation);
   assert((isSendable || ctx.LangOpts.hasFeature(
@@ -9249,7 +9251,7 @@ static Expr *wrapAsyncLetInitializer(
          "Region Isolation should imply SendingArgsAndResults");
   auto extInfo = ASTExtInfoBuilder()
                      .withAsync()
-                     .withThrows(throws, /*FIXME:*/ Type())
+                     .withThrows(throws, thrownError)
                      .withSendable(isSendable)
                      .withSendingResult(hasSendingeResult)
                      .build();
@@ -9265,11 +9267,9 @@ static Expr *wrapAsyncLetInitializer(
   // actual calls and translate them into a different mechanism.
   auto autoclosureCall = CallExpr::createImplicitEmpty(ctx, autoclosureExpr);
   autoclosureCall->setType(initializerType);
-  // FIXME: Use thrown type from above.
   if (throws) {
     autoclosureCall->setThrows(
-        ThrownErrorDestination::forMatchingContextType(
-          ctx.getErrorExistentialType()));
+        ThrownErrorDestination::forMatchingContextType(thrownError));
   } else {
     autoclosureCall->setThrows(nullptr);
   }

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1228,25 +1228,28 @@ public:
       if (var->isAsyncLet()) {
         // If the initializer could throw, we will have a 'try' in the
         // application of its autoclosure.
-        // FIXME: The type checker should record the thrown error type in
-        // the AST.
-        bool throws = false;
+        CallExpr *callExpr;
         if (auto init = var->getParentInitializer()) {
           if (auto await = dyn_cast<AwaitExpr>(init))
             init = await->getSubExpr();
-          if (isa<TryExpr>(init))
-            throws = true;
+          if (auto tryExpr = dyn_cast<TryExpr>(init))
+            init = tryExpr->getSubExpr();
+          if (auto autoclosure = dyn_cast<CallExpr>(init))
+            callExpr = autoclosure;
+          else
+            callExpr = nullptr;
+        } else {
+          callExpr = nullptr;
         }
 
         result.merge(Classification::forAsync(
                         ConditionalEffectKind::Always,
                         PotentialEffectReason::forAsyncLet()));
-        if (throws) {
-          ASTContext &ctx = var->getASTContext();
+        if (callExpr && callExpr->isThrowsSet()) {
+          Type thrownError = callExpr->throws().getThrownErrorType();
           result.merge(Classification::forThrows(
-                         /*FIXME:*/ctx.getErrorExistentialType(),
-                         ConditionalEffectKind::Always,
-                         PotentialEffectReason::forAsyncLet()));
+              thrownError, ConditionalEffectKind::Always,
+              PotentialEffectReason::forAsyncLet()));
         }
 
         return result;
@@ -1922,9 +1925,8 @@ public:
           break;
         case EffectKind::Throws:
           result.merge(Classification::forThrows(
-                         /*FIXME:*/ctx.getErrorExistentialType(),
-                         ConditionalEffectKind::Always,
-                         PotentialEffectReason::forApply()));
+              fnType->getThrownError(), ConditionalEffectKind::Always,
+              PotentialEffectReason::forApply()));
           break;
         case EffectKind::Unsafe:
           llvm_unreachable("@unsafe isn't handled in applies");

--- a/test/Concurrency/typed_throws.swift
+++ b/test/Concurrency/typed_throws.swift
@@ -22,6 +22,19 @@ func testAsyncFor<S: AsyncSequence>(seq: S) async throws(MyError)
   }
 }
 
+@available(SwiftStdlib 6.0, *)
+func testAsyncLet<V, E: Error>(action: () async throws(E) -> V) async throws(MyError) -> V {
+  async let value = try await action()
+  // expected-error@+1{{thrown expression type 'E' cannot be converted to error type 'MyError'}}
+  return try await value
+}
+
+@available(SwiftStdlib 6.0, *)
+func testAsyncLet<V>(action: () async throws(MyError) -> V) async throws(MyError) -> V {
+  async let value = try await action()
+  return try await value
+}
+
 do {
   struct Test {
     func compute(_: () async throws -> Void) async rethrows {} // expected-note {{found this candidate}}

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -9,6 +9,7 @@ import _Concurrency
 func getInt() async -> Int { 0 }
 func getString() async -> String { "" }
 func getStringThrowingly() async throws -> String { "" }
+func getStringWithTypedThrows() async throws(SomeError) -> String { "" }
 func getIntAndString() async -> (Int, String) { (5, "hello") }
 
 enum SomeError: Error {
@@ -47,6 +48,22 @@ func testAsyncLetThrows() async throws -> String {
 
   // CHECK: [[ASYNC_LET_GET_THROWING:%.*]] = function_ref @swift_asyncLet_get_throwing
   // CHECK: try_apply [[ASYNC_LET_GET_THROWING]]
+  return try await s
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test0A19AsyncLetTypedThrowsSSyYaAA9SomeErrorOYKF : $@convention(thin) @async () -> (@owned String, @error SomeError) {
+func testAsyncLetTypedThrows() async throws(SomeError) -> String {
+  async let s = try await getStringWithTypedThrows()
+
+  // CHECK: [[ASYNC_LET_GET_THROWING:%.*]] = function_ref @swift_asyncLet_get_throwing
+  // CHECK: try_apply [[ASYNC_LET_GET_THROWING]]
+  // CHECK: bb{{[0-9]+}}([[ERASED_ERROR:%.*]] : @owned $any Error):
+  // CHECK: [[ERASED_ERROR_BUFFER:%.*]] = alloc_stack $any Error
+  // CHECK: store [[ERASED_ERROR]] to [init] [[ERASED_ERROR_BUFFER]] : $*any Error
+  // CHECK: [[TYPED_ERROR_BUFFER:%.*]] = alloc_stack $SomeError
+  // CHECK: unconditional_checked_cast_addr any Error in [[ERASED_ERROR_BUFFER]] : $*any Error to SomeError in [[TYPED_ERROR_BUFFER]] : $*SomeError
+  // CHECK: [[TYPED_ERROR:%.*]] = load [trivial] [[TYPED_ERROR_BUFFER]] : $*SomeError
+  // CHECK: throw [[TYPED_ERROR]] : $SomeError
   return try await s
 }
 


### PR DESCRIPTION
When an `async let` initializer uses typed throws, its error type is not reserved through async-let processing. As a result, awaiting the async let loses information about the declared error type.

The idea was to preserve the initializer’s thrown error type during sema by replacing the existing paths that used the error existential type, then carry that type through effect checking and async-let child-task state. The Swift runtime async-let APIs remain unchanged to preserve their ABI and therefore continue to return type-erased errors so when the SILGen awaits a typed-throwing async let, it routes the runtime-provided erased failures through a temporary error block, force-casts it back to the recorded thrown-error type and propagates the resulting typed error to the enclosing throw destination. This cast is emitted only for non-existential typed errors.

Added type-checking coverage for typed async-let errors and SILGen coverage verifying the generated runtime call, cast and typed throw.

This resolves https://github.com/swiftlang/swift/issues/76169