### PR TITLE
[test] Stop using the nonexistent `%swift-frontend` substitution

### DIFF
--- a/test/ClangImporter/ctypes_valist_wasm.swift
+++ b/test/ClangImporter/ctypes_valist_wasm.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -target wasm32-unknown-wasip1 -parse-stdlib -module-name Swift -I %S/Inputs/custom-modules -typecheck %s
+// RUN: %swift -target wasm32-unknown-wasip1 -parse-stdlib -module-name Swift -I %S/Inputs/custom-modules -typecheck %s
 
 // REQUIRES: CODEGENERATOR=WebAssembly
 

--- a/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
+++ b/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
@@ -1,6 +1,6 @@
 // Emit the explicit module.
 // RUN: %empty-directory(%t)
-// RUN: %swift-frontend -emit-pcm -direct-clang-cc1-module-build -module-name script -o %t/script.pcm %S/Inputs/custom-modules/module.modulemap -Xcc %S/Inputs/custom-modules/module.modulemap -Xcc -o -Xcc %t/script.pcm -Xcc -fmodules -Xcc -triple -Xcc %target-triple -Xcc -x -Xcc objective-c -dump-clang-diagnostics 2> %t.diags.txt
+// RUN: %swift -emit-pcm -direct-clang-cc1-module-build -module-name script -o %t/script.pcm %S/Inputs/custom-modules/module.modulemap -Xcc %S/Inputs/custom-modules/module.modulemap -Xcc -o -Xcc %t/script.pcm -Xcc -fmodules -Xcc -triple -Xcc %target-triple -Xcc -x -Xcc objective-c -dump-clang-diagnostics 2> %t.diags.txt
 
 // Verify some of the output of the -dump-pcm flag.
 // RUN: %swift-dump-pcm %t/script.pcm | %FileCheck %s --check-prefix=CHECK-DUMP

--- a/test/Concurrency/nonisolated_nonsending_lazy_typecheck.swift
+++ b/test/Concurrency/nonisolated_nonsending_lazy_typecheck.swift
@@ -4,11 +4,11 @@
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // Test both with and without '-experimental-lazy-typecheck'
-// RUN: %swift-frontend -emit-module %t/Lib.swift -swift-version 6 -experimental-lazy-typecheck -experimental-skip-all-function-bodies -enable-upcoming-feature NonisolatedNonsendingByDefault -module-name Lib -o %t/Modules/Lib.swiftmodule
-// RUN: %swift-frontend -emit-sil %t/Test.swift -I %t/Modules -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 6 -experimental-lazy-typecheck -experimental-skip-all-function-bodies -enable-upcoming-feature NonisolatedNonsendingByDefault -module-name Lib -o %t/Modules/Lib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil %t/Test.swift -I %t/Modules -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
 
-// RUN: %swift-frontend -emit-module %t/Lib.swift -swift-version 6 -experimental-skip-all-function-bodies -enable-upcoming-feature NonisolatedNonsendingByDefault -module-name Lib -o %t/Modules/Lib.swiftmodule
-// RUN: %swift-frontend -emit-sil %t/Test.swift -I %t/Modules -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 6 -experimental-skip-all-function-bodies -enable-upcoming-feature NonisolatedNonsendingByDefault -module-name Lib -o %t/Modules/Lib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil %t/Test.swift -I %t/Modules -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 //--- Lib.swift
 

--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift-frontend -emit-ir -o - %s -module-name test \
+// RUN: %swift -emit-ir -o - %s -module-name test \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \
 // RUN:   -target %target-cpu-apple-macosx15 \
 // RUN:   > %t/test_new.irgen
 
-// RUN: %swift-frontend -emit-ir -o - %s -module-name test \
+// RUN: %swift -emit-ir -o - %s -module-name test \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \
 // RUN:   -target %target-cpu-apple-macosx14 \
@@ -14,7 +14,7 @@
 // When targeting an OS new enough to ship the runtime with the noncopyable
 // Mirror guards, the accessor function is elided and the field's typeref is
 // referenced directly.
