### PR TITLE
[Sema] Fix ternary expression failing to form a C function pointer

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1577,16 +1577,25 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
 
       // Prefer the "stripped" form of a type. See getStrippedType()
       // for the definition.
-      auto stripped1 = getStrippedType(type1, cs.getASTContext());
-      auto stripped2 = getStrippedType(type2, cs.getASTContext());
-      if (stripped1->isEqual(stripped2)) {
-        if (type1->isEqual(stripped1) && !types.Type1WasLabeled) {
-          ++score1;
-          continue;
-        }
-        if (type2->isEqual(stripped2) && !types.Type2WasLabeled) {
-          ++score2;
-          continue;
+      //
+      // Only do this when the types are mutually subtypes of one another;
+      // if the subtype relationship only holds in one direction, the
+      // subtype is genuinely better, and the stripped-form check would
+      // cancel that out. For example, with `@convention(c) () -> Int` vs.
+      // `() -> Int`, only the former is a subtype of the other, even
+      // though their stripped forms are equal.
+      if (type1Better && type2Better) {
+        auto stripped1 = getStrippedType(type1, cs.getASTContext());
+        auto stripped2 = getStrippedType(type2, cs.getASTContext());
+        if (stripped1->isEqual(stripped2)) {
+          if (type1->isEqual(stripped1) && !types.Type1WasLabeled) {
+            ++score1;
+            continue;
+          }
+          if (type2->isEqual(stripped2) && !types.Type2WasLabeled) {
+            ++score2;
+            continue;
+          }
         }
       }
 

--- a/test/Constraints/bidirectional_conversions.swift
+++ b/test/Constraints/bidirectional_conversions.swift
@@ -77,3 +77,24 @@ struct MyString: Comparable {
 }
 
 let _: (MyString, MyString) -> Bool = false ? (<) : (>)
+
+/////////////
+
+// https://github.com/swiftlang/swift/issues/91997
+
+typealias CFunction = @convention(c) () -> Int32
+
+func performCall(msgh: CFunction?) {}
+func performCall(overload: Int) {}
+
+func defaultTracebackFn() -> Int32 { return 0 }
+
+func testCFunctionPointerTernary(cond: Bool) {
+  performCall(msgh: cond ? defaultTracebackFn : nil)
+}
+
+func performCall2(msgh: CFunction?) {}
+
+func testCFunctionPointerTernaryNoOverload(cond: Bool) {
+  performCall2(msgh: cond ? defaultTracebackFn : nil)
+}


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/91997

Ranking treated the solution converting the whole ternary to
`@convention(c)` and the one converting only the function reference as
identical: the stripped-form tie-break introduced in f3e6b4ceda5
cancels the genuine subtype preference between the two solutions.

This change only applies the tie-break when the subtype relationship is
bidirectional.

Noticed this using the Xcode 27 beta and [LuaSwift](https://github.com/tomsci/LuaSwift/pull/21)