### PR TITLE
[SIL forEach unroller] Delete the entire array literal after unrolling

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
@@ -60,6 +60,12 @@
 // 4. Delete the forEach calls that were unrolled and clean up dead code
 //    resulting due to that.
 //
+// 5. Once every forEach call on the array literal is unrolled, the array
+//    literal itself is typically dead, as the unrolled code uses the elements
+//    and not the array. In that case, delete the whole initialization pattern:
+//    the allocation, the stores of the elements, the finalize call and the
+//    destroys of the array.
+//
 // This transformation is illustrated below on a small example:
 //
 // Input:
@@ -78,15 +84,8 @@
 //
 // Output:
 //
-//      %initResult = apply %arrayUninitialized(...)
-//      (%array, %storage_ptr) = destructure_tuple %initResult
-//      %elem1copy = copy_value %elem1  <--
-//      store %elem1 at array index 1
-//      %elem2copy = copy_value %elem2  <--
-//      store %elem2 at array index 2
-//      ..
 //      alloc_stack %stack
-//      %elem1borrow = begin_borrow %elem1copy
+//      %elem1borrow = begin_borrow %elem1
 //      store_borrow %elem1borrow to %stack
 //      try_apply %body(%stack) normal normalbb1, error errbb1
 //
@@ -96,7 +95,7 @@
 //
 //    normalbb1(%res : $()):
 //      end_borrow %elem1borrow
-//      %elem2borrow = begin_borrow %elem2copy
+//      %elem2borrow = begin_borrow %elem2
 //      store_borrow %elem2borrow to %stack
 //      try_apply %body(%stack) normal bb1, error errbb2
 //
@@ -112,9 +111,12 @@
 //      ...
 //      dealloc_stack %stack
 //    bb3:
-//      destroy_value %elem1copy
-//      destroy_value %elem2copy
-//      destroy_value %array
+//      destroy_value %elem1
+//      destroy_value %elem2
+//
+// Note that the array literal is gone entirely here, and that the unrolled code
+// uses the elements directly: deleting the stores hands the ownership of the
+// elements over to it.
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Expr.h"
@@ -127,7 +129,9 @@
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/Projection.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILConstants.h"
@@ -475,6 +479,135 @@ void ArrayInfo::getLastDestroys(
   }
 }
 
