### PR TITLE
[stdlib] Stop SIMD vector-index subscripts from trapping

### DIFF
--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -274,7 +274,9 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD2<Scalar>()
     for i in result.indices {
-      result[i] = self[Int(index[i]) % scalarCount]
+      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
+      if position < 0 { position &+= scalarCount }
+      result[i] = self[position]
     }
     return result
   }
@@ -289,7 +291,9 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD3<Scalar>()
     for i in result.indices {
-      result[i] = self[Int(index[i]) % scalarCount]
+      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
+      if position < 0 { position &+= scalarCount }
+      result[i] = self[position]
     }
     return result
   }
@@ -304,7 +308,9 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD4<Scalar>()
     for i in result.indices {
-      result[i] = self[Int(index[i]) % scalarCount]
+      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
+      if position < 0 { position &+= scalarCount }
+      result[i] = self[position]
     }
     return result
   }
@@ -319,7 +325,9 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD8<Scalar>()
     for i in result.indices {
-      result[i] = self[Int(index[i]) % scalarCount]
+      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
+      if position < 0 { position &+= scalarCount }
+      result[i] = self[position]
     }
     return result
   }
@@ -334,7 +342,9 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD16<Scalar>()
     for i in result.indices {
-      result[i] = self[Int(index[i]) % scalarCount]
+      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
+      if position < 0 { position &+= scalarCount }
+      result[i] = self[position]
     }
     return result
   }
@@ -349,7 +359,9 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD32<Scalar>()
     for i in result.indices {
-      result[i] = self[Int(index[i]) % scalarCount]
+      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
+      if position < 0 { position &+= scalarCount }
+      result[i] = self[position]
     }
     return result
   }
