### PR TITLE
[SIL] Teach the forEach loop unroller to deal with direct "self"

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
@@ -264,18 +264,56 @@ static FixLifetimeInst *isFixLifetimeUseOfArray(SILInstruction *user,
   return result;
 }
 
+/// Return true iff \c apply invokes a function annotated with the
+/// "sequence.forEach" semantics attribute.
+static bool isForEachCallee(TryApplyInst *apply) {
+  SILFunction *callee = apply->getCalleeFunction();
+  return callee && callee->hasSemanticsAttr(semantics::SEQUENCE_FOR_EACH);
+}
+
 /// Given an array-typed SIL value \c array and an instruction \c user that uses
 /// the array, check whether this use actually represents a call to the
-/// Sequence.forEach function. This would be case if \c user is a store_borrow
-/// instruction that stores into an alloc_stack which is passed to a try-apply
-/// of the Sequence.forEach function. That is, if the following pattern holds:
+/// Sequence.forEach function. There are two shapes to match, depending on how
+/// the callee's `self` parameter is passed.
+///
+/// (1) `self` is passed indirectly, which is the case when the callee is the
+///     unspecialized generic Sequence.forEach. Here \c user is a store_borrow
+///     into an alloc_stack that is passed to the try-apply:
 ///
 ///            %stack = alloc_stack
 ///      user: store_borrow %array to %stack
