### PR TITLE
[test] re-enable a long-disabled test

### DIFF
--- a/test/stdlib/SIMDConcreteFP.swift.gyb
+++ b/test/stdlib/SIMDConcreteFP.swift.gyb
@@ -15,7 +15,6 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %line-directive %t/SIMDConcreteFP.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
-// REQUIRES: rdar76545659
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest


### PR DESCRIPTION
This test was completely disabled 5 years ago, and I don't think the blame for the failure was correctly attributed. Re-enabling in order to get the coverage we expect. If this test needs to be disabled again, then it shouldn't be with a blanket disablement.

Related to rdar://76545659