### PR TITLE
[cxx-interop] Check thrown errors before materializing return values

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1353,7 +1353,23 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   }
   if (hasThrows) {
     os << "  void* opaqueError = nullptr;\n";
-    os << "  void* _ctx = nullptr;\n";
+    // The lowered signature only has a synthesized context parameter when
+    // there is no self parameter that already acts as the context (e.g. for
+    // free functions). Only emit the placeholder context variable when it's
+    // actually passed to the call, to avoid an unused variable in the thunk.
+    bool hasContextParam = false;
+    signature.visitParameterList(
+        [](const LoweredFunctionSignature::IndirectResultValue &) {},
+        [](const LoweredFunctionSignature::DirectParameter &) {},
+        [](const LoweredFunctionSignature::IndirectParameter &) {},
+        [](const LoweredFunctionSignature::GenericRequirementParameter &) {},
+        [](const LoweredFunctionSignature::MetadataSourceParameter &) {},
+        [&](const LoweredFunctionSignature::ContextParameter &) {
+          hasContextParam = true;
+        },
+        [](const LoweredFunctionSignature::ErrorResultValue &) {});
+    if (hasContextParam)
+      os << "  void* _ctx = nullptr;\n";
   }
   std::optional<StringRef> indirectFunctionVar;
   using DispatchKindTy = IRABIDetailsProvider::MethodDispatchInfo::Kind;
