### PR TITLE
[Sema] Fix isolated conformance can be escaped by coercing metatype to protocol

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3390,6 +3390,16 @@ namespace {
       }
 
       if (auto erasureExpr = dyn_cast<ErasureExpr>(expr)) {
+        // Erasure lets everything the conformance is built from escape, so
+        // look through specialized conformances into their substitutions.
+        for (auto conformance : erasureExpr->getConformances()) {
+          if (conformance.isConcrete()) {
+            checkIsolatedConformancesInContext(
+                conformance.getConcrete()->getSubstitutionMap(),
+                erasureExpr->getLoc(), getDeclContext(),
+                RefineConformances{*this});
+          }
+        }
         checkIsolatedConformancesInContext(
             erasureExpr->getConformances(), erasureExpr->getLoc(),
             getDeclContext(), RefineConformances{*this});

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3390,16 +3390,6 @@ namespace {
       }
 
       if (auto erasureExpr = dyn_cast<ErasureExpr>(expr)) {
-        // Erasure lets everything the conformance is built from escape, so
-        // look through specialized conformances into their substitutions.
-        for (auto conformance : erasureExpr->getConformances()) {
-          if (conformance.isConcrete()) {
-            checkIsolatedConformancesInContext(
-                conformance.getConcrete()->getSubstitutionMap(),
-                erasureExpr->getLoc(), getDeclContext(),
-                RefineConformances{*this});
-          }
-        }
         checkIsolatedConformancesInContext(
             erasureExpr->getConformances(), erasureExpr->getLoc(),
             getDeclContext(), RefineConformances{*this});
@@ -9384,9 +9374,14 @@ namespace {
       if (!normal)
         return false;
 
+      // Keep walking through a nonisolated conformance: its substitutions
+      // can still carry an isolated one. Returning true would stop the whole
+      // traversal, not just this subtree.
       auto conformanceIsolation = concrete->getIsolation();
-      if (!conformanceIsolation.isGlobalActor() ||
-          conformanceIsolation == getIsolation())
+      if (!conformanceIsolation.isGlobalActor())
+        return false;
+
+      if (conformanceIsolation == getIsolation())
         return true;
 
       // In a nonisolated(nonsending) context the conformance is valid because

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -598,3 +598,17 @@ func testEnumElementPatternParentType(_ x: Any) {
     break
   }
 }
+
+// https://github.com/swiftlang/swift/issues/91755
+// Erasure must look through a specialized conformance to its substitutions.
+
+struct GenericP<T: P>: P {
+  func f() { }
+}
+
+func testErasureOfSpecializedConformance(_ g: GenericP<C>) {
+  _ = g as any P
+  // expected-warning@-1{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  _ = GenericP<C>.self as any P.Type
+  // expected-warning@-1{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+}

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -235,14 +235,14 @@ extension HasAssociatedType where Self: Sendable {
 
 func testIsolatedConformancesOnAssociatedTypes(hc: HoldsC, c: C) {
   acceptHasAssocWithP(hc)
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
   acceptSendableHasAssocWithP(hc) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a 'Sendable' type parameter }}
 
-  HoldsC.acceptAliased(C.self) // okay
+  HoldsC.acceptAliased(C.self)
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
 
-  // FIXME: the following should produce an error, because the isolated
-  // conformance of C: P can cross isolation boundaries via the Sendable Self's
-  // associated type.
   HoldsC.acceptSendableAliased(C.self)
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
 }
 
 
@@ -600,15 +600,51 @@ func testEnumElementPatternParentType(_ x: Any) {
 }
 
 // https://github.com/swiftlang/swift/issues/91755
-// Erasure must look through a specialized conformance to its substitutions.
+// A nonisolated conformance must not stop the walk short of the isolated
+// conformances among its substitutions.
 
 struct GenericP<T: P>: P {
   func f() { }
 }
 
+struct PairP<T: P, U: P>: P {
+  func f() { }
+}
+
+struct NonIsolatedP: P {
+  func f() { }
+}
+
 func testErasureOfSpecializedConformance(_ g: GenericP<C>) {
   _ = g as any P
-  // expected-warning@-1{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
   _ = GenericP<C>.self as any P.Type
-  // expected-warning@-1{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+}
+
+// Order among siblings must not matter.
+func testErasureOfSiblingConformances(_ a: PairP<C, NonIsolatedP>,
+                                      _ b: PairP<NonIsolatedP, C>) {
+  _ = a as any P
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  _ = b as any P
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+}
+
+// Same isolation domain: no diagnostic.
+@MainActor
+func testErasureFromMatchingIsolation(_ g: GenericP<C>) {
+  _ = g as any P
+}
+
+// A conditional conformance's requirement conformances live only in its own
+// substitution map, so only the walk can reach them.
+struct Conditional<T> { }
+extension Conditional: P where T: P {
+  func f() { }
+}
+
+func testErasureOfConditionalConformance(_ c: Conditional<C>) {
+  _ = c as any P
+  // expected-warning@-1 {{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
 }

--- a/test/Concurrency/isolated_conformance_6.swift
+++ b/test/Concurrency/isolated_conformance_6.swift
@@ -20,3 +20,24 @@ protocol Q: SendableMetatype {
 @MainActor struct QSendableSMainActor: @MainActor Q {
   func f() { }
 }
+
+// https://github.com/swiftlang/swift/issues/91755
+// Error rather than warning in Swift 6 mode.
+
+protocol R {
+  func f()
+}
+
+@MainActor
+class CIsolatedR: @MainActor R {
+  func f() { }
+}
+
+struct GenericR<T: R>: R {
+  func f() { }
+}
+
+func testErasureOfSpecializedConformance(_ g: GenericR<CIsolatedR>) {
+  _ = g as any R
+  // expected-error@-1 {{main actor-isolated conformance of 'CIsolatedR' to 'R' cannot be used in nonisolated context}}
+}


### PR DESCRIPTION
Resolves #91755 

A main actor isolated conformance could be used from a nonisolated context by erasing a generic type to an existential.

The check that should catch this walks a conformance and everything it is built from, but it stops as soon as it reaches a conformance that is not isolated. A generic type that conforms through its type parameter is
not isolated itself, so the walk stopped there and never looked at the type parameter, whose conformance is isolated.

```swift
protocol P {
  static func foo()
}
struct S<T: P>: P {
  static func foo() { T.foo() }
}
@MainActor struct K: @MainActor P {
  static func foo() {
    MainActor.preconditionIsolated("💥")
  }
}
await Task.detached {
  let x = S<K>.self
  (x as P.Type).foo()
}.value
```

Before:
No error during compilation.

After:
`error: main actor-isolated conformance of 'K' to 'P' cannot be used in @concurrent context`

