### PR TITLE
[SILOptimizer] Diagnose isolated conformance on sending existential result

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -2054,38 +2054,51 @@ public:
     if (!doesParentFunctionHaveSendingResult(op))
       return;
 
-    auto instance = getRepresentativeValue(op.getOpArg1());
-    if (!instance)
+    auto checkAssign = [&](Element destElt, Element srcElt) -> bool {
+      auto instance = getRepresentativeValue(destElt);
+      if (!instance)
+        return false;
+
+      auto *fArg =
+          dyn_cast_or_null<SILFunctionArgument>(instance.maybeGetValue());
+      if (!fArg || !fArg->getArgumentConvention().isIndirectOutParameter())
+        return false;
+
+      auto staticRegionIsolation = getIsolationRegionInfo(srcElt);
+      Region srcRegion = p.getRegion(srcElt);
+      auto dynamicRegionIsolation = getIsolationRegionInfo(srcRegion);
+
+      if (dynamicRegionIsolation.isDisconnected() ||
+          staticRegionIsolation.isUnsafeNonIsolated()) {
+        REGIONBASEDISOLATION_VERBOSE_LOG(
+            llvm::dbgs()
+            << "    * Note: Eliding assign-into-sending-result error. "
+               "Reason: "
+            << (dynamicRegionIsolation.isDisconnected()
+                    ? "assigned region is disconnected"
+                    : "assigned value is nonisolated(unsafe)")
+            << "\n");
+        return false;
+      }
+
+      SILValue rep = getRepresentativeValue(srcElt).maybeGetValue();
+      if (!rep && op.getSourceOp())
+        rep = op.getSourceOp()->get();
+      if (!rep)
+        rep = fArg;
+
+      handleError(AssignNeverSendableIntoSendingResultError(
+          op, destElt, fArg, srcElt, rep, dynamicRegionIsolation,
+          getSnapshotForIsolationHistory()));
+      return true;
+    };
+
+    if (checkAssign(op.getOpArg1(), op.getOpArg2()))
       return;
 
-    auto *fArg =
-        dyn_cast_or_null<SILFunctionArgument>(instance.maybeGetValue());
-    if (!fArg || !fArg->getArgumentConvention().isIndirectOutParameter())
-      return;
-
-    auto staticRegionIsolation = getIsolationRegionInfo(op.getOpArg2());
-    Region srcRegion = p.getRegion(op.getOpArg2());
-    auto dynamicRegionIsolation = getIsolationRegionInfo(srcRegion);
-
-    // We can unconditionally getValue here since we can never
-    // assign an actor introducing inst.
-    auto rep = getRepresentativeValue(op.getOpArg2()).getValue();
-    if (dynamicRegionIsolation.isDisconnected() ||
-        staticRegionIsolation.isUnsafeNonIsolated()) {
-      REGIONBASEDISOLATION_VERBOSE_LOG(
-          llvm::dbgs()
-          << "    * Note: Eliding assign-into-sending-result error. "
-             "Reason: "
-          << (dynamicRegionIsolation.isDisconnected()
-                  ? "assigned region is disconnected"
-                  : "assigned value is nonisolated(unsafe)")
-          << "\n");
-      return;
+    if (op.getKind() == PartitionOpKind::Merge) {
+      checkAssign(op.getOpArg2(), op.getOpArg1());
     }
-
-    handleError(AssignNeverSendableIntoSendingResultError(
-        op, op.getOpArg1(), fArg, op.getOpArg2(), rep, dynamicRegionIsolation,
-        getSnapshotForIsolationHistory()));
   }
 
   /// Apply \p op to the partition op.

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -4747,8 +4747,29 @@ public:
   ~AssignNeverSendableIntoSendingResultDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
     // pattern error.