@@ -364,7 +376,9 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD64<Scalar>()
     for i in result.indices {
-      result[i] = self[Int(index[i]) % scalarCount]
+      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
+      if position < 0 { position &+= scalarCount }
+      result[i] = self[position]
     }
     return result
   }

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -273,9 +273,17 @@ extension SIMD {
   public subscript<Index>(index: SIMD2<Index>) -> SIMD2<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD2<Scalar>()
+    let n = scalarCount
+    if n.nonzeroBitCount == 1 {
+      let mask = n &- 1
+      for i in result.indices {
+        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
+      }
+      return result
+    }
     for i in result.indices {
-      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
-      if position < 0 { position &+= scalarCount }
+      var position = Int(truncatingIfNeeded: index[i]) % n
+      if position < 0 { position &+= n }
       result[i] = self[position]
     }
     return result
@@ -290,9 +298,17 @@ extension SIMD {
   public subscript<Index>(index: SIMD3<Index>) -> SIMD3<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD3<Scalar>()
+    let n = scalarCount
+    if n.nonzeroBitCount == 1 {
+      let mask = n &- 1
+      for i in result.indices {
+        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
+      }
+      return result
+    }
     for i in result.indices {
-      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
-      if position < 0 { position &+= scalarCount }
+      var position = Int(truncatingIfNeeded: index[i]) % n
+      if position < 0 { position &+= n }
       result[i] = self[position]
     }
     return result
@@ -307,9 +323,17 @@ extension SIMD {
   public subscript<Index>(index: SIMD4<Index>) -> SIMD4<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD4<Scalar>()
+    let n = scalarCount
+    if n.nonzeroBitCount == 1 {
+      let mask = n &- 1
+      for i in result.indices {
+        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
+      }
+      return result
+    }
     for i in result.indices {
-      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
-      if position < 0 { position &+= scalarCount }
+      var position = Int(truncatingIfNeeded: index[i]) % n
+      if position < 0 { position &+= n }
       result[i] = self[position]
     }
     return result
@@ -324,9 +348,17 @@ extension SIMD {
   public subscript<Index>(index: SIMD8<Index>) -> SIMD8<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD8<Scalar>()
+    let n = scalarCount
+    if n.nonzeroBitCount == 1 {
+      let mask = n &- 1
+      for i in result.indices {
+        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
+      }
+      return result
+    }
     for i in result.indices {
-      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
-      if position < 0 { position &+= scalarCount }
+      var position = Int(truncatingIfNeeded: index[i]) % n
+      if position < 0 { position &+= n }
       result[i] = self[position]
     }
     return result
@@ -341,9 +373,17 @@ extension SIMD {
   public subscript<Index>(index: SIMD16<Index>) -> SIMD16<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD16<Scalar>()
+    let n = scalarCount
+    if n.nonzeroBitCount == 1 {
+      let mask = n &- 1
+      for i in result.indices {
+        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
+      }
+      return result
+    }
     for i in result.indices {
-      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
-      if position < 0 { position &+= scalarCount }
+      var position = Int(truncatingIfNeeded: index[i]) % n
+      if position < 0 { position &+= n }
       result[i] = self[position]
     }
     return result
@@ -358,9 +398,17 @@ extension SIMD {
   public subscript<Index>(index: SIMD32<Index>) -> SIMD32<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD32<Scalar>()
+    let n = scalarCount
+    if n.nonzeroBitCount == 1 {
+      let mask = n &- 1
+      for i in result.indices {
+        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
+      }
+      return result
+    }
     for i in result.indices {
-      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
-      if position < 0 { position &+= scalarCount }
+      var position = Int(truncatingIfNeeded: index[i]) % n
+      if position < 0 { position &+= n }
       result[i] = self[position]
     }
     return result
@@ -375,9 +423,17 @@ extension SIMD {
   public subscript<Index>(index: SIMD64<Index>) -> SIMD64<Scalar>
   where Index: FixedWidthInteger {
     var result = SIMD64<Scalar>()
+    let n = scalarCount
+    if n.nonzeroBitCount == 1 {
+      let mask = n &- 1
+      for i in result.indices {
+        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
+      }
+      return result
+    }
     for i in result.indices {
-      var position = Int(truncatingIfNeeded: index[i]) % scalarCount
-      if position < 0 { position &+= scalarCount }
+      var position = Int(truncatingIfNeeded: index[i]) % n
+      if position < 0 { position &+= n }
       result[i] = self[position]
     }
     return result

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -274,13 +274,6 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD2<Scalar>()
     let n = scalarCount
-    if n.nonzeroBitCount == 1 {
-      let mask = n &- 1
-      for i in result.indices {
-        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
-      }
-      return result
-    }
     for i in result.indices {
       var position = Int(truncatingIfNeeded: index[i]) % n
       if position < 0 { position &+= n }
@@ -299,13 +292,6 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD3<Scalar>()
     let n = scalarCount
-    if n.nonzeroBitCount == 1 {
-      let mask = n &- 1
-      for i in result.indices {
-        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
-      }
-      return result
-    }
     for i in result.indices {
       var position = Int(truncatingIfNeeded: index[i]) % n
       if position < 0 { position &+= n }
@@ -324,13 +310,6 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD4<Scalar>()
     let n = scalarCount
-    if n.nonzeroBitCount == 1 {
-      let mask = n &- 1
-      for i in result.indices {
-        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
-      }
-      return result
-    }
     for i in result.indices {
       var position = Int(truncatingIfNeeded: index[i]) % n
       if position < 0 { position &+= n }
@@ -349,13 +328,6 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD8<Scalar>()
     let n = scalarCount
-    if n.nonzeroBitCount == 1 {
-      let mask = n &- 1
-      for i in result.indices {
-        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
-      }
-      return result
-    }
     for i in result.indices {
       var position = Int(truncatingIfNeeded: index[i]) % n
       if position < 0 { position &+= n }
@@ -374,13 +346,6 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD16<Scalar>()
     let n = scalarCount
-    if n.nonzeroBitCount == 1 {
-      let mask = n &- 1
-      for i in result.indices {
-        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
-      }
-      return result
-    }
     for i in result.indices {
       var position = Int(truncatingIfNeeded: index[i]) % n
       if position < 0 { position &+= n }
@@ -399,13 +364,6 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD32<Scalar>()
     let n = scalarCount
-    if n.nonzeroBitCount == 1 {
-      let mask = n &- 1
-      for i in result.indices {
-        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
-      }
-      return result
-    }
     for i in result.indices {
       var position = Int(truncatingIfNeeded: index[i]) % n
       if position < 0 { position &+= n }
@@ -424,13 +382,6 @@ extension SIMD {
   where Index: FixedWidthInteger {
     var result = SIMD64<Scalar>()
     let n = scalarCount
-    if n.nonzeroBitCount == 1 {
-      let mask = n &- 1
-      for i in result.indices {
-        result[i] = self[Int(truncatingIfNeeded: index[i]) & mask]
-      }
-      return result
-    }
     for i in result.indices {
       var position = Int(truncatingIfNeeded: index[i]) % n
       if position < 0 { position &+= n }

--- a/test/stdlib/SIMD/SIMDVectorIndexing.swift
+++ b/test/stdlib/SIMD/SIMDVectorIndexing.swift
@@ -1,0 +1,125 @@
+//===--- SIMDVectorIndexing.swift -----------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let suite = TestSuite("SIMDVectorIndexing")
+defer {
+  runAllTests()
+}
+
+// A helper to build vectors where the lane value equals the lane index.
+func laneVec<V: SIMD>(_: V.Type) -> V where V.Scalar: FixedWidthInteger {
+  var result = V()
+  for i in result.indices { result[i] = V.Scalar(truncatingIfNeeded: i) }
+  return result
+}
+
+suite.test("indexing") {
+  let v = laneVec(SIMD16<UInt8>.self)
+  for i in 0 ..< 16 {
+    expectEqual(
+      SIMD4<UInt8>(repeating: UInt8(i)),
+      v[SIMD4<Int>(repeating: i)]
+    )
+  }
+}
+
+suite.test("negative indices") {
+  // A negative index -k where (0 < k <= scalarCount) means (scalarCount - k).
+  let v = laneVec(SIMD16<UInt8>.self)
+  for k in 1 ... 16 {
+    expectEqual(
+      SIMD2<UInt8>(repeating: UInt8(16 - k)),
+      v[SIMD2<Int>(repeating: -k)]
+    )
+  }
+  // Make sure that Int8.min also behaves correctly.
+  expectEqual(
+    SIMD2<UInt8>(repeating: 0),
+    v[SIMD2<Int8>(repeating: Int8.min)]
+  )
+}
+
+suite.test("indices over Int.max") {
+  // Int(_:) traps on these; the subscript must not.
+  let v = laneVec(SIMD16<UInt8>.self)
+  expectEqual(
+    SIMD2<UInt8>(repeating: 15),
+    v[SIMD2<UInt64>(repeating: .max)]
+  )
+  expectEqual(
+    SIMD2<UInt8>(repeating: 0),
+    v[SIMD2<UInt64>(repeating: 1 << 63)]
+  )
+  expectEqual(
+    SIMD2<UInt8>(repeating: 15),
+    v[SIMD2<UInt>(repeating: .max)]
+  )
+}
+
+suite.test("every Int8 index into 4 bits") {
+  let v = laneVec(SIMD16<UInt8>.self)
+  for raw in Int8.min ... Int8.max {
+    let expected = UInt8(bitPattern: raw) & 15
+    expectEqual(
+      SIMD2<UInt8>(repeating: expected),
+      v[SIMD2<Int8>(repeating: raw)],
+      "index \(raw)"
+    )
+  }
+}
+
+suite.test("every Int8 index into 3 lanes") {
+  // masking the index doesn't work when subscripting a SIMD3.
+  let v = laneVec(SIMD3<UInt8>.self)
+  for raw in Int8.min ... Int8.max {
+    let m = Int(raw) % 3
+    let expected = UInt8(m < 0 ? m + 3 : m)
+    expectEqual(
+      SIMD2<UInt8>(repeating: expected),
+      v[SIMD2<Int8>(repeating: raw)],
+      "index \(raw)"
+    )
+  }
+}
+
+suite.test("result vector length equals index vector length") {
+  let v = laneVec(SIMD16<UInt8>.self)
+  let i = SIMD8<Int>(0, 1, 2, 3, 4, 5, 6, 7)
+  expectEqual(SIMD8<UInt8>(0, 1, 2, 3, 4, 5, 6, 7), v[i])
+  expectEqual(2, v[SIMD2<Int>(repeating: 2)].scalarCount)
+  expectEqual(3, v[SIMD3<Int>(repeating: 2)].scalarCount)
+  expectEqual(4, v[SIMD4<Int>(repeating: 2)].scalarCount)
+  expectEqual(8, v[SIMD8<Int>(repeating: 2)].scalarCount)
+  expectEqual(16, v[SIMD16<Int>(repeating: 2)].scalarCount)
+  expectEqual(32, v[SIMD32<Int>(repeating: 2)].scalarCount)
+  expectEqual(64, v[SIMD64<Int>(repeating: 2)].scalarCount)
+}
+
+suite.test("check interesting index values") {
+  // make sure that the extreme values do not cause runtime crashes
+  let v = laneVec(SIMD16<UInt8>.self)
+  func check<Index: FixedWidthInteger & SIMDScalar>(_: Index.Type) {
+    for raw in [Index.min, Index.max, 1, 0, 0 &- 1] {
+      let lane = v[SIMD2<Index>(repeating: raw)][0]
+      expectTrue(v.indices.contains(Int(lane)), "\(Index.self) \(raw)")
+    }
+  }
+  check(Int8.self);  check(UInt8.self)
+  check(Int16.self); check(UInt16.self)
+  check(Int32.self); check(UInt32.self)
+  check(Int64.self); check(UInt64.self)
+  check(Int.self);   check(UInt.self)
+}


### PR DESCRIPTION
The generic implementations of the SIMD vector-indexed permutation subscripts had trapping index calculations, even though their doc-comments specifically state that they do not trap.

Updated to a calculation that can't trap, and added tests (these subscripts had no coverage.)

Addresses rdar://186707704