+/// Return true iff the array literal initialized by \c arrayAllocCall becomes
+/// dead once the forEach calls in \c forEachCalls are unrolled, i.e. nothing
+/// else reads the array and nothing depends on its lifetime.
+static bool
+isDeadArrayLiteralAfterUnrolling(ApplyInst *arrayAllocCall,
+                                 ArrayRef<TryApplyInst *> forEachCalls) {
+  SILFunction *fun = arrayAllocCall->getFunction();
+
+  // The pointer to the element storage, which the initialization pattern makes
+  // dependent on the array. Note that this is null if the storage is reached
+  // from the array value instead (through a ref_tail_addr).
+  SILValue storagePointer =
+      ArraySemanticsCall(arrayAllocCall, semantics::ARRAY_UNINITIALIZED_INTRINSIC)
+          .getArrayElementStoragePointer();
+
+  // Walk everything derived from the result of the initializer call: the array
+  // value as well as the addresses of its element storage.
+  ValueWorklist worklist(fun);
+  for (SILValue result : arrayAllocCall->getResults())
+    worklist.pushIfNotVisited(result);
+
+  while (SILValue value = worklist.pop()) {
+    for (Operand *use : value->getUses()) {
+      SILInstruction *user = use->getUser();
+
+      // Deleting the array literal drops the debug information of the array,
+      // which is not worth it in code that is not being optimized anyway.
+      if (fun->preserveDebugInfo() && user->isDebugInstruction())
+        return false;
+
+      // A fix_lifetime is a request to keep the array alive even though it is
+      // otherwise unused.
+      if (isa<FixLifetimeInst>(user))
+        return false;
+
+      // debug_value, end_borrow, end_lifetime, ...
+      if (isIncidentalUse(user) || isa<DestroyValueInst>(user))
+        continue;
+
+      // A forEach call that unrolling will remove.
+      if (llvm::is_contained(forEachCalls, user))
+        continue;
+
+      // The initialization pattern makes the pointer to the element storage
+      // depend on the array.
+      if (auto *markDependence = dyn_cast<MarkDependenceInst>(user)) {
+        if (!storagePointer || markDependence->getValue() != storagePointer)
+          return false;
+        worklist.pushIfNotVisited(markDependence);
+        continue;
+      }
+
+      // Instructions that forward the array or project out the storage of its
+      // elements: the array literal is dead only if what they produce is dead
+      // as well.
+      auto *singleValueUser = dyn_cast<SingleValueInstruction>(user);
+      if (getSingleValueCopyOrCast(user) ||
+          Projection::isAddressProjection(user) ||
+          (singleValueUser && Projection::isObjectProjection(singleValueUser)) ||
+          isa<DestructureTupleInst>(user) || isa<PointerToAddressInst>(user)) {
+        for (SILValue result : user->getResults())
+          worklist.pushIfNotVisited(result);
+        continue;
+      }
+
+      // A store of an element into the array's storage. (A store of the array
+      // itself into some other memory would let it escape.)
+      if (auto *store = dyn_cast<StoreInst>(user)) {
+        if (store->getDest() != value)
+          return false;
+        continue;
+      }
+
+      // A borrow of the array into a temporary, which is how the array is
+      // passed indirectly to a forEach call.
+      if (auto *storeBorrow = dyn_cast<StoreBorrowInst>(user)) {
+        if (storeBorrow->getSrc() != value)
+          return false;
+        for (Operand *storeBorrowUse : storeBorrow->getUses()) {
+          SILInstruction *storeBorrowUser = storeBorrowUse->getUser();
+          if (isa<EndBorrowInst>(storeBorrowUser) ||
+              storeBorrowUser->isDebugInstruction() ||
+              llvm::is_contained(forEachCalls, storeBorrowUser))
+            continue;
+          return false;
+        }
+        continue;
+      }
+
+      // The finalize call that completes the initialization is part of the
+      // idiom. Any other call could read the array.
+      if (isa<ApplyInst>(user) &&
+          ArraySemanticsCall(user).getKind() == ArrayCallKind::kArrayFinalizeIntrinsic) {
+        worklist.pushIfNotVisited(cast<ApplyInst>(user));
+        continue;
+      }
+
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Delete the array literal initialized by \c arrayAllocCall along with
+/// everything that is derived from it: the allocation, the address projections
+/// that reach the element storage, the stores of the elements, the finalize
+/// call and the lifetime-ending uses of the array.
+///
+/// \param elementsConsumedByUnrolledCode when set, the unrolled code uses the
+/// elements of the array directly rather than copies of them, so this function
+/// hands the ownership of the elements over to it by deleting their stores
+/// without destroying what they store. Note that the unrolled code has already
+/// destroyed the elements at the point where the array's lifetime used to end.
+///
+/// \pre every forEach call over the array has been unrolled, and
+/// \c isDeadArrayLiteralAfterUnrolling held for \c arrayAllocCall.
+static void deleteDeadArrayLiteral(ApplyInst *arrayAllocCall,
+                                   ArrayInfo &arrayInfo,
+                                   bool elementsConsumedByUnrolledCode,
+                                   InstructionDeleter &deleter) {
+  assert(isDeadArrayLiteralAfterUnrolling(arrayAllocCall, {}) &&
+         "deleting an array literal that is still in use");
+  if (elementsConsumedByUnrolledCode) {
+    for (uint64_t i = 0; i < arrayInfo.getNumElements(); ++i)
+      deleter.forceDelete(arrayInfo.getElementStore(i));
+  }
+  deleter.recursivelyForceDeleteUsersAndFixLifetimes(arrayAllocCall);
+}
+
 /// Delete the forEach calls from the SIL that contains it. This function will
 /// not clean up any resulting dead instructions.
 static void removeForEachCall(TryApplyInst *forEachCall,
@@ -522,8 +655,13 @@ static void removeForEachCall(TryApplyInst *forEachCall,
 ///
 ///  - Destroy all the copies of the elements (if it is non-trivial) just
 ///   before the array's lifetime ends.
+///
+/// \param consumeElements when set, the unrolled code uses the elements of the
+/// array directly instead of copies of them, taking over the ownership that the
+/// element stores used to have. This is only correct if the caller deletes
+/// those stores afterwards, which \c deleteDeadArrayLiteral does.
 static void unrollForEach(ArrayInfo &arrayInfo, TryApplyInst *forEachCall,
-                          InstructionDeleter &deleter) {
+                          InstructionDeleter &deleter, bool consumeElements) {
   if (arrayInfo.getNumElements() == 0) {
     // If this is an empty array, delete the forEach entirely.
     removeForEachCall(forEachCall, deleter);
@@ -544,34 +682,31 @@ static void unrollForEach(ArrayInfo &arrayInfo, TryApplyInst *forEachCall,
          ParameterConvention::Indirect_In_Guaranteed &&
          "forEach body closure is expected to take @in_guaranteed argument");
 
-  // Copy the elements stored into the array. This is necessary as we need to
-  // extend the lifetime of the stored elements at least until the forEach call,
-  // which will now be unrolled. The following code inserts a copy_value of the
-  // elements just before the point where they are stored into the array, and
-  // a corresponding destroy_value at the end of the lifetime of the array. In
-  // other words, the lifetime of the element copies are made to match the
-  // lifetime of the array. Even though copies can be destroyed sooner after
-  // they are used by the unrolled code, doing so may introduce more destroys
-  // than needed as the unrolled code have many branches (due to try applies)
-  // all of which joins later into a single path eventually.
-  SmallVector<SILValue, 4> elementCopies;
+  // Make the values of the elements available to the unrolled code. Unless the
+  // unrolled code can consume the elements, this is done by copying them, as we
+  // need to extend the lifetime of the stored elements at least until the
+  // forEach call, which will now be unrolled.
+  SmallVector<SILValue, 4> elementValues;
   for (uint64_t i = 0; i < arrayInfo.getNumElements(); ++i) {
     StoreInst *elementStore = arrayInfo.getElementStore(i);
+    if (consumeElements) {
+      elementValues.push_back(elementStore->getSrc());
+      continue;
+    }
     // Insert the copy just before the store of the element into the array.
     SILValue copy = SILBuilderWithScope(elementStore)
                         .emitCopyValueOperation(elementStore->getLoc(),
                                                 elementStore->getSrc());
-    elementCopies.push_back(copy);
+    elementValues.push_back(copy);
   }
 
-  // Destroy the copy_value of the elements before the last destroys of the
-  // array. It is important that the copied elements are destroyed before the
-  // array is destroyed. This enables other optimizations.
+  // Destroy the elements used by the unrolled code before the last destroys of
+  // the array.
   SmallVector<DestroyValueInst *, 4> lastDestroys;
   arrayInfo.getLastDestroys(lastDestroys);
   for (DestroyValueInst *destroy : lastDestroys) {
     SILBuilderWithScope destroyBuilder(destroy);
-    for (SILValue element : elementCopies) {
+    for (SILValue element : elementValues) {
       destroyBuilder.emitDestroyValueOperation(destroy->getLoc(), element);
     }
   }
@@ -642,7 +777,7 @@ static void unrollForEach(ArrayInfo &arrayInfo, TryApplyInst *forEachCall,
   //     Jump to a new error block: err_i in the error case. Note that all
   //     error blocks jump to the error target of the original forEach call.
   for (uint64_t num = arrayInfo.getNumElements(); num > 0; --num) {
-    SILValue elementCopy = elementCopies[num - 1];
+    SILValue elementValue = elementValues[num - 1];
     // Creating the next normal block ends the borrow scope for borrowedElem
     // from the previous iteration.
     SILBasicBlock *currentBB = num > 1 ? normalTargetGenerator(nextNormalBB)
@@ -653,14 +788,13 @@ static void unrollForEach(ArrayInfo &arrayInfo, TryApplyInst *forEachCall,
     SILValue addr;
 
     if (arrayElementType.isTrivial(*fun)) {
-      unrollBuilder.createStore(forEachLoc, elementCopy, allocStack,
+      unrollBuilder.createStore(forEachLoc, elementValue, allocStack,
                                 StoreOwnershipQualifier::Trivial);
       addr = allocStack;
     } else {
-      // Borrow the elementCopy and store it in the allocStack. Note that the
-      // element's copy is guaranteed to be alive until the array is alive.
-      // Therefore it is okay to use a borrow here.
-      borrowedElem = unrollBuilder.createBeginBorrow(forEachLoc, elementCopy);
+      // Borrow the element and store it in the allocStack. Note that the
+      // element is guaranteed to be alive until the array is alive.
+      borrowedElem = unrollBuilder.createBeginBorrow(forEachLoc, elementValue);
       addr =
           unrollBuilder.createStoreBorrow(forEachLoc, borrowedElem, allocStack);
       normalBuilder.createEndBorrow(forEachLoc, addr);
@@ -723,8 +857,16 @@ static bool tryUnrollForEachCallsOverArrayLiteral(ApplyInst *apply,
   // If the array is too large to unroll, bail out.
   if (!canUnrollForEachOfArray(arrayInfo, apply->getParent()->getModule()))
     return false;
+  // Determine whether unrolling leaves the array literal itself dead, which is
+  // the common case: the unrolled code operates on the elements, not on the
+  // array.
+  bool deleteArrayLiteral =
+      isDeadArrayLiteralAfterUnrolling(apply, forEachCalls);
+  bool consumeElements = deleteArrayLiteral && forEachCalls.size() == 1;
   for (TryApplyInst *forEachCall : forEachCalls)
-    unrollForEach(arrayInfo, forEachCall, deleter);
+    unrollForEach(arrayInfo, forEachCall, deleter, consumeElements);
+  if (deleteArrayLiteral)
+    deleteDeadArrayLiteral(apply, arrayInfo, consumeElements, deleter);
   return true;
 }
 
@@ -740,20 +882,25 @@ class ForEachLoopUnroller : public SILFunctionTransform {
       return;
 
     InstructionDeleter deleter(/*assumeFixedLifetimes=*/ false);
+
+    // Collect the apply instructions before transforming any of them, as
+    // unrolling the forEach calls over an array literal can delete the
+    // literal's own initializer call, which makes it impossible to hold an
+    // instruction iterator across the transformation.
+    SmallVector<ApplyInst *, 8> applies;
     for (SILBasicBlock &bb : fun) {
-      for (auto instIter = bb.begin(); instIter != bb.end();) {
-        SILInstruction *inst = &*instIter;
-        ApplyInst *apply = dyn_cast<ApplyInst>(inst);
-        if (!apply) {
-          ++instIter;
-          continue;
-        }
-        // Note that the following operation may delete a forEach call but
-        // would not delete this apply instruction, which is an array
-        // initializer. Therefore, the iterator should be valid here.
-        changed |= tryUnrollForEachCallsOverArrayLiteral(apply, deleter);
-        ++instIter;
+      for (SILInstruction &inst : bb) {
+        if (ApplyInst *apply = dyn_cast<ApplyInst>(&inst))
+          applies.push_back(apply);
       }
+    }
+
+    for (ApplyInst *apply : applies) {
+      // An earlier iteration may have deleted this apply, e.g. when it is the
+      // call that finalizes an array literal that has been deleted.
+      if (apply->isDeleted())
+        continue;
+      changed |= tryUnrollForEachCallsOverArrayLiteral(apply, deleter);
     }
 
     if (changed) {

--- a/test/SILOptimizer/for_each_loop_unroll_test.sil
+++ b/test/SILOptimizer/for_each_loop_unroll_test.sil
@@ -28,6 +28,7 @@ sil [_semantics "sequence.forEach"] @forEach : $@convention(method) <τ_0_0 wher
 sil @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error any Error
 
 // CHECK-LABEL: forEachLoopUnrollTest
+// CHECK-NOT: _allocateUninitializedArray
 // CHECK: [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int64, 15
 // CHECK: [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int64, 27
 // CHECK: [[BODYCLOSURE:%[0-9]+]] = thin_to_thick_function
@@ -48,13 +49,15 @@ sil @forEachBody : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @error a
 
 // CHECK: [[NORMAL2]](%{{.*}} : $()):
 // CHECK: dealloc_stack [[STACK]]
-// Note that the temporary alloc_stack of the array created for the forEach call
-// will be cleaned up when the forEach call is removed.
-// CHECK: destroy_value
+// Note that the array literal is deleted along with the forEach call, as
+// nothing uses it anymore, and so is the temporary alloc_stack of the array
+// that was created for the call.
+// CHECK: return
 
 // CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $any Error):
 // CHECK: dealloc_stack [[STACK]]
 // CHECK: unreachable
+// CHECK-LABEL: end sil function 'forEachLoopUnrollTest'
 
 sil hidden [ossa] @forEachLoopUnrollTest : $@convention(thin) () -> () {
 bb0:
@@ -101,15 +104,15 @@ bb2(%39 : @owned $Error):
 
 sil @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
 
+// The array literal is dead once the forEach call is unrolled, so it is
+// deleted and the unrolled code uses the elements directly instead of copies.
 // CHECK-LABEL: nonTrivialForEachLoopUnrollTest
-// CHECK: [[ELEM1:%[0-9]+]] = copy_value %0
-// CHECK-NEXT: store %0 to [init] %{{.*}} : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
-// CHECK: [[ELEM2:%[0-9]+]] = copy_value %1
-// CHECK-NEXT: store %1 to [init] %{{.*}} : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+// CHECK-NOT: _allocateUninitializedArray
+// CHECK-NOT: copy_value
 // CHECK: [[BODYCLOSURE:%[0-9]+]] = thin_to_thick_function
 // CHECK-NOT: forEach
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
-// CHECK: [[ELEM1BORROW:%[0-9]+]] = begin_borrow [[ELEM1]]
+// CHECK: [[ELEM1BORROW:%[0-9]+]] = begin_borrow %0
 // CHECK: [[SB1:%.*]] = store_borrow [[ELEM1BORROW]] to [[STACK]]
 // CHECK: try_apply [[BODYCLOSURE]]([[SB1]]) : $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @error any Error, normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
 
@@ -118,7 +121,7 @@ sil @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @subst
 
 // CHECK: [[NORMAL]](%{{.*}} : $()):
 // CHECK: end_borrow [[ELEM1BORROW]]
-// CHECK: [[ELEM2BORROW:%[0-9]+]] = begin_borrow [[ELEM2]]
+// CHECK: [[ELEM2BORROW:%[0-9]+]] = begin_borrow %1
 // CHECK: [[SB2:%.*]] = store_borrow [[ELEM2BORROW]] to [[STACK]]
 // CHECK: try_apply [[BODYCLOSURE]]([[SB2]]) : $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @error any Error, normal [[NORMAL2:bb[0-9]+]], error [[ERROR2:bb[0-9]+]]
 
@@ -128,13 +131,16 @@ sil @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @subst
 // CHECK: [[NORMAL2]](%{{.*}} : $()):
 // CHECK: end_borrow [[ELEM2BORROW]]
 // CHECK: dealloc_stack [[STACK]]
-// Note that the temporary alloc_stack of the array created for the forEach call
-// will be cleaned up when the forEach call is removed.
-// CHECK: destroy_value
+// The elements are destroyed where the array's lifetime used to end.
+// CHECK: destroy_value %0
+// CHECK: destroy_value %1
 
 // CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $any Error):
 // CHECK: dealloc_stack [[STACK]]
+// CHECK: destroy_value %0
+// CHECK: destroy_value %1
 // CHECK: unreachable
+// CHECK-LABEL: end sil function 'nonTrivialForEachLoopUnrollTest'
 sil hidden [ossa] @nonTrivialForEachLoopUnrollTest : $@convention(thin) (@owned @callee_guaranteed @substituted <A> () -> @out A for <Int>, @owned @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> () {
 bb0(%0: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>, %1: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>):
   %2 = integer_literal $Builtin.Word, 2
@@ -176,8 +182,14 @@ bb2(%39 : @owned $Error):
   unreachable
 }
 
+// The fix_lifetime is a request to keep the array alive, so the array literal
+// must be preserved even though the forEach call over it is unrolled.
+//
 // CHECK-LABEL: @checkIndirectFixLifetimeUsesAreIgnored
 // CHECK-NOT: function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error any Error, @in_guaranteed τ_0_0) -> @error any Error
+// CHECK: @_allocateUninitializedArray
+// CHECK: @_finalizeArray
+// CHECK: fix_lifetime
 // CHECK: end sil function 'checkIndirectFixLifetimeUsesAreIgnored'
 sil hidden [ossa] @checkIndirectFixLifetimeUsesAreIgnored : $@convention(thin) () -> () {
 bb0:
@@ -229,11 +241,13 @@ bb2(%39 : @owned $Error):
 }
 
 // Test that dead instructions (specifically a begin_borrow of the array used
-// for the forEach call) are cleaned up after unrolling.
+// for the forEach call) are cleaned up after unrolling. Here the array literal
+// itself is dead as well, so all of it goes away.
 //
 // CHECK-LABEL: @testDeadInstructionCleanupAfterUnroll
-// CHECK-NOT: forEach
-// CHECK: @_finalizeArray
+// CHECK-NOT: @forEach :
+// CHECK-NOT: @_allocateUninitializedArray
+// CHECK-NOT: @_finalizeArray
 // CHECK-NOT: begin_borrow
 // CHECK: end sil function 'testDeadInstructionCleanupAfterUnroll'
 sil hidden [ossa] @testDeadInstructionCleanupAfterUnroll : $@convention(thin) () -> () {
@@ -360,11 +374,12 @@ sil [_semantics "sequence.forEach"] @forEachDirectSelf : $@convention(method) (@
 
 // CHECK: [[NORMAL2]](%{{.*}} : $()):
 // CHECK: dealloc_stack [[STACK]]
-// CHECK: destroy_value
+// CHECK: return
 
 // CHECK: [[ERROR3]]([[ERRPARAM3:%[0-9]+]] : @owned $any Error):
 // CHECK: dealloc_stack [[STACK]]
 // CHECK: unreachable
+// CHECK-LABEL: end sil function 'forEachLoopUnrollDirectSelfTest'
 
 sil hidden [ossa] @forEachLoopUnrollDirectSelfTest : $@convention(thin) () -> () {
 bb0:
@@ -512,6 +527,134 @@ bb2(%39 : @owned $any Error):
   end_borrow %sb : $*MyArray<Builtin.Int64>
   dealloc_stack %22 : $*MyArray<Builtin.Int64>
   destroy_value [dead_end] %39
+  destroy_value [dead_end] %a2
+  unreachable
+}
+
+// A fix_lifetime keeps the array alive past the forEach call, so the array
+// literal has to be kept and the unrolled code has to use copies of the
+// elements.
+
+// CHECK-LABEL: sil hidden [ossa] @forEachUnrollWithSurvivingArrayTest
+// CHECK: @_allocateUninitializedArray
+// CHECK: [[ELEM1:%[0-9]+]] = copy_value %0
+// CHECK-NEXT: store %0 to [init] %{{.*}} : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+// CHECK: [[ELEM2:%[0-9]+]] = copy_value %1
+// CHECK-NEXT: store %1 to [init] %{{.*}} : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+// CHECK: [[ARRAY:%[0-9]+]] = apply %{{[0-9]+}}<() -> Int>(%{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+// CHECK-NOT: @forEach :
+// CHECK: begin_borrow [[ELEM1]]
+// CHECK: begin_borrow [[ELEM2]]
+// CHECK: fix_lifetime [[ARRAY]]
+// CHECK-LABEL: } // end sil function 'forEachUnrollWithSurvivingArrayTest'
+
+sil hidden [ossa] @forEachUnrollWithSurvivingArrayTest : $@convention(thin) (@owned @callee_guaranteed @substituted <A> () -> @out A for <Int>, @owned @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> () {
+bb0(%0: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>, %1: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>):
+  %2 = integer_literal $Builtin.Word, 2
+  %3 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  %4 = apply %3<() -> Int>(%2) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  (%5, %6a) = destructure_tuple %4 : $(MyArray<()->Int>, Builtin.RawPointer)
+  %6 = begin_borrow %5
+  %b = struct_extract %6, #MyArray.buffer
+  %7 = ref_tail_addr %b, $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  store %0 to [init] %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>, %12 : $Builtin.Word
+  store %1 to [init] %13 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
+  end_borrow %6
+  %f = function_ref @_finalizeArray : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %a2 = apply %f<()->Int>(%5) : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %21 = begin_borrow %a2
+  %22 = alloc_stack $MyArray<()->Int>
+  %23 = store_borrow %21 to %22 : $*MyArray<()->Int>
+  %24 = function_ref @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  // A stub for Sequence.forEach(_:)
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<MyArray<() -> Int>>(%26, %23) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  end_borrow %23 : $*MyArray<() -> Int>
+  dealloc_stack %22 : $*MyArray<() -> Int>
+  end_borrow %21 : $MyArray<() -> Int>
+  // A use of the array that outlives the forEach call.
+  fix_lifetime %a2 : $MyArray<() -> Int>
+  destroy_value %a2
+  %37 = tuple ()
+  return %37 : $()
+
+bb2(%39 : @owned $Error):
+  destroy_value [dead_end] %39
+  end_borrow %21
+  destroy_value [dead_end] %a2
+  unreachable
+}
+
+// Two forEach calls over the same array literal. The literal is still dead once
+// both are unrolled, but the ownership of the elements cannot be handed over to
+// two callers, so the elements are copied.
+
+// CHECK-LABEL: sil hidden [ossa] @twoForEachCallsOverArrayTest
+// CHECK-NOT: @_allocateUninitializedArray
+// CHECK: copy_value %0
+// CHECK: copy_value %1
+// CHECK-NOT: @forEach :
+// CHECK-LABEL: } // end sil function 'twoForEachCallsOverArrayTest'
+
+sil hidden [ossa] @twoForEachCallsOverArrayTest : $@convention(thin) (@owned @callee_guaranteed @substituted <A> () -> @out A for <Int>, @owned @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> () {
+bb0(%0: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>, %1: @owned $@callee_guaranteed @substituted <A> () -> @out A for <Int>):
+  %2 = integer_literal $Builtin.Word, 2
+  %3 = function_ref @_allocateUninitializedArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  %4 = apply %3<() -> Int>(%2) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned MyArray<τ_0_0>, Builtin.RawPointer)
+  (%5, %6a) = destructure_tuple %4 : $(MyArray<()->Int>, Builtin.RawPointer)
+  %6 = begin_borrow %5
+  %b = struct_extract %6, #MyArray.buffer
+  %7 = ref_tail_addr %b, $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  store %0 to [init] %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
+  %12 = integer_literal $Builtin.Word, 1
+  %13 = index_addr %7 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>, %12 : $Builtin.Word
+  store %1 to [init] %13 : $*@callee_guaranteed @substituted <A> () -> @out A for <Int>
+  end_borrow %6
+  %f = function_ref @_finalizeArray : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %a2 = apply %f<()->Int>(%5) : $@convention(thin) <τ_0_0> (@owned MyArray<τ_0_0>) -> @owned MyArray<τ_0_0>
+  %21 = begin_borrow %a2
+  %22 = alloc_stack $MyArray<()->Int>
+  %23 = store_borrow %21 to %22 : $*MyArray<()->Int>
+  %24 = function_ref @forEachBody2 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  %25 = convert_function %24 : $@convention(thin) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  %26 = thin_to_thick_function %25 : $@convention(thin) @noescape (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error to $@noescape @callee_guaranteed (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <Int>) -> @error any Error
+  // A stub for Sequence.forEach(_:)
+  %30 = function_ref @forEach : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error
+  try_apply %30<MyArray<() -> Int>>(%26, %23) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb1, error bb2
+
+bb1(%32 : $()):
+  end_borrow %23 : $*MyArray<() -> Int>
+  dealloc_stack %22 : $*MyArray<() -> Int>
+  // A second forEach call over the same array.
+  %40 = alloc_stack $MyArray<()->Int>
+  %41 = store_borrow %21 to %40 : $*MyArray<()->Int>
+  try_apply %30<MyArray<() -> Int>>(%26, %41) : $@convention(method) <τ_0_0 where τ_0_0 : Sequence> (@noescape @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @error Error, @in_guaranteed τ_0_0) -> @error Error, normal bb3, error bb4
+
+bb2(%39 : @owned $Error):
+  destroy_value [dead_end] %39
+  end_borrow %21
+  destroy_value [dead_end] %a2
+  unreachable
+
+bb3(%42 : $()):
+  end_borrow %41 : $*MyArray<() -> Int>
+  dealloc_stack %40 : $*MyArray<() -> Int>
+  end_borrow %21 : $MyArray<() -> Int>
+  destroy_value %a2
+  %43 = tuple ()
+  return %43 : $()
+
+bb4(%44 : @owned $Error):
+  destroy_value [dead_end] %44
+  end_borrow %41 : $*MyArray<() -> Int>
+  dealloc_stack %40 : $*MyArray<() -> Int>
+  end_borrow %21
   destroy_value [dead_end] %a2
   unreachable
 }


### PR DESCRIPTION
After unrolling a forEach on an array literal, we were leaving around the initialization of the literal, even though it's dead code. Keep track of when we do this and remove all of the literal initialization and subsequent copies.

Eliminates dead objects from the logging calls in rdar://186404026.
