### PR TITLE
[cxx-interop] Do not cache FRTInfo during NameImporter

### DIFF
--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -523,6 +523,13 @@ importer::getUncachedForeignReferenceTypeInfo(const clang::RecordDecl *decl) {
 
 ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
     Evaluator &evaluator, ForeignReferenceTypeInfoDescriptor desc) const {
+
+  // Decls belonging to a module-building Clang sub-instance are freed once that
+  // sub-instance goes away, so this request must not cache decls allocated from
+  // that sub-instance's clang::ASTContext.
+  ASSERT(!desc.decl->getASTContext().getLangOpts().isCompilingModule() &&
+         "caching FRT info for a decl from a transient Clang sub-instance");
+
   return importer::getUncachedForeignReferenceTypeInfo(desc.decl);
 }
 

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -480,10 +480,8 @@ swift::extractNearestSourceLoc(const ForeignReferenceTypeInfoDescriptor &desc) {
   return SourceLoc();
 }
 
-ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
-    Evaluator &evaluator, ForeignReferenceTypeInfoDescriptor desc) const {
-  auto *decl = desc.decl;
-
+ForeignReferenceTypeInfo
+importer::getUncachedForeignReferenceTypeInfo(const clang::RecordDecl *decl) {
   // A swift_attr propagates to later redeclarations only, so an earlier
   // declaration does not see the annotation, and the retain/release parameters
   // of SWIFT_SHARED_REFERENCE declare the type before the annotated declaration
@@ -502,7 +500,6 @@ ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
       }
     }
   }
-
   if (auto *cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl))
     return ForeignReferenceTypeChecker(cxxDecl).check();
 
@@ -522,6 +519,11 @@ ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
   }
 
   return ForeignReferenceTypeInfo::Value();
