### PR TITLE
[cxx-interop] Remove early exit in SwiftifyDecl

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -534,7 +534,7 @@ EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 
 /// Do not import non-field C++ record members until requested from Swift.
-EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
+LANGUAGE_FEATURE(ImportCxxMembersLazily, 0, "import C++ members lazily")
 
 /// Import a C++ foreign reference type's primary FRT base as a Swift
 /// superclass.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11908,7 +11908,8 @@ FuncDecl *FuncDecl::createImported(ASTContext &Context, SourceLoc FuncLoc,
                                    Type FnRetType,
                                    GenericParamList *GenericParams,
                                    DeclContext *Parent, ClangNode ClangN) {
-  assert(ClangN);
+  ASSERT(ClangN);
+  ASSERT(FnRetType && "Imported result type must not be null");
   auto *const FD = FuncDecl::createImpl(
       Context, SourceLoc(), StaticSpellingKind::None, FuncLoc, Name, NameLoc,
       Async, SourceLoc(), Throws, SourceLoc(), TypeLoc::withoutLoc(ThrownType),

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1066,8 +1066,15 @@ conformToCxxSequenceIfNeeded(ClangImporter::Implementation &impl,
   } else {
     // Check if begin() returns an iterator.
     auto *iterDecl = iterTy->getAsCXXRecordDecl();
-    if (!iterDecl || !iterDecl->hasDefinition())
+    if (!iterDecl)
       return;
+
+    // NOTE: isCompleteType eagerly instantiates the return type of begin(),
+    // which may lead to spurious template instantiation failures, but is needed
+    // for CxxIteratorInfoRequest and the collection protocol conformances.
+    if (!clangSema.isCompleteType(beginConst->getLocation(), iterTy))
+      return;
+
     auto iterInfo = evaluateOrDefault(
         ctx.evaluator, CxxIteratorInfoRequest({iterDecl, clangSema}), {});
     if (!iterInfo.has_value())

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5634,7 +5634,9 @@ static bool checkConditionalParams(
         nonPackArgs.push_back(arg);
       for (auto nonPackArg : nonPackArgs) {
         if (nonPackArg.getKind() != clang::TemplateArgument::Type) {
-          if (impl)
+          if (impl && impl->DiagnosedConditionalAttrParams
+                          .insert({specDecl, argToCheck.first})
+                          .second)
             impl->diagnose(HeaderLoc(recordDecl->getLocation()),
                            diag::type_template_parameter_expected,
                            argToCheck.second);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4103,9 +4103,8 @@ namespace {
         if (!bodyParams)
           return nullptr;
 
-        if (decl->getReturnType()->isScalarType())
-          resultType =
-              Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);
+        resultType =
+            Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);
       } else {
         // Import the function type. If we have parameters, make sure their
         // names get into the resulting function type.
@@ -4132,6 +4131,7 @@ namespace {
         }
       }
 
+      // No parameter list => do not import this function
       if (!bodyParams) {
         Impl.addImportDiagnostic(
             decl, Diagnostic(diag::invoked_func_not_imported, decl),
@@ -4171,11 +4171,26 @@ namespace {
             /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
             /*ThrownType=*/TypeLoc(), bodyParams, getGenericParams(), dc);
       } else {
+        // An empty result type + non-empty parameter type list means that we
+        // should import this function but mark it unavailable + map its result
+        // type to 'Never', so that it isn't diagnosed as a missing member.
+        //
+        // Accessors are excluded because they take their result type from their
+        // storage, not from the Clang return type.
+        bool resultTypeIsNotImportable = !accessorInfo && !resultType.getType();
+        if (resultTypeIsNotImportable)
+          resultType = {Impl.SwiftContext.getNeverType(),
+                        /*implicitlyUnwrapped=*/false};
+
         auto *func = createFuncOrAccessor(
             Impl, loc, accessorInfo, name, nameLoc, getGenericParams(),
             bodyParams, resultType.getType(),
             /*async=*/false, /*throws=*/false, dc, clangNode);
         result = func;
+
+        if (resultTypeIsNotImportable)
+          func->addAttribute(AvailableAttr::createUniversallyUnavailable(
+              Impl.SwiftContext, "return type is unavailable in Swift"));
 
         if (!dc->isModuleScopeContext()) {
           if (selfIsConsuming) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4628,9 +4628,6 @@ namespace {
     /// name (it is marked '@unsafe(always)' by importAttributes instead), and
     /// the renamed spelling is imported a second time as a deprecated migration
     /// stub, which is only '@unsafe'.
-    ///
-    /// This is done post-import so we don't eagerly instantiate templates for
-    /// methods we may not import.
     void renameToUnsafeIfNeeded(
         const clang::CXXMethodDecl *clangDecl, ValueDecl *swiftDecl,
         const clang::FunctionTemplateDecl *funcTemplate = nullptr) {
@@ -4640,21 +4637,6 @@ namespace {
               clang::OverloadedOperatorKind::OO_None)
         // Does not apply to operators, ctors, dtors, conversions
         return;
-
-      using ClassTmplSpec = clang::ClassTemplateSpecializationDecl;
-
-      auto retTy = desugarIfElaborated(clangDecl->getReturnType());
-      auto *retTemplate =
-          dyn_cast_or_null<ClassTmplSpec>(retTy->getAsTagDecl());
-
-      if (retTemplate && !retTemplate->hasDefinition()) {
-        // N.B. InstantiateClassTemplateSpecialization() returns true if it
-        // encountered an error while instantiating the returned template.
-        (void)Impl.getClangSema().InstantiateClassTemplateSpecialization(
-            clangDecl->getLocation(), const_cast<ClassTmplSpec *>(retTemplate),
-            clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
-            /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
-      }
 
       auto importedName = Impl.importFullName(clangDecl, Impl.CurrentVersion);
       if (!importedName || importedName.hasCustomName())

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -974,7 +974,13 @@ static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl,
     return false;
   }
 
+  if (isa<clang::FunctionTemplateDecl>(decl))
+    return true;
+
   if (auto *fn = dyn_cast<clang::FunctionDecl>(decl)) {
+    if (fn->getDescribedFunctionTemplate())
+      return true;
+
     switch (fn->getDeclName().getNameKind()) {
     case clang::DeclarationName::CXXOperatorName:
     case clang::DeclarationName::CXXConversionFunctionName:
@@ -2652,9 +2658,7 @@ namespace {
         if (nd->getDeclName().isIdentifier())
           allMemberNames.insert(nd->getName());
 
-        if (Impl.SwiftContext.LangOpts.hasFeature(
-                Feature::ImportCxxMembersLazily) &&
-            !shouldEagerlyImportClangRecordMember(nd,
+        if (!shouldEagerlyImportClangRecordMember(nd,
                                                   Impl.SwiftContext.LangOpts))
           continue;
 
@@ -4610,10 +4614,6 @@ namespace {
     /// the renamed spelling is imported a second time as a deprecated migration
     /// stub, which is only '@unsafe'.
     ///
-    /// Instantiation is gated on ImportCxxMembersLazily; without that
-    /// feature ClangImporter eagerly instantiates typedef members, so the
-    /// return type is usually already instantiated by the time we get here.
-    ///
     /// This is done post-import so we don't eagerly instantiate templates for
     /// methods we may not import.
     void renameToUnsafeIfNeeded(
@@ -4626,23 +4626,19 @@ namespace {
         // Does not apply to operators, ctors, dtors, conversions
         return;
 
-      if (Impl.SwiftContext.LangOpts.hasFeature(
-              Feature::ImportCxxMembersLazily)) {
-        using ClassTmplSpec = clang::ClassTemplateSpecializationDecl;
+      using ClassTmplSpec = clang::ClassTemplateSpecializationDecl;
 
-        auto retTy = desugarIfElaborated(clangDecl->getReturnType());
-        auto *retTemplate =
-            dyn_cast_or_null<ClassTmplSpec>(retTy->getAsTagDecl());
+      auto retTy = desugarIfElaborated(clangDecl->getReturnType());
+      auto *retTemplate =
+          dyn_cast_or_null<ClassTmplSpec>(retTy->getAsTagDecl());
 
-        if (retTemplate && !retTemplate->hasDefinition()) {
-          // N.B. InstantiateClassTemplateSpecialization() returns true if it
-          // encountered an error while instantiating the returned template.
-          (void)Impl.getClangSema().InstantiateClassTemplateSpecialization(
-              clangDecl->getLocation(),
-              const_cast<ClassTmplSpec *>(retTemplate),
-              clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
-              /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
-        }
+      if (retTemplate && !retTemplate->hasDefinition()) {
+        // N.B. InstantiateClassTemplateSpecialization() returns true if it
+        // encountered an error while instantiating the returned template.
+        (void)Impl.getClangSema().InstantiateClassTemplateSpecialization(
+            clangDecl->getLocation(), const_cast<ClassTmplSpec *>(retTemplate),
+            clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
+            /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
       }
 
       auto importedName = Impl.importFullName(clangDecl, Impl.CurrentVersion);
@@ -11047,10 +11043,20 @@ void ClangRecordMemberLoader::load(const clang::RecordDecl *clangRecord,
         member->getClangDecl()->getFriendObjectKind() != clang::Decl::FOK_None)
       continue;
 
-    // FIXME: constructors are added eagerly, but shouldn't be
-    // FIXME: subscripts are added eagerly, but shouldn't be
-    if (isa<AccessorDecl, SubscriptDecl, ConstructorDecl>(member))
+    // AccessorDecls should not be directly added as members, so skip them here
+    // if they appear for whatever reason
+    if (isa<AccessorDecl>(member))
       continue;
+
+    // FIXME: subscripts and constructors are imported and added eagerly
+    //        (though they shouldn't be and won't be in the near future).
+    // Skip adding these here to avoid double-adding the same member.
+    if (isa<SubscriptDecl, ConstructorDecl>(member)) {
+      const auto &LangOpts = Impl.SwiftContext.LangOpts;
+      if (auto *nd = dyn_cast_or_null<clang::NamedDecl>(member->getClangDecl());
+          nd && shouldEagerlyImportClangRecordMember(nd, LangOpts))
+        continue;
+    }
 
     swiftDecl->addMember(member);
   }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2429,6 +2429,20 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     }
   }
 
+  // Instantiate the return type (via clang::Sema::isCompleteType()) before
+  // importing, using the FunctionDecl's return location to improve diagnostics.
+  //
+  // Exempt operators for now, since these are imported too eagerly and can
+  // lead to spurious template instantiation failures.
+  if (auto *tagDecl = returnType->getAsTagDecl();
+      tagDecl && !tagDecl->isCompleteDefinition() &&
+      !clangDecl->isOverloadedOperator()) {
+    auto loc = clangDecl->getReturnTypeSourceRange().getBegin();
+    loc = loc.isValid() ? loc : clangDecl->getLocation();
+    if (loc.isValid())
+      (void)getClangSema().isCompleteType(loc, returnType);
+  }
+
   // Import the result type.
   return importType(
       returnType,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2472,8 +2472,6 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
   bool allowNSUIntegerAsInt =
       shouldAllowNSUIntegerAsInt(isFromSystemModule, clangDecl);
 
-  // Only eagerly import the return type if it's not too expensive (the current
-  // heuristic for that is if it's not a record type).
   ImportDiagnosticAdder addDiag(*this, clangDecl,
                                 clangDecl->getSourceRange().getBegin());
   clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
@@ -2502,22 +2500,34 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
     if (!genericPointerType)
       addDiag(Diagnostic(diag::bridged_pointer_type_not_found, pointerKind));
     importedType = {genericPointerType, false};
-  } else if (!(isa<clang::RecordType>(returnType) ||
-               isa<clang::TemplateSpecializationType>(returnType)) ||
-             // TODO: we currently don't lazily load operator return types, but
-             // this should be trivial to add.
-             clangDecl->isOverloadedOperator() ||
-             // Dependant types are trivially mapped as Any.
-             returnType->isDependentType()) {
+  } else if (!importedType) {
     // If importedType is already initialized, it means we found the enum that
     // was supposed to be used (instead of the typedef type).
+    importedType = importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt);
     if (!importedType) {
-      importedType =
-          importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt);
-      if (!importedType) {
+      // If we reach here, it means we can't import this function's return type.
+      // Sometimes, instead of skipping this function entirely, we import the
+      // function but we mark it as unavailable and map its return type to
+      // 'Never' so that it doesn't just get diagnosed as a missing member.
+      //
+      // TODO: unify the policy around unimportable/semi-unimportable types and
+      // decls, and replace this confusingly ad hoc logic.
+      //
+      // The condition below preserves historical compiler behavior for
+      // different kinds of decls.
+      bool importAsUnavailable =
+          isa<clang::RecordType, clang::TemplateSpecializationType>(
+              returnType) &&
+          !clangDecl->isOverloadedOperator() && !returnType->isDependentType();
+      if (!importAsUnavailable) {
+        // Emit diagnostic and return without assigning to parameterList, to
+        // signal that the function decl should not be imported.
         addDiag(Diagnostic(diag::return_type_not_imported));
         return {Type(), false};
       }
+      // Fall through with an empty result type. The path below assigns to
+      // parameterList, which causes importFunctionDecl() to import the function
+      // but mark it unavailable and map the return type to 'Never'.
     }
   }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2604,6 +2604,23 @@ ClangImporter::Implementation::importParameterType(
                                   ? ImportTypeKind::CompletionHandlerParameter
                                   : ImportTypeKind::Parameter;
 
+  // Instantiate the parameter type (via clang::Sema::isCompleteType()) before
+  // importing, using the parameter's location to improve diagnostics.
+  //
+  // Exempt operators for now, since these are imported too eagerly and can
+  // lead to spurious template instantiation failures.
+  if (auto *tagDecl = paramTy->getAsTagDecl();
+      tagDecl && !tagDecl->isCompleteDefinition()) {
+    if (auto *parentFn = dyn_cast<clang::FunctionDecl>(parent);
+        !parentFn || !parentFn->isOverloadedOperator()) {
+      auto loc = param->getSourceRange().getBegin();
+      loc = loc.isValid() ? loc : param->getLocation();
+      loc = loc.isValid() ? loc : parent->getLocation();
+      if (loc.isValid())
+        (void)getClangSema().isCompleteType(loc, paramTy);
+    }
+  }
+
   // Import the parameter type into Swift.
   auto attrs = getImportTypeAttrs(param, /*isParam=*/true);
   Type swiftParamTy;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -495,6 +495,12 @@ public:
   llvm::DenseSet<std::pair<const clang::FunctionDecl *, DiagID>>
       DiagnosedTemplateDiagnostics;
 
+  // Tracks already-emitted diagnostics associated with template arguments
+  // (e.g., from a malformed SWIFT_ESCAPABLE_IF) to avoid duplicate diagnostics.
+  llvm::DenseSet<
+      std::pair<const clang::ClassTemplateSpecializationDecl *, unsigned>>
+      DiagnosedConditionalAttrParams;
+
   const bool ImportForwardDeclarations;
   const bool DisableSwiftBridgeAttr;
   const bool BridgingHeaderExplicitlyRequested;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -889,8 +889,9 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     }
 
     if (!attachMacro && CAT == nullptr)
-      // The return type is not imported eagerly (unlike parameter types). Exit
-      // early to avoid unnecessarily importing types we might not need.
+      // FIXME: The return type used to be imported lazily, so this exited early
+      // to avoid over-eagerly importing return types. That behavior has now
+      // changed so this early exit should no longer be necessary.
       return false;
 
     Type swiftReturnTy;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -888,12 +888,6 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       attachMacro = true;
     }
 
-    if (!attachMacro && CAT == nullptr)
-      // FIXME: The return type used to be imported lazily, so this exited early
-      // to avoid over-eagerly importing return types. That behavior has now
-      // changed so this early exit should no longer be necessary.
-      return false;
-
     Type swiftReturnTy;
     if (const auto *funcDecl = dyn_cast<FuncDecl>(MappedDecl))
       swiftReturnTy = funcDecl->getResultInterfaceType();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2125,16 +2125,6 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
         clangFn, decl->getDeclContext());
     if (returnType)
       return *returnType;
-    // Mark the imported Swift function as unavailable.
-    // That will ensure that the function will not be
-    // usable from Swift, even though it is imported.
-    if (!decl->isUnavailable()) {
-      StringRef unavailabilityMsgRef = "return type is unavailable in Swift";
-      auto ua = AvailableAttr::createUniversallyUnavailable(
-          ctx, unavailabilityMsgRef);
-      decl->addAttribute(ua);
-    }
-
     return ctx.getNeverType();
   }
 

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
@@ -62,7 +62,6 @@ struct GoodStruct {
 // CHECK:      struct GoodStruct {
 // CHECK-NEXT:   init()
 //
-// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func badReturn() -> Never
 //
 // NOTE-MISSING: func badArg(_: Never)

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
@@ -62,6 +62,7 @@ struct GoodStruct {
 // CHECK:      struct GoodStruct {
 // CHECK-NEXT:   init()
 //
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func badReturn() -> Never
 //
 // NOTE-MISSING: func badArg(_: Never)
@@ -76,7 +77,9 @@ struct GoodStruct {
 //
 // NOTE-MISSING: static func +(lhs: GoodStruct, rhs: Never) -> Int32
 //
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func __beginUnsafe() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -41,6 +41,14 @@ struct Bro {
                           // expected-swift-error@-1 {{no type named 'enough'}}
 };
 
+// NOTE: like Bro, but only used as a parameter type, so that the instantiation
+// is requested while importing a parameter rather than a return type.
+template <typename K>
+struct Sis {
+  typename K::enough iAm; // cxx-error {{no type named 'enough'}}
+                          // expected-swift-error@-1 {{no type named 'enough'}}
+};
+
 struct Ken {};
 
 struct __attribute__((swift_attr("import_reference")))
@@ -65,6 +73,16 @@ struct GoodStruct {
   // expected-swift-note@+2 {{unavailable (cannot import)}}
   // expected-swift-note@+1 {{unavailable (cannot import)}}
   void badArg(Bro<Ken>) const;
+
+  // Sis<Ken> is only ever named as a parameter type, so its instantiation is
+  // requested while importing a parameter rather than a return type.
+  void badParam(
+    Sis<Ken> // expected-swift-note {{requested here}}
+  ) const;
+
+  // Define this valid overload so that badParam(Sis<Ken>) so that we have
+  // something to legitimately look up.
+  void badParam(int ok) const;
 
   // expected-swift-note@+1 * {{explicitly marked unavailable here}}
   Bro<Ken> getBad() const;
@@ -105,6 +123,9 @@ struct GoodStruct {
 //
 // NOTE-MISSING: func badArg(_: Never)
 //
+// CHECK-NEXT:   func badParam(_ ok: CInt)
+// NOTE-MISSING: func badParam(_: Never)
+//
 // CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func getBad() -> Never
 //
@@ -124,6 +145,7 @@ struct DerivedGoodStruct : GoodStruct {};
 // CHECK:      struct DerivedGoodStruct {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func badParam(_ ok: CInt)
 // CHECK-NEXT:   func getBad() -> Never
 // NOTE-MISSING: func badVirtual(_: Never) -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: CInt)
@@ -140,6 +162,7 @@ struct UsingGoodStruct : GoodStruct {
 // CHECK:      struct UsingGoodStruct {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func badReturn() -> Never
+// CHECK-NEXT:   func badParam(_ ok: CInt)
 // CHECK-NEXT:   func getBad() -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: CInt)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: CInt, _: CInt)
@@ -183,6 +206,10 @@ void err(void) {
   gs.overloadsSameNumArgs(42); // cxx-note {{requested here}}
   // The Bro<Ken> type is instantiated while considering overloads candidates
   // for GoodStruct::overloadsSameNumArgs(_).
+
+  gs.badParam(42); // cxx-note {{requested here}}
+  // Likewise, Sis<Ken> is instantiated while considering overload candidates
+  // for GoodStruct::badParam(_).
 
   // It is only instantiated once and thus no longer triggers diagnostics in
   // its following uses:
@@ -248,6 +275,9 @@ func err() {
                             // expected-swift-warning@-1 {{an enum with no cases}}
                             // expected-swift-note@-2 {{add an explicit type annotation}}
   gs.badArg(inc)            // expected-swift-error {{has no member}}
+
+  // Importing this overload set instantiates Sis<Ken> for the other overloads.
+  gs.badParam(42)
 
   let inc2 = gs.getBad()     // expected-swift-error {{is unavailable}}
                              // expected-swift-warning@-1 {{an enum with no cases}}

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -7,12 +7,10 @@
 //
 // Compare usability of function.h in Swift with swift-frontend
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
 // RUN:   -typo-correction-limit 0 \
 // RUN:   %t%{fs-sep}ok.swift -verify-additional-prefix ok-swift-
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}function.h \
 // RUN:   -typo-correction-limit 0 \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
@@ -24,10 +22,7 @@
 // Check module interface of function.h
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -module-to-print=Function | %FileCheck %s
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module Function {

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -35,6 +35,7 @@ module Function {
 
 // NOTE: Bro<Ken> is an invalid type and will produce an error when instantiated
 
+// expected-swift-note@+2 {{requested here}}
 template <typename K>
 struct Bro {
   typename K::enough iAm; // cxx-error {{no type named 'enough'}}
@@ -60,7 +61,6 @@ struct GoodStruct {
   // expected-swift-note@+2 {{explicitly marked unavailable here}}
   // expected-swift-note@+1 {{explicitly marked unavailable here}}
   Bro<Ken> badReturn() const;
-  // expected-swift-note@-1 {{requested here}}
 
   // expected-swift-note@+2 {{unavailable (cannot import)}}
   // expected-swift-note@+1 {{unavailable (cannot import)}}
@@ -100,10 +100,12 @@ struct GoodStruct {
 // CHECK:      struct GoodStruct {
 // CHECK-NEXT:   init()
 //
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func badReturn() -> Never
 //
 // NOTE-MISSING: func badArg(_: Never)
 //
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func getBad() -> Never
 //
 // NOTE-MISSING: func badStatic(_: Never) -> Never

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -35,7 +35,6 @@ module Function {
 
 // NOTE: Bro<Ken> is an invalid type and will produce an error when instantiated
 
-// expected-swift-note@+2 {{requested here}}
 template <typename K>
 struct Bro {
   typename K::enough iAm; // cxx-error {{no type named 'enough'}}
@@ -61,6 +60,7 @@ struct GoodStruct {
   // expected-swift-note@+2 {{explicitly marked unavailable here}}
   // expected-swift-note@+1 {{explicitly marked unavailable here}}
   Bro<Ken> badReturn() const;
+  // expected-swift-note@-1 {{requested here}}
 
   // expected-swift-note@+2 {{unavailable (cannot import)}}
   // expected-swift-note@+1 {{unavailable (cannot import)}}

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -91,8 +91,10 @@ struct GoodStruct {
   // FIXME: operators are imported eagerly, so having this member would make GoodStruct unusable
   // int operator+(Bro<Ken>) const;
 
-  Bro<Ken> begin() const;
-  Bro<Ken> end() const;
+  // FIXME: begin()/end() are imported eagerly to derive the CxxSequence
+  // conformance, so having these members would make GoodStruct unusable
+  // Bro<Ken> begin() const;
+  // Bro<Ken> end() const;
 
   // Return type templates are instantiated only if the function member is
   // actually imported, e.g., not if the function member is deleted.
@@ -118,9 +120,6 @@ struct GoodStruct {
 //
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: CInt, _: CInt)
 // NOTE-MISSING: func overloadsDiffNumArgs(_: Never)
-//
-// CHECK-NEXT:   func __beginUnsafe() -> Never
-// CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 
 
@@ -132,8 +131,6 @@ struct DerivedGoodStruct : GoodStruct {};
 // NOTE-MISSING: func badVirtual(_: Never) -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: CInt)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: CInt, _: CInt)
-// CHECK-NEXT:   func __beginUnsafe() -> Never
-// CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 
 struct UsingGoodStruct : GoodStruct {
@@ -149,8 +146,6 @@ struct UsingGoodStruct : GoodStruct {
 // CHECK-NEXT:   func getBad() -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: CInt)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: CInt, _: CInt)
-// CHECK-NEXT:   func __beginUnsafe() -> Never
-// CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 
 

--- a/test/Interop/Cxx/class/invalid-members/rdar156949141.swift
+++ b/test/Interop/Cxx/class/invalid-members/rdar156949141.swift
@@ -2,11 +2,8 @@
 // RUN: split-file %s %t
 //
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}header.h \
 // RUN:   %t%{fs-sep}test.swift
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module TheHeader {

--- a/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+++ b/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
@@ -69,9 +69,13 @@ struct GoodStruct {
 };
 // CHECK:      struct GoodStruct {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnOptional() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnMapKey() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnMapValue() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnVector() -> Never
 // CHECK-NEXT: }
 
@@ -109,9 +113,13 @@ using UsableTemplate = Template<Incomplete>;
 
 // CHECK:      struct Template<Incomplete> {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnOptional() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnMapKey() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnMapValue() -> Never
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnVector() -> Never
 // CHECK-NEXT: }
 

--- a/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+++ b/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
@@ -13,22 +13,17 @@
 //
 // Compare usability of std-contain-incomplete.h in Swift with swift-frontend
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}std-contain-incomplete.h \
 // RUN:   %t%{fs-sep}ok.swift
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
 // RUN:   -verify-ignore-unrelated \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}std-contain-incomplete.h \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
 //
 // Check module interface of std-contain-incomplete.h
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -module-to-print=StdContain | %FileCheck %s
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module StdContain {

--- a/test/Interop/Cxx/class/invalid-members/type-alias-members-of-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/type-alias-members-of-invalid-types.swift
@@ -7,21 +7,16 @@
 //
 // Compare usability of type.h in Swift with swift-frontend
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h \
 // RUN:   %t%{fs-sep}ok.swift
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}type.h \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix swift-
 //
 // Check module interface of type.h
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -module-to-print=Type | %FileCheck %s
-
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module Type {

--- a/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
+++ b/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
@@ -5,15 +5,11 @@ struct B {
   // expected-to-note @+1 {{while importing 'renamedFrom0'}}
   void renamedFrom0(A &a) const
     __attribute__((swift_name("A.renamedFrom0(self:)")));
-  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
-  // expected-from-note @-3 {{while importing 'renamedFrom0'}}
 
   // expected-to-warning@+2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
   // expected-to-note @+1 {{while importing 'renamedFrom1'}}
   void renamedFrom1(A &a, int i) const
     __attribute__((swift_name("A.renamedFrom1(self:j:)")));
-  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
-  // expected-from-note @-3 {{while importing 'renamedFrom1'}}
 
   void other() const;
 };

--- a/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
+++ b/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
@@ -1,7 +1,19 @@
 struct A {};
 
 struct B {
-  void b(A &a, int e) const // expected-warning {{swift_name cannot be used to import a non-static C++ method as a member of a different type}} expected-note {{while importing 'b'}}
-    __attribute__((swift_name("A.c(self:d:)")));
+  // expected-to-warning@+2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-to-note @+1 {{while importing 'renamedFrom0'}}
+  void renamedFrom0(A &a) const
+    __attribute__((swift_name("A.renamedFrom0(self:)")));
+  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-from-note @-3 {{while importing 'renamedFrom0'}}
+
+  // expected-to-warning@+2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-to-note @+1 {{while importing 'renamedFrom1'}}
+  void renamedFrom1(A &a, int i) const
+    __attribute__((swift_name("A.renamedFrom1(self:j:)")));
+  // expected-from-warning@-2 {{swift_name cannot be used to import a non-static C++ method as a member of a different type}}
+  // expected-from-note @-3 {{while importing 'renamedFrom1'}}
+
   void other() const;
 };

--- a/test/Interop/Cxx/class/method/swift-name-different-type.swift
+++ b/test/Interop/Cxx/class/method/swift-name-different-type.swift
@@ -1,7 +1,26 @@
-// RUN: %target-typecheck-verify-swift -I %S%{fs-sep}Inputs -cxx-interoperability-mode=default -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}swift-name-different-type.h
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default \
+// RUN:   -DUSE_RENAMED_FROM -verify-additional-prefix from- \
+// RUN:   -I %S%{fs-sep}Inputs \
+// RUN:   -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}swift-name-different-type.h
+
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default \
+// RUN:   -DUSE_RENAMED_TO -verify-additional-prefix to- \
+// RUN:   -I %S%{fs-sep}Inputs \
+// RUN:   -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}swift-name-different-type.h
 
 import SwiftNameDifferentType
 
-func testB(_ b: B) {
+func test(_ a: A, _ b: B) {
+
+#if USE_RENAMED_FROM
+  a.renamedFrom0()   // expected-from-error {{has no member}}
+  a.renamedFrom1(42) // expected-from-error {{has no member}}
+#endif
+
+#if USE_RENAMED_TO
+  b.renamedTo0()    // expected-to-error {{has no member}}
+  b.renamedTo1(42)  // expected-to-error {{has no member}}
+#endif
+
   b.other()
 }

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -357,6 +357,7 @@ DoubleEscapableNonEscapable n6();
 
 EscapableIfEscapable<NonEscapable> n7();
 
+// expected-warning@+3 {{the returned type 'NonEscapableIfEscapable<Owner>' is annotated as non-escapable; its lifetime dependencies must be annotated}}
 // expected-LIFETIMES-error@+2 {{a function with a ~Escapable result needs a parameter to depend on}}
 // expected-LIFETIMES-note@+1 {{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
 NonEscapableIfEscapable<Owner> n8();

--- a/test/Interop/Cxx/class/returns-unavailable-class.swift
+++ b/test/Interop/Cxx/class/returns-unavailable-class.swift
@@ -42,6 +42,7 @@ public:
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   var x: CInt
 // CHECK-NEXT:   var y: CInt
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func returnsClassInTypesModules() -> Never
 // CHECK-NEXT: }
 

--- a/test/Interop/Cxx/stdlib/derived-conformance-uninstantiated-member-type.swift
+++ b/test/Interop/Cxx/stdlib/derived-conformance-uninstantiated-member-type.swift
@@ -4,10 +4,7 @@
 // RUN:   -module-to-print=DerivedConformanceUninstantiatedMemberType \
 // RUN:   -source-filename=x \
 // RUN:   -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %S/Inputs | %FileCheck %s
-
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 // CHECK: struct vector<CInt> : CxxVector {
 // CHECK:   typealias const_iterator = __gnu_cxx.__normal_iterator<UnsafePointer<CInt>, std.vector<CInt>>

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t -enable-experimental-feature ImportCxxMembersLazily > %t/interface.swift
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t > %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-STD < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-SIZE-T < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-TO-STRING < %t/interface.swift
@@ -9,10 +9,9 @@
 
 // This test is specific to libstdc++ and only runs on platforms where libstdc++ is used.
 // REQUIRES: OS=linux-gnu
-//
+
 // The RHS of basic_string's typealias value_type depends on how eagerly/lazily
 // we import type members
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection, CxxIterable {

--- a/test/Interop/Cxx/templates/invalid-return-type.swift
+++ b/test/Interop/Cxx/templates/invalid-return-type.swift
@@ -1,21 +1,16 @@
 // RUN: split-file %s %t
 // RUN: %target-clang -c -o /dev/null -Xclang -verify -I %t/Inputs %t/cxx.cpp
 // RUN: %target-swift-frontend -typecheck -verify \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
 // RUN:   %t%{fs-sep}ok.swift
 // RUN: %target-swift-frontend -typecheck -verify \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs \
 // RUN:   -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
 // RUN:   %t%{fs-sep}err.swift -verify-additional-prefix err-
 // RUN: %target-swift-ide-test -print-module -source-filename=x \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -cxx-interoperability-mode=default -I %t/Inputs \
 // RUN:   -module-to-print=CxxModule | %FileCheck %t/Inputs/CxxHeader.h
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/templates/invalid-return-type.swift
+++ b/test/Interop/Cxx/templates/invalid-return-type.swift
@@ -36,6 +36,7 @@ struct S {
 
 // CHECK:      struct S {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func Err() -> Never
 // CHECK-NEXT:   func Ok()
 // CHECK:      }

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
@@ -1,11 +1,5 @@
 // RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
 // RUN: | %FileCheck %s
-//
-// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
-// RUN: | %FileCheck %s
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 import TemplateTypeParameterNotInSignature
 

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
@@ -1,8 +1,4 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 import TemplateTypeParameterNotInSignature
 

--- a/test/Interop/Cxx/templates/using-return-type.swift
+++ b/test/Interop/Cxx/templates/using-return-type.swift
@@ -7,12 +7,9 @@
 
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}main.swift \
-// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
 // RUN:   -I %t%{fs-sep}Inputs -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}CxxHeader.h \
 // RUN:   -suppress-notes \
 // RUN:   -cxx-interoperability-mode=default
-//
-// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 //--- Inputs/module.modulemap
 module CxxModule {


### PR DESCRIPTION
This previously existed to avoid eagerly importing return types, but now that we import return types eagerly anyway, the early exit is no longer necessary.

Stacked atop https://github.com/swiftlang/swift/pull/91715