@@ -1691,8 +1707,14 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
     if (resultTy->isVoid()) {
       os << "    return swift::Expected<void>(swift::Error(opaqueError));\n";
       os << "#endif\n";
-      if (FD->getInterfaceType()->castTo<FunctionType>()->getResult()->isUninhabited())
+      const auto *funcDecl = dyn_cast<FuncDecl>(FD);
+      if (funcDecl && funcDecl->getResultInterfaceType()->isUninhabited()) {
         os << "  abort();\n";
+      } else {
+        os << "#ifndef __cpp_exceptions\n";
+        os << "  return swift::Expected<void>();\n";
+        os << "#endif\n";
+      }
     } else {
       auto directResultType = signature.getDirectResultType();
       printDirectReturnOrParamCType(

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -163,13 +163,17 @@ public:
 
   static void
   printGenericReturnScaffold(raw_ostream &os, StringRef templateParamName,
-                             llvm::function_ref<void(StringRef)> bodyOfReturn) {
+                             llvm::function_ref<void(StringRef)> bodyOfReturn,
+                             llvm::function_ref<void()> afterCallPrinter =
+                                 nullptr) {
     printReturnScaffold(false, os, templateParamName, templateParamName,
-                        bodyOfReturn);
+                        bodyOfReturn, afterCallPrinter);
   }
 
   void printReturnScaffold(ASTContext &Context, raw_ostream &os,
-                           llvm::function_ref<void(StringRef)> bodyOfReturn) {
+                           llvm::function_ref<void(StringRef)> bodyOfReturn,
+                           llvm::function_ref<void()> afterCallPrinter =
+                               nullptr) {
     std::string fullQualifiedType;
     std::string typeName;
     {
@@ -179,26 +183,34 @@ public:
       unqualTypeNameOS << typeDecl->getName();
     }
     printReturnScaffold(isTrivial(typeDecl), os, fullQualifiedType, typeName,
-                        bodyOfReturn);
+                        bodyOfReturn, afterCallPrinter);
   }
 
   static void
   printSIMDReturnScaffold(StringRef simdTypeName, raw_ostream &os,
-                          llvm::function_ref<void(StringRef)> bodyOfReturn) {
-    printReturnScaffold(true, os, simdTypeName, simdTypeName, bodyOfReturn);
+                          llvm::function_ref<void(StringRef)> bodyOfReturn,
+                          llvm::function_ref<void()> afterCallPrinter =
+                              nullptr) {
+    printReturnScaffold(true, os, simdTypeName, simdTypeName, bodyOfReturn,
+                        afterCallPrinter);
   }
 
 private:
   static void
   printReturnScaffold(bool isTrivial, raw_ostream &os,
                       StringRef fullQualifiedType, StringRef typeName,
-                      llvm::function_ref<void(StringRef)> bodyOfReturn) {
+                      llvm::function_ref<void(StringRef)> bodyOfReturn,
+                      llvm::function_ref<void()> afterCallPrinter) {
     os << "alignas(alignof(" << fullQualifiedType << ")) char storage[sizeof("
        << fullQualifiedType << ")];\n";
     os << "auto * _Nonnull storageObjectPtr = reinterpret_cast<"
        << fullQualifiedType << " *>(storage);\n";
     bodyOfReturn("storage");
     os << ";\n";
+    // The error check has to run before the returned value is materialized,
+    // as the storage holds no valid value when the callee threw an error.
+    if (afterCallPrinter)
+      afterCallPrinter();
     if (isTrivial) {
       // Trivial object can be just copied and not destroyed.
       os << "return *storageObjectPtr;\n";
@@ -1273,7 +1285,12 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
 void DeclAndTypeClangFunctionPrinter::printGenericReturnSequence(
     raw_ostream &os, const GenericTypeParamType *gtpt,
     llvm::function_ref<void(StringRef)> invocationPrinter,
-    std::optional<StringRef> initializeWithTakeFromValue) {
+    std::optional<StringRef> initializeWithTakeFromValue,
+    llvm::function_ref<void()> errorCheckPrinter) {
+  // The take-from-value mode reads an already-produced value, so there is no
+  // call that could throw; combining it with an error check is unsupported.
+  assert(!(errorCheckPrinter && initializeWithTakeFromValue) &&
+         "cannot check for a thrown error when taking from a value");
   std::string returnAddress;
   llvm::raw_string_ostream ros(returnAddress);
   ros << "reinterpret_cast<void *>(&returnValue)";
@@ -1294,6 +1311,8 @@ void DeclAndTypeClangFunctionPrinter::printGenericReturnSequence(
          << *initializeWithTakeFromValue << ")";
     }
     os << ";\n";
+    if (errorCheckPrinter)
+      errorCheckPrinter();
     os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
        << "::implClassFor<" << resultTyName
        << ">::type::makeRetained(returnValue);\n";
@@ -1301,26 +1320,68 @@ void DeclAndTypeClangFunctionPrinter::printGenericReturnSequence(
        << cxx_synthesis::getCxxImplNamespaceName() << "::isValueType<"
        << resultTyName << ">) {\n";
 
-    os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
-       << "::implClassFor<" << resultTyName
-       << ">::type::returnNewValue([&](void * _Nonnull returnValue) "
-          "SWIFT_INLINE_THUNK_ATTRIBUTES {\n";
-    if (!initializeWithTakeFromValue) {
-      invocationPrinter(/*additionalParam=*/StringRef("returnValue"));
+    if (errorCheckPrinter && !initializeWithTakeFromValue) {
+      // The result value must only be materialized in its C++ representation
+      // when the callee didn't throw an error: perform the call into
+      // temporary heap storage first, and move the result into place after
+      // the error check. Otherwise the C++ value would be constructed from
+      // (and later destroyed with) uninitialized storage whenever the thrown
+      // error propagates.
+      os << "  void *returnMetadata = swift::TypeMetadataTrait<"
+         << resultTyName << ">::getTypeMetadata();\n";
+      os << "  auto *returnVWTableAddr = reinterpret_cast<::swift::"
+         << cxx_synthesis::getCxxImplNamespaceName()
+         << "::ValueWitnessTable **>(returnMetadata) - 1;\n";
+      os << "#ifdef __arm64e__\n";
+      os << "  auto *returnVWTable = reinterpret_cast<::swift::"
+         << cxx_synthesis::getCxxImplNamespaceName()
+         << "::ValueWitnessTable *>(ptrauth_auth_data("
+            "reinterpret_cast<void *>(*returnVWTableAddr), "
+            "ptrauth_key_process_independent_data, "
+            "ptrauth_blend_discriminator(returnVWTableAddr, "
+         << SpecialPointerAuthDiscriminators::ValueWitnessTable << ")));\n";
+      os << "#else\n";
+      os << "  auto *returnVWTable = *returnVWTableAddr;\n";
+      os << "#endif\n";
+      os << "  ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+         << "::OpaqueStorage returnStorage(returnVWTable->size, "
+            "returnVWTable->getAlignment());\n";
+      os << "  ";
+      invocationPrinter(
+          /*additionalParam=*/StringRef("returnStorage.getOpaquePointer()"));
+      os << ";\n";
+      errorCheckPrinter();
+      os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+         << "::implClassFor<" << resultTyName
+         << ">::type::returnNewValue([&](void * _Nonnull returnValue) "
+            "SWIFT_INLINE_THUNK_ATTRIBUTES {\n";
+      os << "    ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+         << "::implClassFor<" << resultTyName
+         << ">::type::initializeWithTake(reinterpret_cast<char * "
+            "_Nonnull>(returnValue), returnStorage.getOpaquePointer());\n";
+      os << "  });\n";
     } else {
       os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
          << "::implClassFor<" << resultTyName
-         << ">::type::initializeWithTake(reinterpret_cast<char * "
-            "_Nonnull>(returnValue), "
-         << *initializeWithTakeFromValue << ")";
+         << ">::type::returnNewValue([&](void * _Nonnull returnValue) "
+            "SWIFT_INLINE_THUNK_ATTRIBUTES {\n";
+      if (!initializeWithTakeFromValue) {
+        invocationPrinter(/*additionalParam=*/StringRef("returnValue"));
+      } else {
+        os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+           << "::implClassFor<" << resultTyName
+           << ">::type::initializeWithTake(reinterpret_cast<char * "
+              "_Nonnull>(returnValue), "
+           << *initializeWithTakeFromValue << ")";
+      }
+      os << ";\n  });\n";
     }
-    os << ";\n  });\n";
     os << "  } else if constexpr (::swift::"
        << cxx_synthesis::getCxxImplNamespaceName()
        << "::isSwiftBridgedCxxRecord<" << resultTyName << ">) {\n";
     if (!initializeWithTakeFromValue) {
-      ClangTypeHandler::printGenericReturnScaffold(os, resultTyName,
-                                                   invocationPrinter);
+      ClangTypeHandler::printGenericReturnScaffold(
+          os, resultTyName, invocationPrinter, errorCheckPrinter);
     } else {
       // FIXME: support taking a C++ record type.
       os << "abort();\n";
@@ -1333,7 +1394,10 @@ void DeclAndTypeClangFunctionPrinter::printGenericReturnSequence(
       os << "memcpy(&returnValue, " << *initializeWithTakeFromValue
          << ", sizeof(returnValue))";
     }
-    os << ";\n  return returnValue;\n";
+    os << ";\n";
+    if (errorCheckPrinter)
+      errorCheckPrinter();
+    os << "  return returnValue;\n";
     os << "  }\n";
   });
 }
@@ -1604,6 +1668,41 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
     os << ')';
   };
 
+  // The C++ type the value returned from a throwing function is wrapped in
+  // (the `T` in `swift::ThrowingResult<T>`); used by the error propagation
+  // code below.
+  std::string throwsReturnTypeStr;
+  if (hasThrows) {
+    llvm::raw_string_ostream returnTypeOS(throwsReturnTypeStr);
+    OptionalTypeKind retKind;
+    Type objTy;
+    std::tie(objTy, retKind) =
+        DeclAndTypePrinter::getObjectTypeAndOptionality(FD, resultTy);
+    auto retTypeRepr = printClangFunctionReturnType(
+        returnTypeOS, objTy, retKind, const_cast<ModuleDecl *>(moduleContext),
+        OutputLanguageMode::Cxx);
+    assert(!retTypeRepr.isUnsupported());
+    (void)retTypeRepr;
+  }
+
+  // Emits the check that propagates a thrown Swift error to C++, either by
+  // throwing a `swift::Error` exception, or by returning it wrapped in
+  // `swift::Expected` when C++ exceptions are unavailable. This must run
+  // after the call to the native Swift function, but before the returned
+  // value is materialized in its C++ representation.
+  auto printThrowsErrorCheckImpl = [&]() {
+    os << "  if (opaqueError != nullptr)\n";
+    os << "#ifdef __cpp_exceptions\n";
+    os << "    throw (swift::Error(opaqueError));\n";
+    os << "#else\n";
+    os << "    return swift::Expected<" << throwsReturnTypeStr
+       << ">(swift::Error(opaqueError));\n";
+    os << "#endif\n";
+  };
+  llvm::function_ref<void()> printThrowsErrorCheck =
+      hasThrows ? llvm::function_ref<void()>(printThrowsErrorCheckImpl)
+                : llvm::function_ref<void()>(nullptr);
+
   // Values types are returned either direcly in their C representation, or
   // indirectly by a pointer.
   auto knownTypeKind =
@@ -1611,15 +1710,37 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   if (knownTypeKind != KnownTypeKind::Known &&
       !hasKnownOptionalNullableCxxMapping(resultTy)) {
     if (const auto *gtpt = resultTy->getAs<GenericTypeParamType>()) {
-      printGenericReturnSequence(os, gtpt, printCallToCFunc);
+      printGenericReturnSequence(os, gtpt, printCallToCFunc,
+                                 /*initializeWithTakeFromValue=*/std::nullopt,
+                                 printThrowsErrorCheck);
       return;
     }
     if (auto *classDecl = resultTy->getClassOrBoundGenericClass()) {
       if (classDecl->hasClangNode()) {
         assert(!isa<clang::ObjCContainerDecl>(classDecl->getClangDecl()));
+        if (hasThrows) {
+          os << "  auto returnValue = ";
+          printCallToCFunc(/*additionalParam=*/std::nullopt);
+          os << ";\n";
+          printThrowsErrorCheck();
+          os << "  return SWIFT_RETURN_THUNK(" << throwsReturnTypeStr
+             << ", returnValue);\n";
+          return;
+        }
         os << "return ";
         printCallToCFunc(/*additionalParam=*/std::nullopt);
         os << ";\n";
+        return;
+      }
+      if (hasThrows) {
+        // Stash the returned opaque class pointer and check for a thrown
+        // error before wrapping it in its C++ representation.
+        os << "  void *returnValue = ";
+        printCallToCFunc(/*additionalParam=*/std::nullopt);
+        os << ";\n";
+        printThrowsErrorCheck();
+        ClangClassTypePrinter::printClassTypeReturnScaffold(
+            os, classDecl, moduleContext, [&]() { os << "returnValue"; });
         return;
       }
       ClangClassTypePrinter::printClassTypeReturnScaffold(
@@ -1650,18 +1771,85 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
                 dyn_cast<TypeAliasType>(resultTy.getPointer())) {
           auto info = getKnownTypeInfo(typeAliasType->getDecl(), typeMapping,
                                        OutputLanguageMode::Cxx);
-          ClangTypeHandler::printSIMDReturnScaffold(info->name, os,
-                                                    valueTypeReturnThunker);
+          ClangTypeHandler::printSIMDReturnScaffold(
+              info->name, os, valueTypeReturnThunker, printThrowsErrorCheck);
           return;
         }
       }
       if (decl->hasClangNode()) {
         ClangTypeHandler handler(decl->getClangDecl());
         assert(handler.isRepresentable());
-        handler.printReturnScaffold(moduleContext->getASTContext(), os, valueTypeReturnThunker);
+        handler.printReturnScaffold(moduleContext->getASTContext(), os,
+                                    valueTypeReturnThunker,
+                                    printThrowsErrorCheck);
         return;
       }
       ClangValueTypePrinter valueTypePrinter(os, cPrologueOS, interopContext);
+
+      if (hasThrows) {
+        // The returned value must only be materialized in its C++
+        // representation when the callee didn't throw an error, as its
+        // storage is left uninitialized when an error is thrown. Perform the
+        // call first, then check for an error, and only then construct the
+        // returned value.
+        if (auto directResultType = signature.getDirectResultType()) {
+          // The direct aggregate returned from the call is trivial and can
+          // be stashed in a local before the error check.
+          std::string typeEncoding =
+              encodeTypeInfo(*directResultType, moduleContext, typeMapping);
+          os << "  auto returnValue = ";
+          printCallToCFunc(/*additionalParam=*/std::nullopt);
+          os << ";\n";
+          printThrowsErrorCheck();
+          valueTypePrinter.printValueTypeReturnScaffold(
+              decl, moduleContext,
+              [&]() { printTypeImplTypeSpecifier(resultTy, moduleContext); },
+              [&](StringRef resultPointerName) {
+                ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+                    .printBaseName(moduleContext);
+                os << "::" << cxx_synthesis::getCxxImplNamespaceName()
+                   << "::swift_interop_returnDirect_" << typeEncoding << '('
+                   << resultPointerName << ", returnValue)";
+              });
+          return;
+        }
+        // The value is returned indirectly; perform the call into temporary
+        // heap storage, and move the result into place after the error
+        // check.
+        os << "  void *returnMetadata = swift::TypeMetadataTrait<"
+           << throwsReturnTypeStr << ">::getTypeMetadata();\n";
+        os << "  auto *returnVWTableAddr = reinterpret_cast<::swift::"
+           << cxx_synthesis::getCxxImplNamespaceName()
+           << "::ValueWitnessTable **>(returnMetadata) - 1;\n";
+        os << "#ifdef __arm64e__\n";
+        os << "  auto *returnVWTable = reinterpret_cast<::swift::"
+           << cxx_synthesis::getCxxImplNamespaceName()
+           << "::ValueWitnessTable *>(ptrauth_auth_data("
+              "reinterpret_cast<void *>(*returnVWTableAddr), "
+              "ptrauth_key_process_independent_data, "
+              "ptrauth_blend_discriminator(returnVWTableAddr, "
+           << SpecialPointerAuthDiscriminators::ValueWitnessTable << ")));\n";
+        os << "#else\n";
+        os << "  auto *returnVWTable = *returnVWTableAddr;\n";
+        os << "#endif\n";
+        os << "  ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+           << "::OpaqueStorage returnStorage(returnVWTable->size, "
+              "returnVWTable->getAlignment());\n";
+        os << "  ";
+        printCallToCFunc(
+            /*additionalParam=*/StringRef("returnStorage.getOpaquePointer()"));
+        os << ";\n";
+        printThrowsErrorCheck();
+        valueTypePrinter.printValueTypeReturnScaffold(
+            decl, moduleContext,
+            [&]() { printTypeImplTypeSpecifier(resultTy, moduleContext); },
+            [&](StringRef resultPointerName) {
+              printTypeImplTypeSpecifier(resultTy, moduleContext);
+              os << "::initializeWithTake(" << resultPointerName
+                 << ", returnStorage.getOpaquePointer())";
+            });
+        return;
+      }
 
       valueTypePrinter.printValueTypeReturnScaffold(
           decl, moduleContext,
@@ -1678,6 +1866,16 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
       (classDecl && isa<clang::ObjCContainerDecl>(classDecl->getClangDecl())) ||
       nonOptResultType->isObjCExistentialType()) {
     assert(!classDecl || classDecl->hasClangNode());
+    if (hasThrows) {
+      os << "  void *returnValue = (__bridge void *)";
+      printCallToCFunc(/*additionalParam=*/std::nullopt);
+      os << ";\n";
+      printThrowsErrorCheck();
+      os << "  return (__bridge_transfer ";
+      declPrinter.withOutputStream(os).print(nonOptResultType);
+      os << ")returnValue;\n";
+      return;
+    }
     os << "return (__bridge_transfer ";
     declPrinter.withOutputStream(os).print(nonOptResultType);
     os << ")(__bridge void *)";
@@ -1700,50 +1898,26 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
 
   // Create the condition and the statement to throw an exception.
   if (hasThrows) {
-    os << "  if (opaqueError != nullptr)\n";
-    os << "#ifdef __cpp_exceptions\n";
-    os << "    throw (swift::Error(opaqueError));\n";
-    os << "#else\n";
+    printThrowsErrorCheck();
     if (resultTy->isVoid()) {
-      os << "    return swift::Expected<void>(swift::Error(opaqueError));\n";
-      os << "#endif\n";
+      // A `Never` returning function can't return normally after the error
+      // check.
       const auto *funcDecl = dyn_cast<FuncDecl>(FD);
       if (funcDecl && funcDecl->getResultInterfaceType()->isUninhabited()) {
         os << "  abort();\n";
       } else {
+        // When C++ exceptions are unavailable the thunk returns
+        // `swift::Expected<void>`, so the success path needs an explicit
+        // return.
         os << "#ifndef __cpp_exceptions\n";
         os << "  return swift::Expected<void>();\n";
         os << "#endif\n";
       }
     } else {
-      auto directResultType = signature.getDirectResultType();
-      printDirectReturnOrParamCType(
-          *directResultType, resultTy, moduleContext, os, cPrologueOS,
-          typeMapping, interopContext, [&]() {
-            os << "    return swift::Expected<";
-            OptionalTypeKind retKind;
-            Type objTy;
-            std::tie(objTy, retKind) =
-                DeclAndTypePrinter::getObjectTypeAndOptionality(FD, resultTy);
-
-            auto s = printClangFunctionReturnType(
-                os, objTy, retKind, const_cast<ModuleDecl *>(moduleContext),
-                OutputLanguageMode::Cxx);
-            os << ">(swift::Error(opaqueError));\n";
-            os << "#endif\n";
-
-            // Return the function result value if it doesn't throw.
-            if (!resultTy->isVoid() && hasThrows) {
-              os << "\n";
-              os << "  return SWIFT_RETURN_THUNK(";
-              printClangFunctionReturnType(
-                  os, objTy, retKind, const_cast<ModuleDecl *>(moduleContext),
-                  OutputLanguageMode::Cxx);
-              os << ", returnValue);\n";
-            }
-
-            assert(!s.isUnsupported());
-          });
+      // Return the function result value if it doesn't throw.
+      os << "\n";
+      os << "  return SWIFT_RETURN_THUNK(" << throwsReturnTypeStr
+         << ", returnValue);\n";
     }
   }
 }

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -157,10 +157,16 @@ public:
       raw_ostream &stream, Type ty, OptionalTypeKind optKind,
       ModuleDecl *moduleContext, OutputLanguageMode outputLang);
 
+  /// If \p errorCheckPrinter is non-null, the function being called can
+  /// throw, and the given callback is responsible for emitting the code that
+  /// checks `opaqueError` and propagates the error. It is invoked after the
+  /// call to the native Swift function, but before the returned value is
+  /// materialized in its C++ representation.
   static void printGenericReturnSequence(
       raw_ostream &os, const GenericTypeParamType *gtpt,
       llvm::function_ref<void(StringRef)> invocationPrinter,
-      std::optional<StringRef> initializeWithTakeFromValue = std::nullopt);
+      std::optional<StringRef> initializeWithTakeFromValue = std::nullopt,
+      llvm::function_ref<void()> errorCheckPrinter = nullptr);
 
   using PrinterTy =
       llvm::function_ref<void(llvm::MapVector<Type, std::string> &)>;

--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -372,10 +372,9 @@ private:
 template<>
 class Expected<void> {
 public:
-  /// Default
+  /// Default: a successful `void` result.
   Expected() noexcept {
-    new (&buffer) Error();
-    has_val = false;
+    has_val = true;
   }
 
   Expected(const swift::Error &error_val) noexcept {
@@ -385,9 +384,7 @@ public:
 
   /// Copy
   Expected(Expected const& other) noexcept {
-    if (other.has_value())
-      abort();
-    else
+    if (!other.has_value())
       new (&buffer) Error(other.error());
 
     has_val = other.has_value();
@@ -397,7 +394,10 @@ public:
   // FIXME: Implement move semantics when move swift values is possible
   [[noreturn]] Expected(Expected&&) noexcept { abort(); }
 
-  ~Expected() noexcept { reinterpret_cast<swift::Error *>(buffer)->~Error(); }
+  ~Expected() noexcept {
+    if (!has_value())
+      reinterpret_cast<swift::Error *>(buffer)->~Error();
+  }
 
   /// assignment
   constexpr auto operator=(Expected&& other) noexcept = delete;

--- a/test/Interop/SwiftToCxx/functions/throwing-results-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/throwing-results-execution.cpp
@@ -1,21 +1,19 @@
+// clang-format off
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/throwing-results.swift -module-name Results
-// -clang-header-expose-decls=all-public -enable-experimental-feature
-// GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path
-// %t/results.h RUN: %target-interop-build-clangxx -std=c++17 -c %s -I %t -o
-// %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
-// %target-interop-build-swift %S/throwing-results.swift -o %t/test -Xlinker
-// %t/test.o -module-name Results -Xfrontend -entry-point-function-name
-// -Xfrontend swiftMain RUN: %target-codesign %t/test RUN: %target-run %t/test
-// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o
-// %t/no-exceptions.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
-// %target-interop-build-swift %S/throwing-results.swift -o %t/no-exceptions
-// -Xlinker %t/no-exceptions.o -module-name Results -Xfrontend
-// -entry-point-function-name -Xfrontend swiftMain RUN: %target-codesign
-// %t/no-exceptions RUN: %target-run %t/no-exceptions REQUIRES: executable_test
+// RUN: %target-swift-frontend %S/throwing-results.swift -module-name Results -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path %t/results.h
+// RUN: %target-interop-build-clangxx -std=c++17 -c %s -I %t -o %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+// RUN: %target-interop-build-swift %S/throwing-results.swift -o %t/test -Xlinker %t/test.o -module-name Results -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/test
+// RUN: %target-run %t/test
+// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o %t/no-exceptions.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+// RUN: %target-interop-build-swift %S/throwing-results.swift -o %t/no-exceptions -Xlinker %t/no-exceptions.o -module-name Results -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/no-exceptions
+// RUN: %target-run %t/no-exceptions
+// REQUIRES: executable_test
 // REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
 // UNSUPPORTED: OS=windows-msvc
 // UNSUPPORTED: CPU=arm64e
+// clang-format on
 
 #include "results.h"
 #include <cassert>

--- a/test/Interop/SwiftToCxx/functions/throwing-results-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/throwing-results-execution.cpp
@@ -1,0 +1,96 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/throwing-results.swift -module-name Results
+// -clang-header-expose-decls=all-public -enable-experimental-feature
+// GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path
+// %t/results.h RUN: %target-interop-build-clangxx -std=c++17 -c %s -I %t -o
+// %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
+// %target-interop-build-swift %S/throwing-results.swift -o %t/test -Xlinker
+// %t/test.o -module-name Results -Xfrontend -entry-point-function-name
+// -Xfrontend swiftMain RUN: %target-codesign %t/test RUN: %target-run %t/test
+// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o
+// %t/no-exceptions.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
+// %target-interop-build-swift %S/throwing-results.swift -o %t/no-exceptions
+// -Xlinker %t/no-exceptions.o -module-name Results -Xfrontend
+// -entry-point-function-name -Xfrontend swiftMain RUN: %target-codesign
+// %t/no-exceptions RUN: %target-run %t/no-exceptions REQUIRES: executable_test
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+// UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: CPU=arm64e
+
+#include "results.h"
+#include <cassert>
+#include <string>
+
+template <class Operation, class Validate>
+void checkResult(Operation operation, Validate validate) {
+#ifdef __cpp_exceptions
+  {
+    auto value = operation(false);
+    validate(value);
+  }
+  try {
+    (void)operation(true);
+    assert(false && "a Swift error must propagate");
+  } catch (swift::Error &error) {
+    assert(error.as<Results::ResultError>().get() ==
+           Results::ResultError::failure);
+  }
+#else
+  {
+    auto value = operation(false);
+    assert(value.has_value());
+    validate(value.value());
+  }
+  auto error = operation(true);
+  assert(!error.has_value());
+  assert(error.error().template as<Results::ResultError>().get() ==
+         Results::ResultError::failure);
+#endif
+}
+
+int main() {
+  auto small = [](const Results::Small &value) {
+    assert(value.getValue() == 42);
+  };
+  auto large = [](const Results::Large &value) {
+    assert(value.getA() == 1 && value.getE() == 5);
+    assert(Results::canaryCount() == 1);
+  };
+  auto ref = [](Results::Ref &value) { assert(value.getValue() == 42); };
+  checkResult(Results::direct, small);
+  checkResult(Results::indirect, large);
+  assert(Results::canaryCount() == 0);
+  checkResult(Results::reference, ref);
+  checkResult(Results::string, [](const swift::String &value) {
+    assert(std::string(value) == "Hello from Swift");
+  });
+  checkResult([](bool fail) { return Results::Small::init(42, fail); }, small);
+  checkResult(Results::Large::init, large);
+  assert(Results::canaryCount() == 0);
+  checkResult(Results::Holder::init, [](const Results::Holder &) {
+    assert(Results::canaryCount() == 1);
+  });
+  assert(Results::canaryCount() == 0);
+  checkResult(Results::Ref::init, ref);
+  checkResult(Results::Small::make, small);
+  auto value = Results::Small::init(21);
+  checkResult([&](bool fail) { return value.doubled(fail); }, small);
+  checkResult([&](bool fail) { return value.increment(fail); },
+              [](swift::Int i) { assert(i == 22); });
+  assert(value.getValue() == 22);
+  checkResult([](bool fail) { return Results::generic(swift::Int(42), fail); },
+              [](swift::Int i) { assert(i == 42); });
+  auto genericValue = Results::Small::init(42);
+  checkResult([&](bool fail) { return Results::generic(genericValue, fail); },
+              small);
+  // Exercise all generic return representations, including reference values.
+  checkResult(Results::reference, [&](Results::Ref &object) {
+    checkResult([&](bool fail) { return Results::generic(object, fail); }, ref);
+    checkResult([&](bool fail) { return object.result(fail); }, small);
+  });
+  checkResult(Results::indirect, [&](const Results::Large &object) {
+    checkResult([&](bool fail) { return Results::generic(object, fail); },
+                large);
+  });
+  assert(Results::canaryCount() == 0);
+}

--- a/test/Interop/SwiftToCxx/functions/throwing-results.swift
+++ b/test/Interop/SwiftToCxx/functions/throwing-results.swift
@@ -1,0 +1,106 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Results -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/results.h
+// RUN: %FileCheck %s < %t/results.h
+// RUN: %check-interop-cxx-header-in-clang(%t/results.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+public enum ResultError: Error { case failure }
+private func check(_ fail: Bool) throws {
+  if fail { throw ResultError.failure }
+}
+
+private var livingCanaries = 0
+public func canaryCount() -> Int { livingCanaries }
+private final class Canary {
+  init() { livingCanaries += 1 }
+  deinit { livingCanaries -= 1 }
+}
+
+public struct Small {
+  public var value: Int
+  public init(_ value: Int) { self.value = value }
+  public init(checked value: Int, _ fail: Bool) throws {
+    try check(fail)
+    self.value = value
+  }
+  public func doubled(_ fail: Bool) throws -> Small {
+    try check(fail)
+    return Small(value * 2)
+  }
+  public mutating func increment(_ fail: Bool) throws -> Int {
+    try check(fail)
+    value += 1
+    return value
+  }
+  public static func make(_ fail: Bool) throws -> Small {
+    try Small(checked: 42, fail)
+  }
+}
+
+public struct Large {
+  public let a, b, c, d, e: Int
+  private let canary: Canary
+  public init(_ fail: Bool) throws {
+    // A failed initializer must clean up this partially initialized state.
+    canary = Canary()
+    try check(fail)
+    a = 1; b = 2; c = 3; d = 4; e = 5
+  }
+}
+
+public struct Holder {
+  private let canary: Canary
+  public init(_ fail: Bool) throws {
+    try check(fail)
+    canary = Canary()
+  }
+}
+
+public final class Ref {
+  public let value: Int
+  public init(_ fail: Bool) throws {
+    try check(fail)
+    value = 42
+  }
+  public func result(_ fail: Bool) throws -> Small {
+    try Small(checked: value, fail)
+  }
+}
+
+public func direct(_ fail: Bool) throws -> Small {
+  try Small(checked: 42, fail)
+}
+public func indirect(_ fail: Bool) throws -> Large { try Large(fail) }
+public func reference(_ fail: Bool) throws -> Ref { try Ref(fail) }
+public func string(_ fail: Bool) throws -> String {
+  try check(fail)
+  return "Hello from Swift"
+}
+public func generic<T>(_ value: T, _ fail: Bool) throws -> T {
+  try check(fail)
+  return value
+}
+
+// No Swift value may be materialized or destroyed on the error path.
+// CHECK: swift::ThrowingResult<Small> direct
+// CHECK: auto returnValue =
+// CHECK: if (opaqueError != nullptr)
+// CHECK: return {{.*}}returnNewValue
+
+// CHECK: swift::ThrowingResult<T_0_0> generic
+// CHECK: void *returnValue;
+// CHECK: if (opaqueError != nullptr)
+// CHECK: makeRetained(returnValue)
+// CHECK: ::OpaqueStorage returnStorage
+// CHECK: if (opaqueError != nullptr)
+// CHECK: ::initializeWithTake
+
+// CHECK: swift::ThrowingResult<Large> indirect
+// CHECK: ::OpaqueStorage returnStorage
+// CHECK: if (opaqueError != nullptr)
+// CHECK: ::initializeWithTake
+
+// CHECK: swift::ThrowingResult<Ref> reference
+// CHECK: void *returnValue =
+// CHECK: if (opaqueError != nullptr)
+// CHECK: makeRetained(returnValue)

--- a/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
@@ -1,16 +1,15 @@
+// clang-format off
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/throwing-void.swift -module-name ThrowingVoid
-// -clang-header-expose-decls=all-public -enable-experimental-feature
-// GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path
-// %t/void.h RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s
-// -I %t -o %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
-// %target-interop-build-swift %S/throwing-void.swift -o %t/test -Xlinker
-// %t/test.o -module-name ThrowingVoid -Xfrontend -entry-point-function-name
-// -Xfrontend swiftMain RUN: %target-codesign %t/test RUN: %target-run %t/test
+// RUN: %target-swift-frontend %S/throwing-void.swift -module-name ThrowingVoid -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path %t/void.h
+// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s -I %t -o %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+// RUN: %target-interop-build-swift %S/throwing-void.swift -o %t/test -Xlinker %t/test.o -module-name ThrowingVoid -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/test
+// RUN: %target-run %t/test
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
 // UNSUPPORTED: OS=windows-msvc
 // UNSUPPORTED: CPU=arm64e
+// clang-format on
 
 #include "void.h"
 #include <cassert>

--- a/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/throwing-void-execution.cpp
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/throwing-void.swift -module-name ThrowingVoid
+// -clang-header-expose-decls=all-public -enable-experimental-feature
+// GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path
+// %t/void.h RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -c %s
+// -I %t -o %t/test.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR RUN:
+// %target-interop-build-swift %S/throwing-void.swift -o %t/test -Xlinker
+// %t/test.o -module-name ThrowingVoid -Xfrontend -entry-point-function-name
+// -Xfrontend swiftMain RUN: %target-codesign %t/test RUN: %target-run %t/test
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+// UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: CPU=arm64e
+
+#include "void.h"
+#include <cassert>
+
+int main() {
+  swift::Expected<void> success;
+  assert(success.has_value());
+  const auto copy = success;
+  assert(copy.has_value());
+  swift::Error error;
+  swift::Expected<void> failure(error);
+  assert(!failure.has_value());
+  const auto errorCopy = failure;
+  assert(!errorCopy.has_value());
+
+  assert(ThrowingVoid::checkedVoid(false).has_value());
+  assert(!ThrowingVoid::checkedVoid(true).has_value());
+  assert(ThrowingVoid::genericVoid(swift::Int(1), false).has_value());
+  assert(!ThrowingVoid::genericVoid(swift::Int(1), true).has_value());
+  assert(!ThrowingVoid::genericNever(swift::Int(1)).has_value());
+  auto object = ThrowingVoid::VoidMethods::init();
+  assert(object.checked(false).has_value());
+  assert(!object.checked(true).has_value());
+}

--- a/test/Interop/SwiftToCxx/functions/throwing-void.swift
+++ b/test/Interop/SwiftToCxx/functions/throwing-void.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name ThrowingVoid -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -verify -emit-clang-header-path %t/void.h
+// RUN: %FileCheck %s < %t/void.h
+// RUN: %check-interop-cxx-header-in-clang(%t/void.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+public enum VoidError: Error { case failure }
+
+public func checkedVoid(_ fail: Bool) throws {
+  if fail { throw VoidError.failure }
+}
+
+public func genericVoid<T>(_ value: T, _ fail: Bool) throws {
+  try checkedVoid(fail)
+}
+
+public func genericNever<T>(_ value: T) throws -> Never {
+  throw VoidError.failure
+}
+
+public final class VoidMethods {
+  public init() {}
+  public func checked(_ fail: Bool) throws { try checkedVoid(fail) }
+}
+
+// A generic Void result must not cast a GenericFunctionType to FunctionType.
+// CHECK: swift::ThrowingResult<void> genericNever
+// CHECK: abort();
+// CHECK: swift::ThrowingResult<void> genericVoid
+// CHECK: #ifndef __cpp_exceptions
+// CHECK-NEXT: return swift::Expected<void>();
+
+// Class self supplies the context; don't emit an unused placeholder.
+// CHECK: swift::ThrowingResult<void> VoidMethods::checked
+// CHECK-NEXT: void* opaqueError = nullptr;
+// CHECK-NOT: void* _ctx
+// CHECK: if (opaqueError != nullptr)
+// CHECK: return swift::Expected<void>();


### PR DESCRIPTION
Throwing functions that return structs, classes or generic values currently construct a C++ result before checking the Swift error slot. On failure that storage is uninitialized. Emit the call, check the error, then materialize the returned value; indirect Swift values use temporary storage and `initializeWithTake` on success.

Focused header/execution tests cover direct and indirect structs, String, classes, generic primitive/value/reference results, instance/mutating/static methods and throwing initializers. A live-object canary checks cleanup, including a partially initialized failing initializer. Execution coverage runs with and without C++ exceptions.

Split from #91112 in response to the request for smaller, independently reviewable PRs. Based on current `main` (`cfbd3c5`).

Depends on #92024. This branch includes that prerequisite; [review only the return-value increment](https://github.com/mrousavy/swift/compare/cxx-interop-throwing-void...cxx-interop-throwing-return-values).

Validation: The new Swift fixture typechecks with the installed Swift 6.3.3 toolchain. Compiler/header-generation lit tests still need Swift CI: this machine has no development compiler, and its production compiler rejects `GenerateBindingsForThrowingFunctionsInCXX`. No toolchain or build dependencies were downloaded.