+}
+
+ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
+    Evaluator &evaluator, ForeignReferenceTypeInfoDescriptor desc) const {
+  return importer::getUncachedForeignReferenceTypeInfo(desc.decl);
 }
 
 bool importer::diagnoseForeignReferenceType(

--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -15,7 +15,6 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "clang/AST/TemplateArgumentVisitor.h"
-#include "clang/AST/Type.h"
 #include "clang/AST/TypeVisitor.h"
 
 using namespace swift;
@@ -23,18 +22,12 @@ using namespace swift::importer;
 
 struct TemplateInstantiationNamePrinter
     : clang::TypeVisitor<TemplateInstantiationNamePrinter, std::string> {
-  ASTContext &swiftCtx;
   NameImporter *nameImporter;
   ImportNameVersion version;
 
-  ClangImporter::Implementation *importerImpl;
-
-  TemplateInstantiationNamePrinter(ASTContext &swiftCtx,
-                                   NameImporter *nameImporter,
-                                   ImportNameVersion version,
-                                   ClangImporter::Implementation *importerImpl)
-      : swiftCtx(swiftCtx), nameImporter(nameImporter), version(version),
-        importerImpl(importerImpl) {}
+  TemplateInstantiationNamePrinter(NameImporter *nameImporter,
+                                   ImportNameVersion version)
+      : nameImporter(nameImporter), version(version) {}
 
   std::string VisitType(const clang::Type *type) {
     // Print "_" as a fallback if we couldn't emit a more meaningful type name.
@@ -133,12 +126,14 @@ struct TemplateInstantiationNamePrinter
     // If this is a pointer to foreign reference type, we should not wrap
     // it in Unsafe(Mutable)?Pointer, since it will be imported as a class
     // in Swift.
+    //
+    // Use the uncached FRT info API here, because NamePrinter is used during
+    // PCM building (via NameImporter), which means pointee->getAsRecordDecl()
+    // might live in a transient clang::ASTContext (from a module-building
+    // Clang sub-instance). Caching that pointer can lead to faulty cache hits.
     bool isReferenceType = false;
     if (auto *rd = pointee->getAsRecordDecl())
-      isReferenceType =
-          evaluateOrDefault(swiftCtx.evaluator,
-                            ForeignReferenceTypeInfoRequest({rd}), {})
-              .isReference();
+      isReferenceType = getUncachedForeignReferenceTypeInfo(rd).isReference();
 
     llvm::SmallString<128> storage;
     llvm::raw_svector_ostream buffer(storage);
@@ -213,10 +208,8 @@ struct TemplateArgumentPrinter
                                           llvm::raw_svector_ostream &> {
   TemplateInstantiationNamePrinter typePrinter;
 
-  TemplateArgumentPrinter(ASTContext &swiftCtx, NameImporter *nameImporter,
-                          ImportNameVersion version,
-                          ClangImporter::Implementation *importerImpl)
-      : typePrinter(swiftCtx, nameImporter, version, importerImpl) {}
+  TemplateArgumentPrinter(NameImporter *nameImporter, ImportNameVersion version)
+      : typePrinter(nameImporter, version) {}
 
   void VisitTemplateArgument(const clang::TemplateArgument &arg,
                              llvm::raw_svector_ostream &buffer) {
@@ -278,10 +271,9 @@ struct TemplateArgumentPrinter
 };
 
 std::string swift::importer::printClassTemplateSpecializationName(
-    const clang::ClassTemplateSpecializationDecl *decl, ASTContext &swiftCtx,
+    const clang::ClassTemplateSpecializationDecl *decl,
     NameImporter *nameImporter, ImportNameVersion version) {
-  TemplateArgumentPrinter templateArgPrinter(swiftCtx, nameImporter, version,
-                                             nameImporter->getImporterImpl());
+  TemplateArgumentPrinter templateArgPrinter(nameImporter, version);
 
   llvm::SmallString<128> storage;
   llvm::raw_svector_ostream buffer(storage);

--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.h
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.h
@@ -31,7 +31,7 @@ namespace importer {
 /// This function does not instantiate any templates and does not modify the AST
 /// in any way.
 std::string printClassTemplateSpecializationName(
-    const clang::ClassTemplateSpecializationDecl *decl, ASTContext &swiftCtx,
+    const clang::ClassTemplateSpecializationDecl *decl,
     NameImporter *nameImporter, ImportNameVersion version);
 
 } // namespace importer

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2394,7 +2394,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
           dyn_cast<clang::ClassTemplateSpecializationDecl>(D)) {
     if (!isa<clang::ClassTemplatePartialSpecializationDecl>(D)) {
       auto name = printClassTemplateSpecializationName(classTemplateSpecDecl,
-                                                       swiftCtx, this, version);
+                                                       this, version);
       baseName = swiftCtx.getIdentifier(name).get();
     }
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2444,6 +2444,16 @@ getImplicitObjectParamAnnotation(const clang::FunctionDecl *FD) {
   return nullptr;
 }
 
+/// Compute the foreign reference type info for \p decl without consulting or
+/// populating the \c ForeignReferenceTypeInfoRequest cache.
+///
+/// Prefer \c ForeignReferenceTypeInfoRequest in almost all cases. This function
+/// should only be used when the result must not be cached, with a Clang decl
+/// that belongs to a short-lived clang::ASTContext (caching that pointer can
+/// lead to spurious false cache hits).
+ForeignReferenceTypeInfo
+getUncachedForeignReferenceTypeInfo(const clang::RecordDecl *decl);
+
 /// Emit diagnostics related to foreign reference types for \a decl.
 bool diagnoseForeignReferenceType(const clang::CXXRecordDecl *decl,
                                   ClangImporter::Implementation &Impl);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -49,6 +49,7 @@
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallVector.h"
@@ -415,8 +416,9 @@ void CompilerInstance::setupStatsReporter() {
   };
 
   auto getClangSourceManager = [](ASTContext &Ctx) -> clang::SourceManager * {
-    if (auto *clangImporter = static_cast<ClangImporter *>(
-            Ctx.getClangModuleLoader())) {
+    if (auto *clangImporter =
+            static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
+        clangImporter && clangImporter->getClangInstance().hasASTContext()) {
       return &clangImporter->getClangASTContext().getSourceManager();
     }
     return nullptr;

--- a/test/ClangImporter/pcm-emit-stats.swift
+++ b/test/ClangImporter/pcm-emit-stats.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/stats)
+// RUN: %empty-directory(%t/dump-stats)
+
+// RUN: %target-swift-emit-pcm -module-name script -o %t/script.pcm %S/Inputs/custom-modules/module.modulemap -stats-output-dir %t/stats
+// RUN: %swift-dump-pcm %t/script.pcm -stats-output-dir %t/dump-stats

--- a/test/Interop/Cxx/templates/class-template-frt-not-cached-during-pcm.swift
+++ b/test/Interop/Cxx/templates/class-template-frt-not-cached-during-pcm.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %empty-directory(%t/stats)
+
+// Building a PCM must not populate the ForeignReferenceTypeInfo request cache.
+// Emitting the PCM name-imports Wrapper<Frt *>, which has to know whether Frt
+// is a foreign reference type. That query must not go through the evaluator.
+
+// RUN: %target-swift-frontend -emit-pcm -module-name TemplateWithFrt -o %t/TemplateWithFrt.pcm %t/Inputs/module.modulemap -cxx-interoperability-mode=default -stats-output-dir %t/stats -print-zero-stats
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'ForeignReferenceTypeInfoRequest == 0' %t/stats
+
+// Confirm those names really do depend on foreign reference type info, so that
+// the counter above cannot be zero for the wrong reason.
+// RUN: %target-swift-ide-test -print-module -module-to-print=TemplateWithFrt -I %t/Inputs -source-filename=x -cxx-interoperability-mode=default | %FileCheck %s
+
+// CHECK: typealias WrappedFrt = Wrapper<Frt>
+// CHECK: typealias WrappedValue = Wrapper<UnsafeMutablePointer<Value>>
+
+//--- Inputs/module.modulemap
+module TemplateWithFrt {
+  header "template-with-frt.h"
+  requires cplusplus
+}
+
+//--- Inputs/template-with-frt.h
+template <class T>
+struct Wrapper {};
+
+class __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal"))) Frt {};
+
+struct Value {};
+
+using WrappedFrt = Wrapper<Frt *>;
+using WrappedValue = Wrapper<Value *>;


### PR DESCRIPTION
0699fd2cfe736eb5ead380767eb4c45ac93a1128 previously disabled caching for FRTInfo requests, to prevent stale cache entries keyed on AST nodes allocated out of transient Clang sub-instances used to build the PCMs used by Swift/C++ interop. Specifically, NameImporter is used during PCM building, so requests from NameImporter should not be cached.

6e9a49117264e99ba26d8fd39c677816306291dc brought back FRTInfo caching after name lookup was redesigned to eliminate the need for that FRTInfo during name lookup (it was involved in determining whether C++ methods need the "__Unsafe" name mangling).

It turns out FRTInfo is needed in one other place during NameImporter, to determine the template instance name. I did not realize it existed while working on 6e9a49117264e99ba26d8fd39c677816306291dc.

This patch avoids the stale cache issues by introduces an uncached FRTInfo API, for use during PCM building.

Also fixes a pre-existing bug that prevented us from dumping `swift-frontend` stats for `-emit-pcm` invocations. These stats are used for checking the number of times we evaluate that request in a regression test.

rdar://184577717