### PR TITLE
[6.4.0][android] Switch to LTS NDK 30 on the Windows CI

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -71,7 +71,7 @@ Build Android SDKs. Requires Android NDK to be available.
 
 .PARAMETER AndroidNDKVersion
 The version number of the Android NDK to be used.
-Format: r{number}[{letter}] (e.g., r28c)
+Format: r{number}[{letter}][-revision-suffix] (e.g., r28c or r30-beta2)
 Default: "r28c"
 
 .PARAMETER AndroidAPILevel
@@ -166,7 +166,7 @@ param
 
   # Android SDK Options
   [switch] $Android = $false,
-  [ValidatePattern("^r(?:[1-9]|[1-9][0-9])(?:[a-z])?$")]
+  [ValidatePattern("^r(?:[1-9]|[1-9][0-9])(?:[a-z])?(-beta[1-9])?$")]
   [string] $AndroidNDKVersion = "r28c",
   [ValidateRange(21, 36)]
   [int] $AndroidAPILevel = 23,
@@ -448,6 +448,11 @@ $KnownNDKs = @{
     URL = "https://dl.google.com/android/repository/android-ndk-r28c-windows.zip"
     SHA256 = "6bec98ac2354d8a919760889a1a41d020132e5e8cfa1b1fe51610a72c36a466b"
     ClangVersion = 19
+  }
+  "r30-beta2" = @{
+    URL = "https://dl.google.com/android/repository/android-ndk-r30-beta2-windows.zip"
+    SHA256 = "e2c01b70794365a95ad84b5a68b7a52df11b7672097fc3f487cdfd205483d6b5"
+    ClangVersion = 21
   }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -72,7 +72,7 @@ Build Android SDKs. Requires Android NDK to be available.
 .PARAMETER AndroidNDKVersion
 The version number of the Android NDK to be used.
 Format: r{number}[{letter}][-revision-suffix] (e.g., r28c or r30-beta2)
-Default: "r28c"
+Default: "r30"
 
 .PARAMETER AndroidAPILevel
 The API Level to target when building the Android SDKs. Must be between 21 and 36.
@@ -449,9 +449,9 @@ $KnownNDKs = @{
     SHA256 = "6bec98ac2354d8a919760889a1a41d020132e5e8cfa1b1fe51610a72c36a466b"
     ClangVersion = 19
   }
-  "r30-beta2" = @{
-    URL = "https://dl.google.com/android/repository/android-ndk-r30-beta2-windows.zip"
-    SHA256 = "e2c01b70794365a95ad84b5a68b7a52df11b7672097fc3f487cdfd205483d6b5"
+  "r30" = @{
+    URL = "https://dl.google.com/android/repository/android-ndk-r30-windows.zip"
+    SHA256 = "b830098aaf18b67a42eb831c404e15e5f2990a474f054ac145b0bc957ac6d729"
     ClangVersion = 21
   }
 }


### PR DESCRIPTION
- **Explanation**: Switch the upcoming 6.4.0 Windows toolchain to build the Android SDKs with the new LTS NDK 30.
  
- **Scope**: Changes the NDK used on CI to the only currently supported NDK upstream

- **Issues**: swiftlang/swift-docker#580

- **Original PRs**: #87985, #92105

- **Risk**: Low, haven't seen any problem

- **Testing**: Been running the NDK 30 betas and final release from yesterday [through trunk Windows CI manually for weeks](https://github.com/swiftlang/swift/pull/87867#issuecomment-5395718791) and [both 6.4.x](https://github.com/swiftlang/swift/pull/91677) and [6.4.0 too](https://github.com/swiftlang/swift/pull/92006), no problems.

- **Reviewers**: @compnerd @shahmishal