### PR TITLE
[cxx-interop] Guard throwing bindings with the Swift error opt-in

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -464,6 +464,16 @@ void ClangSyntaxPrinter::printIncludeForShimHeader(StringRef headerName) {
   });
 }
 
+void ClangSyntaxPrinter::printSwiftErrorBindingsGuardBegin() {
+  os << "#if defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR) && "
+        "!defined(SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR)\n";
+}
+
+void ClangSyntaxPrinter::printSwiftErrorBindingsGuardEnd() {
+  os << "#endif // defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR) && "
+        "!defined(SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR)\n";
+}
+
 void ClangSyntaxPrinter::printDefine(StringRef macroName) {
   os << "#define " << macroName << "\n";
 }

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -226,6 +226,15 @@ public:
   // Print the #include sequence for the specified C++ interop shim header.
   void printIncludeForShimHeader(StringRef headerName);
 
+  // Print the opening/closing of the preprocessor guard that hides the C++
+  // bindings for throwing Swift functions from consumers that did not opt
+  // into the experimental Swift error handling support (the swift::Error,
+  // swift::Expected and swift::ThrowingResult support types are only
+  // available when SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR is defined and
+  // SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR is not).
+  void printSwiftErrorBindingsGuardBegin();
+  void printSwiftErrorBindingsGuardEnd();
+
   // Print the #define for the given macro.
   void printDefine(StringRef macroName);
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1233,7 +1233,18 @@ private:
           return;
       }
 
+      // Bindings for throwing functions are only usable when the consumer
+      // opted into the experimental Swift error handling support; the
+      // C declaration is guarded here, the C++ thunks are guarded by the
+      // method printers themselves.
+      bool needsThrowsGuard = AFD->hasThrows();
+      if (needsThrowsGuard)
+        ClangSyntaxPrinter(AFD->getASTContext(), owningPrinter.prologueOS)
+            .printSwiftErrorBindingsGuardBegin();
       owningPrinter.prologueOS << cFuncPrologueOS.str();
+      if (needsThrowsGuard)
+        ClangSyntaxPrinter(AFD->getASTContext(), owningPrinter.prologueOS)
+            .printSwiftErrorBindingsGuardEnd();
 
       printDocumentationComment(AFD);
       DeclAndTypeClangFunctionPrinter declPrinter(
@@ -2014,8 +2025,23 @@ private:
       }
       if (!canPrintOverloadOfFunction(FD))
         return;
+      // Bindings for throwing functions are only usable when the consumer
+      // opted into the experimental Swift error handling support.
+      bool needsThrowsGuard = FD->hasThrows();
+      if (needsThrowsGuard) {
+        ClangSyntaxPrinter(FD->getASTContext(), owningPrinter.prologueOS)
+            .printSwiftErrorBindingsGuardBegin();
+        ClangSyntaxPrinter(FD->getASTContext(), os)
+            .printSwiftErrorBindingsGuardBegin();
+      }
       owningPrinter.prologueOS << cFuncPrologueOS.str();
+      if (needsThrowsGuard)
+        ClangSyntaxPrinter(FD->getASTContext(), owningPrinter.prologueOS)
+            .printSwiftErrorBindingsGuardEnd();
       printAbstractFunctionAsCxxFunctionThunk(FD, *funcABI);
