### PR TITLE
Pass typed allocation IDs for PODBoxTypeInfo/SingleRefcountedBoxTypeInfo

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -650,10 +650,11 @@ HeapLayout::computeTypedMallocTypeDescriptor(IRGenModule &IGM) const {
 
   for (auto elType : ElementTypes) {
     if (!elType) {
-      // FIXME: In partial function application, the bindings get stored as
-      //        opaque storage with SILType(). Can we find a way to get a proper
-      //        type mapping instead?
-      return std::nullopt;
+      // A null entry means this field's real type was erased (e.g.,
+      // PODBoxTypeInfo) to share destructors. Rather than give up,
+      // describe at least the fields collected so far (in practice,
+      // the header) while still allowing shared destructors.
+      break;
     }
     storageEntries.push_back(elType.getObjectType());
   }
@@ -1752,27 +1753,34 @@ public:
 };
 
 static HeapLayout getHeapLayoutForSingleTypeInfo(IRGenModule &IGM,
-                                                 const TypeInfo &ti) {
-  return HeapLayout(IGM, LayoutStrategy::Optimal, SILType(), &ti);
+                                                 const TypeInfo &ti,
+                                                 SILType fieldType) {
+  return HeapLayout(IGM, LayoutStrategy::Optimal, fieldType, &ti);
 }
 
 /// Common implementation for POD boxes of a known stride and alignment.
 class PODBoxTypeInfo final : public FixedBoxTypeInfoBase {
 public:
   PODBoxTypeInfo(IRGenModule &IGM, Size stride, Alignment alignment)
-    : FixedBoxTypeInfoBase(IGM, getHeapLayoutForSingleTypeInfo(IGM,
-                             IGM.getOpaqueStorageTypeInfo(stride, alignment))) {
-  }
+      : FixedBoxTypeInfoBase(
+            IGM, getHeapLayoutForSingleTypeInfo(
+                     IGM, IGM.getOpaqueStorageTypeInfo(stride, alignment),
+                     // Erase the payload type to share destructors
+                     SILType())) {}
 };
 
 /// Common implementation for single-refcounted boxes.
 class SingleRefcountedBoxTypeInfo final : public FixedBoxTypeInfoBase {
 public:
   SingleRefcountedBoxTypeInfo(IRGenModule &IGM, ReferenceCounting refcounting)
-    : FixedBoxTypeInfoBase(IGM, getHeapLayoutForSingleTypeInfo(IGM,
-                                   IGM.getReferenceObjectTypeInfo(refcounting)))
-  {
-  }
+      : FixedBoxTypeInfoBase(
+            IGM, getHeapLayoutForSingleTypeInfo(
+                     IGM, IGM.getReferenceObjectTypeInfo(refcounting),
+                     // We can share the destructor by describing the
+                     // payload as a pointer.
+                     refcounting == ReferenceCounting::Native
+                         ? SILType::getNativeObjectType(IGM.Context)
+                         : SILType())) {}
 };
 
 /// Implementation of a box for a specific type.

--- a/test/IRGen/typed_allocation.swift
+++ b/test/IRGen/typed_allocation.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature TypedAllocation -target arm64-apple-macos99.99 -wmo | %FileCheck %s --check-prefix=UNSAFEMUTABLEPOINTERALLOC
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature TypedAllocation -target arm64-apple-macos99.99 -wmo | %FileCheck %s --check-prefix=ERRORBOX
 // RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature TypedAllocation -target arm64-apple-macos99.99 -wmo | %FileCheck %s --check-prefix=COROFRAME
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -enable-experimental-feature TypedAllocation -target arm64-apple-macos99.99 -wmo | %FileCheck %s --check-prefix=PODREFCOUNTBOX
 
 // REQUIRES: OS=macosx
 // REQUIRES: SWIFT_STDLIB_ARCH=arm64
@@ -81,30 +82,34 @@ public func makeClosure(x: Int, y: MyClass) -> () -> Void {
   }
 }
 
