### PR TITLE
[cxx-interop] Reject typed throws before emitting error-slot bindings

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -326,12 +326,30 @@ swift::cxx_translation::getDeclRepresentation(
   // Don't expose decls with definitions that are emitted into the client.
   if (VD->isAlwaysEmittedIntoClient())
     return {Unsupported, UnrepresentableRequiresClientEmission};
+  // Returns true when the given throwing function cannot be represented in
+  // C++: either bindings for throwing functions are disabled, or the function
+  // uses typed throws (SE-0413), whose ABI differs from untyped throws (the
+  // thrown error is not returned as an `any Error` box in the error slot) and
+  // is not yet supported by the C++ bindings.
+  auto isUnrepresentableThrowingFunction =
+      [](const AbstractFunctionDecl *AFD) -> bool {
+    if (!AFD->hasThrows())
+      return false;
+    if (!AFD->getASTContext().LangOpts.hasFeature(
+            Feature::GenerateBindingsForThrowingFunctionsInCXX))
+      return true;
+    // Only untyped throws (whose effective thrown type is `any Error`) uses
+    // the error-slot ABI the C++ bindings understand.
+    auto thrownType = AFD->getEffectiveThrownErrorType();
+    if (!thrownType)
+      return true;
+    return !(*thrownType)->isEqual(
+        AFD->getASTContext().getErrorExistentialType());
+  };
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
     if (AFD->hasAsync())
       return {Unsupported, UnrepresentableAsync};
-    if (AFD->hasThrows() &&
-        !AFD->getASTContext().LangOpts.hasFeature(
-            Feature::GenerateBindingsForThrowingFunctionsInCXX))
+    if (isUnrepresentableThrowingFunction(AFD))
       return {Unsupported, UnrepresentableThrows};
     if (AFD->hasGenericParamList())
       genericSignature = AFD->getGenericSignature();
@@ -357,9 +375,10 @@ swift::cxx_translation::getDeclRepresentation(
     if (!isa<ClassDecl>(typeDecl) && isZeroSized && (*isZeroSized)(typeDecl))
       return {Unsupported, UnrepresentableZeroSizedValueType};
   }
-  if (const auto *varDecl = dyn_cast<VarDecl>(VD)) {
-    // Check if any property accessor throws, do not expose it in that case.
-    for (const auto *accessor : varDecl->getAllAccessors()) {
+  if (const auto *storageDecl = dyn_cast<AbstractStorageDecl>(VD)) {
+    // Throwing accessors are not supported yet. Check subscripts as well as
+    // properties so typed throws cannot bypass the error ABI restriction.
+    for (const auto *accessor : storageDecl->getAllAccessors()) {
       if (accessor->hasThrows())
         return {Unsupported, UnrepresentableThrows};
     }

--- a/test/Interop/SwiftToCxx/unsupported/typed-throws-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/typed-throws-in-cxx.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Functions -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/functions.h
+
+// RUN: cat %s | grep -v _expose > %t/clean.swift
+// RUN: %target-swift-frontend %t/clean.swift -module-name Functions -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/header.h
+// RUN: %FileCheck %s < %t/header.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/header.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
+
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+// Typed throws (SE-0413) uses a different ABI than untyped throws: the
+// thrown error is not returned as an `any Error` box in the error slot.
+// Such functions cannot be exposed to C++ yet, even with
+// GenerateBindingsForThrowingFunctionsInCXX enabled.
+
+public enum MyError: Error {
+    case fail
+    case worse
+}
+
+@_expose(Cxx) // expected-error {{global function 'typedThrowsFunction()' can not yet be represented in C++ as it may throw an error}}
+public func typedThrowsFunction() throws(MyError) { }
+
+@_expose(Cxx) // expected-error {{global function 'typedThrowsFunctionWithReturn()' can not yet be represented in C++ as it may throw an error}}
+public func typedThrowsFunctionWithReturn() throws(MyError) -> Int { return 0 }
+
+@_expose(Cxx)
+public struct HasTypedThrowsMembers {
+    public let stored: Int = 0
+
+    @_expose(Cxx) // expected-error {{instance method 'typedThrowsMethod()' can not yet be represented in C++ as it may throw an error}}
+    public func typedThrowsMethod() throws(MyError) { }
+
+    @_expose(Cxx) // expected-error {{initializer 'init(checked:)' can not yet be represented in C++ as it may throw an error}}
+    public init(checked: Int) throws(MyError) { }
+
+    public subscript(index: Int) -> Int {
+        get throws(MyError) { index }
+    }
+
+    public var computed: Int {
+        get throws(MyError) { 42 }
+    }
+}
+
+// No throwing thunk may be emitted anywhere in the header for these decls.
+// CHECK-NOT: SWIFT_INLINE_THUNK swift::ThrowingResult
+
+// CHECK: // Unavailable in C++: Swift global function 'typedThrowsFunction()'.
+// CHECK: // Unavailable in C++: Swift global function 'typedThrowsFunctionWithReturn()'.


### PR DESCRIPTION
Typed throws uses a different result ABI from untyped `throws`. Reject these declarations before emitting C++ bindings that would interpret the error-slot sentinel as a Swift error object. Check throwing subscripts as well as properties, which are not supported on main yet.

The diagnostic/header test covers free functions, methods, initializers, properties and subscripts. Untyped free functions retain their existing experimental support.

Split from #91112 in response to the request for smaller, independently reviewable PRs. Based on current `main` (`cfbd3c5`).

Validation: The new Swift fixture typechecks with the installed Swift 6.3.3 toolchain. Compiler/header-generation lit tests still need Swift CI: this machine has no development compiler, and its production compiler rejects `GenerateBindingsForThrowingFunctionsInCXX`. No toolchain or build dependencies were downloaded.
