### PR TITLE
[cxx-interop] Fix throwing Void thunks and Expected<void> success

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1353,7 +1353,23 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   }
   if (hasThrows) {
     os << "  void* opaqueError = nullptr;\n";
-    os << "  void* _ctx = nullptr;\n";
+    // The lowered signature only has a synthesized context parameter when
+    // there is no self parameter that already acts as the context (e.g. for
+    // free functions). Only emit the placeholder context variable when it's
+    // actually passed to the call, to avoid an unused variable in the thunk.
+    bool hasContextParam = false;
+    signature.visitParameterList(
+        [](const LoweredFunctionSignature::IndirectResultValue &) {},
+        [](const LoweredFunctionSignature::DirectParameter &) {},
+        [](const LoweredFunctionSignature::IndirectParameter &) {},
+        [](const LoweredFunctionSignature::GenericRequirementParameter &) {},
+        [](const LoweredFunctionSignature::MetadataSourceParameter &) {},
+        [&](const LoweredFunctionSignature::ContextParameter &) {
+          hasContextParam = true;
+        },
+        [](const LoweredFunctionSignature::ErrorResultValue &) {});
+    if (hasContextParam)
+      os << "  void* _ctx = nullptr;\n";
   }
   std::optional<StringRef> indirectFunctionVar;
   using DispatchKindTy = IRABIDetailsProvider::MethodDispatchInfo::Kind;
