### PR TITLE
[stdlib] Do not compile the wasi-threads Concurrency runtime single-threaded

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -203,9 +203,17 @@ function(swift_create_stdlib_targets name variant define_all_alias)
   endif()
 endfunction()
 
+# The cooperative ("singlethreaded") global executor needs no threads, so a
+# runtime without a threading package can only pair it with
+# SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY. A runtime that HAS threads (e.g.
+# wasm32-unknown-wasip1-threads with the pthreads package) may still use the
+# cooperative executor — async work is serial on the main thread — but must
+# not be compiled single-threaded, or the actor runtime treats every thread
+# as the main thread.
 if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded"
-   AND NOT SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY)
-  message(SEND_ERROR "Cannot enable the single-threaded global executor without enabling SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY")
+   AND NOT SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY
+   AND "${SWIFT_THREADING_PACKAGE}" STREQUAL "none")
+  message(SEND_ERROR "Cannot enable the single-threaded global executor without enabling SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY (no threading package)")
 endif()
 
 if(SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY)

--- a/test/Concurrency/Runtime/wasi_threads_main_thread_isolation.swift
+++ b/test/Concurrency/Runtime/wasi_threads_main_thread_isolation.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out pass 2>&1 | %FileCheck --check-prefix=PASS %s
+// RUN: not --crash %target-run %t/a.out trap 2>&1 | %FileCheck --check-prefix=TRAP %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: OS=wasip1
+// REQUIRES: wasi_threads
+
+// The wasm32-unknown-wasip1-threads runtime is not compiled single-threaded,
+// so the actor runtime can tell a pthread from the main thread: an isolation
+// assumption holds on the main thread and traps on a worker. (With
+// SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY every thread counts as the main
+// thread and the worker's `assumeIsolated` passed silently.)
+
+import WASILibc
+import wasi_pthread
+
+@MainActor func onMain() { print("main: isolated") }
+
+func worker(_: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
+  // TRAP: Fatal error
+  MainActor.assumeIsolated { print("worker: assumeIsolated passed (BUG)") }
+  return nil
+}
+
+@main struct Main {
+  static func main() {
+    // PASS: main: isolated
+    MainActor.assumeIsolated { onMain() }
+    print("main: after")
+    // PASS: main: after
+    guard CommandLine.arguments.last == "trap" else { return }
+    var thread = pthread_t(bitPattern: 0)
+    let rc = pthread_create(&thread, nil, worker, nil)
+    precondition(rc == 0, "pthread_create failed: \(rc)")
+    if let thread { pthread_join(thread, nil) }
+    print("worker returned")
+  }
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -276,6 +276,9 @@ if kIsWASI:
   if run_os == 'wasip1-threads':
       run_os = 'wasip1'
       run_environment = 'threads'
+      # The wasi-threads stdlib: real pthreads under a Concurrency runtime
+      # that is not compiled single-threaded.
+      config.available_features.add('wasi_threads')
 
 lto_flags = ""
 use_just_built_liblto = ""

--- a/utils/swift_build_support/swift_build_support/helpers/wasmstdlibhelpers.py
+++ b/utils/swift_build_support/swift_build_support/helpers/wasmstdlibhelpers.py
@@ -113,7 +113,6 @@ def build_stdlib(args, toolchain, source_dir, build_dir, host_target,
     opts.define('SWIFT_STDLIB_HAS_ASLR:BOOL', 'FALSE')
     opts.define('SWIFT_STDLIB_INSTALL_PARENT_MODULE_FOR_SHIMS:BOOL', 'FALSE')
     opts.define('SWIFT_RUNTIME_CRASH_REPORTER_CLIENT:BOOL', 'FALSE')
-    opts.define('SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'TRUE')
     opts.define('SWIFT_ENABLE_DISPATCH:BOOL', 'FALSE')
     opts.define('SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING:BOOL', 'FALSE')
     opts.define('SWIFT_STDLIB_HAS_DLADDR:BOOL', 'FALSE')

--- a/utils/swift_build_support/swift_build_support/products/emscriptenstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/emscriptenstdlib.py
@@ -80,6 +80,9 @@ class EmscriptenStdlib(cmake_product.CMakeProduct):
                              ' ' + ' '.join(test_driver_options))
 
         cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
+        # No threads: single-threaded Concurrency runtime (see wasistdlib.py).
+        cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'TRUE')
         # Emscripten keeps compatibility headers (e.g. xlocale.h) in a
         # separate include/compat directory that emcc adds automatically.
         # Since we use raw clang, we need to add it ourselves.

--- a/utils/swift_build_support/swift_build_support/products/wasistdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasistdlib.py
@@ -97,6 +97,11 @@ class WASIStdlib(cmake_product.CMakeProduct):
 
     def _append_threading_options(self, cmake_options):
         cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
+        # No threads: the Concurrency runtime may assume every thread is the
+        # main thread (SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY), and the
+        # cooperative global executor runs everything on it.
+        cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'TRUE')
 
     def test(self, host_target):
         self._test(host_target, 'wasm32-wasip1')
