### PR TITLE
[cxx-interop] Expose throwing property and subscript accessors

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -376,10 +376,10 @@ swift::cxx_translation::getDeclRepresentation(
       return {Unsupported, UnrepresentableZeroSizedValueType};
   }
   if (const auto *storageDecl = dyn_cast<AbstractStorageDecl>(VD)) {
-    // Throwing accessors are not supported yet. Check subscripts as well as
-    // properties so typed throws cannot bypass the error ABI restriction.
+    // Check if any property or subscript accessor throws; do not expose it in
+    // that case, unless bindings for throwing functions are enabled.
     for (const auto *accessor : storageDecl->getAllAccessors()) {
-      if (accessor->hasThrows())
+      if (isUnrepresentableThrowingFunction(accessor))
         return {Unsupported, UnrepresentableThrows};
     }
   }

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -326,12 +326,30 @@ swift::cxx_translation::getDeclRepresentation(
   // Don't expose decls with definitions that are emitted into the client.
   if (VD->isAlwaysEmittedIntoClient())
     return {Unsupported, UnrepresentableRequiresClientEmission};
+  // Returns true when the given throwing function cannot be represented in
+  // C++: either bindings for throwing functions are disabled, or the function
+  // uses typed throws (SE-0413), whose ABI differs from untyped throws (the
+  // thrown error is not returned as an `any Error` box in the error slot) and
+  // is not yet supported by the C++ bindings.
+  auto isUnrepresentableThrowingFunction =
+      [](const AbstractFunctionDecl *AFD) -> bool {
+    if (!AFD->hasThrows())
+      return false;
+    if (!AFD->getASTContext().LangOpts.hasFeature(
+            Feature::GenerateBindingsForThrowingFunctionsInCXX))
+      return true;
+    // Only untyped throws (whose effective thrown type is `any Error`) uses
+    // the error-slot ABI the C++ bindings understand.
+    auto thrownType = AFD->getEffectiveThrownErrorType();
+    if (!thrownType)
+      return true;
+    return !(*thrownType)->isEqual(
+        AFD->getASTContext().getErrorExistentialType());
+  };
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
     if (AFD->hasAsync())
       return {Unsupported, UnrepresentableAsync};
-    if (AFD->hasThrows() &&
-        !AFD->getASTContext().LangOpts.hasFeature(
-            Feature::GenerateBindingsForThrowingFunctionsInCXX))
+    if (isUnrepresentableThrowingFunction(AFD))
       return {Unsupported, UnrepresentableThrows};
     if (AFD->hasGenericParamList())
       genericSignature = AFD->getGenericSignature();
@@ -357,9 +375,10 @@ swift::cxx_translation::getDeclRepresentation(
     if (!isa<ClassDecl>(typeDecl) && isZeroSized && (*isZeroSized)(typeDecl))
       return {Unsupported, UnrepresentableZeroSizedValueType};
   }
-  if (const auto *varDecl = dyn_cast<VarDecl>(VD)) {
-    // Check if any property accessor throws, do not expose it in that case.
-    for (const auto *accessor : varDecl->getAllAccessors()) {
+  if (const auto *storageDecl = dyn_cast<AbstractStorageDecl>(VD)) {
+    // Throwing accessors are not supported yet. Check subscripts as well as
+    // properties so typed throws cannot bypass the error ABI restriction.
+    for (const auto *accessor : storageDecl->getAllAccessors()) {
       if (accessor->hasThrows())
         return {Unsupported, UnrepresentableThrows};
     }

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1837,8 +1837,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
   // FIXME: should it be objTy for resultTy?
   printCxxThunkBody(accessor, signature, swiftSymbolName, typeDeclContext,
                     accessor->getModuleContext(), resultTy,
-                    accessor->getParameters(),
-                    /*hasThrows=*/false, nullptr, isStatic, dispatchInfo);
+                    accessor->getParameters(), accessor->hasThrows(), nullptr,
+                    isStatic, dispatchInfo);
   os << "  }\n";
   if (result.isObjCxxOnly())
     os << "#endif\n";
@@ -1879,7 +1879,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
   printCxxThunkBody(
       accessor, signature, swiftSymbolName, typeDeclContext,
       accessor->getModuleContext(), resultTy, accessor->getParameters(),
-      /*hasThrows=*/false, nullptr, /*isStatic=*/false, dispatchInfo);
+      accessor->hasThrows(), nullptr, /*isStatic=*/false, dispatchInfo);
   os << "  }\n";
   if (result.isObjCxxOnly())
     os << "#endif\n";

--- a/test/Interop/SwiftToCxx/properties/throwing-getter-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/properties/throwing-getter-in-cxx-execution.cpp
@@ -1,27 +1,17 @@
+// clang-format off
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %S/throwing-getter-in-cxx.swift -module-name
-// Properties -clang-header-expose-decls=all-public -enable-experimental-feature
-// GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify
-// -emit-clang-header-path %t/properties.h
+// RUN: %target-swift-frontend %S/throwing-getter-in-cxx.swift -module-name Properties -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/properties.h
 
-// RUN: %target-interop-build-clangxx -c %s -I %t -o
-// %t/swift-properties-errors-execution.o
-// -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN: %target-interop-build-swift
-// %S/throwing-getter-in-cxx.swift -o %t/swift-properties-errors-execution
-// -Xlinker %t/swift-properties-errors-execution.o -module-name Properties
-// -Xfrontend -entry-point-function-name -Xfrontend swiftMain
-// -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX
-
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-properties-errors-execution.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+// RUN: %target-interop-build-swift %S/throwing-getter-in-cxx.swift -o %t/swift-properties-errors-execution -Xlinker %t/swift-properties-errors-execution.o -module-name Properties -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX
 // RUN: %target-codesign %t/swift-properties-errors-execution
 // RUN: %target-run %t/swift-properties-errors-execution | %FileCheck %s
 
-// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o
-// %t/no-exceptions.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
-// %target-interop-build-swift %S/throwing-getter-in-cxx.swift -o
-// %t/no-exceptions -Xlinker %t/no-exceptions.o -module-name Properties
-// -Xfrontend -entry-point-function-name -Xfrontend swiftMain RUN:
-// %target-codesign %t/no-exceptions RUN: %target-run %t/no-exceptions
+// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o %t/no-exceptions.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+// RUN: %target-interop-build-swift %S/throwing-getter-in-cxx.swift -o %t/no-exceptions -Xlinker %t/no-exceptions.o -module-name Properties -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/no-exceptions
+// RUN: %target-run %t/no-exceptions
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
@@ -29,6 +19,7 @@
 
 // rdar://102167469
 // UNSUPPORTED: CPU=arm64e
+// clang-format on
 
 #include "properties.h"
 #include <cassert>

--- a/test/Interop/SwiftToCxx/properties/throwing-getter-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/properties/throwing-getter-in-cxx-execution.cpp
@@ -1,0 +1,81 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/throwing-getter-in-cxx.swift -module-name
+// Properties -clang-header-expose-decls=all-public -enable-experimental-feature
+// GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify
+// -emit-clang-header-path %t/properties.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o
+// %t/swift-properties-errors-execution.o
+// -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN: %target-interop-build-swift
+// %S/throwing-getter-in-cxx.swift -o %t/swift-properties-errors-execution
+// -Xlinker %t/swift-properties-errors-execution.o -module-name Properties
+// -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX
+
+// RUN: %target-codesign %t/swift-properties-errors-execution
+// RUN: %target-run %t/swift-properties-errors-execution | %FileCheck %s
+
+// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o
+// %t/no-exceptions.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
+// %target-interop-build-swift %S/throwing-getter-in-cxx.swift -o
+// %t/no-exceptions -Xlinker %t/no-exceptions.o -module-name Properties
+// -Xfrontend -entry-point-function-name -Xfrontend swiftMain RUN:
+// %target-codesign %t/no-exceptions RUN: %target-run %t/no-exceptions
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+// UNSUPPORTED: OS=windows-msvc
+
+// rdar://102167469
+// UNSUPPORTED: CPU=arm64e
+
+#include "properties.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  using namespace Properties;
+
+  auto props = ThrowingProps::init(false);
+  static_assert(!noexcept(props.getComputed()), "throwing getter");
+  static_assert(!noexcept(props[4]), "throwing subscript");
+#ifdef __cpp_exceptions
+  swift::Int value = props.getComputed();
+  printf("computed: %zd\n", static_cast<ptrdiff_t>(value));
+  swift::Int element = props[4];
+  printf("subscript: %zd\n", static_cast<ptrdiff_t>(element));
+
+  auto throwingProps = ThrowingProps::init(true);
+  try {
+    (void)throwingProps.getComputed();
+    puts("no exception");
+  } catch (const swift::Error &e) {
+    puts("getter threw");
+  }
+  try {
+    (void)throwingProps[4];
+    puts("no exception");
+  } catch (const swift::Error &e) {
+    puts("subscript threw");
+  }
+#else
+  auto value = props.getComputed();
+  assert(value.has_value() && value.value() == 21);
+  auto element = props[4];
+  assert(element.has_value() && element.value() == 8);
+  auto throwingProps = ThrowingProps::init(true);
+  assert(!throwingProps.getComputed().has_value());
+  assert(!throwingProps[4].has_value());
+#endif
+  return 0;
+}
+
+// CHECK: passThrowingGetter
+// CHECK-NEXT: computed: 21
+// CHECK-NEXT: passThrowingSubscript
+// CHECK-NEXT: subscript: 8
+// CHECK-NEXT: passThrowingGetter
+// CHECK-NEXT: getter threw
+// CHECK-NEXT: passThrowingSubscript
+// CHECK-NEXT: subscript threw

--- a/test/Interop/SwiftToCxx/properties/throwing-getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/throwing-getter-in-cxx.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Properties -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/properties.h
+// RUN: %FileCheck %s < %t/properties.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/properties.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
+
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+public enum PropError: Error {
+    case failure
+}
+
+public struct ThrowingProps {
+    public var shouldThrow: Bool
+
+    public init(shouldThrow: Bool) {
+        self.shouldThrow = shouldThrow
+    }
+
+    public var computed: Int {
+        get throws {
+            print("passThrowingGetter")
+            if shouldThrow { throw PropError.failure }
+            return 21
+        }
+    }
+
+    public subscript(index: Int) -> Int {
+        get throws {
+            print("passThrowingSubscript")
+            if shouldThrow { throw PropError.failure }
+            return index * 2
+        }
+    }
+}
+
+// CHECK: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> getComputed() const
+// CHECK: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> operator [](swift::Int index) const
+
+// CHECK: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> ThrowingProps::getComputed() const {
+// CHECK-NEXT: void* opaqueError = nullptr;
+// CHECK-NEXT: void* _ctx = nullptr;
+// CHECK-NEXT: auto returnValue = Properties::_impl::$s10Properties13ThrowingPropsV8computedSivg(Properties::_impl::swift_interop_passDirect_Properties_bool_0_1(_getOpaquePointer()), _ctx, &opaqueError);
+// CHECK-NEXT: if (opaqueError != nullptr)
+// CHECK-NEXT: #ifdef __cpp_exceptions
+// CHECK-NEXT: throw (swift::Error(opaqueError));
+// CHECK-NEXT: #else
+// CHECK-NEXT: return swift::Expected<swift::Int>(swift::Error(opaqueError));
+// CHECK-NEXT: #endif
+// CHECK-EMPTY:
+// CHECK-NEXT: return SWIFT_RETURN_THUNK(swift::Int, returnValue);
+// CHECK-NEXT: }
+
+// CHECK: SWIFT_INLINE_THUNK swift::ThrowingResult<swift::Int> ThrowingProps::operator [](swift::Int index) const SWIFT_SYMBOL("s:10Properties13ThrowingPropsVyS2icig") {
+// CHECK-NEXT: void* opaqueError = nullptr;
+// CHECK-NEXT: void* _ctx = nullptr;
+// CHECK-NEXT: auto returnValue = Properties::_impl::$s10Properties13ThrowingPropsVyS2icig(index, Properties::_impl::swift_interop_passDirect_Properties_bool_0_1(_getOpaquePointer()), _ctx, &opaqueError);
+// CHECK-NEXT: if (opaqueError != nullptr)
+// CHECK-NEXT: #ifdef __cpp_exceptions
+// CHECK-NEXT: throw (swift::Error(opaqueError));
+// CHECK-NEXT: #else
+// CHECK-NEXT: return swift::Expected<swift::Int>(swift::Error(opaqueError));
+// CHECK-NEXT: #endif
+// CHECK-EMPTY:
+// CHECK-NEXT: return SWIFT_RETURN_THUNK(swift::Int, returnValue);
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/unsupported/typed-throws-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/typed-throws-in-cxx.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Functions -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -clang-header-expose-decls=has-expose-attr -typecheck -verify -emit-clang-header-path %t/functions.h
+
+// RUN: cat %s | grep -v _expose > %t/clean.swift
+// RUN: %target-swift-frontend %t/clean.swift -module-name Functions -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/header.h
+// RUN: %FileCheck %s < %t/header.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/header.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
+
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+// Typed throws (SE-0413) uses a different ABI than untyped throws: the
+// thrown error is not returned as an `any Error` box in the error slot.
+// Such functions cannot be exposed to C++ yet, even with
+// GenerateBindingsForThrowingFunctionsInCXX enabled.
+
+public enum MyError: Error {
+    case fail
+    case worse
+}
+
+@_expose(Cxx) // expected-error {{global function 'typedThrowsFunction()' can not yet be represented in C++ as it may throw an error}}
+public func typedThrowsFunction() throws(MyError) { }
+
+@_expose(Cxx) // expected-error {{global function 'typedThrowsFunctionWithReturn()' can not yet be represented in C++ as it may throw an error}}
+public func typedThrowsFunctionWithReturn() throws(MyError) -> Int { return 0 }
+
+@_expose(Cxx)
+public struct HasTypedThrowsMembers {
+    public let stored: Int = 0
+
+    @_expose(Cxx) // expected-error {{instance method 'typedThrowsMethod()' can not yet be represented in C++ as it may throw an error}}
+    public func typedThrowsMethod() throws(MyError) { }
+
+    @_expose(Cxx) // expected-error {{initializer 'init(checked:)' can not yet be represented in C++ as it may throw an error}}
+    public init(checked: Int) throws(MyError) { }
+
+    public subscript(index: Int) -> Int {
+        get throws(MyError) { index }
+    }
+
+    public var computed: Int {
+        get throws(MyError) { 42 }
+    }
+}
+
+// No throwing thunk may be emitted anywhere in the header for these decls.
+// CHECK-NOT: SWIFT_INLINE_THUNK swift::ThrowingResult
+
+// CHECK: // Unavailable in C++: Swift global function 'typedThrowsFunction()'.
+// CHECK: // Unavailable in C++: Swift global function 'typedThrowsFunctionWithReturn()'.

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-funcs-in-cxx.swift
@@ -35,6 +35,15 @@ public struct HasMethods {
         }
     }
 