+      if (needsThrowsGuard)
+        ClangSyntaxPrinter(FD->getASTContext(), os)
+            .printSwiftErrorBindingsGuardEnd();
       recordEmittedDeclInCurrentCxxLexicalScope(FD);
       return;
     }

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1733,6 +1733,19 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
     Type resultTy, bool isStatic, bool isDefinition,
     std::optional<IRABIDetailsProvider::MethodDispatchInfo> dispatchInfo) {
   bool isConstructor = isa<ConstructorDecl>(FD);
+
+  // The C++ bindings for a throwing function are only usable when the
+  // consumer opted into the experimental Swift error handling support.
+  bool needsThrowsGuard = FD->hasThrows();
+  if (needsThrowsGuard)
+    ClangSyntaxPrinter(FD->getASTContext(), os)
+        .printSwiftErrorBindingsGuardBegin();
+  auto printThrowsGuardEnd = [&]() {
+    if (needsThrowsGuard)
+      ClangSyntaxPrinter(FD->getASTContext(), os)
+          .printSwiftErrorBindingsGuardEnd();
+  };
+
   os << "  ";
 
   FunctionSignatureModifiers modifiers;
@@ -1748,8 +1761,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
   auto result = printFunctionSignature(
       FD, signature, cxx_translation::getNameForCxx(FD), resultTy,
       FunctionSignatureKind::CxxInlineThunk, modifiers);
-  if (result.isUnsupported())
+  if (result.isUnsupported()) {
+    printThrowsGuardEnd();
     return;
+  }
 
   printCxxReturnsRetainedAttribute(os, resultTy);
   declAndTypePrinter.printAvailability(os, FD);
@@ -1757,6 +1772,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
     os << ";\n";
     if (result.isObjCxxOnly())
       os << "#endif // defined(__OBJC__)\n";
+    printThrowsGuardEnd();
     return;
   }
 
@@ -1770,6 +1786,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
   os << "  }\n";
   if (result.isObjCxxOnly())
     os << "#endif // defined(__OBJC__)\n";
+  printThrowsGuardEnd();
 }
 
 /// Returns true if the given property name like `isEmpty` can be remapped
@@ -1810,6 +1827,13 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
   assert(accessor->isSetter() || accessor->getParameters()->size() == 0);
   std::string accessorName = remapPropertyName(accessor, resultTy);
 
+  // The C++ bindings for a throwing accessor are only usable when the
+  // consumer opted into the experimental Swift error handling support.
+  bool needsThrowsGuard = accessor->hasThrows();
+  if (needsThrowsGuard)
+    ClangSyntaxPrinter(accessor->getASTContext(), os)
+        .printSwiftErrorBindingsGuardBegin();
+
   os << "  ";
 
   FunctionSignatureModifiers modifiers;
@@ -1831,6 +1855,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
     os << ";\n";
     if (result.isObjCxxOnly())
       os << "#endif\n";
+    if (needsThrowsGuard)
+      ClangSyntaxPrinter(accessor->getASTContext(), os)
+          .printSwiftErrorBindingsGuardEnd();
     return;
   }
   os << " {\n";
@@ -1842,6 +1869,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
   os << "  }\n";
   if (result.isObjCxxOnly())
     os << "#endif\n";
+  if (needsThrowsGuard)
+    ClangSyntaxPrinter(accessor->getASTContext(), os)
+        .printSwiftErrorBindingsGuardEnd();
 }
 
 void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
@@ -1851,6 +1881,12 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
     Type resultTy, bool isDefinition,
     std::optional<IRABIDetailsProvider::MethodDispatchInfo> dispatchInfo) {
   assert(accessor->isGetter());
+  // The C++ bindings for a throwing subscript are only usable when the
+  // consumer opted into the experimental Swift error handling support.
+  bool needsThrowsGuard = accessor->hasThrows();
+  if (needsThrowsGuard)
+    ClangSyntaxPrinter(accessor->getASTContext(), os)
+        .printSwiftErrorBindingsGuardBegin();
   // operator[] with multiple parameters only supported C++23 and up.
   bool multiParam = accessor->getParameters()->size() > 1;
   if (multiParam)
@@ -1872,6 +1908,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
       os << "#endif\n";
     if (multiParam)
       os << "#endif // #if __cplusplus >= 202302L\n";
+    if (needsThrowsGuard)
+      ClangSyntaxPrinter(accessor->getASTContext(), os)
+          .printSwiftErrorBindingsGuardEnd();
     return;
   }
   os << " {\n";
