### PR TITLE
Introduce CrashInfo and Swift-Inspect support for TaskRegistry

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -214,6 +214,7 @@ public:
     std::vector<StoredPointer> WaitingTasks;
     std::vector<StoredPointer> AsyncBacktraceFrames;
     StoredPointer ResumeAsyncContext;
+    StoredPointer RegistryNext;
 
     std::string Name;
   };
@@ -2035,6 +2036,7 @@ private:
         AsyncTaskObj->Id | ((uint64_t)AsyncTaskObj->PrivateStorage.Id << 32);
     Info.AllocatorSlabPtr = AsyncTaskObj->PrivateStorage.Allocator.FirstSlab;
     Info.RunJob = getRunJob(AsyncTaskObj.get());
+    Info.RegistryNext = AsyncTaskObj->PrivateStorage.RegistryNext;
 
     Info.ParentTask = 0;
     if (Info.IsChildTask && asyncTaskSize != 0) {

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1659,6 +1659,60 @@ public:
   /// Iterate the metadata allocations in the target process, calling Call with
   /// each allocation found. Returns None on success, and a string describing
   /// the error on failure.
+  std::optional<std::string> iterateTaskRegistry(
+      std::function<void(StoredPointer)> Call) {
+    auto RegistryAddr = getReader().getSymbolAddress("_swift_concurrency_task_registry");
+    if (!RegistryAddr) {
+      return "could not find _swift_concurrency_task_registry symbol";
+    }
+
+    auto EnabledAddr = getReader().getSymbolAddress("_swift_concurrency_task_registry_enabled");
+    if (EnabledAddr) {
+      uint8_t Enabled = 0;
+      if (getReader().readInteger(EnabledAddr, 1, &Enabled) && !Enabled) {
+        return "task registry disabled by environment variable";
+      }
+    }
+
+    auto ShardSizeAddr = getReader().getSymbolAddress("_swift_concurrency_task_registry_shard_size");
+    if (!ShardSizeAddr) {
+      return "could not find _swift_concurrency_task_registry_shard_size symbol";
+    }
+    
+    uint8_t PointerSize = getReader().getPointerSize().value_or(sizeof(void*));
+    uint32_t ShardSize = 0;
+    if (!getReader().readInteger(ShardSizeAddr, PointerSize, &ShardSize)) {
+      return "could not read _swift_concurrency_task_registry_shard_size";
+    }
+
+    for (uint32_t i = 0; i < 64; ++i) {
+      // Each shard head is a pointer to the head of a linked list.
+      auto ShardAddr = RegistryAddr + (i * ShardSize);
+      
+      uint64_t TaskAddr = 0;
+      if (!getReader().readInteger(ShardAddr, PointerSize, &TaskAddr)) {
+         return "could not read TaskRegistryShard head";
+      }
+
+      int32_t nodes = 0;
+      int32_t max_registry_nodes = 10000;
+      while (TaskAddr && nodes++ < max_registry_nodes) {
+        Call(TaskAddr);
+        
+        // Find the next task using ReflectionContext's AsyncTaskObj out of process.
+        auto [Error, TaskInfo] = asyncTaskInfo(RemoteAddress(TaskAddr, RegistryAddr.getAddressSpace()), 0, 0);
+        if (Error) {
+          // If we can't read the task info (e.g. memory is corrupted), stop traversing this shard.
+          break;
+        }
+        
+        TaskAddr = TaskInfo.RegistryNext;
+      }
+    }
+
+    return std::nullopt;
+  }
+
   std::optional<std::string> iterateMetadataAllocations(
       std::function<void(MetadataAllocation<Runtime>)> Call) {
     std::string IterationEnabledName =

--- a/include/swift/Runtime/CrashInfo.h
+++ b/include/swift/Runtime/CrashInfo.h
@@ -52,6 +52,10 @@ struct CrashInfo {
   // The EXCEPTION_POINTERS pointer.
   uint64_t exception_info;
 #endif
+
+  // The memory address of the Task Registry in the crashed process,
+  // populated immediately before spawning the backtracer.
+  uint64_t concurrency_task_registry_addr;
 };
 
 #ifdef __linux__

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -484,9 +484,24 @@ swift_reflection_ptr_t
 swift_reflection_nextJob(SwiftReflectionContextRef ContextRef,
                          swift_reflection_ptr_t JobPtr);
 
+/// Task registry iterator callback passed to
+/// swift_reflection_iterateTaskRegistry
+typedef void (*swift_taskRegistryIterator)(swift_reflection_ptr_t Task,
+                                           void *ContextPtr);
+
+/// Iterate over all live tasks in the target process's task registry.
+///
+/// Calls the passed in Call function for each task in the registry.
+///
+/// Returns NULL on success. On error, returns a pointer to a C string
+/// describing the error.
+SWIFT_REMOTE_MIRROR_LINKAGE
+const char *swift_reflection_iterateTaskRegistry(
+    SwiftReflectionContextRef ContextRef,
+    swift_taskRegistryIterator Call, void *ContextPtr);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
 #endif // SWIFT_REFLECTION_SWIFT_REFLECTION_H
-

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -270,6 +270,7 @@ typedef struct swift_async_task_info {
   swift_reflection_ptr_t *AsyncBacktraceFrames;
 
   const char *Name;
+  swift_reflection_ptr_t RegistryNext;
 } swift_async_task_info_t;
 
 typedef struct swift_actor_info {

--- a/stdlib/public/Concurrency/TaskRegistry.cpp
+++ b/stdlib/public/Concurrency/TaskRegistry.cpp
@@ -31,6 +31,9 @@ TaskRegistryShard
 SWIFT_EXPORT_FROM(swift_Concurrency)
 bool _swift_concurrency_task_registry_enabled = true;
 
+SWIFT_EXPORT_FROM(swift_Concurrency)
+const size_t _swift_concurrency_task_registry_shard_size = sizeof(TaskRegistryShard);
+
 static inline bool isTaskRegistryEnabled() {
   static bool initialized = false;
   if (!initialized) {

--- a/stdlib/public/Concurrency/TaskRegistry.cpp
+++ b/stdlib/public/Concurrency/TaskRegistry.cpp
@@ -28,9 +28,16 @@ TaskRegistryShard
 
 #if SWIFT_CONCURRENCY_ENABLE_TASK_REGISTRY
 
+SWIFT_EXPORT_FROM(swift_Concurrency)
+bool _swift_concurrency_task_registry_enabled = true;
+
 static inline bool isTaskRegistryEnabled() {
-  static bool enabled = runtime::environment::concurrencyEnableTaskRegistry();
-  return enabled;
+  static bool initialized = false;
+  if (!initialized) {
+    _swift_concurrency_task_registry_enabled = runtime::environment::concurrencyEnableTaskRegistry();
+    initialized = true;
+  }
+  return _swift_concurrency_task_registry_enabled;
 }
 
 void swift::taskRegistryInsert(AsyncTask *task) {

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -1097,6 +1097,7 @@ swift_reflection_asyncTaskInfo(SwiftReflectionContextRef ContextRef,
 
     Result.RunJob = TaskInfo.RunJob;
     Result.AllocatorSlabPtr = TaskInfo.AllocatorSlabPtr;
+    Result.RegistryNext = TaskInfo.RegistryNext;
 
     auto *ChildTasks =
         ContextRef
@@ -1155,5 +1156,62 @@ swift_reflection_nextJob(SwiftReflectionContextRef ContextRef,
   return ContextRef->withContext([&](auto *Context) {
     return Context->nextJob(
         RemoteAddress(JobPtr, RemoteAddress::DefaultAddressSpace));
+  });
+}
+
+const char *swift_reflection_iterateTaskRegistry(
+    SwiftReflectionContextRef ContextRef,
+    swift_taskRegistryIterator Call, void *ContextPtr) {
+  return ContextRef->withContext([&](auto *Context) -> const char * {
+    auto &Reader = Context->getReader();
+
+    auto RegistryAddr = Reader.getSymbolAddress("_swift_concurrency_task_registry");
+    if (!RegistryAddr) {
+      return "could not find _swift_concurrency_task_registry symbol";
+    }
+
+    auto EnabledAddr = Reader.getSymbolAddress("_swift_concurrency_task_registry_enabled");
+    if (EnabledAddr) {
+      uint8_t Enabled = 0;
+      if (Reader.readInteger(EnabledAddr, 1, &Enabled) && !Enabled) {
+        return "task registry disabled by environment variable";
+      }
+    }
+
+    auto ShardSizeAddr = Reader.getSymbolAddress("_swift_concurrency_task_registry_shard_size");
+    if (!ShardSizeAddr) {
+      return "could not find _swift_concurrency_task_registry_shard_size symbol";
+    }
+    
+    uint8_t PointerSize = Reader.getPointerSize().value_or(sizeof(void*));
+    uint32_t ShardSize = 0;
+    if (!Reader.readInteger(ShardSizeAddr, PointerSize, &ShardSize)) {
+      return "could not read _swift_concurrency_task_registry_shard_size";
+    }
+
+    for (uint32_t i = 0; i < 64; ++i) {
+      // Each shard head is a pointer to the head of a linked list.
+      auto ShardAddr = RegistryAddr + (i * ShardSize);
+      
+      uint64_t TaskAddr = 0;
+      if (!Reader.readInteger(ShardAddr, PointerSize, &TaskAddr)) {
+         return "could not read TaskRegistryShard head";
+      }
+
+      while (TaskAddr) {
+        Call(TaskAddr, ContextPtr);
+        
+        // Find the next task using ReflectionContext's AsyncTaskObj out of process.
+        auto [Error, TaskInfo] = Context->asyncTaskInfo(RemoteAddress(TaskAddr, RegistryAddr.getAddressSpace()), 0, 0);
+        if (Error) {
+          // If we can't read the task info (e.g. memory is corrupted), stop traversing this shard.
+          break;
+        }
+        
+        TaskAddr = TaskInfo.RegistryNext;
+      }
+    }
+
+    return nullptr;
   });
 }

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -1162,56 +1162,10 @@ swift_reflection_nextJob(SwiftReflectionContextRef ContextRef,
 const char *swift_reflection_iterateTaskRegistry(
     SwiftReflectionContextRef ContextRef,
     swift_taskRegistryIterator Call, void *ContextPtr) {
-  return ContextRef->withContext([&](auto *Context) -> const char * {
-    auto &Reader = Context->getReader();
-
-    auto RegistryAddr = Reader.getSymbolAddress("_swift_concurrency_task_registry");
-    if (!RegistryAddr) {
-      return "could not find _swift_concurrency_task_registry symbol";
-    }
-
-    auto EnabledAddr = Reader.getSymbolAddress("_swift_concurrency_task_registry_enabled");
-    if (EnabledAddr) {
-      uint8_t Enabled = 0;
-      if (Reader.readInteger(EnabledAddr, 1, &Enabled) && !Enabled) {
-        return "task registry disabled by environment variable";
-      }
-    }
-
-    auto ShardSizeAddr = Reader.getSymbolAddress("_swift_concurrency_task_registry_shard_size");
-    if (!ShardSizeAddr) {
-      return "could not find _swift_concurrency_task_registry_shard_size symbol";
-    }
-    
-    uint8_t PointerSize = Reader.getPointerSize().value_or(sizeof(void*));
-    uint32_t ShardSize = 0;
-    if (!Reader.readInteger(ShardSizeAddr, PointerSize, &ShardSize)) {
-      return "could not read _swift_concurrency_task_registry_shard_size";
-    }
-
-    for (uint32_t i = 0; i < 64; ++i) {
-      // Each shard head is a pointer to the head of a linked list.
-      auto ShardAddr = RegistryAddr + (i * ShardSize);
-      
-      uint64_t TaskAddr = 0;
-      if (!Reader.readInteger(ShardAddr, PointerSize, &TaskAddr)) {
-         return "could not read TaskRegistryShard head";
-      }
-
-      while (TaskAddr) {
-        Call(TaskAddr, ContextPtr);
-        
-        // Find the next task using ReflectionContext's AsyncTaskObj out of process.
-        auto [Error, TaskInfo] = Context->asyncTaskInfo(RemoteAddress(TaskAddr, RegistryAddr.getAddressSpace()), 0, 0);
-        if (Error) {
-          // If we can't read the task info (e.g. memory is corrupted), stop traversing this shard.
-          break;
-        }
-        
-        TaskAddr = TaskInfo.RegistryNext;
-      }
-    }
-
-    return nullptr;
+  return ContextRef->withContext([&](auto *Context) {
+    auto Error = Context->iterateTaskRegistry([&](auto TaskAddr) {
+      Call(TaskAddr, ContextPtr);
+    });
+    return returnableCString(ContextRef, Error);
   });
 }

--- a/stdlib/public/libexec/swift-backtrace/TargetLinux.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetLinux.swift
@@ -48,6 +48,7 @@ class Target {
 
   var pid: pid_t
   var name: String
+  var concurrencyTaskRegistryAddr: UInt64?
   var signal: UInt64
   var faultAddress: Address
   var crashingThread: TargetThread.ThreadID
@@ -132,6 +133,7 @@ class Target {
     crashingThread = TargetThread.ThreadID(crashInfo.crashing_thread)
     signal = crashInfo.signal
     faultAddress = crashInfo.fault_address
+    concurrencyTaskRegistryAddr = crashInfo.concurrency_task_registry_addr
 
     images = ImageMap.capture(using: reader, forProcess: Int(pid))
 

--- a/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
@@ -71,6 +71,8 @@ class Target {
 
   var task: task_t
   var images: ImageMap
+  
+  var concurrencyTaskRegistryAddr: UInt64?
 
   var threads: [TargetThread] = []
   var crashingThreadNdx: Int = -1
@@ -185,6 +187,7 @@ class Target {
     crashingThread = crashInfo.crashing_thread
     signal = crashInfo.signal
     faultAddress = crashInfo.fault_address
+    concurrencyTaskRegistryAddr = crashInfo.concurrency_task_registry_addr
 
     guard let mctx: MContext = try? reader.fetch(from: crashInfo.mctx,
                                                  as: MContext.self) else {

--- a/stdlib/public/libexec/swift-backtrace/TargetWindows.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetWindows.swift
@@ -187,6 +187,7 @@ class Target {
   var exceptionCode: DWORD
   var faultAddress: Address
   var exceptionInfo: Address
+  var concurrencyTaskRegistryAddr: UInt64?
 
   var images: ImageMap
 
@@ -309,6 +310,7 @@ class Target {
     exceptionCode = DWORD(crashInfo.signal)
     faultAddress = Address(truncatingIfNeeded: crashInfo.fault_address)
     exceptionInfo = Address(truncatingIfNeeded: crashInfo.exception_info)
+    concurrencyTaskRegistryAddr = crashInfo.concurrency_task_registry_addr
 
     images = ImageMap.capture(for: UInt(bitPattern: hProcess))
 

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -1099,6 +1099,13 @@ Generate a backtrace for the parent process.
         writeln("\n\nImages:\n")
         writeln(formatter.format(images: target.images))
     }
+    
+    if let taskRegistryAddr = target.concurrencyTaskRegistryAddr,
+       taskRegistryAddr != 0 {
+      writeln("\n\nActive Tasks:\n")
+      writeln(theme.info("  Concurrency Task Registry located at 0x\(String(taskRegistryAddr, radix: 16, uppercase: true))"))
+      writeln(theme.info("  (Run `swift-inspect dump concurrency <pid>` in LLDB or terminal to dump tasks)"))
+    }
   }
 
   static func startDebugger() {

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -50,6 +50,8 @@
 #include <cstring>
 #include <cerrno>
 
+extern "C" SWIFT_RUNTIME_EXPORT uint64_t _swift_concurrency_task_registry_addr = 0;
+
 #ifdef _WIN32
 // We'll probably want dbghelp.h here
 #else
@@ -1445,6 +1447,9 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
 
   _swift_formatUnsigned(_swift_backtraceSettings.top, top_buf);
   _swift_formatAddress(crashInfo, addr_buf);
+  
+  crashInfo->concurrency_task_registry_addr = _swift_concurrency_task_registry_addr;
+  
   #ifdef _WIN32
   _swift_formatUnsigned(GetCurrentProcessId(), pid_buf);
   #endif

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -471,6 +471,7 @@ Added: __swift_concurrency_debug_task_registryCount
 Added: __swift_concurrency_debug_task_registryWalk
 Added: __swift_concurrency_task_registry
 Added: __swift_concurrency_task_registry_enabled
+Added: __swift_concurrency_task_registry_shard_size
 
 // withDeadline / TaskCancellationScope: structured-concurrency deadlines,
 // scoped cancellation (SPI), and CancellationError.Reason plumbing.

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -470,6 +470,7 @@ Added: __swift_concurrency_debug_task_getTaskNext
 Added: __swift_concurrency_debug_task_registryCount
 Added: __swift_concurrency_debug_task_registryWalk
 Added: __swift_concurrency_task_registry
+Added: __swift_concurrency_task_registry_enabled
 
 // withDeadline / TaskCancellationScope: structured-concurrency deadlines,
 // scoped cancellation (SPI), and CancellationError.Reason plumbing.

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1355,6 +1355,7 @@ Added: _swift_distributed_getGenericEnvironmentKeyArgumentCount
 
 // Task Registry
 Added: _concurrencyEnableTaskRegistry
+Added: __swift_concurrency_task_registry_addr
 
 // Privilege gating for environment variables
 Added: __swift_isRestrictedProcess

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -471,6 +471,7 @@ Added: __swift_concurrency_debug_task_registryCount
 Added: __swift_concurrency_debug_task_registryWalk
 Added: __swift_concurrency_task_registry
 Added: __swift_concurrency_task_registry_enabled
+Added: __swift_concurrency_task_registry_shard_size
 
 // withDeadline / TaskCancellationScope: structured-concurrency deadlines,
 // scoped cancellation (SPI), and CancellationError.Reason plumbing.

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -470,6 +470,7 @@ Added: __swift_concurrency_debug_task_getTaskNext
 Added: __swift_concurrency_debug_task_registryCount
 Added: __swift_concurrency_debug_task_registryWalk
 Added: __swift_concurrency_task_registry
+Added: __swift_concurrency_task_registry_enabled
 
 // withDeadline / TaskCancellationScope: structured-concurrency deadlines,
 // scoped cancellation (SPI), and CancellationError.Reason plumbing.

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1350,6 +1350,7 @@ Added: _swift_distributed_getGenericEnvironmentKeyArgumentCount
 
 // Task Registry
 Added: _concurrencyEnableTaskRegistry
+Added: __swift_concurrency_task_registry_addr
 
 // Privilege gating for environment variables
 Added: __swift_isRestrictedProcess

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -116,13 +116,23 @@ fileprivate class ConcurrencyDumper {
 
   func gatherHeapInfo() -> HeapInfo {
     var result = HeapInfo()
+    var usedRegistry = false
+
+    do {
+      try context.iterateTaskRegistry { taskAddr in
+        result.tasks.append(taskAddr)
+      }
+      usedRegistry = true
+    } catch {
+      // Fallback to heap scan if task registry fails (e.g. older runtime)
+    }
 
     process.iterateHeap { (pointer, size) in
       let metadata = swift_reflection_ptr_t(swift_reflection_metadataForObject(context, UInt(pointer)))
       if metadata == 0 || metadata == .max { return }
       if metadata == jobMetadata {
         result.jobs.append(swift_reflection_ptr_t(pointer))
-      } else if metadata == taskMetadata {
+      } else if !usedRegistry && metadata == taskMetadata {
         result.tasks.append(swift_reflection_ptr_t(pointer))
       } else if isActorMetadata(metadata) {
         result.actors.append(swift_reflection_ptr_t(pointer))

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
@@ -53,6 +53,7 @@ extension SwiftReflectionContextRef {
   typealias ConformanceIterationCallback = (swift_reflection_ptr_t, swift_reflection_ptr_t) -> Void
   typealias MetadataAllocationIterationCallback = (swift_metadata_allocation_t) -> Void
   typealias MetadataAllocationBacktraceIterationCallback = (swift_reflection_ptr_t, Int, UnsafePointer<swift_reflection_ptr_t>) -> Void
+  typealias TaskRegistryIterationCallback = (swift_reflection_ptr_t) -> Void
 
   internal var allocations: [swift_metadata_allocation_t] {
     get throws {
@@ -169,6 +170,17 @@ extension SwiftReflectionContextRef {
     if let error = withUnsafeMutablePointer(to: &body, {
       swift_reflection_iterateMetadataAllocationBacktraces(self, {
         $3!.bindMemory(to: MetadataAllocationBacktraceIterationCallback.self, capacity: 1).pointee($0, $1, $2!)
+      }, $0)
+    }) {
+      throw Error(cString: error)
+    }
+  }
+
+  internal func iterateTaskRegistry(_ body: @escaping TaskRegistryIterationCallback) throws {
+    var body = body
+    if let error = withUnsafeMutablePointer(to: &body, {
+      swift_reflection_iterateTaskRegistry(self, {
+        $1!.bindMemory(to: TaskRegistryIterationCallback.self, capacity: 1).pointee($0)
       }, $0)
     }) {
       throw Error(cString: error)


### PR DESCRIPTION

## Description
This Pull Request builds upon the recently merged `TaskRegistry` infrastructure to expose task tracking capabilities to out-of-process debugging tools. 

Specifically, it introduces the following changes:
1. **SwiftRemoteMirror C API:** Adds `swift_reflection_iterateTaskRegistry`, allowing out-of-process tools to safely traverse the 64-way sharded Task Registry in `O(1)` time without memory allocations.
2. **Crash-Safety (swift-backtrace):** Modifies `CrashInfo` to export `concurrency_task_registry_addr` upon fatal signals. The `swift-backtrace` tool now extracts and prints the exact memory location of the registry when a process crashes, providing a breadcrumb for developers to inspect deadlocks in LLDB.
3. **Swift-Inspect Enhancements:** Updates `swift-inspect dump concurrency` to prefer the `TaskRegistry` over expensive heap scans.
4. **Deterministic Fallbacks:** Exports `_swift_concurrency_task_registry_enabled` globally. Debugging tools can now read this flag to deterministically know if the registry is disabled, allowing them to instantly return `0` tasks rather than falling back to an expensive heap-scan heuristic.

## Testing
- Verified `swift-inspect` correctly dumps tasks.
- Verified that disabling the registry (via environment variables or embedded macros) gracefully falls back to the legacy heap scan.
- Triggered artificial crashes to verify `swift-backtrace` prints the registry pointer.