### PR TITLE
[ClangImported] Fix inconsistent enum ambiguity

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3414,8 +3414,16 @@ namespace {
                                           : ConstantConvertKind::None,
             isStatic, decl,
             importer::convertClangAccess(clangEnum->getAccess()));
-        Impl.ImportedDecls[Impl.getImportedDeclsKey(decl, getVersion())] =
-            result;
+
+        auto key = Impl.getImportedDeclsKey(decl, getVersion());
+        Impl.ImportedDecls[key] = result;
+
+        // We sometimes import an enum constant more than once when a
+        // redeclaration has changed its underlying type. Mark all but one as
+        // disfavored so this doesn't cause type-checking ambiguities.
+        if (key.first != decl->getCanonicalDecl())
+          result->addAttribute(
+            new (Impl.SwiftContext) DisfavoredOverloadAttr(/*Implicit=*/true));
 
         // If this is a compatibility stub, mark it as such.
         if (correctSwiftName)

--- a/test/ClangImporter/enum-cross-module-inconsistent-redeclaration.swift
+++ b/test/ClangImporter/enum-cross-module-inconsistent-redeclaration.swift
@@ -82,12 +82,14 @@ import Typed
 import Untyped
 
 let z: UInt16 = SHARED_CONSTANT_NAME
+let w = UInt16(SHARED_CONSTANT_NAME)
 
 //--- untyped-then-typed.swift
 import Untyped
 import Typed
 
 let z: UInt16 = SHARED_CONSTANT_NAME
+let w = UInt16(SHARED_CONSTANT_NAME)
 
 //--- transitivetyped-then-transitiveuntyped.swift
 // This transitive case is interesting because the order that the compiler
@@ -97,6 +99,7 @@ import TransitiveTyped
 import TransitiveUntyped
 
 let z: UInt16 = SHARED_CONSTANT_NAME
+let w = UInt16(SHARED_CONSTANT_NAME)
 
 //--- typed-then-untyped-then-untypedduplicate.swift
 // Typed, whose type doesn't match Untyped/UntypedDuplicate, is imported first
@@ -108,6 +111,7 @@ import UntypedDuplicate
 
 let a: UInt16 = SHARED_CONSTANT_NAME
 let b: Int = SHARED_CONSTANT_NAME
+let c = UInt16(SHARED_CONSTANT_NAME)
 
 //--- untyped-then-untypedduplicate-then-typed.swift
 // Untyped or UntypedDuplicate is imported first and becomes canonical, so the
@@ -119,3 +123,4 @@ import Typed
 
 let a: UInt16 = SHARED_CONSTANT_NAME
 let b: Int = SHARED_CONSTANT_NAME
+let c = UInt16(SHARED_CONSTANT_NAME)


### PR DESCRIPTION
In #91828, ClangImporter began importing (global) enum constants several times when they were redeclared with different underlying types. It was hoped that the potential type-checking ambiguity caused by this would not be a problem in practice, but qualification testing has shown otherwise. Mark all but one of these duplicate constants with `@_disfavoredOverload` so these expressions can be type-checked unambiguously.

Fixes rdar://186281637.