### PR TITLE
Expose `SwiftLexicalLookup` to SourceKitLSP through `SWIFT_SYNTAX_MODULES`

### DIFF
--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SWIFT_SYNTAX_MODULES
   # Support for LSP
   SwiftIDEUtils
   SwiftRefactor
+  SwiftLexicalLookup
   # For swift-plugin-server
   SwiftLibraryPluginProvider
 )


### PR DESCRIPTION
It seems like we can’t reference `SwiftLexicalLookup` from CMake in SourceKit-LSP because it’s not in this list. `SwiftLexicalLookup` will be used by https://github.com/swiftlang/sourcekit-lsp/pull/2754, so we need to expose it.