@@ -1885,6 +1924,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
     os << "#endif\n";
   if (multiParam)
     os << "#endif // #if __cplusplus >= 202302L\n";
+  if (needsThrowsGuard)
+    ClangSyntaxPrinter(accessor->getASTContext(), os)
+        .printSwiftErrorBindingsGuardEnd();
 }
 
 bool DeclAndTypeClangFunctionPrinter::hasKnownOptionalNullableCxxMapping(

--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -153,7 +153,8 @@ SWIFT_INLINE_THUNK cxxOverlay::IterationEndSentinel end(const Array<T> &) {
   return {};
 }
 
-#ifdef SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+#if defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR) &&                     \
+    !defined(__EmbeddedSwift__)
 
 extern "C" void *_Nonnull swift_errorRetain(void *_Nonnull swiftError) noexcept;
 
@@ -443,6 +444,6 @@ template <class T> using ThrowingResult = swift::Expected<T>;
 #endif
 
 #endif // SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
-#endif // SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+#endif // SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR && !__EmbeddedSwift__
 
 #endif

--- a/test/Interop/SwiftToCxx/functions/Inputs/throwing-bindings-guards.cpp
+++ b/test/Interop/SwiftToCxx/functions/Inputs/throwing-bindings-guards.cpp
@@ -1,0 +1,7 @@
+#include "guards.h"
+
+int useOrdinaryBindings() {
+  auto value = Guards::Guarded::init(Guards::ordinary());
+  value.setValue(7);
+  return static_cast<int>(value.getValue());
+}

--- a/test/Interop/SwiftToCxx/functions/throwing-bindings-guards.swift
+++ b/test/Interop/SwiftToCxx/functions/throwing-bindings-guards.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Guards -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/guards.h
+// RUN: %FileCheck %s < %t/guards.h
+// RUN: %check-interop-cxx-header-in-clang(%t/guards.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/guards.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/guards.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR -Wno-unused-function)
+// RUN: %target-interop-build-clangxx -fsyntax-only %S/Inputs/throwing-bindings-guards.cpp -I %t
+// RUN: %target-interop-build-clangxx -fsyntax-only %S/Inputs/throwing-bindings-guards.cpp -I %t -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -DSWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+public func ordinary() -> Int { 42 }
+public func throwing() throws -> Int { 42 }
+
+public struct Guarded {
+  public var value: Int
+  public init(_ value: Int) { self.value = value }
+  public init(checked value: Int) throws { self.value = value }
+  public func checked() throws -> Int { value }
+  public static func checkedStatic() throws -> Int { 42 }
+}
+
+// The low-level declaration, member declaration and out-of-line thunk must
+// all use the same opt-in condition as swift::Error/ThrowingResult.
+// CHECK: #if defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR) && !defined(SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR)
+// CHECK-NEXT: SWIFT_EXTERN
+// CHECK: #endif // defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR)
+// CHECK: #if defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR) && !defined(SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR)
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> checked()
+// CHECK-NEXT: #endif // defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR)
+// CHECK: #if defined(SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR) && !defined(SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR)
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> Guarded::checked()


### PR DESCRIPTION
A header containing a throwing declaration currently references error-support types even when the C++ consumer has not opted in. Guard the C declarations, member declarations and C++ thunks with the same opt-in/hide condition as the support types. Skip error support for Embedded Swift.

The regression test compiles the header with the opt-in enabled, absent and explicitly hidden, and verifies that ordinary functions, initializers and properties remain callable without error support.

Split from #91112 in response to the request for smaller, independently reviewable PRs. Based on current `main` (`cfbd3c5`).

Validation: The new Swift fixture typechecks with the installed Swift 6.3.3 toolchain. Compiler/header-generation lit tests still need Swift CI: this machine has no development compiler, and its production compiler rejects `GenerateBindingsForThrowingFunctionsInCXX`. No toolchain or build dependencies were downloaded.
