### PR TITLE
[build.ps1] Bind correct Swift runtime for `swift-refactor`

### DIFF
--- a/test/refactoring/Macros/expand_derived_conformance.swift
+++ b/test/refactoring/Macros/expand_derived_conformance.swift
@@ -1,8 +1,5 @@
 // REQUIRES: swift_feature_DeriveConformancesViaMacros
 
-// https://github.com/swiftlang/swift/issues/91958
-// UNSUPPORTED: OS=windows-msvc
-
 // RUN: %empty-directory(%t)
 
 // RUN: %refactor-check-compiles -expand-derived-conformance -enable-experimental-feature DeriveConformancesViaMacros -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) --dump-text -source-filename %s -pos=%(line+1):21 | %FileCheck -check-prefix=DIRECT %s

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3382,6 +3382,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
     Build-CMakeProject @BuildCMakeArgs -BuildTargets @(
       "swift-frontend",
       "sourcekitd-test",
+      "swift-refactor",
       "swift-ide-test",
       "swift-plugin-server"
     )
@@ -3421,6 +3422,7 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
                                    "swift-synthesize-interface.exe",
                                    "sil-opt.exe",
                                    "sourcekitd-test.exe",
+                                   "swift-refactor.exe",
                                    "swift-ide-test.exe",
                                    "swift-plugin-server.exe",
                                    "swiftc-legacy-driver.exe",


### PR DESCRIPTION
Add `swift-refactor` alongside `sourcekitd-test` and `swift-ide-test` in the list of tools where we explicitly set the correct runtime library to use. This fixes a crash when attempting to use a macro plugin in a `swift-refactor` test.

Resolves #91958