### PR TITLE
Include class inherited properties in typed allocation descriptors

### DIFF
--- a/lib/IRGen/ClassLayout.cpp
+++ b/lib/IRGen/ClassLayout.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include "ClassLayout.h"
+#include "ClassTypeInfo.h"
 #include "GenHeap.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
@@ -85,6 +86,31 @@ Size ClassLayout::getInstanceStart() const {
   return getSize();
 }
 
+void ClassLayout::collectAllStoredPropertyTypes(
+    IRGenModule &IGM, SILType classType, SmallVectorImpl<SILType> &fieldTypes) {
+  auto *classDecl = classType.getClassOrBoundGenericClass();
+  // ClassLayout::AllStoredProperties for a class is populated to
+  // include its ancestors' properties only when the class includes a
+  // generic parameter and fully specialized (which is the same
+  // condition as collectStoredProperties in
+  // addDirectFieldsFromClass()). We need to walk the superclass chain
+  // up to find the first class that meets that condition.
+  bool alreadyIncludesAncestors =
+      classDecl->isGenericContext() &&
+      !classType.getASTType()->getRecursiveProperties().hasUnboundGeneric();
+  if (!alreadyIncludesAncestors) {
+    if (SILType superclassType = classType.getSuperclass())
+      collectAllStoredPropertyTypes(IGM, superclassType, fieldTypes);
+  }
+  auto &classTI = IGM.getTypeInfo(classType).as<ClassTypeInfo>();
+  auto &classLayout = classTI.getClassLayout(IGM, classType,
+                                             /*forBackwardDeployment=*/false);
+  for (Field field : classLayout.AllStoredProperties) {
+    assert(field.isConcrete() && "Missing member on fixed size class");
+    fieldTypes.push_back(field.getType(IGM, classType).getObjectType());
+  }
+}
+
 std::optional<uint64_t>
 ClassLayout::computeTypedMallocTypeDescriptor(IRGenModule &IGM,
                                               SILType selfType) const {
@@ -105,12 +131,7 @@ ClassLayout::computeTypedMallocTypeDescriptor(IRGenModule &IGM,
     storageEntries.push_back(rawPointerType);
   }
 
-  // Add entries for each stored property
-  for (auto field : AllStoredProperties) {
-    assert(field.isConcrete() && "Missing member on fixed size class");
-    auto fieldType = field.getType(IGM, selfType).getObjectType();
-    storageEntries.push_back(fieldType);
-  }
+  collectAllStoredPropertyTypes(IGM, selfType, storageEntries);
 
   return irgen::computeTypedMallocTypeDescriptor(IGM, storageEntries);
 }

--- a/lib/IRGen/ClassLayout.h
+++ b/lib/IRGen/ClassLayout.h
@@ -224,6 +224,11 @@ public:
 
   std::optional<uint64_t>
   computeTypedMallocTypeDescriptor(IRGenModule &IGM, SILType selfType) const;
+
+private:
+  static void collectAllStoredPropertyTypes(
+      IRGenModule &IGM, SILType classType,
+      SmallVectorImpl<SILType> &fieldTypes);
 };
 
 } // end namespace irgen

--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -47,6 +47,124 @@ public class MyOtherClass {
   }
 }
 