@@ -193,3 +198,15 @@ class WASIThreadsStdlib(WASIStdlib):
                              '-Xcc;-mthread-model;-Xcc;posix;'
                              '-Xcc;-pthread;-Xcc;-ftls-model=local-exec')
         cmake_options.define('SWIFT_ENABLE_WASI_THREADS:BOOL', 'TRUE')
+        # The threads triple has real OS threads, so the Concurrency runtime
+        # must NOT be compiled single-threaded: with that define
+        # `isExecutingOnMainThread()` returns true on every thread, and the
+        # actor runtime treats any pthread as the main actor (e.g.
+        # `MainActor.assumeIsolated` passes off the main thread). The global
+        # executor stays the cooperative one — async work is still serial by
+        # default; a multithreaded executor is opt-in via
+        # `DefaultExecutorFactory`.
+        cmake_options.define(
+            'SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY:BOOL', 'FALSE')
+        cmake_options.define(
+            'SWIFT_CONCURRENCY_GLOBAL_EXECUTOR:STRING', 'singlethreaded')


### PR DESCRIPTION
The `wasm32-unknown-wasip1-threads` stdlib is built with `SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY=TRUE`: the shared wasm helper (`wasmstdlibhelpers.py`) defines it after the product's own options, and CMake keeps the last `-D`. With that define `isExecutingOnMainThread()` in `Actor.cpp` returns `true` on every thread, so the actor runtime treats any pthread as the main thread — `MainActor.assumeIsolated` passes silently off the main thread (verified below). No package or app can fix this; it needs the runtime rebuilt.

**Fix**
- Define `SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY` per product: `TRUE` for `WASIStdlib` and `EmscriptenStdlib`, `FALSE` for `WASIThreadsStdlib`; the helper no longer defines it.
- The threads triple keeps the cooperative (`singlethreaded`) global executor, set explicitly — with the flag off the CMake default would become `hooked`, i.e. no executor. `stdlib/CMakeLists.txt` previously refused `singlethreaded` without `SINGLE_THREADED_CONCURRENCY`; it now allows it when a threading package is present (the executor needs no threads; the runtime just must not assume there is only one).
- Behaviour after this change: async work on wasip1-threads is still serial by default. Multithreaded execution is opt-in (`typealias DefaultExecutorFactory = …`), which needs `-disable-availability-checking` today because `CustomGlobalExecutors` is `FUTURE` in `FeatureAvailability.def` (separate topic).

**Effective cache** (wasmthreadsstdlib): `SWIFT_THREADING_PACKAGE=pthreads`, `SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY=FALSE`, `SWIFT_CONCURRENCY_GLOBAL_EXECUTOR=singlethreaded`.

**Testing** — new lit feature `wasi_threads` + `test/Concurrency/Runtime/wasi_threads_main_thread_isolation.swift` (main-thread `assumeIsolated` passes; on a pthread it traps). CI compiles it but WasmKit cannot run wasi-threads, so runtime evidence was gathered locally with a `swift-6.3.2-RELEASE`-based build of the same change under `wasmtime run -W threads=y,shared-memory=y`:

| build | TaskGroup peak | `assumeIsolated` on main | `assumeIsolated` on a pthread |
|---|---|---|---|
| today (TRUE + cooperative) | 1 | passes | **passes silently (bug)** |
| this PR (FALSE + cooperative) | 1 | passes | traps: `Unexpected isolation context, expected to be executing on CooperativeExecutor` |

No hangs, no crashes elsewhere; `Thread::onMainThread()` (pthreads package, static-init remembered main thread) is correct on wasi.


**Downstream.** The executor that needs this is now in review as swiftlang/swift-platform-executors#33 (from swift-platform-executors#30): the package's `PThreadExecutor` extended to `wasm32-unknown-wasip1-threads`, installed with `typealias DefaultExecutorFactory = PlatformExecutorFactory`. Its `Examples/WASIThreads` probe, run under wasmtime against a `swift-6.3.2-RELEASE` build of this change, reaches `TaskGroup` peak concurrency 4 on a 4-executor pool and sees a detached hop leave the main thread and its continuation return to it. Without this PR the same probe cannot distinguish the main thread from a pool worker, so that isolation check is the part only the runtime can fix.