+    // Note: `@_expose` cannot be applied to subscripts directly; the
+    // all-public FileCheck lines below ensure a throwing subscript is not
+    // exposed (and does not produce a non-compiling header).
+    public subscript(index: Int) -> Int {
+        get throws {
+            return index
+        }
+    }
+
     @_expose(Cxx) // expected-error {{property 'unsupportedAEICProp' can not be exposed to C++ as it requires code to be emitted into client}}
     @_alwaysEmitIntoClient
     public var unsupportedAEICProp: Bool {
@@ -42,8 +51,17 @@ public struct HasMethods {
     }
 }
 
-// CHECK: HasMethods
-// CHECK: supported
+// The throwing property and subscript accessors must not be exposed
+// anywhere: neither in the class body (anchored below between the class
+// definition and the 'supported' thunk that follows it), nor among the
+// out-of-line member definitions (anchored between the 'supported' thunk
+// and the trailing unavailability comments).
+// CHECK: class SWIFT_SYMBOL("s:9Functions10HasMethodsV") HasMethods final {
+// CHECK-NOT: operator [](
+// CHECK-NOT: unsupportedProp
+// CHECK: SWIFT_INLINE_THUNK void supported()
+// CHECK-NOT: operator [](
+// CHECK-NOT: unsupportedProp
 
 // CHECK: // Unavailable in C++: Swift global function 'unsupportedAEIC()'.{{.*}}can not be exposed to C++ as it requires code to be emitted into client.
 // CHECK-EMPTY:


### PR DESCRIPTION
Honor the experimental throwing-bindings feature for `get throws` properties and subscripts, and propagate the accessor's throwing bit through the thunk printer. Typed throwing accessors remain unrepresentable.

Tests cover feature-disabled diagnostics, emitted error checks, success/failure execution with and without C++ exceptions, and the throwing accessors' exception specifications.

Split from #91112 in response to the request for smaller, independently reviewable PRs. Based on current `main` (`cfbd3c5`).

Depends on #92025. This branch includes that prerequisite; [review only the accessor increment](https://github.com/mrousavy/swift/compare/cxx-interop-reject-typed-throws...cxx-interop-throwing-accessors).

Validation: The new Swift fixture typechecks with the installed Swift 6.3.3 toolchain. Compiler/header-generation lit tests still need Swift CI: this machine has no development compiler, and its production compiler rejects `GenerateBindingsForThrowingFunctionsInCXX`. No toolchain or build dependencies were downloaded.
