### PR TITLE
[Sema] Fix assertion crash on unreachable-in-ABI attributes with @abi

### DIFF
--- a/lib/Sema/TypeCheckAttrABI.cpp
+++ b/lib/Sema/TypeCheckAttrABI.cpp
@@ -851,19 +851,11 @@ public:
     auto behaviors = DeclAttribute::getBehaviors(kind);
 
     switch (behaviors & DeclAttribute::InABIAttrMask) {
-    case DeclAttribute::UnreachableInABIAttr:
-      ASSERT(abiAttr->canAppearOnDecl(apiDecl)
-                && "checking @abi on decl that can't have it???");
-      ASSERT(!abiAttr->canAppearOnDecl(apiDecl)
-                 && "unreachable-in-@abi attr on reachable decl???");
-
-      // If the asserts are disabled, fall through to no checking.
-      LLVM_FALLTHROUGH;
-
     case DeclAttribute::UnconstrainedInABIAttr:
       // No checking required.
       return false;
 
+    case DeclAttribute::UnreachableInABIAttr:
     case DeclAttribute::ForbiddenInABIAttr:
       // Diagnose if ABI has attribute.
       if (abi) {

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -2373,6 +2373,13 @@ func func_with_nested_abi() {
 @abi(var x = 1) // expected-error {{initial value is not allowed here}} expected-error {{type annotation missing in pattern}}
 var x = 1
 
+@freestanding(expression) // expected-error {{'@freestanding' attribute cannot be applied to this declaration}}
+@abi(func unreachableInABIAttrOnDecl_abi())
+public func unreachableInABIAttrOnDecl() {}
+
+@abi(@freestanding(expression) func unreachableInABIAttrInABI_abi()) // expected-error {{unused 'freestanding' attribute in '@abi'}}
+public func unreachableInABIAttrInABI() {}
+
 //
 // Examples of expected use cases
 //


### PR DESCRIPTION
Resolves #92001

In ABIDeclChecker::checkAttr, attributes marked UnreachableInABIAttr hit contradictory assertions when user code placed them on a declaration that also has @abi, causing swift-frontend to crash.

This PR treats UnreachableInABIAttr symmetrically with ForbiddenInABIAttr: if specified inside @abi(...), the compiler reports that the attribute is unused in @abi. If placed on the declaration itself, normal attribute typechecking reports the misplaced attribute gracefully without crashing. Added regression tests in test/attr/attr_abi.swift.
