### PR TITLE
Reject inout conversions to parameter-pack functions

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4451,7 +4451,8 @@ private:
     if (param.getConvention() == ParameterConvention::Pack_Inout) {
       SGF.SGM.diagnose(ApplyLoc, diag::not_implemented,
                        "inout pack argument emission");
-      Args.push_back(ManagedValue::forLValue(pack));
+      Args.push_back(
+          ManagedValue::forLValue(SILUndef::get(SGF.F, pack->getType())));
       return;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -179,6 +179,18 @@ bool constraints::containsPackExpansionType(TupleType *tuple) {
   });
 }
 
+static bool isInOutTypeOrPackElement(Type type) {
+  if (auto *expansion = type->getAs<PackExpansionType>())
+    return isInOutTypeOrPackElement(expansion->getPatternType());
+
+  if (auto *pack = type->getAs<PackType>()) {
+    return llvm::any_of(pack->getElementTypes(),
+                        isInOutTypeOrPackElement);
+  }
+
+  return type->is<InOutType>();
+}
+
 bool constraints::doesMemberRefApplyCurriedSelf(Type baseTy,
                                                 const ValueDecl *decl) {
   assert(decl->getDeclContext()->isTypeContext() &&
@@ -3605,6 +3617,12 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       return SolutionKind::Error;
 
     for (auto pair : matcher.pairs) {
+      // Inout-to-value conversions are not supported for parameter-pack
+      // function types. They produce invalid reabstraction SIL.
+      if (isInOutTypeOrPackElement(pair.lhs) !=
+          isInOutTypeOrPackElement(pair.rhs))
+        return SolutionKind::Error;
+
       // Compare the parameter types, taking contravariance into account.
       auto result = matchTypes(pair.rhs, pair.lhs, subKind, subflags,
                                (func1Params.size() == 1

--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -92,6 +92,15 @@ do {
     }
   }
 
+  // Parameter-pack function types cannot reabstract inout parameters.
+  do {
+    func acceptsPackFunction<each T>(_: (repeat each T) -> Void) {}
+    func takesInout(_: inout Int) {}
+
+    acceptsPackFunction(takesInout)
+    // expected-error@-1 {{cannot convert value of type '(inout Int) -> ()' to expected argument type}}
+  }
+
   func coerce(_: Int) {}
 
   func test(first: Value<Int?>, second: Value<(a: Int, b: Int)>) {


### PR DESCRIPTION
Fixes #90195.

The constraint solver previously accepted an inout function when converting to a parameter-pack function type. SILGen then produced a reabstraction thunk that IRGen could not lower and crashed.

Reject inout mismatches in parameter-pack function matching, and use an undef address in the existing unsupported Pack_Inout SILGen recovery path. Add a focused constraint regression test.

Validation: git diff --check passed. The issue reproduces with the installed Swift 6.3.3 compiler; source-built test execution is blocked because this checkout has no build artifacts and the machine only has CommandLineTools, so utils/build-script cannot run without Xcode.