### PR TITLE
[IDE] Fix module selector reference ranges

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -899,7 +899,9 @@ bool SemaAnnotator::passCallAsFunctionReference(ValueDecl *D, SourceLoc Loc,
 
 bool SemaAnnotator::
 passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data) {
-  return passReference(D, Ty, Loc.getBaseNameLoc(), Loc.getSourceRange(), Data);
+  return passReference(D, Ty, Loc.getBaseNameLoc(),
+                       SourceRange(Loc.getBaseNameLoc(), Loc.getEndLoc()),
+                       Data);
 }
 
 bool SemaAnnotator::

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -27,6 +27,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/IDE/SourceEntityWalker.h"
 #include "swift/IDE/Utils.h"
+#include "swift/Parse/Lexer.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/Basic/Module.h"
 
@@ -899,6 +900,19 @@ bool SemaAnnotator::passCallAsFunctionReference(ValueDecl *D, SourceLoc Loc,
 
 bool SemaAnnotator::
 passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data) {
+  if (auto SelectorLoc = Loc.getModuleSelectorLoc(); SelectorLoc.isValid()) {
+    auto &Ctx = D->getASTContext();
+    auto SelectorToken = Lexer::getTokenAtLocation(Ctx.SourceMgr, SelectorLoc);
+    auto Selector = Ctx.getIdentifier(SelectorToken.getText());
+    // Resolve the written selector, which may re-export the declaration's
+    // module.
+    auto *Mod = Ctx.getLoadedModule(Selector);
+    if (!Mod && Selector == Ctx.TheBuiltinModule->getName())
+      Mod = Ctx.TheBuiltinModule;
+    // Include backticks in the reference range for an escaped selector.
+    if (Mod && !SEWalker.visitModuleReference(Mod, SelectorToken.getRange()))
+      return false;
+  }
   return passReference(D, Ty, Loc.getBaseNameLoc(),
                        SourceRange(Loc.getBaseNameLoc(), Loc.getEndLoc()),
                        Data);

--- a/test/IDE/annotation.swift
+++ b/test/IDE/annotation.swift
@@ -371,3 +371,6 @@ func testKeyPath() {
   keyPathTester(keyPath: \.topLeft)
   // CHECK: <Func@[[@LINE-3]]:6>keyPathTester</Func>(<Func@[[@LINE-3]]:6#keyPath>keyPath</Func>: \.<Var@[[@LINE-12]]:7>topLeft</Var>)
 }
+
+// CHECK: typealias <TypeAlias>EscapedModuleSelector</TypeAlias> = <iMod>`Swift`</iMod>::<iStruct@>Int</iStruct>{{$}}
+typealias EscapedModuleSelector = `Swift`::Int

--- a/test/Index/index_module_selector.swift
+++ b/test/Index/index_module_selector.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+// RUN: %target-swift-frontend -emit-module -module-name TestModule -emit-module-path %t/TestModule.swiftmodule %t/TestModule.swift
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/main.swift -I %t | %FileCheck %s
+
+//--- TestModule.swift
+public struct Widget {
+  public init() {}
+  public func method(label: Int) {}
+}
+
+//--- main.swift
+import TestModule
+
+let unbound: () = TestModule::Widget.TestModule::method(Widget())(label: 1)
+// CHECK: [[@LINE-1]]:31 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref
+// CHECK: [[@LINE-2]]:50 | instance-method/Swift | method(label:) | s:10TestModule6WidgetV6method5labelySi_tF | Ref
+
+let compound: () = TestModule::Widget.TestModule::method(label:)(Widget())(1)
+// CHECK: [[@LINE-1]]:32 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref
+// CHECK: [[@LINE-2]]:51 | instance-method/Swift | method(label:) | s:10TestModule6WidgetV6method5labelySi_tF | Ref

--- a/test/Index/index_module_selector.swift
+++ b/test/Index/index_module_selector.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
 // RUN: %target-swift-frontend -emit-module -module-name TestModule -emit-module-path %t/TestModule.swiftmodule %t/TestModule.swift
+// RUN: %target-swift-frontend -emit-module -module-name Facade -emit-module-path %t/Facade.swiftmodule %t/Facade.swift -I %t
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/main.swift -I %t | %FileCheck %s
 
 //--- TestModule.swift
@@ -9,13 +10,29 @@ public struct Widget {
   public func method(label: Int) {}
 }
 
+//--- Facade.swift
+@_exported import TestModule
+
 //--- main.swift
 import TestModule
+import Facade
 
 let unbound: () = TestModule::Widget.TestModule::method(Widget())(label: 1)
-// CHECK: [[@LINE-1]]:31 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref
-// CHECK: [[@LINE-2]]:50 | instance-method/Swift | method(label:) | s:10TestModule6WidgetV6method5labelySi_tF | Ref
+// CHECK: [[@LINE-1]]:19 | module/Swift | TestModule | c:@M@TestModule | Ref
+// CHECK: [[@LINE-2]]:31 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref
+// CHECK: [[@LINE-3]]:38 | module/Swift | TestModule | c:@M@TestModule | Ref
+// CHECK: [[@LINE-4]]:50 | instance-method/Swift | method(label:) | s:10TestModule6WidgetV6method5labelySi_tF | Ref
 
 let compound: () = TestModule::Widget.TestModule::method(label:)(Widget())(1)
-// CHECK: [[@LINE-1]]:32 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref
-// CHECK: [[@LINE-2]]:51 | instance-method/Swift | method(label:) | s:10TestModule6WidgetV6method5labelySi_tF | Ref
+// CHECK: [[@LINE-1]]:20 | module/Swift | TestModule | c:@M@TestModule | Ref
+// CHECK: [[@LINE-2]]:32 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref
+// CHECK: [[@LINE-3]]:39 | module/Swift | TestModule | c:@M@TestModule | Ref
+// CHECK: [[@LINE-4]]:51 | instance-method/Swift | method(label:) | s:10TestModule6WidgetV6method5labelySi_tF | Ref
+
+let reexported = Facade::Widget.self
+// CHECK: [[@LINE-1]]:18 | module/Swift | Facade | c:@M@Facade | Ref
+// CHECK: [[@LINE-2]]:26 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref
+
+let dotted = TestModule.Widget.self
+// CHECK: [[@LINE-1]]:14 | module/Swift | TestModule | c:@M@TestModule | Ref
+// CHECK: [[@LINE-2]]:25 | struct/Swift | Widget | s:10TestModule6WidgetV | Ref

--- a/test/SourceKit/CursorInfo/module_selector.swift
+++ b/test/SourceKit/CursorInfo/module_selector.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -module-name TestModule -emit-module-path %t/TestModule.swiftmodule %t/TestModule.swift
+
+// RUN: %sourcekitd-test -req=cursor -pos=3:50 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=UNBOUND
+// RUN: %sourcekitd-test -req=cursor -pos=4:51 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=COMPOUND
+
+// UNBOUND: key.kind: source.lang.swift.ref.function.method.instance
+// UNBOUND: key.name: "method(label:)"
+// UNBOUND: key.usr: "s:10TestModule6WidgetV6method5labelySi_tF"
+// UNBOUND: key.modulename: "TestModule"
+
+// COMPOUND: key.kind: source.lang.swift.ref.function.method.instance
+// COMPOUND: key.name: "method(label:)"
+// COMPOUND: key.usr: "s:10TestModule6WidgetV6method5labelySi_tF"
+// COMPOUND: key.modulename: "TestModule"
+
+//--- TestModule.swift
+public struct Widget {
+  public init() {}
+  public func method(label: Int) {}
+}
+
+//--- main.swift
+import TestModule
+
+let unbound: () = TestModule::Widget.TestModule::method(Widget())(label: 1)
+let compound: () = TestModule::Widget.TestModule::method(label:)(Widget())(1)

--- a/test/SourceKit/CursorInfo/module_selector.swift
+++ b/test/SourceKit/CursorInfo/module_selector.swift
@@ -5,6 +5,25 @@
 // RUN: %sourcekitd-test -req=cursor -pos=3:50 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=UNBOUND
 // RUN: %sourcekitd-test -req=cursor -pos=4:51 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=COMPOUND
 
+// RUN: %sourcekitd-test -req=cursor -pos=3:19 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=MODULE
+// RUN: %sourcekitd-test -req=cursor -pos=3:38 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=MODULE
+// RUN: %sourcekitd-test -req=cursor -pos=4:39 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=MODULE
+// RUN: %sourcekitd-test -req=cursor -pos=3:31 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=WIDGET
+// RUN: %sourcekitd-test -req=cursor -pos=3:29 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=NONE
+// RUN: %sourcekitd-test -req=cursor -pos=3:30 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=NONE
+// RUN: %sourcekitd-test -req=cursor -pos=4:49 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=NONE
+// RUN: %sourcekitd-test -req=cursor -pos=4:50 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=NONE
+// RUN: %sourcekitd-test -req=cursor -pos=5:14 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=MODULE
+// RUN: %sourcekitd-test -req=cursor -pos=5:25 -print-raw-response %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=WIDGET
+
+// MODULE: key.kind: source.lang.swift.ref.module
+// MODULE: key.name: "TestModule"
+// WIDGET: key.kind: source.lang.swift.ref.struct
+// WIDGET: key.name: "Widget"
+// WIDGET: key.usr: "s:10TestModule6WidgetV"
+// NONE-NOT: key.kind
+// NONE: key.internal_diagnostic: "Unable to resolve cursor info."
+
 // UNBOUND: key.kind: source.lang.swift.ref.function.method.instance
 // UNBOUND: key.name: "method(label:)"
 // UNBOUND: key.usr: "s:10TestModule6WidgetV6method5labelySi_tF"
@@ -26,3 +45,4 @@ import TestModule
 
 let unbound: () = TestModule::Widget.TestModule::method(Widget())(label: 1)
 let compound: () = TestModule::Widget.TestModule::method(label:)(Widget())(1)
+let dotted = TestModule.Widget.self

--- a/test/SourceKit/SemanticTokens/module_selector.swift
+++ b/test/SourceKit/SemanticTokens/module_selector.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -module-name TestModule -emit-module-path %t/TestModule.swiftmodule %t/TestModule.swift
+
+// RUN: %sourcekitd-test -req=semantic-tokens %t/main.swift -- %t/main.swift -I %t -target %target-triple | %FileCheck %s --check-prefix=RANGES
+// RUN: %sourcekitd-test -req=open %t/main.swift -- %t/main.swift -I %t -target %target-triple == -req=print-annotations %t/main.swift | %FileCheck %s --check-prefix=RANGES
+
+// RANGES:      key.kind: source.lang.swift.ref.struct
+// RANGES-NEXT: key.offset: 49
+// RANGES-NEXT: key.length: 6
+// RANGES:      key.kind: source.lang.swift.ref.function.method.instance
+// RANGES-NEXT: key.offset: 68
+// RANGES-NEXT: key.length: 6
+// RANGES:      key.kind: source.lang.swift.ref.struct
+// RANGES-NEXT: key.offset: 75
+// RANGES-NEXT: key.length: 6
+// RANGES:      key.kind: source.lang.swift.ref.struct
+// RANGES-NEXT: key.offset: 126
+// RANGES-NEXT: key.length: 6
+// RANGES:      key.kind: source.lang.swift.ref.function.method.instance
+// RANGES-NEXT: key.offset: 145
+// RANGES-NEXT: key.length: 14
+// RANGES:      key.kind: source.lang.swift.ref.struct
+// RANGES-NEXT: key.offset: 160
+// RANGES-NEXT: key.length: 6
+
+//--- TestModule.swift
+public struct Widget {
+  public init() {}
+  public func method(label: Int) {}
+}
+
+//--- main.swift
+import TestModule
+
+let unbound: () = TestModule::Widget.TestModule::method(Widget())(label: 1)
+let compound: () = TestModule::Widget.TestModule::method(label:)(Widget())(1)


### PR DESCRIPTION
Exclude module selectors from declaration reference ranges reported by `SourceEntityWalker` while preserving compound declaration names.

This fixes cursor info, semantic annotations, and index occurrences for module-qualified references.

Add regression coverage for cursor info, semantic tokens, editor annotations, and indexing.

Resolves https://github.com/swiftlang/swift/issues/91977

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->