### PR TITLE
[DebugInfo] Enable -debug-callsite-info by default in -O

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -4369,6 +4369,12 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   }
 
   Opts.DebugCallsiteInfo |= Args.hasArg(OPT_debug_callsite_info);
+  // These are the conditions clang uses to emit call site info for optimized
+  // binaries.
+  if (Opts.shouldOptimize() &&
+      Opts.DebugInfoLevel >= IRGenDebugInfoLevel::ASTTypes &&
+      Triple.supportsDebugEntryValues())
+    Opts.DebugCallsiteInfo = true;
 
   if (Args.hasArg(OPT_mergeable_symbols))
     Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -153,6 +153,8 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx,
   // Explicitly request debugger tuning for LLDB which is the default
   // on Darwin platforms but not on others.
   TargetOpts.DebuggerTuning = llvm::DebuggerKind::LLDB;
+
+  TargetOpts.EmitCallSiteInfo = Opts.DebugCallsiteInfo;
   TargetOpts.FunctionSections = Opts.FunctionSections;
 
   // Set option to UseCASBackend if CAS was enabled on the command line.

--- a/test/DebugInfo/call-site-info.swift
+++ b/test/DebugInfo/call-site-info.swift
@@ -1,4 +1,11 @@
 // RUN: %target-swift-frontend -debug-callsite-info -emit-ir -parse-as-library -g -O -module-name S %s -o - | %FileCheck %s
+// Make sure -debug-callsite-info is turned on by default in -O.
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -g -O -module-name S %s -o - | %FileCheck %s
+
+// Only backends that can describe call sites turn this on by default, so the
+// rest of the targets have nothing to check here.
+// REQUIRES: CPU=x86_64 || CPU=i386 || CPU=arm64 || CPU=arm64e || CPU=aarch64
+
 // CHECK: {{[0-9]+}} = distinct !DISubprogram(name: "f", linkageName: {{.*}}, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: !{{[0-9]+}}, scopeLine: {{[0-9]+}}, flags: DIFlagAllCallsDescribed
 // CHECK: {{[0-9]+}} = distinct !DISubprogram(linkageName: {{.*}}, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, type: !{{[0-9]+}}, flags: {{.*}} DIFlagAllCallsDescribed
 


### PR DESCRIPTION
In order for LLDB to find variables that are dead, but are recoverable
from parent frames we need to turn on this option. This matches what
clang already does when optmization is enabled.

Assisted-by: Claude

rdar://186478816