@@ -1691,8 +1707,14 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
     if (resultTy->isVoid()) {
       os << "    return swift::Expected<void>(swift::Error(opaqueError));\n";
       os << "#endif\n";
-      if (FD->getInterfaceType()->castTo<FunctionType>()->getResult()->isUninhabited())
+      const auto *funcDecl = dyn_cast<FuncDecl>(FD);
+      if (funcDecl && funcDecl->getResultInterfaceType()->isUninhabited()) {
         os << "  abort();\n";
+      } else {
+        os << "#ifndef __cpp_exceptions\n";
+        os << "  return swift::Expected<void>();\n";
+        os << "#endif\n";
+      }
     } else {
       auto directResultType = signature.getDirectResultType();
       printDirectReturnOrParamCType(

--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -372,10 +372,9 @@ private:
 template<>
 class Expected<void> {
 public:
-  /// Default
+  /// Default: a successful `void` result.
   Expected() noexcept {
-    new (&buffer) Error();
-    has_val = false;
+    has_val = true;
   }
 
   Expected(const swift::Error &error_val) noexcept {
@@ -385,9 +384,7 @@ public:
 
   /// Copy
   Expected(Expected const& other) noexcept {
-    if (other.has_value())
-      abort();
-    else
+    if (!other.has_value())
       new (&buffer) Error(other.error());
 
     has_val = other.has_value();
@@ -397,7 +394,10 @@ public:
   // FIXME: Implement move semantics when move swift values is possible
   [[noreturn]] Expected(Expected&&) noexcept { abort(); }
 
-  ~Expected() noexcept { reinterpret_cast<swift::Error *>(buffer)->~Error(); }
+  ~Expected() noexcept {
+    if (!has_value())
+      reinterpret_cast<swift::Error *>(buffer)->~Error();
+  }
 
   /// assignment
   constexpr auto operator=(Expected&& other) noexcept = delete;

--- a/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
@@ -1,16 +1,15 @@
+// clang-format off
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/throwing-void.swift -module-name ThrowingVoid
-// -clang-header-expose-decls=all-public -enable-experimental-feature
-// GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path
-// %t/void.h RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s
-// -I %t -o %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
-// %target-interop-build-swift %S/throwing-void.swift -o %t/test -Xlinker
-// %t/test.o -module-name ThrowingVoid -Xfrontend -entry-point-function-name
-// -Xfrontend swiftMain RUN: %target-codesign %t/test RUN: %target-run %t/test
+// RUN: %target-swift-frontend %S/throwing-void.swift -module-name ThrowingVoid -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path %t/void.h
+// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+// RUN: %target-interop-build-swift %S/throwing-void.swift -o %t/test -Xlinker %t/test.o -module-name ThrowingVoid -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/test
+// RUN: %target-run %t/test
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
 // UNSUPPORTED: OS=windows-msvc
 // UNSUPPORTED: CPU=arm64e
+// clang-format on
 
 #include "void.h"
 #include <cassert>

--- a/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/throwing-void.swift -module-name ThrowingVoid
+// -clang-header-expose-decls=all-public -enable-experimental-feature
+// GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path
+// %t/void.h RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s
+// -I %t -o %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
+// %target-interop-build-swift %S/throwing-void.swift -o %t/test -Xlinker
+// %t/test.o -module-name ThrowingVoid -Xfrontend -entry-point-function-name
+// -Xfrontend swiftMain RUN: %target-codesign %t/test RUN: %target-run %t/test
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+// UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: CPU=arm64e
+
+#include "void.h"
+#include <cassert>
+
+int main() {
+  swift::Expected<void> success;
+  assert(success.has_value());
+  const auto copy = success;
+  assert(copy.has_value());
+  swift::Error error;
+  swift::Expected<void> failure(error);
+  assert(!failure.has_value());
+  const auto errorCopy = failure;
+  assert(!errorCopy.has_value());
+
+  assert(ThrowingVoid::checkedVoid(false).has_value());
+  assert(!ThrowingVoid::checkedVoid(true).has_value());
+  assert(ThrowingVoid::genericVoid(swift::Int(1), false).has_value());
+  assert(!ThrowingVoid::genericVoid(swift::Int(1), true).has_value());
+  assert(!ThrowingVoid::genericNever(swift::Int(1)).has_value());
+  auto object = ThrowingVoid::VoidMethods::init();
+  assert(object.checked(false).has_value());
+  assert(!object.checked(true).has_value());
+}

--- a/test/Interop/SwiftToCxx/functions/throwing-void.swift
+++ b/test/Interop/SwiftToCxx/functions/throwing-void.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name ThrowingVoid -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/void.h
+// RUN: %FileCheck %s < %t/void.h
+// RUN: %check-interop-cxx-header-in-clang(%t/void.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+public enum VoidError: Error { case failure }
+
+public func checkedVoid(_ fail: Bool) throws {
+  if fail { throw VoidError.failure }
+}
+
+public func genericVoid<T>(_ value: T, _ fail: Bool) throws {
+  try checkedVoid(fail)
+}
+
+public func genericNever<T>(_ value: T) throws -> Never {
+  throw VoidError.failure
+}
+
+public final class VoidMethods {
+  public init() {}
+  public func checked(_ fail: Bool) throws { try checkedVoid(fail) }
+}
+
+// A generic Void result must not cast a GenericFunctionType to FunctionType.
+// CHECK: swift::ThrowingResult<void> genericNever
+// CHECK: abort();
+// CHECK: swift::ThrowingResult<void> genericVoid
+// CHECK: #ifndef __cpp_exceptions
+// CHECK-NEXT: return swift::Expected<void>();
+
+// Class self supplies the context; don't emit an unused placeholder.
+// CHECK: swift::ThrowingResult<void> VoidMethods::checked
+// CHECK-NEXT: void* opaqueError = nullptr;
+// CHECK-NOT: void* _ctx
+// CHECK: if (opaqueError != nullptr)
+// CHECK: return swift::Expected<void>();


### PR DESCRIPTION
A successful throwing Swift function returning `Void` falls off the end of its C++ thunk under `-fno-exceptions`, and `Expected<void>()` reports failure. Give it a success state, preserve that state when copying, and explicitly return it from the thunk. Also avoid the `GenericFunctionType` cast crash for generic `Void`/`Never` functions and omit unused context placeholders for methods.

Split from #91112 in response to the request for smaller, independently reviewable PRs. Based on `cfbd3c5`.