-// RUN: %swift-frontend -emit-ir -o - %s -module-name test \
+// RUN: %swift -emit-ir -o - %s -module-name test \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \
 // RUN:   -target %target-swift-6.4-abi-triple \

--- a/test/IRGen/noncopyable_metadata_requests.swift
+++ b/test/IRGen/noncopyable_metadata_requests.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift-frontend %s -target %target-cpu-apple-macosx15 -module-name main -emit-ir -o %t/new.ir
-// RUN: %swift-frontend %s -target %target-cpu-apple-macosx14 -module-name main -emit-ir -o %t/old.ir
+// RUN: %swift %s -target %target-cpu-apple-macosx15 -module-name main -emit-ir -o %t/new.ir
+// RUN: %swift %s -target %target-cpu-apple-macosx14 -module-name main -emit-ir -o %t/old.ir
 
 // RUN: %FileCheck %s --check-prefix=NEW < %t/new.ir
 // RUN: %FileCheck %s --check-prefix=OLD < %t/old.ir

--- a/test/IRGen/noncopyable_private.swift
+++ b/test/IRGen/noncopyable_private.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -primary-file %s %S/Inputs/noncopyable_private_other.swift -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/noncopyable_private_other.swift -emit-ir -o - | %FileCheck %s
 
 public struct SomeStruct : ~Copyable {
   // PublicType is a struct without a deinit but a non-copyable field with a

--- a/test/IRGen/noncopyable_struct_deinit_value_witness.swift
+++ b/test/IRGen/noncopyable_struct_deinit_value_witness.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -O -emit-ir -module-name foo %s -o - | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-ir -module-name foo %s -o - | %FileCheck %s
 
 // CHECK-LABEL: define internal void @"$s3foo3FooVwxx"(ptr noalias %object, ptr {{(nofree )?}}readonly captures(none) %"Foo<T>")
 // CHECK-NEXT: entry:

--- a/test/IRGen/ptrauth-global.swift
+++ b/test/IRGen/ptrauth-global.swift
@@ -1,5 +1,5 @@
-// RUN: %swift-frontend -swift-version 4 -target arm64e-apple-ios12.0 -primary-file %s -emit-ir -module-name A | %FileCheck %s --check-prefix=CHECK
-// RUN: %swift-frontend -swift-version 4 -target arm64e-apple-ios12.0 %s -primary-file %S/Inputs/ptrauth-global-2.swift -emit-ir -module-name A | %FileCheck %s --check-prefix=CHECK2
+// RUN: %swift -swift-version 4 -target arm64e-apple-ios12.0 -primary-file %s -emit-ir -module-name A | %FileCheck %s --check-prefix=CHECK
+// RUN: %swift -swift-version 4 -target arm64e-apple-ios12.0 %s -primary-file %S/Inputs/ptrauth-global-2.swift -emit-ir -module-name A | %FileCheck %s --check-prefix=CHECK2
 
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios

--- a/test/IRGen/ptrauth_field_fptr_import.swift
+++ b/test/IRGen/ptrauth_field_fptr_import.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend %s -emit-ir -target arm64e-apple-ios13.0 -I %S/Inputs/ -validate-tbd-against-ir=none -Xllvm -sil-disable-pass=OnoneSimplification | %FileCheck %s
+// RUN: %swift %s -emit-ir -target arm64e-apple-ios13.0 -I %S/Inputs/ -validate-tbd-against-ir=none -Xllvm -sil-disable-pass=OnoneSimplification | %FileCheck %s
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios
 

--- a/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
+++ b/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=SomeModule -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
-// RUN: %swift-frontend -c -enable-experimental-cxx-interop -enable-objc-interop -I %S/Inputs %s -o - -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -c -enable-experimental-cxx-interop -enable-objc-interop -I %S/Inputs %s -o - -emit-sil | %FileCheck %s
 
 import SomeModule
 

--- a/test/Interop/Cxx/objc-correctness/protocol-naming-conflict.swift
+++ b/test/Interop/Cxx/objc-correctness/protocol-naming-conflict.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ProtocolNamingConflict -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
-// RUN: %swift-frontend -c -enable-experimental-cxx-interop -enable-objc-interop -I %S/Inputs %s -emit-sil -o - | %FileCheck %s
+// RUN: %target-swift-frontend -c -enable-experimental-cxx-interop -enable-objc-interop -I %S/Inputs %s -emit-sil -o - | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Misc/target-cpu.swift
+++ b/test/Misc/target-cpu.swift
@@ -40,6 +40,6 @@
 // RUN: not %swift -typecheck -target s390x-unknown-linux-gnu -Xcc -### %s 2>&1 | %FileCheck -check-prefix=S390X_CPU %s
 // S390X_CPU: "-target-cpu" "z13"
 
-// RUN: not %swiftc -typecheck -target x86_64-unknown-windows-msvc -target-cpu haswell -Xcc -### %s 2>&1 | %FileCheck -check-prefix X86_64 %s
+// RUN: not %swift -typecheck -target x86_64-unknown-windows-msvc -target-cpu haswell -Xcc -### %s 2>&1 | %FileCheck -check-prefix X86_64 %s
 // X86_64: "-target-cpu" "haswell"
 // X86_64: "-tune-cpu" "haswell"

--- a/test/Parse/discard.swift
+++ b/test/Parse/discard.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -dump-parse -verify %s > /dev/null
+// RUN: %target-swift-frontend -dump-parse -verify %s > /dev/null
 
 func discard<T>(_ t: T) {}
 

--- a/test/SILGen/ptrauth_field_fptr_import.swift
+++ b/test/SILGen/ptrauth_field_fptr_import.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend %s -emit-silgen -Xllvm -sil-print-types -target arm64e-apple-ios13.0 -I %S/Inputs/ | %FileCheck %s
+// RUN: %swift %s -emit-silgen -Xllvm -sil-print-types -target arm64e-apple-ios13.0 -I %S/Inputs/ | %FileCheck %s
 
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios

--- a/test/ScanDependencies/clang-target-clang-irgen.swift
+++ b/test/ScanDependencies/clang-target-clang-irgen.swift
@@ -15,7 +15,7 @@
 // Pre-build the clang deps with versioned code
 // RUN: %target-swift-emit-pcm -target %target-cpu-apple-macosx12.0 -module-name Bar %S/Inputs/CHeaders/ExtraCModules/module.modulemap -o %t/inputs/Bar.pcm -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules
 
-// RUN: %swift-frontend -target %target-cpu-apple-macosx10.14 -O -emit-ir -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -disable-implicit-swift-modules -explicit-swift-module-map-file %t/inputs/map.json -o %t/explicit-clang-target-irgen.ll %t/test.swift -clang-target %target-cpu-apple-macosx12.0
+// RUN: %swift -target %target-cpu-apple-macosx10.14 -O -emit-ir -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -disable-implicit-swift-modules -explicit-swift-module-map-file %t/inputs/map.json -o %t/explicit-clang-target-irgen.ll %t/test.swift -clang-target %target-cpu-apple-macosx12.0
 // RUN: %FileCheck %s < %t/explicit-clang-target-irgen.ll
 
 // Ensure that the platform version check is not optimized away, which it would, if we code-generate for '-clang-target' of macosx12.0

--- a/test/ScanDependencies/direct-cc1-cpu-target.swift
+++ b/test/ScanDependencies/direct-cc1-cpu-target.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %swift-frontend-plain -target arm64-apple-ios18 -clang-target arm64-apple-ios26 -scan-dependencies -o %t/deps.json -I %t \
+// RUN: %swift_frontend_plain -target arm64-apple-ios18 -clang-target arm64-apple-ios26 -scan-dependencies -o %t/deps.json -I %t \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -enable-builtin-module \
 // RUN:   %t/test.swift -module-name Test -swift-version 5 -experimental-clang-importer-direct-cc1-scan
 
@@ -21,7 +21,7 @@
 
 // CLANG-DIAG-NOT: clang importer driver args:
 
-// RUN: %swift-frontend-plain -target arm64-apple-ios18 -clang-target arm64-apple-ios26 \
+// RUN: %swift_frontend_plain -target arm64-apple-ios18 -clang-target arm64-apple-ios26 \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -enable-builtin-module \
 // RUN:   %t/test.swift -module-name Test -swift-version 5 -O @%t/Test.cmd -S -o %t/test.s
 

--- a/test/embedded/avr/avrCallbackEmission.swift
+++ b/test/embedded/avr/avrCallbackEmission.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -S -O %s -target avr-none-none-elf \
+// RUN: %swift -S -O %s -target avr-none-none-elf \
 // RUN:   -wmo -enable-experimental-feature Embedded | %FileCheck %s
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: CODEGENERATOR=AVR

--- a/test/embedded/avr/testIRGenFunctioning.swift
+++ b/test/embedded/avr/testIRGenFunctioning.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -emit-ir %s -target avr-none-none-elf \
+// RUN: %swift -emit-ir %s -target avr-none-none-elf \
 // RUN:   -wmo -enable-experimental-feature Embedded | %FileCheck %s
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: CODEGENERATOR=AVR

--- a/test/embedded/avr/testStdlibFunctioning.swift
+++ b/test/embedded/avr/testStdlibFunctioning.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-frontend -typecheck %s -target avr-none-none-elf \
+// RUN: %swift -typecheck %s -target avr-none-none-elf \
 // RUN:   -wmo -enable-experimental-feature Embedded
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: CODEGENERATOR=AVR

--- a/test/embedded/wasm/classes.swift
+++ b/test/embedded/wasm/classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %swift-frontend -c %t/check.swift -parse-as-library -target wasm32-unknown-none-wasm \
+// RUN: %swift -c %t/check.swift -parse-as-library -target wasm32-unknown-none-wasm \
 // RUN:   -resource-dir %test-resource-dir \
 // RUN:   -enable-experimental-feature Embedded -Xcc -fdeclspec -disable-stack-protector \
 // RUN:   -o %t/check.o

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -758,9 +758,9 @@ if test_options:
     config.swift_test_options += ' '
     config.swift_test_options += test_options
 
-config.swift_frontend_test_options += os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
-config.swift_driver_test_options += os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
-config.swift_ide_test_test_options += os.environ.get('SWIFT_IDE_TEST_TEST_OPTIONS', '')
+config.swift_frontend_test_options += ' ' + os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
+config.swift_driver_test_options += ' ' + os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
+config.swift_ide_test_test_options += ' ' + os.environ.get('SWIFT_IDE_TEST_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
 # Check if we overrode the linker; if we do, set a feature to say that, which

--- a/test/refactoring/ConvertAsync/check_compiles.swift
+++ b/test/refactoring/ConvertAsync/check_compiles.swift
@@ -5,7 +5,7 @@
 func simple(completion: @escaping () -> Void) { }
 func anything() -> Bool { return true }
 
-// RUN: %swift-frontend -typecheck %s
+// RUN: %target-swift-frontend -typecheck %s
 // RUN: not %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6
 func cannotCompile() {
   simple {

--- a/validation-test/compiler_crashers_fixed/parser-cutoff.swift
+++ b/validation-test/compiler_crashers_fixed/parser-cutoff.swift
@@ -789,4 +789,4 @@ if a > 1 {
 if a > 1 {
 
 // This test case used to cause an assertion failure during parsing cut off.
-// RUN: not %swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s


### PR DESCRIPTION
`%swift-frontend` is not a Lit substitution; `%swift` is. Because it starts with `%swift`, Lit expanded that prefix and left a bare `-frontend` behind, which concatenated onto the last argument of the `%swift` expansion -- the final `-define-availability` value -- rather than becoming an argument of its own. These tests have therefore been running with a corrupted availability macro.

Nothing failed while the `%swift` expansion ended without whitespace. Once it gained a trailing space in https://github.com/swiftlang/swift/pull/91891, `-frontend` became a separate argument, and `swift-frontend` honors it only in first position, so the tests began failing with:

```
<unknown>:0: error: unknown argument: '-frontend'
```

Likewise, spell `%swift-frontend-plain` as `%swift_frontend_plain`.