+// Check that inherited properties are included in the type descriptor.
+public class MyThreeFieldClass {
+  let x: Int
+  let y: Int
+  let z: Int
+  init(x: Int, y: Int, z: Int) {
+    self.x = x
+    self.y = y
+    self.z = z
+  }
+}
+@inline(never)
+public func makeMyThreeFieldClass(x: Int, y: Int, z: Int) -> MyThreeFieldClass {
+  return MyThreeFieldClass(x: x, y: y, z: z)
+}
+// CHECK-LABEL: define swiftcc ptr @"$e16typed_allocation17MyThreeFieldClassC1x1y1zACSi_S2itcfC"(i64 %0, i64 %1, i64 %2, ptr swiftself %3) #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   {{.*}} = call noalias ptr @swift_allocObjectTyped(ptr {{.*}}, i64 40, i64 7, i64 [[MYSUBCLASS_TYPEID:[0-9]+]])
+public class MySubclass: MyClass {
+  let z: Int
+  init(x: Int, y: Int, z: Int) {
+    self.z = z
+    super.init(x: x, y: y)
+  }
+}
+@inline(never)
+public func makeMySubclass(x: Int, y: Int, z: Int) -> MySubclass {
+  return MySubclass(x: x, y: y, z: z)
+}
+// CHECK-LABEL: define swiftcc ptr @"$e16typed_allocation10MySubclassC1x1y1zACSi_S2itcfC"(i64 %0, i64 %1, i64 %2, ptr swiftself %3) #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   {{.*}} = call noalias ptr @swift_allocObjectTyped(ptr {{.*}}, i64 40, i64 7, i64 [[MYSUBCLASS_TYPEID]])
+
+// Same as above, include a generic class.
+public class ClassA {
+  let x: Int
+  init(x: Int) {
+    self.x = x
+  }
+}
+public class ClassB<T>: ClassA {
+  let y: T
+  init(x: Int, y: T) {
+    self.y = y
+    super.init(x: x)
+  }
+}
+public class ClassC: ClassB<Int> {
+  let z: Int
+  init(x: Int, y: Int, z: Int) {
+    self.z = z
+    super.init(x: x, y: y)
+  }
+}
+@inline(never)
+public func makeClassC(x: Int, y: Int, z: Int) -> ClassC {
+  return ClassC(x: x, y: y, z: z)
+}
+// CHECK-LABEL: define swiftcc ptr @"$e16typed_allocation6ClassCC1x1y1zACSi_S2itcfC"(i64 %0, i64 %1, i64 %2, ptr swiftself %3) #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   {{.*}} = call noalias ptr @swift_allocObjectTyped(ptr {{.*}}, i64 40, i64 7, i64 [[MYSUBCLASS_TYPEID]])
+
+public class ClassD<T> {
+  let x: T
+  init(x: T) {
+    self.x = x
+  }
+}
+public class ClassE: ClassD<Int> {
+  let y: Int
+  init(x: Int, y: Int) {
+    self.y = y
+    super.init(x: x)
+  }
+}
+public class ClassF: ClassE {
+  let z: Int
+  init(x: Int, y: Int, z: Int) {
+    self.z = z
+    super.init(x: x, y: y)
+  }
+}
+@inline(never)
+public func makeClassF(x: Int, y: Int, z: Int) -> ClassF {
+  return ClassF(x: x, y: y, z: z)
+}
+// CHECK-LABEL: define swiftcc ptr @"$e16typed_allocation6ClassFC1x1y1zACSi_S2itcfC"(i64 %0, i64 %1, i64 %2, ptr swiftself %3) #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   {{.*}} = call noalias ptr @swift_allocObjectTyped(ptr {{.*}}, i64 40, i64 7, i64 [[MYSUBCLASS_TYPEID]])
+
+public class ClassG {
+  let x: Int
+  init(x: Int) {
+    self.x = x
+  }
+}
+public class ClassH: ClassG {
+  let y: Int
+  init(x: Int, y: Int) {
+    self.y = y
+    super.init(x: x)
+  }
+}
+public class ClassI<T>: ClassH {
+  let z: T
+  init(x: Int, y: Int, z: T) {
+    self.z = z
+    super.init(x: x, y: y)
+  }
+}
+@inline(never)
+public func makeClassI(x: Int, y: Int, z: Int) -> ClassI<Int> {
+  return ClassI<Int>(x: x, y: y, z: z)
+}
+// CHECK-LABEL: define {{.*}}swiftcc ptr @"$e16typed_allocation6ClassIC1x1y1zACyxGSi_SixtcfCSi_Tt2g5"(i64 %0, i64 %1, i64 %2) #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   {{.*}} = call noalias ptr @swift_allocObjectTyped(ptr {{.*}}, i64 40, i64 7, i64 [[MYSUBCLASS_TYPEID]])
+
 // CHECK-LABEL: define swiftcc void @"$e16typed_allocation3runyyAA3RefCFyyXEfU0_"(ptr %0, ptr captures(none) dereferenceable(16) %1)
 // CHECK: %2 = call {{.*}} ptr @swift_allocObjectTyped(ptr {{.*}}, i64 {{.*}}, i64 {{.*}}, i64 [[P_CAPTURE_TYPEID:.*]])
 // CHECK: call void @swift_deallocUninitializedObjectTyped(ptr %2, i64 {{.*}}, i64 {{.*}}, i64 [[P_CAPTURE_TYPEID]])


### PR DESCRIPTION
This fixes a bug where class inherited properties are not always included in the type descriptor computation.