-    if (!emittedErrorDiagnostic)
+    if (!emittedErrorDiagnostic) {
       emitUnknownPatternError();
+    } else if (auto proto = isolatedValueIsolationRegionInfo.getIsolationInfo()
+                                .getIsolatedConformance()) {
+      if (auto value = isolatedValueIsolationRegionInfo.getIsolationInfo()
+                           .maybeGetIsolatedValue()) {
+        if (auto loc = value.getLoc()) {
+          diagnoseNote(
+              loc, diag::regionbasedisolation_isolated_conformance_introduced,
+              proto);
+        } else if (srcOperand) {
+          diagnoseNote(
+              srcOperand->getUser()->getLoc(),
+              diag::regionbasedisolation_isolated_conformance_introduced,
+              proto);
+        }
+      } else if (srcOperand) {
+        diagnoseNote(
+            srcOperand->getUser()->getLoc(),
+            diag::regionbasedisolation_isolated_conformance_introduced,
+            proto);
+      }
+    }
   }
 
   SILFunction *getFunction() const { return srcOperand->getFunction(); }

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -149,6 +149,29 @@ func acceptSendingAnyObjectR(_ s: sending AnyObject & R) { }
   acceptSendingAnyObjectR(w)
 }
 
+@MainActor func returnSendingExistential() -> sending any P {
+  S() // expected-warning{{returning a main actor-isolated 'any P' value as a 'sending' result risks causing data races}}
+  // expected-note@-1{{isolated conformance to protocol 'P' can be introduced here}}
+  // expected-note@-2{{returning a main actor-isolated 'any P' value risks causing races}}
+  // expected-note@-3{{type 'any P' does not conform to the 'Sendable' protocol}}
+}
+
+@MainActor func returnSendingClassExistential() -> sending any P {
+  SC() // expected-warning{{returning a main actor-isolated 'any P' value as a 'sending' result risks causing data races}}
+  // expected-note@-1{{isolated conformance to protocol 'P' can be introduced here}}
+  // expected-note@-2{{returning a main actor-isolated 'any P' value risks causing races}}
+  // expected-note@-3{{type 'any P' does not conform to the 'Sendable' protocol}}
+}
+
+@MainActor func returnSendingAnyObjectP() -> sending AnyObject & P {
+  SC() // expected-warning{{task or actor-isolated value cannot be sent}}
+  // expected-note@-1{{isolated conformance to protocol 'P' can be introduced here}}
+}
+
+@MainActor func returnSendingR() -> sending any R {
+  S()
+}
+
 func dynamicCastingExistential(
   _ s1: sending Any,
   _ s2: sending Any

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -311,6 +311,20 @@ func indirectSendingOptionalClassField<T>(_ t: GenericNonSendableKlass<T>) -> se
   // expected-note @-2 {{'Optional<T>' is a non-Sendable type}}
 }
 
+protocol IsolatedP {
+  func f()
+}
+final class IsolatedS: @MainActor IsolatedP {
+  @MainActor func f() {}
+}
+
+@MainActor func returnSendingExistentialIsolatedConformance() -> sending any IsolatedP {
+  IsolatedS() // expected-warning {{returning a main actor-isolated 'any IsolatedP' value as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{isolated conformance to protocol 'IsolatedP' can be introduced here}}
+  // expected-note @-2 {{returning a main actor-isolated 'any IsolatedP' value risks causing races since the caller assumes the value can be safely sent to other isolation domains}}
+  // expected-note @-3 {{type 'any IsolatedP' does not conform to the 'Sendable' protocol}}
+}
+
 func useBlock<T>(block: () throws -> T) throws -> sending T {
   fatalError()
 }


### PR DESCRIPTION
Resolves #91971

When returning a sending existential result whose conversion introduces an isolated conformance, partition analysis lowers the result as an indirect out parameter. However, PartitionOpKind::Merge only checked its first argument when inspecting assignments into sending results, missing cases where the sending result was the second operand. Furthermore, calling getValue() unconditionally caused an assertion crash when representative values were actor-introducing instructions.

This patch updates handleAssignNonDisconnectedIntoSendingResult to inspect both operands for Merge operations, safely accesses representative values, and emits the isolated conformance diagnostic note when applicable.

### Testing
- Added regression tests in `test/Concurrency/sendable_metatype.swift` and `test/Concurrency/transfernonsendable_sending_results.swift`.