+// An indirect enum with POD-type payload (PODBoxTypeInfo).
 public indirect enum Indirect {
   case x(Int, Int)
   case y(Int, Int)
 }
-
-// TODO: For some boxes we can't compute the typed malloc ID, because some of the fields are opaque,
-//       so this test would not pass right now.
-
-// DISABLED-CHECK-LABEL: define swiftcc i64 @"$e16typed_allocation8makeEnum1x1y1bAA8IndirectOSi_SiSbtF"(i64 %0, i64 %1, i1 %2) #0 {
-// DISABLED-CHECK: entry:
-// DISABLED-CHECK:   br i1 {{%.*}}, label %[[L1:.*]], label %[[L2:.*]]
-// DISABLED-CHECK: [[L1]]:
-// DISABLED-CHECK:   call noalias ptr @swift_allocObjectTyped(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata{{.*}}, i32 0, i32 2), i64 {{.*}}, i64 7, i64 {{.*}})
-// DISABLED-CHECK: [[L2]]:
-// DISABLED-CHECK:   call noalias ptr @swift_allocObjectTyped(ptr getelementptr inbounds (%swift.full_boxmetadata, ptr @metadata{{.*}}, i32 0, i32 2), i64 {{.*}}, i64 7, i64 {{.*}})
-// DISABLED-CHECK:   ret i64 {{%.*}}
-// DISABLED-CHECK: }
-public func makeEnum(x: Int, y: Int, b: Bool) -> Indirect {
-  if b {
-    return .x(y, x)
-  }
-
-  return .y(x, y)
+@inline(never)
+public func makeAndDropEnum(x: Int, y: Int) {
+  _ = Indirect.x(x, y)
 }
+// PODREFCOUNTBOX-DAG: define swiftcc void @"$e16typed_allocation15makeAndDropEnum1x1yySi_SitF"(i64 %0, i64 %1)
+// PODREFCOUNTBOX-DAG:   call noalias ptr @swift_allocObjectTyped(ptr @metadata{{.*}}, i64 {{.*}}, i64 {{.*}}, i64 [[INDIRECT_BOX_TYPEID:[0-9]+]])
+// PODREFCOUNTBOX-DAG: define internal swiftcc void @__swift{{.*}}destructor{{.*}}(ptr swiftself %0)
+// PODREFCOUNTBOX-DAG:   call void @swift_deallocObjectTyped(ptr %0, i64 {{.*}}, i64 {{.*}}, i64 [[INDIRECT_BOX_TYPEID]])
+
+// An indirect enum with single refcounted payload (SingleRefcountedBoxTypeInfo)
+public class Payload {}
+public indirect enum IndirectRef {
+  case a(Payload)
+  case b(Payload)
+}
+@inline(never)
+public func makeAndDropRefEnum(p: Payload) {
+  _ = IndirectRef.a(p)
+}
+// PODREFCOUNTBOX-DAG: define swiftcc void @"$e16typed_allocation18makeAndDropRefEnum1pyAA7PayloadC_tF"(ptr %0)
+// PODREFCOUNTBOX-DAG:   call noalias ptr @swift_allocObjectTyped(ptr @metadata{{.*}}, i64 {{.*}}, i64 {{.*}}, i64 [[INDIRECT_REF_BOX_TYPEID:[0-9]+]])
+// PODREFCOUNTBOX-DAG: define internal swiftcc void @__swift{{.*}}destructor{{.*}}(ptr swiftself %0)
+// PODREFCOUNTBOX-DAG:   call void @swift_deallocObjectTyped(ptr %0, i64 {{.*}}, i64 {{.*}}, i64 [[INDIRECT_REF_BOX_TYPEID]])
 
 @inline(never)
 public func allocateInts(_ count: Int) -> UnsafeMutablePointer<Int> {


### PR DESCRIPTION
These were missed from the previous PRs. For PODBoxTypeInfo, we pass the header-only type descriptor as the payload type is explicitly erased to share the destructors. For SingleRefcountedBoxTypeInfo, we pass the full type descriptor as the payload type is a single refcounted pointer.
