### PR TITLE
[ClangImporter] Do not assume ClangImporter always has a Clang ASTContext

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -49,6 +49,7 @@
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallVector.h"
@@ -415,8 +416,9 @@ void CompilerInstance::setupStatsReporter() {
   };
 
   auto getClangSourceManager = [](ASTContext &Ctx) -> clang::SourceManager * {
-    if (auto *clangImporter = static_cast<ClangImporter *>(
-            Ctx.getClangModuleLoader())) {
+    if (auto *clangImporter =
+            static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
+        clangImporter && clangImporter->getClangInstance().hasASTContext()) {
       return &clangImporter->getClangASTContext().getSourceManager();
     }
     return nullptr;

--- a/test/ClangImporter/pcm-emit-stats.swift
+++ b/test/ClangImporter/pcm-emit-stats.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/stats)
+// RUN: %empty-directory(%t/dump-stats)
+
+// RUN: %target-swift-emit-pcm -module-name script -o %t/script.pcm %S/Inputs/custom-modules/module.modulemap -stats-output-dir %t/stats
+// RUN: %swift-dump-pcm %t/script.pcm -stats-output-dir %t/dump-stats


### PR DESCRIPTION
Setting up the stats reporter must not assume the ClangImporter has a Clang ASTContext. Configuring the importer for precompiling only (-emit-pcm, -dump-pcm) leaves its Clang instance without one, since ClangImporter::create returns before beginning a source file in that mode.

Without this, triggers:

```
Assertion failed: (Context && "Compiler instance has no AST context!"), function getASTContext, file CompilerInstance.h, line 587.
```