-///            try_apply %forEachCall(%closure, %array)
+///            try_apply %forEachCall(%closure, %stack)
+///
+/// (2) `self` is passed directly. This is the case when the callee is a
+///     specialization of Sequence.forEach in which `Self` has been substituted
+///     with a concrete, loadable Array type, so the parameter is lowered to
+///     @guaranteed. In embedded Swift, MandatoryPerformanceOptimizations
+///     produces exactly such specializations before this pass runs. Here
+///     \c user is the try-apply itself:
+///
+///      user: try_apply %forEachCall(%closure, %array)
+///
 /// \returns the try-apply instruction invoking the forEach function if this is
 /// a forEach use of the array, nullptr otherwise.
 static TryApplyInst *isForEachUseOfArray(SILInstruction *user, SILValue array) {
+  // Case (2): the array is passed directly as the `self` argument.
+  if (TryApplyInst *apply = dyn_cast<TryApplyInst>(user)) {
+    if (!isForEachCallee(apply))
+      return nullptr;
+    // forEach takes the body closure followed by `self`.
+    if (apply->getNumArguments() != 2)
+      return nullptr;
+    Operand &selfOperand = apply->getArgumentOperands()[1];
+    if (selfOperand.get() != array)
+      return nullptr;
+    // Unrolling deletes this call, so it must not consume the array.
+    if (ApplySite(apply).getArgumentConvention(selfOperand) !=
+        SILArgumentConvention::Direct_Guaranteed)
+      return nullptr;
+    return apply;
+  }
+
+  // Case (1): the array is passed indirectly through an alloc_stack.
   StoreBorrowInst *storeUser = dyn_cast<StoreBorrowInst>(user);
   if (!storeUser || storeUser->getSrc() != array)
     return nullptr;
@@ -290,10 +328,33 @@ static TryApplyInst *isForEachUseOfArray(SILInstruction *user, SILValue array) {
   // We need to have a unique result.
   if (++firstUser != applyUsers.end())
     return nullptr;
-  SILFunction *callee = apply->getCalleeFunction();
-  if (!callee || !callee->hasSemanticsAttr(semantics::SEQUENCE_FOR_EACH))
+  if (!isForEachCallee(apply))
     return nullptr;
   return apply;
+}
+
+/// Check whether \c user is a store_borrow of \c array into an alloc_stack
+/// that nothing reads, i.e. whose only uses end the borrow.
+///
+/// SILGen emits such a temporary in order to pass the array indirectly. When
+/// the callee is subsequently specialized to take the array directly (see case
+/// (2) of \c isForEachUseOfArray), the temporary is left behind with no
+/// remaining readers. Borrowing the array cannot modify it, so this leftover
+/// must not inhibit unrolling.
+static bool isDeadTemporaryStoreBorrowOfArray(SILInstruction *user,
+                                              SILValue array) {
+  StoreBorrowInst *storeUser = dyn_cast<StoreBorrowInst>(user);
+  if (!storeUser || storeUser->getSrc() != array)
+    return false;
+  if (!isa<AllocStackInst>(storeUser->getDest()))
+    return false;
+  for (Operand *use : storeUser->getUses()) {
+    SILInstruction *storeBorrowUser = use->getUser();
+    if (isIncidentalUse(storeBorrowUser) || isa<EndBorrowInst>(storeBorrowUser))
+      continue;
+    return false;
+  }
+  return true;
 }
 
 void ArrayInfo::classifyUsesOfArray(SILValue arrayValue, bool isInInitSection) {
@@ -315,6 +376,9 @@ void ArrayInfo::classifyUsesOfArray(SILValue arrayValue, bool isInInitSection) {
       forEachCalls.insert(forEachCall);
       continue;
     }
+    // Ignore a borrow of the array into a temporary that nothing reads.
+    if (isDeadTemporaryStoreBorrowOfArray(user, arrayValue))
+      continue;
     // Recursively classify begin_borrow, copy_value, and move_value uses.
     if (BeginBorrowInst *beginBorrow = dyn_cast<BeginBorrowInst>(user)) {
       if (isInInitSection) {
@@ -415,11 +479,18 @@ void ArrayInfo::getLastDestroys(
 /// not clean up any resulting dead instructions.
 static void removeForEachCall(TryApplyInst *forEachCall,
                               InstructionDeleter &deleter) {
-  auto *sbi = cast<StoreBorrowInst>(forEachCall->getArgument(1));
-  auto *asi = cast<AllocStackInst>(sbi->getDest());
-  // The allocStack will be used in the forEach call and also in a store
-  // instruction and a dealloc_stack instruction. Force delete all of them.
-  deleter.recursivelyForceDeleteUsersAndFixLifetimes(asi);
+  if (auto *sbi = dyn_cast<StoreBorrowInst>(forEachCall->getArgument(1))) {
+    auto *asi = cast<AllocStackInst>(sbi->getDest());
+    // The allocStack will be used in the forEach call and also in a store
+    // instruction and a dealloc_stack instruction. Force delete all of them.
+    deleter.recursivelyForceDeleteUsersAndFixLifetimes(asi);
+    return;
+  }
+  // The array is passed directly to the call (see case (2) of
+  // `isForEachUseOfArray`), so there is no temporary alloc_stack to clean up.
+  // The array is passed @guaranteed, so dropping the call does not require
+  // fixing up its lifetime.
+  deleter.forceDelete(forEachCall);
 }
 
 /// Unroll the \c forEachCall on an array, using the information in

--- a/test/SILOptimizer/for_each_loop_unroll_test.sil
+++ b/test/SILOptimizer/for_each_loop_unroll_test.sil
@@ -328,3 +328,190 @@ bb4(%39 : @owned $Error):
   unreachable
 }
 
+
+// A stub for a *specialization* of Sequence.forEach(_:) in which `Self` has
+// been substituted with a concrete, loadable array type. The `self` parameter
+// is therefore lowered to a direct @guaranteed convention rather than
+// @in_guaranteed. MandatoryPerformanceOptimizations creates such
+// specializations in embedded Swift before this pass runs.
+sil [_semantics "sequence.forEach"] @forEachDirectSelf : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @guaranteed MyArray<Builtin.Int64>) -> @error any Error
+
+// The array is passed directly to forEach, so there is no store_borrow of the
+// array into an alloc_stack to pattern-match on. The loop must still unroll.
+
+// CHECK-LABEL: sil hidden [ossa] @forEachLoopUnrollDirectSelfTest
+// CHECK: [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int64, 15
+// CHECK: [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int64, 27
+// CHECK: [[BODYCLOSURE:%[0-9]+]] = thin_to_thick_function
+// CHECK-NOT: forEachDirectSelf
+// CHECK: [[STACK:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK: store [[LIT1]] to [trivial] [[STACK]]
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+
+// CHECK: [[ERROR]]([[ERRPARAM:%[0-9]+]] : @owned $any Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM]] : $any Error)
+
+// CHECK: [[NORMAL]](%{{.*}} : $()):
+// CHECK: store [[LIT2]] to [trivial] [[STACK]] : $*Builtin.Int64
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, normal [[NORMAL2:bb[0-9]+]], error [[ERROR2:bb[0-9]+]]
+
+// CHECK: [[ERROR2]]([[ERRPARAM2:%[0-9]+]] : @owned $any Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM2]] : $any Error)
+
+// CHECK: [[NORMAL2]](%{{.*}} : $()):
+// CHECK: dealloc_stack [[STACK]]
+// CHECK: destroy_value
+
+// CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $any Error):
+// CHECK: dealloc_stack [[STACK]]
+// CHECK: unreachable
+
+sil hidden [ossa] @forEachLoopUnrollDirectSelfTest : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 2
+  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  (%3, %4a) = destructure_tuple %2 : $(MyArray<Builtin.Int64>, Builtin.RawPointer)
+  %4 = begin_borrow %3
+  %b = struct_extract %4, #MyArray.buffer
+  %5 = ref_tail_addr %b, $Builtin.Int64
+  %6 = integer_literal $Builtin.Int64, 15
+  store %6 to [trivial] %5 : $*Builtin.Int64
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
+  %14 = integer_literal $Builtin.Int64, 27
+  store %14 to [trivial] %13 : $*Builtin.Int64
+  end_borrow %4
+  %f = function_ref @_finalizeArray : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %a2 = apply %f<Builtin.Int64>(%3) : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error
+  %30 = function_ref @forEachDirectSelf : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @guaranteed MyArray<Builtin.Int64>) -> @error any Error
+  try_apply %30(%26, %a2) : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @guaranteed MyArray<Builtin.Int64>) -> @error any Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  destroy_value %a2
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $any Error):
+  destroy_value [dead_end] %39
+  destroy_value [dead_end] %a2
+  unreachable
+}
+
+// A specialization that takes `self` @owned. Unrolling drops the call, which
+// would drop the consume of the array, so this must be left alone.
+sil [_semantics "sequence.forEach"] @forEachOwnedSelf : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @owned MyArray<Builtin.Int64>) -> @error any Error
+
+// CHECK-LABEL: sil hidden [ossa] @forEachOwnedSelfNoUnrollTest
+// CHECK: try_apply %{{[0-9]+}}(%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @owned MyArray<Builtin.Int64>) -> @error any Error
+// CHECK-LABEL: } // end sil function 'forEachOwnedSelfNoUnrollTest'
+
+sil hidden [ossa] @forEachOwnedSelfNoUnrollTest : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 2
+  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  (%3, %4a) = destructure_tuple %2 : $(MyArray<Builtin.Int64>, Builtin.RawPointer)
+  %4 = begin_borrow %3
+  %b = struct_extract %4, #MyArray.buffer
+  %5 = ref_tail_addr %b, $Builtin.Int64
+  %6 = integer_literal $Builtin.Int64, 15
+  store %6 to [trivial] %5 : $*Builtin.Int64
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
+  %14 = integer_literal $Builtin.Int64, 27
+  store %14 to [trivial] %13 : $*Builtin.Int64
+  end_borrow %4
+  %f = function_ref @_finalizeArray : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %a2 = apply %f<Builtin.Int64>(%3) : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error
+  %30 = function_ref @forEachOwnedSelf : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @owned MyArray<Builtin.Int64>) -> @error any Error
+  try_apply %30(%26, %a2) : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @owned MyArray<Builtin.Int64>) -> @error any Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $any Error):
+  destroy_value [dead_end] %39
+  unreachable
+}
+
+// The shape actually produced in embedded Swift: the callee has been
+// specialized to take `self` directly, but the alloc_stack + store_borrow that
+// SILGen emitted in order to pass the array indirectly is left behind, with
+// nothing but end_borrows reading it. That dead temporary must not be mistaken
+// for a use that could write to the array.
+
+// CHECK-LABEL: sil hidden [ossa] @forEachLoopUnrollDeadTemporaryTest
+// CHECK: [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int64, 15
+// CHECK: [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int64, 27
+// CHECK: [[BODYCLOSURE:%[0-9]+]] = thin_to_thick_function
+// CHECK-NOT: forEachDirectSelf
+// CHECK: [[STACK:%[0-9]+]] = alloc_stack $Builtin.Int64
+// CHECK: store [[LIT1]] to [trivial] [[STACK]]
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+
+// CHECK: [[ERROR]]([[ERRPARAM:%[0-9]+]] : @owned $any Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM]] : $any Error)
+
+// CHECK: [[NORMAL]](%{{.*}} : $()):
+// CHECK: store [[LIT2]] to [trivial] [[STACK]] : $*Builtin.Int64
+// CHECK: try_apply [[BODYCLOSURE]]([[STACK]]) : $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, normal [[NORMAL2:bb[0-9]+]], error [[ERROR2:bb[0-9]+]]
+
+// CHECK: [[ERROR2]]([[ERRPARAM2:%[0-9]+]] : @owned $any Error):
+// CHECK: br [[ERROR3:bb[0-9]+]]([[ERRPARAM2]] : $any Error)
+
+// CHECK: [[NORMAL2]](%{{.*}} : $()):
+// CHECK: dealloc_stack [[STACK]]
+
+// CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $any Error):
+// CHECK: dealloc_stack [[STACK]]
+// CHECK: unreachable
+
+sil hidden [ossa] @forEachLoopUnrollDeadTemporaryTest : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Word, 2
+  %1 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  %2 = apply %1<Builtin.Int64>(%0) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  (%3, %4a) = destructure_tuple %2 : $(MyArray<Builtin.Int64>, Builtin.RawPointer)
+  %4 = begin_borrow %3
+  %b = struct_extract %4, #MyArray.buffer
+  %5 = ref_tail_addr %b, $Builtin.Int64
+  %6 = integer_literal $Builtin.Int64, 15
+  store %6 to [trivial] %5 : $*Builtin.Int64
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %5 : $*Builtin.Int64, %12 : $Builtin.Word
+  %14 = integer_literal $Builtin.Int64, 27
+  store %14 to [trivial] %13 : $*Builtin.Int64
+  end_borrow %4
+  %f = function_ref @_finalizeArray : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %a2 = apply %f<Builtin.Int64>(%3) : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  // The dead temporary left behind by specialization: nothing reads %sb.
+  %22 = alloc_stack $MyArray<Builtin.Int64>
+  %sb = store_borrow %a2 to %22 : $*MyArray<Builtin.Int64>
+  %24 = function_ref @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed Builtin.Int64) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error
+  %30 = function_ref @forEachDirectSelf : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @guaranteed MyArray<Builtin.Int64>) -> @error any Error
+  try_apply %30(%26, %a2) : $@convention(method) (@noescape @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @error any Error, @guaranteed MyArray<Builtin.Int64>) -> @error any Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  end_borrow %sb : $*MyArray<Builtin.Int64>
+  dealloc_stack %22 : $*MyArray<Builtin.Int64>
+  destroy_value %a2
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $any Error):
+  end_borrow %sb : $*MyArray<Builtin.Int64>
+  dealloc_stack %22 : $*MyArray<Builtin.Int64>
+  destroy_value [dead_end] %39
+  destroy_value [dead_end] %a2
+  unreachable
+}


### PR DESCRIPTION
The Embedded Swift specialization pass can end up pass the "self" to forEach directly rather than indirectly, which was thwarting the forEach unroller that the OSLog optimization was depending on. Teach the unroller to recognize this pattern as well.

Fixes the embedded-specific part of rdar://186404026, bringing it into line with what happens for non-embedded. However, there are still some stray allocations in either mode.
