### PR TITLE
COM: manage COM identity and analyze use

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5906,6 +5906,12 @@ public:
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 
+  /// Whether this is a compiler-managed COM identity protocol.
+  bool isCOMIdentity() const {
+    return isSpecificProtocol(KnownProtocolKind::COMInterface) ||
+           isSpecificProtocol(KnownProtocolKind::COMActivatable);
+  }
+
   /// Whether this protocol declares a COM interface.
   bool isCOMInterface() const {
     return getCOMDeclInfo() != nullptr;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2319,9 +2319,12 @@ ERROR(com_interface_refinement_requires_identity, none,
 ERROR(com_interface_repeated_iid, none,
       "COM interface %0 and inherited interface %1 use the same interface "
       "identifier '%2'", (DeclName, DeclName, StringRef))
-ERROR(com_cominterface_existential, none,
-      "'any COMInterface' is invalid because 'COMInterface' does not identify a COM interface",
-      ())
+ERROR(com_identity_existential, none,
+      "'any %0' is invalid because '%0' describes a COM metatype identity",
+      (StringRef))
+ERROR(com_identity_explicit_conformance, none,
+      "%0 conformance is compiler-managed and cannot be declared explicitly",
+      (DeclName))
 ERROR(com_identity_invalid_requirement, none,
       "expected '%0' to declare 'var %1: %2 { get }'",
       (StringRef, StringRef, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2322,6 +2322,12 @@ ERROR(com_interface_repeated_iid, none,
 ERROR(com_cominterface_existential, none,
       "'any COMInterface' is invalid because 'COMInterface' does not identify a COM interface",
       ())
+ERROR(com_identity_invalid_requirement, none,
+      "expected '%0' to declare 'var %1: %2 { get }'",
+      (StringRef, StringRef, StringRef))
+ERROR(com_identity_unsupported_requirement, none,
+      "requirement %0 of %1 is not supported by this compiler",
+      (DeclName, DeclName))
 ERROR(com_existential_multiple_interfaces, none,
       "COM existential cannot contain interfaces %0 and %1 because neither refines the other",
       (DeclName, DeclName))

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -42,9 +42,16 @@ struct COMExistentialInterfaceResolution {
   /// The first non-marker Swift protocol, retained for diagnostics.
   ProtocolDecl *firstNonMarkerProtocol = nullptr;
 
-  /// Whether the composition contains the compiler-managed \c COMInterface
-  /// protocol itself.
-  bool containsCOMInterfaceProtocol = false;
+  /// A compiler-managed COM identity protocol contained by the composition.
+  ProtocolDecl *identityProtocol = nullptr;
+
+  /// A resolution is invalid if there are incomparable interfaces, non-marker
+  /// Swift protocol conformances, or if there is an explicitly stated identity
+  /// protocol conformance.
+  bool isInvalid() const {
+    return firstIncomparableInterface || firstNonMarkerProtocol ||
+           identityProtocol;
+  }
 };
 
 struct ExistentialLayout {

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -162,6 +162,8 @@ CXX_PROTOCOL(UnsafeCxxMutableContiguousIterator)
 COM_PROTOCOL(IUnknown)
 COM_PROTOCOL(ISwiftObject)
 COM_PROTOCOL(COMInterface)
+COM_PROTOCOL(COMActivatable)
+COM_PROTOCOL(COMAggregatable)
 
 PROTOCOL(AsyncSequence)
 PROTOCOL(AsyncIteratorProtocol)

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -20,8 +20,8 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ProtocolConformanceOptions.h"
 #include "swift/AST/Type.h"
-#include "swift/AST/Types.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/AST/Types.h"
 #include "swift/AST/Witness.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Debug.h"
@@ -29,6 +29,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
+#include <optional>
 #include <utility>
 
 namespace swift {
@@ -103,6 +104,17 @@ enum class BuiltinConformanceKind {
 
   Last_Kind = Missing
 };
+
+/// Requirements of COM identity protocols that have compiler-provided
+/// witnesses.
+enum class COMIdentityRequirementKind {
+  InterfaceID,
+  ActivationID,
+};
+
+/// Classify a compiler-managed COM identity requirement.
+std::optional<COMIdentityRequirementKind>
+classifyCOMIdentityRequirement(ValueDecl *requirement);
 
 enum : unsigned {
   NumProtocolConformanceStateBits =

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1697,6 +1697,8 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   case KnownProtocolKind::IUnknown:
   case KnownProtocolKind::ISwiftObject:
   case KnownProtocolKind::COMInterface:
+  case KnownProtocolKind::COMActivatable:
+  case KnownProtocolKind::COMAggregatable:
     M = getLoadedModule(Id_COM);
     if (!M)
       M = MainModule;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1801,6 +1801,28 @@ BuiltinProtocolConformance::BuiltinProtocolConformance(
   Bits.BuiltinProtocolConformance.Kind = unsigned(kind);
 }
 
+std::optional<COMIdentityRequirementKind>
+swift::classifyCOMIdentityRequirement(ValueDecl *requirement) {
+  AbstractStorageDecl *storage = dyn_cast<AbstractStorageDecl>(requirement);
+  if (auto *accessor = dyn_cast<AccessorDecl>(requirement))
+    storage = accessor->getStorage();
+
+  auto *property = dyn_cast_or_null<VarDecl>(storage);
+  auto *protocol =
+      property ? dyn_cast<ProtocolDecl>(property->getDeclContext()) : nullptr;
+  if (!protocol)
+    return std::nullopt;
+
+  auto &context = property->getASTContext();
+  if (protocol->isSpecificProtocol(KnownProtocolKind::COMInterface) &&
+      property->getBaseName() == context.Id_IID)
+    return COMIdentityRequirementKind::InterfaceID;
+  if (protocol->isSpecificProtocol(KnownProtocolKind::COMActivatable) &&
+      property->getBaseName() == context.Id_CLSID)
+    return COMIdentityRequirementKind::ActivationID;
+  return std::nullopt;
+}
+
 // See swift/Basic/Statistic.h for declaration: this enables tracing
 // ProtocolConformances, is defined here to avoid too much layering violation /
 // circular linkage dependency.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -526,8 +526,8 @@ ExistentialLayout::resolveCOMInterface() const {
   COMExistentialInterfaceResolution resolution;
 
   for (ProtocolDecl *protocol : getProtocols()) {
-    if (protocol->isSpecificProtocol(KnownProtocolKind::COMInterface)) {
-      resolution.containsCOMInterfaceProtocol = true;
+    if (protocol->isCOMIdentity()) {
+      resolution.identityProtocol = protocol;
       continue;
     }
 
@@ -561,10 +561,7 @@ ExistentialLayout::resolveCOMInterface() const {
 
 ProtocolDecl *ExistentialLayout::getCOMInterface() const {
   COMExistentialInterfaceResolution result = resolveCOMInterface();
-  if (hasExplicitAnyObject || explicitSuperclass ||
-      result.containsCOMInterfaceProtocol ||
-      result.firstIncomparableInterface ||
-      result.firstNonMarkerProtocol)
+  if (hasExplicitAnyObject || explicitSuperclass || result.isInvalid())
     return nullptr;
   return result.interface;
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7716,6 +7716,8 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::IUnknown:
   case KnownProtocolKind::ISwiftObject:
   case KnownProtocolKind::COMInterface:
+  case KnownProtocolKind::COMActivatable:
+  case KnownProtocolKind::COMAggregatable:
     return SpecialProtocol::None;
   }
 

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -553,38 +553,42 @@ void com::validateImplementation(ClassDecl *CD) {
 
 void com::validateConformance(ProtocolConformance *conformance) {
   auto *normal = dyn_cast<NormalProtocolConformance>(conformance);
-  if (!normal ||
-      normal->getSourceKind() != ConformanceEntryKind::Explicit)
+  if (!normal || normal->getSourceKind() != ConformanceEntryKind::Explicit)
     return;
 
+  auto &diagnostics = normal->getDeclContext()->getASTContext().Diags;
+
   auto *protocol = normal->getProtocol();
+  if (protocol->isCOMIdentity()) {
+    diagnostics.diagnose(normal->getLoc(),
+                         diag::com_identity_explicit_conformance,
+                         protocol->getName());
+    normal->setInvalid();
+    return;
+  }
+
   if (!protocol->isCOMInterface())
     return;
 
   Type type = normal->getType();
   auto *nominal = type->getAnyNominal();
   auto *CD = dyn_cast_or_null<ClassDecl>(nominal);
-  auto &context = normal->getDeclContext()->getASTContext();
   if (!CD) {
-    context.Diags.diagnose(normal->getLoc(),
-                           diag::com_conformance_requires_class, type,
-                           protocol->getDeclaredInterfaceType());
+    diagnostics.diagnose(normal->getLoc(), diag::com_conformance_requires_class,
+                         type, protocol->getDeclaredInterfaceType());
     return;
   }
 
   auto *typeModule = CD->getParentModule();
   auto *conformanceModule = normal->getDeclContext()->getParentModule();
-  if (!typeModule->isSameModuleLookingThroughOverlays(conformanceModule)) {
-    context.Diags.diagnose(normal->getLoc(),
-                           diag::com_conformance_must_be_in_type_module, type,
-                           protocol->getDeclaredInterfaceType());
-  }
+  if (!typeModule->isSameModuleLookingThroughOverlays(conformanceModule))
+    diagnostics.diagnose(normal->getLoc(),
+                         diag::com_conformance_must_be_in_type_module, type,
+                         protocol->getDeclaredInterfaceType());
 
-  if (!normal->getConditionalRequirements().empty()) {
-    context.Diags.diagnose(normal->getLoc(),
-                           diag::com_conditional_conformance, type,
-                           protocol->getDeclaredInterfaceType());
-  }
+  if (!normal->getConditionalRequirements().empty())
+    diagnostics.diagnose(normal->getLoc(), diag::com_conditional_conformance,
+                         type, protocol->getDeclaredInterfaceType());
 }
 
 namespace {

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -587,6 +587,78 @@ void com::validateConformance(ProtocolConformance *conformance) {
   }
 }
 
+namespace {
+/// Validate a protocol whose sole requirement is the given identity property.
+void validateIdentityRequirement(ProtocolDecl *PD,
+                                 COMIdentityRequirementKind expected,
+                                 Identifier ident) {
+  VarDecl *identity = nullptr;
+  for (auto *requirement : PD->getProtocolRequirements()) {
+    auto kind = classifyCOMIdentityRequirement(requirement);
+    if (!kind || *kind != expected) {
+      requirement->diagnose(diag::com_identity_unsupported_requirement,
+                            requirement->getName(), PD->getName());
+      PD->setInvalid();
+      continue;
+    }
+
+    identity = dyn_cast<VarDecl>(requirement);
+  }
+
+  auto &context = PD->getASTContext();
+  auto *decl =
+      ::com::lookup(context, PD->getDeclContext(), ident, PD->getLoc());
+
+  if (!decl) {
+    PD->setInvalid();
+    return;
+  }
+
+  auto *getter = identity ? identity->getAccessor(AccessorKind::Get) : nullptr;
+  bool hasValidIdentity = identity && !identity->isStatic() &&
+                          !identity->isSettable(nullptr) && getter &&
+                          !getter->hasAsync() && !getter->hasThrows() &&
+                          identity->getValueInterfaceType()->isEqual(
+                              decl->getDeclaredInterfaceType());
+  if (!hasValidIdentity) {
+    PD->diagnose(diag::com_identity_invalid_requirement, PD->getName().str(),
+                 ident.str(), ident.str());
+    PD->setInvalid();
+  }
+}
+}
+
+void com::validateIdentityProtocol(ProtocolDecl *PD) {
+  if (!PD->isCOMIdentity())
+    return;
+
+  auto &context = PD->getASTContext();
+  if (PD->isSpecificProtocol(KnownProtocolKind::COMInterface)) {
+    validateIdentityRequirement(PD, COMIdentityRequirementKind::InterfaceID,
+                                context.Id_IID);
+    return;
+  }
+
+  ASSERT(PD->isSpecificProtocol(KnownProtocolKind::COMActivatable));
+  ASSERT(context.LangOpts.COMModel &&
+         "COM activation requires an interop model");
+  switch (*context.LangOpts.COMModel) {
+  case LangOptions::COMInteropModel::Microsoft:
+    validateIdentityRequirement(PD, COMIdentityRequirementKind::ActivationID,
+                                context.Id_CLSID);
+    return;
+  case LangOptions::COMInteropModel::CoreFoundation:
+    // The current CoreFoundation activation contract has no requirements.
+    for (auto *requirement : PD->getProtocolRequirements()) {
+      requirement->diagnose(diag::com_identity_unsupported_requirement,
+                            requirement->getName(), PD->getName());
+      PD->setInvalid();
+    }
+    return;
+  }
+  llvm_unreachable("unhandled COMInteropModel");
+}
+
 ProtocolConformance *
 com::deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP) {
   const auto *CD = dyn_cast<ClassDecl>(NTD);

--- a/lib/Sema/TypeCheckCOM.h
+++ b/lib/Sema/TypeCheckCOM.h
@@ -17,6 +17,7 @@
 
 namespace swift {
 class ClassDecl;
+class ProtocolDecl;
 class NominalTypeDecl;
 class ProtocolConformance;
 enum class KnownProtocolKind : uint8_t;
@@ -29,6 +30,9 @@ deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP);
 
 /// Diagnose declaration-level restrictions on a native COM implementation.
 void validateImplementation(ClassDecl *CD);
+
+/// Validate the compiler-managed requirements of a COM identity protocol.
+void validateIdentityProtocol(ProtocolDecl *PD);
 
 /// Diagnose restrictions on an explicitly declared COM conformance.
 void validateConformance(ProtocolConformance *conformance);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -300,6 +300,28 @@ static void checkInheritanceClause(
         isa<AssociatedTypeDecl>(decl))
       continue;
 
+    // The COM identity protocols describe compiler-managed metatype
+    // conformances. Protocols cannot refine them in source, including through
+    // protocol compositions.
+    if (ctx.LangOpts.EnableCOMInterop && isa<ProtocolDecl>(decl) &&
+        inheritedTy->isConstraintType()) {
+      auto layout = inheritedTy->getExistentialLayout();
+      bool hasIdentity = false;
+      for (auto *protocol : layout.getProtocols()) {
+        if (!protocol->isCOMIdentity())
+          continue;
+        diags.diagnose(inherited.getLoc(),
+                       diag::com_identity_explicit_conformance,
+                       protocol->getName());
+        hasIdentity = true;
+      }
+      if (hasIdentity) {
+        if (auto *repr = inherited.getTypeRepr())
+          repr->setInvalid();
+        continue;
+      }
+    }
+
     if (inherited.isReparented())
       checkReparentedExtensionEntry(ext, inherited, inheritedTy);
 
@@ -3881,7 +3903,12 @@ public:
   static void diagnoseExtensionOfMarkerProtocol(ExtensionDecl *ED) {
     auto *nominal = ED->getExtendedNominal();
     if (auto *proto = dyn_cast_or_null<ProtocolDecl>(nominal)) {
-      if (proto->getKnownProtocolKind() && proto->isMarkerProtocol()) {
+      bool isExternalCOMInterfaceExtension =
+          ED->getASTContext().LangOpts.EnableCOMInterop &&
+          proto->isSpecificProtocol(KnownProtocolKind::COMInterface) &&
+          ED->getModuleContext() != proto->getModuleContext();
+      if ((proto->getKnownProtocolKind() && proto->isMarkerProtocol()) ||
+          isExternalCOMInterfaceExtension) {
         ED->diagnose(diag::cannot_extend_nominal, nominal);
       }
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3630,6 +3630,9 @@ public:
     for (auto Member : PD->getMembers())
       visit(Member);
 
+    if (Ctx.LangOpts.EnableCOMInterop)
+      com::validateIdentityProtocol(PD);
+
     checkDeclCommon(PD);
 
     checkProtocolRefinementRequirements(PD);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6937,7 +6937,11 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
 
     // Check and record normal conformances.
     if (auto normal = dyn_cast<NormalProtocolConformance>(conformance)) {
-      groupChecker.addConformance(normal);
+      auto *protocol = normal->getProtocol();
+      bool isCOMIdentity =
+          Context.LangOpts.EnableCOMInterop && protocol->isCOMIdentity();
+      if (!normal->isInvalid() || !isCOMIdentity)
+        groupChecker.addConformance(normal);
     }
 
     // Diagnose @NSCoding on file/fileprivate/nested/generic classes, which

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6574,8 +6574,9 @@ TypeResolver::validateCOMExistential(Type constraintType, TypeRepr *repr,
 
   auto layout = constraintType->getExistentialLayout();
   auto resolution = layout.resolveCOMInterface();
-  if (resolution.containsCOMInterfaceProtocol) {
-    diagnose(repr->getLoc(), diag::com_cominterface_existential);
+  if (resolution.identityProtocol) {
+    diagnose(repr->getLoc(), diag::com_identity_existential,
+             resolution.identityProtocol->getName().str());
     repr->setInvalid();
     return ErrorType::get(ctx);
   }

--- a/test/Inputs/COM.swift
+++ b/test/Inputs/COM.swift
@@ -29,3 +29,17 @@ public protocol ISwiftObject {
 public protocol COMInterface {
   var IID: IID { get }
 }
+
+public protocol COMActivatable {
+#if $_MicrosoftCOM
+  var CLSID: CLSID { get }
+#endif
+}
+
+#if $_MicrosoftCOM
+
+public protocol COMAggregatable: AnyObject {
+  var controller: (any IUnknown)? { get }
+}
+
+#endif

--- a/test/Sema/COM-interface-conformance.swift
+++ b/test/Sema/COM-interface-conformance.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM -emit-module-path %t/COM.swiftmodule %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
+
+import COM
+
+// Missing requirements should not produce follow-on conformance diagnostics.
+// expected-error@+1 {{'COMInterface' conformance is compiler-managed and cannot be declared explicitly}}
+final class ExplicitCOMInterface: COMInterface {}
+
+// expected-error@+1 {{'COMActivatable' conformance is compiler-managed and cannot be declared explicitly}}
+final class ExplicitCOMActivatable: COMActivatable {}
+
+// Supplying a witness does not make a source conformance valid.
+// expected-error@+1 {{'COMInterface' conformance is compiler-managed and cannot be declared explicitly}}
+struct WitnessedInterface: COMInterface {
+  var IID: IID { fatalError() }
+}
+
+// expected-error@+1 {{'COMActivatable' conformance is compiler-managed and cannot be declared explicitly}}
+struct WitnessedActivatable: COMActivatable {
+  var CLSID: CLSID { fatalError() }
+}
+
+// expected-error@+1 {{'COMInterface' conformance is compiler-managed and cannot be declared explicitly}}
+protocol RefinesInterface: COMInterface {}
+// expected-error@+1 {{'COMActivatable' conformance is compiler-managed and cannot be declared explicitly}}
+protocol RefinesActivatable: COMActivatable {}
+
+struct InterfaceExtension {}
+// expected-error@+1 {{'COMInterface' conformance is compiler-managed and cannot be declared explicitly}}
+extension InterfaceExtension: COMInterface {}
+
+struct ActivatableExtension {}
+// expected-error@+1 {{'COMActivatable' conformance is compiler-managed and cannot be declared explicitly}}
+extension ActivatableExtension: COMActivatable {}
+
+// expected-error@+1 {{cannot extend protocol 'COMInterface'}}
+extension COMInterface {
+  var member: Int { 0 }
+}
+
+// The activation protocol can have convenience members in client modules.
+extension COMActivatable {
+  var member: Int { 0 }
+}
+
+// expected-error@+1 {{'any COMInterface' is invalid because 'COMInterface' describes a COM metatype identity}}
+func rejectInterface(_: any COMInterface) {}
+// expected-error@+1 {{'any COMActivatable' is invalid because 'COMActivatable' describes a COM metatype identity}}
+func rejectActivatable(_: any COMActivatable) {}
+
+// Aggregation remains an ordinary class-bound, explicitly declared conformance.
+final class Aggregated: COMAggregatable {
+  var controller: (any IUnknown)? { nil }
+}
+
+// Compositions cannot hide a refinement or an identity existential.
+// expected-error@+1 {{'COMInterface' conformance is compiler-managed and cannot be declared explicitly}}
+protocol RefinesInterfaceComposition: COMInterface & Sendable {}
+// expected-error@+1 {{'COMActivatable' conformance is compiler-managed and cannot be declared explicitly}}
+protocol RefinesActivatableComposition: COMActivatable & Sendable {}
+
+// expected-error@+1 {{'any COMInterface' is invalid because 'COMInterface' describes a COM metatype identity}}
+func rejectInterfaceComposition(_: any COMInterface & Sendable) {}
+// expected-error@+1 {{'any COMActivatable' is invalid because 'COMActivatable' describes a COM metatype identity}}
+func rejectActivatableComposition(_: any COMActivatable & Sendable) {}

--- a/test/Sema/COM-known-protocols.swift
+++ b/test/Sema/COM-known-protocols.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM -emit-module-path %t/COM.swiftmodule -emit-ir -o %t/COM.ll %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
+// RUN: %target-swift-frontend -enable-experimental-com-interop -module-name COM -emit-module-path %t/COM.swiftmodule %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
+
+import COM
+
+func interface<T: COMInterface>(_: T) {}
+
+#if $_MicrosoftCOM
+
+func activation<T: COMActivatable>(_: T) {}
+
+final class Aggregated: COMAggregatable {
+  var controller: (any IUnknown)? { nil }
+}
+
+func controller<T: COMAggregatable>(of aggregated: T) -> (any IUnknown)? {
+  aggregated.controller
+}
+
+#endif

--- a/test/Sema/COM-known-protocols.swift
+++ b/test/Sema/COM-known-protocols.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM -emit-module-path %t/COM.swiftmodule -emit-ir -o %t/COM.ll %S/../Inputs/COM.swift
 // RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -I %t
+// RUN: %target-swift-frontend -enable-experimental-com-interop -com-interop-model=corefoundation -module-name COM -emit-module-path %t/COM.swiftmodule %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=corefoundation -I %t
 // RUN: %target-swift-frontend -enable-experimental-com-interop -module-name COM -emit-module-path %t/COM.swiftmodule %S/../Inputs/COM.swift
 // RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t
 
@@ -8,9 +10,9 @@ import COM
 
 func interface<T: COMInterface>(_: T) {}
 
-#if $_MicrosoftCOM
-
 func activation<T: COMActivatable>(_: T) {}
+
+#if $_MicrosoftCOM
 
 final class Aggregated: COMAggregatable {
   var controller: (any IUnknown)? { nil }

--- a/test/Sema/com-activatable-protocol-invalid-identity.swift
+++ b/test/Sema/com-activatable-protocol-invalid-identity.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM
+
+public struct GUID { }
+public typealias IID = GUID
+public typealias CLSID = GUID
+
+public protocol COMInterface {
+  var IID: IID { get }
+}
+
+// expected-error@+1{{expected 'COMActivatable' to declare 'var CLSID: CLSID { get }'}}
+public protocol COMActivatable {
+}

--- a/test/Sema/com-activatable-protocol-model.swift
+++ b/test/Sema/com-activatable-protocol-model.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -com-interop-model=corefoundation -module-name COM %t/corefoundation-empty.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -com-interop-model=corefoundation -module-name COM %t/corefoundation-unsupported.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM %t/microsoft-empty.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM %t/microsoft-valid.swift
+
+//--- corefoundation-empty.swift
+// CoreFoundation activation has no requirements and does not need a CLSID type.
+public protocol COMActivatable {}
+func activation<T: COMActivatable>(_: T) {}
+
+//--- corefoundation-unsupported.swift
+public struct CLSID {}
+public protocol COMActivatable {
+  // The Microsoft requirement is not supported in CoreFoundation mode.
+  var CLSID: CLSID { get } // expected-error {{requirement 'CLSID' of 'COMActivatable' is not supported by this compiler}}
+  func unsupported() // expected-error {{requirement 'unsupported()' of 'COMActivatable' is not supported by this compiler}}
+  associatedtype Value // expected-error {{requirement 'Value' of 'COMActivatable' is not supported by this compiler}}
+}
+
+//--- microsoft-empty.swift
+public struct CLSID {}
+public protocol COMActivatable {} // expected-error {{expected 'COMActivatable' to declare 'var CLSID: CLSID { get }'}}
+
+//--- microsoft-valid.swift
+public struct CLSID {}
+public protocol COMActivatable {
+  var CLSID: CLSID { get }
+}

--- a/test/Sema/com-existentials.swift
+++ b/test/Sema/com-existentials.swift
@@ -42,4 +42,4 @@ func rejectSuperclass(_: any NativeBase & IDerived) {}
 // expected-error@-1 {{COM existential containing interface 'IDerived' cannot also contain class constraint 'NativeBase'}}
 
 func rejectCOMInterface(_: any COMInterface) {}
-// expected-error@-1 {{'any COMInterface' is invalid because 'COMInterface' does not identify a COM interface}}
+// expected-error@-1 {{'any COMInterface' is invalid because 'COMInterface' describes a COM metatype identity}}

--- a/test/Sema/com-identity-protocol-disabled.swift
+++ b/test/Sema/com-identity-protocol-disabled.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM %t/COM.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t %t/client.swift
+
+//--- COM.swift
+public protocol COMInterface {}
+public protocol COMActivatable {}
+
+//--- client.swift
+import COM
+
+// These names impose no identity restrictions with COM interop disabled.
+protocol RefinesInterface: COMInterface & Sendable {}
+protocol RefinesActivatable: COMActivatable & Sendable {}
+struct ExplicitInterface: COMInterface {}
+struct ExplicitActivatable: COMActivatable {}
+extension COMInterface {
+  var member: Int { 0 }
+}
+extension COMActivatable {
+  var member: Int { 0 }
+}
+func interface(_: any COMInterface) {}
+func activatable(_: any COMActivatable) {}

--- a/test/Sema/com-identity-protocol-extensions.swift
+++ b/test/Sema/com-identity-protocol-extensions.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM %S/../Inputs/COM.swift
+
+// The defining module can provide convenience members for identity protocols.
+extension COMInterface {
+  var convenience: Int { 0 }
+}
+extension COMActivatable {
+  var convenience: Int { 0 }
+}

--- a/test/Sema/com-identity-protocol-requirements.swift
+++ b/test/Sema/com-identity-protocol-requirements.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -module-name COM %t/static.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -module-name COM %t/settable.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -module-name COM %t/wrong-type.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -module-name COM %t/async.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -module-name COM %t/throwing.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -module-name COM %t/missing-iid.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM %t/missing-clsid.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-com-interop -module-name COM %t/associated-type.swift
+// RUN: %target-swift-frontend -typecheck -verify -module-name COM %t/disabled.swift
+
+//--- static.swift
+public struct IID {}
+// expected-error@+1 {{expected 'COMInterface' to declare 'var IID: IID { get }'}}
+public protocol COMInterface {
+  static var IID: IID { get }
+}
+
+//--- settable.swift
+public struct IID {}
+// expected-error@+1 {{expected 'COMInterface' to declare 'var IID: IID { get }'}}
+public protocol COMInterface {
+  var IID: IID { get set }
+}
+
+//--- wrong-type.swift
+public struct IID {}
+// expected-error@+1 {{expected 'COMInterface' to declare 'var IID: IID { get }'}}
+public protocol COMInterface {
+  var IID: Int { get }
+}
+
+//--- async.swift
+public struct IID {}
+// expected-error@+1 {{expected 'COMInterface' to declare 'var IID: IID { get }'}}
+public protocol COMInterface {
+  var IID: IID { get async }
+}
+
+//--- throwing.swift
+public struct IID {}
+// expected-error@+1 {{expected 'COMInterface' to declare 'var IID: IID { get }'}}
+public protocol COMInterface {
+  var IID: IID { get throws }
+}
+
+//--- missing-iid.swift
+// expected-error@+1 {{type 'IID' not found in the 'COM' module}}
+public protocol COMInterface {
+  var IID: Int { get }
+}
+
+//--- missing-clsid.swift
+// expected-error@+1 {{type 'CLSID' not found in the 'COM' module}}
+public protocol COMActivatable {
+  var CLSID: Int { get }
+}
+
+//--- associated-type.swift
+public struct IID {}
+public protocol COMInterface {
+  var IID: IID { get }
+  // expected-error@+1 {{requirement 'Extra' of 'COMInterface' is not supported by this compiler}}
+  associatedtype Extra
+}
+
+//--- disabled.swift
+// Without COM interop, these names do not impose a compiler-managed contract.
+public protocol COMInterface {
+  func method()
+}
+public protocol COMActivatable {
+  associatedtype Identity
+}

--- a/test/Sema/com-interface-invalid-identity.swift
+++ b/test/Sema/com-interface-invalid-identity.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -module-name COM
+
+public struct GUID { }
+public typealias IID = GUID
+
+// expected-error@+1{{expected 'COMInterface' to declare 'var IID: IID { get }'}}
+public protocol COMInterface {
+  // expected-error@+1{{requirement 'unsupported()' of 'COMInterface' is not supported by this compiler}}
+  func unsupported()
+}


### PR DESCRIPTION
This pull request introduces robust support for compiler-managed COM identity protocols in Swift, specifically handling `COMInterface`, `COMActivatable`, and `COMAggregatable`. It ensures that conformances to these protocols are managed by the compiler and cannot be declared explicitly in user code. The changes also introduce new diagnostics, validation logic, and test cases to enforce and verify these restrictions.

**COM Identity Protocols Handling:**

* Added new COM identity protocols (`COMActivatable`, `COMAggregatable`) alongside `COMInterface`, and updated protocol classification logic to recognize and handle these as compiler-managed identities. [[1]](diffhunk://#diff-63687868b94621d203a642baa0c346004c3894fa3cb9393ea543ad5d577a5bddR165-R166) [[2]](diffhunk://#diff-d87e42f4d1c72f623a9f9246f244b1ad6f375fa7d1dce3d162ebb302d17f8922R5909-R5914)
* Implemented the `isCOMIdentity` method in `ProtocolDecl` to centralize detection of compiler-managed COM identity protocols.

**Diagnostics and Validation:**

* Introduced new diagnostics for invalid explicit conformances, invalid requirements, and unsupported requirements for COM identity protocols.
* Added validation logic to prevent user code from explicitly conforming to, refining, or extending COM identity protocols, and to check that protocol requirements match expected signatures. [[1]](diffhunk://#diff-3a4e1a1efa35de9c07d2c1ba68dad17b37db38dc0564542028e89c478b0c0d9aL556-R636) [[2]](diffhunk://#diff-fa1198ad7fbbed0b2ad70245eaa658121ebd138b3d92dcb8013d14ce906bfe58R303-R324) [[3]](diffhunk://#diff-fa1198ad7fbbed0b2ad70245eaa658121ebd138b3d92dcb8013d14ce906bfe58R3655-R3657) [[4]](diffhunk://#diff-fa1198ad7fbbed0b2ad70245eaa658121ebd138b3d92dcb8013d14ce906bfe58L3881-R3911)

**Existential and Type System Changes:**

* Updated existential layout resolution to track and reject compositions containing identity protocols, ensuring that `any COMInterface` and similar types are invalid. [[1]](diffhunk://#diff-24be56615db7852a96999ba2a34f6f14a8efe04a5d769ee77cde437980a6414bL45-R54) [[2]](diffhunk://#diff-91171422c4dcebdbac46ba534268f96213ba7f173e5755adb2407619a094465fL529-R530) [[3]](diffhunk://#diff-91171422c4dcebdbac46ba534268f96213ba7f173e5755adb2407619a094465fL564-R564) [[4]](diffhunk://#diff-159b18b3581cdde045e4330ef4a84f581e77a93ecc3d0b83f84f15741da7c481L6577-R6579)

**Compiler Infrastructure:**

* Added `COMIdentityRequirementKind` and the `classifyCOMIdentityRequirement` helper to classify and validate protocol requirements for identity protocols. [[1]](diffhunk://#diff-91d8b08c1f7d84b4a34787bcfc24d5b8690523ca8f26ebedf4ebd7176a170128R108-R118) [[2]](diffhunk://#diff-ae2484a63acaa0ecd8059b9eebb0264dcb6fb2a217b0413f60068939dbbb08a0R1804-R1825)
* Ensured that COM identity protocols are loaded from the correct module and are not treated as special protocols for IRGen. [[1]](diffhunk://#diff-e72124ba4cb2914331ccb632f0fb6e8ed4bcd0adbd08bd866e937d9e6eca3d15R1700-R1701) [[2]](diffhunk://#diff-56fe5ccc6780a820be0e933eca770d0413c87c5f9478f8aff2000eef9ecbbca2R7719-R7720)

**Testing:**

* Added comprehensive tests to verify that explicit conformances, protocol refinements, extensions, and existentials involving COM identity protocols are correctly diagnosed as errors, while ordinary class-bound protocols like `COMAggregatable` remain valid for explicit conformance. [[1]](diffhunk://#diff-ea1056462fbe509398996ffdecdf365931c5b1394c6edee69428984d5a088a63R32-R45) [[2]](diffhunk://#diff-03a0bb4559873d407f0c74eea31f6901614bce8218b4fd9306da51ae031d032cR1-R67)

These changes collectively enforce that COM identity protocols are exclusively compiler-managed, improving correctness and safety in Swift's COM interop model.