### PR TITLE
[cxx-interop] Mark non-throwing Swift member thunks noexcept

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1756,7 +1756,7 @@ private:
         owningPrinter.interopContext, owningPrinter);
     DeclAndTypeClangFunctionPrinter::FunctionSignatureModifiers modifiers;
     modifiers.isInline = true;
-    // FIXME: Support throwing exceptions for Swift errors.
+    // Only throwing Swift functions may propagate a C++ Swift error exception.
     modifiers.isNoexcept = !funcTy->isThrowing();
     auto result = funcPrinter.printFunctionSignature(
         FD, funcABI.getSignature(), cxx_translation::getNameForCxx(FD),

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1756,7 +1756,7 @@ private:
         owningPrinter.interopContext, owningPrinter);
     DeclAndTypeClangFunctionPrinter::FunctionSignatureModifiers modifiers;
     modifiers.isInline = true;
-    // Only throwing Swift functions may propagate a C++ Swift error exception.
+    // FIXME: Support throwing exceptions for Swift errors.
     modifiers.isNoexcept = !funcTy->isThrowing();
     auto result = funcPrinter.printFunctionSignature(
         FD, funcABI.getSignature(), cxx_translation::getNameForCxx(FD),

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1740,6 +1740,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
     modifiers.qualifierContext = typeDeclContext;
   modifiers.isStatic = (isStatic || isConstructor) && !isDefinition;
   modifiers.isInline = true;
+  modifiers.isNoexcept = !FD->hasThrows();
   bool isMutating =
       isa<FuncDecl>(FD) ? cast<FuncDecl>(FD)->isMutating() : false;
   modifiers.isConst = !isa<ClassDecl>(typeDeclContext) && !isMutating &&
@@ -1817,6 +1818,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
     modifiers.qualifierContext = typeDeclContext;
   modifiers.isStatic = isStatic && !isDefinition;
   modifiers.isInline = true;
+  modifiers.isNoexcept = !accessor->hasThrows();
   modifiers.isConst =
       !isStatic && accessor->isGetter() && !isa<ClassDecl>(typeDeclContext);
   modifiers.hasSymbolUSR = !isDefinition;
@@ -1859,6 +1861,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
   if (isDefinition)
     modifiers.qualifierContext = typeDeclContext;
   modifiers.isInline = true;
+  modifiers.isNoexcept = !accessor->hasThrows();
   modifiers.isConst = true;
   auto result =
       printFunctionSignature(accessor, signature, "operator []", resultTy,

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -328,8 +328,8 @@ public struct Strct {
 // CHECK-NEXT:   _impl::$s8UseCxxTy16takeTrivialInoutyySo0E0VzF(swift::_impl::getOpaquePointer(x));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK anonymousStruct Strct::getTransform() const {
+// CHECK: SWIFT_INLINE_THUNK anonymousStruct Strct::getTransform() const noexcept {
 // CHECK-NEXT: alignas(alignof(anonymousStruct)) char storage[sizeof(anonymousStruct)];
 
-// CHECK: SWIFT_INLINE_THUNK ns::anonStructInNS Strct::getTransform2() const {
+// CHECK: SWIFT_INLINE_THUNK ns::anonStructInNS Strct::getTransform2() const noexcept {
 // CHECK-NEXT: alignas(alignof(ns::anonStructInNS)) char storage[sizeof(ns::anonStructInNS)];

--- a/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/simd-bridge-cxx-struct-back-to-cxx.swift
@@ -48,7 +48,7 @@ public func passStruct(_ x : Struct) {
 // CHECK-NEXT:   UseCxxTy::_impl::$s8UseCxxTy10passStructyyAA0E0VF(UseCxxTy::_impl::swift_interop_passDirect_UseCxxTy_swift_float4_0_16_swift_float4_16_32_swift_float4_32_48_swift_float4_48_64(UseCxxTy::_impl::_impl_Struct::getOpaquePointer(x)));
 // CHECK-NEXT:}
 
-// CHECK:  SWIFT_INLINE_THUNK Struct Struct::init() {
+// CHECK:  SWIFT_INLINE_THUNK Struct Struct::init() noexcept {
 // CHECK-NEXT:  return UseCxxTy::_impl::_impl_Struct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    UseCxxTy::_impl::swift_interop_returnDirect_UseCxxTy_swift_float4_0_16_swift_float4_16_32_swift_float4_32_48_swift_float4_48_64(result, UseCxxTy::_impl::$s8UseCxxTy6StructVACycfC());
 // CHECK-NEXT:  });

--- a/test/Interop/ObjCToSwiftToObjCxx/objc-types-in-cxx-mode.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/objc-types-in-cxx-mode.swift
@@ -20,13 +20,13 @@ public struct HasObjCMethod {
   public func takesObjCKlass(_ o: ObjCKlass) {}
 }
 
-// CHECK:      SWIFT_INLINE_THUNK HasObjCInit HasObjCInit::init(ObjCKlass *_Nonnull o) {
+// CHECK:      SWIFT_INLINE_THUNK HasObjCInit HasObjCInit::init(ObjCKlass *_Nonnull o) noexcept {
 // CHECK:        return {{.*}} {
 // CHECK:        }
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif // defined(__OBJC__)
 
-// CHECK:      SWIFT_INLINE_THUNK void HasObjCMethod::takesObjCKlass(ObjCKlass *_Nonnull o) const {
+// CHECK:      SWIFT_INLINE_THUNK void HasObjCMethod::takesObjCKlass(ObjCKlass *_Nonnull o) const noexcept {
 // CHECK-NEXT:   ObjCInCXX::{{.*}}
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif // defined(__OBJC__)

--- a/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
@@ -39,8 +39,8 @@ public final actor ActorWithField {
 // CHECK: SWIFT_EXTERN void $s5Actor0A9WithFieldC6methodyyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // method()
 
 // CHECK: class SWIFT_SYMBOL("s:5Actor0A9WithFieldC") ActorWithField final : public swift::_impl::RefCountedClass {
-// CHECK:   static SWIFT_INLINE_THUNK ActorWithField init() SWIFT_SYMBOL("s:5Actor0A9WithFieldCACycfc");
-// CHECK:   SWIFT_INLINE_THUNK void method() SWIFT_SYMBOL("s:5Actor0A9WithFieldC6methodyyF");
+// CHECK:   static SWIFT_INLINE_THUNK ActorWithField init() noexcept SWIFT_SYMBOL("s:5Actor0A9WithFieldCACycfc");
+// CHECK:   SWIFT_INLINE_THUNK void method() noexcept SWIFT_SYMBOL("s:5Actor0A9WithFieldC6methodyyF");
 
 @_expose(Cxx)
 public func takeActorWithIntField(_ x: ActorWithField) {

--- a/test/Interop/SwiftToCxx/class/swift-class-static-variables.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-static-variables.swift
@@ -10,4 +10,4 @@ public class FileUtilities {
   public let field = 42;
 }
 
-// CHECK: SWIFT_INLINE_THUNK FileUtilities FileUtilities::getShared() {
+// CHECK: SWIFT_INLINE_THUNK FileUtilities FileUtilities::getShared() noexcept {

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
@@ -8,7 +8,7 @@
 
 // note: uses swift-class-virtual-method-dispatch.swift
 
-// CHECK:      void BaseClass::virtualMethod() {
+// CHECK:      void BaseClass::virtualMethod() noexcept {
 // CHECK-NEXT: void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: #ifdef __arm64e__
 // CHECK-NEXT: void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
@@ -116,7 +116,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
   return DerivedDerivedClass()
 }
 
-// CHECK:      void BaseClass::virtualMethod() {
+// CHECK:      void BaseClass::virtualMethod() noexcept {
 // CHECK-NEXT: void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: #ifdef __arm64e__
 // CHECK-NEXT: void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -130,7 +130,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT: (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 
-// CHECK:      swift::Int BaseClass::virtualMethodIntInt(swift::Int x) {
+// CHECK:      swift::Int BaseClass::virtualMethodIntInt(swift::Int x) noexcept {
 // CHECK-NEXT: void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: #ifdef __arm64e__
 // CHECK-NEXT: void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -144,11 +144,11 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   return (* fptrptr_->func)(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        swift::Int BaseClass::finalMethodInBase(swift::Int x) {
+// CHECK:        swift::Int BaseClass::finalMethodInBase(swift::Int x) noexcept {
 // CHECK-NEXT:   return Class::_impl::$s5Class04BaseA0C013finalMethodInB0yS2iF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        swift::Int BaseClass::getVirtualComputedProp() {
+// CHECK:        swift::Int BaseClass::getVirtualComputedProp() noexcept {
 // CHECK-NEXT:   void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   #ifdef __arm64e__
 // CHECK-NEXT:   void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -162,7 +162,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        int64_t BaseClass::getVirtualComputedGetSet() {
+// CHECK:        int64_t BaseClass::getVirtualComputedGetSet() noexcept {
 // CHECK-NEXT:   void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   #ifdef __arm64e__
 // CHECK-NEXT:   void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -176,7 +176,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        void BaseClass::setVirtualComputedGetSet(int64_t newValue) {
+// CHECK:        void BaseClass::setVirtualComputedGetSet(int64_t newValue) noexcept {
 // CHECK-NEXT:   void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   #ifdef __arm64e__
 // CHECK-NEXT:   void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -190,7 +190,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        swift::Int BaseClass::getStoredProp() {
+// CHECK:        swift::Int BaseClass::getStoredProp() noexcept {
 // CHECK-NEXT:   void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   #ifdef __arm64e__
 // CHECK-NEXT:   void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -204,7 +204,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        void BaseClass::setStoredProp(swift::Int value) {
+// CHECK:        void BaseClass::setStoredProp(swift::Int value) noexcept {
 // CHECK-NEXT:   void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   #ifdef __arm64e__
 // CHECK-NEXT:   void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -232,7 +232,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:    return (* fptrptr_->func)(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:    }
 
-// CHECK:        void DerivedClass::virtualMethod() {
+// CHECK:        void DerivedClass::virtualMethod() noexcept {
 // CHECK-NEXT:   void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   #ifdef __arm64e__
 // CHECK-NEXT:   void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -246,7 +246,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        swift::Int DerivedClass::virtualMethodIntInt(swift::Int x) {
+// CHECK:        swift::Int DerivedClass::virtualMethodIntInt(swift::Int x) noexcept {
 // CHECK-NEXT:     void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     #ifdef __arm64e__
 // CHECK-NEXT:     void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -260,7 +260,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     return (* fptrptr_->func)(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:        BaseClass DerivedClass::virtualMethodInDerived(const BaseClass& x) {
+// CHECK:        BaseClass DerivedClass::virtualMethodInDerived(const BaseClass& x) noexcept {
 // CHECK-NEXT:   void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   #ifdef __arm64e__
 // CHECK-NEXT:   void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -274,7 +274,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   return _impl::_impl_BaseClass::makeRetained((* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:   }
 
-// CHECK:         swift::Int DerivedClass::getVirtualComputedProp() {
+// CHECK:         swift::Int DerivedClass::getVirtualComputedProp() noexcept {
 // CHECK-NEXT:     void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     #ifdef __arm64e__
 // CHECK-NEXT:     void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -288,7 +288,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:       return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:       }
 
-// CHECK:         int64_t DerivedClass::getVirtualComputedGetSet() {
+// CHECK:         int64_t DerivedClass::getVirtualComputedGetSet() noexcept {
 // CHECK-NEXT:     void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     #ifdef __arm64e__
 // CHECK-NEXT:     void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -302,7 +302,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:         void DerivedClass::setVirtualComputedGetSet(int64_t newValue) {
+// CHECK:         void DerivedClass::setVirtualComputedGetSet(int64_t newValue) noexcept {
 // CHECK-NEXT:     void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     #ifdef __arm64e__
 // CHECK-NEXT:     void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -316,7 +316,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:         swift::Int DerivedClass::getStoredProp() {
+// CHECK:         swift::Int DerivedClass::getStoredProp() noexcept {
 // CHECK-NEXT:     void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     #ifdef __arm64e__
 // CHECK-NEXT:     void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -330,7 +330,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:       return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:       }
 
-// CHECK:         void DerivedClass::setStoredProp(swift::Int newValue) {
+// CHECK:         void DerivedClass::setStoredProp(swift::Int newValue) noexcept {
 // CHECK-NEXT:     void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     #ifdef __arm64e__
 // CHECK-NEXT:     void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -357,22 +357,22 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:    FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM10]] / sizeof(void *));
 // CHECK-NEXT:      return (* fptrptr_->func)(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:        void DerivedDerivedClass::virtualMethod() {
+// CHECK:        void DerivedDerivedClass::virtualMethod() noexcept {
 // CHECK-NEXT:     _impl::$s5Class07DerivedbA0C13virtualMethodyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:        BaseClass DerivedDerivedClass::virtualMethodInDerived(const BaseClass& x) {
+// CHECK:        BaseClass DerivedDerivedClass::virtualMethodInDerived(const BaseClass& x) noexcept {
 // CHECK-NEXT:     return _impl::_impl_BaseClass::makeRetained(Class::_impl::$s5Class07DerivedbA0C015virtualMethodInB0yAA04BaseA0CAFF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:     }
 
-// CHECK:        void DerivedDerivedClass::methodInDerivedDerived() {
+// CHECK:        void DerivedDerivedClass::methodInDerivedDerived() noexcept {
 // CHECK-NEXT:     _impl::$s5Class07DerivedbA0C08methodInbB0yyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:          swift::Int DerivedDerivedClass::getStoredProp() {
+// CHECK:          swift::Int DerivedDerivedClass::getStoredProp() noexcept {
 // CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C10storedPropSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:          swift::Int DerivedDerivedClass::getComputedPropInDerivedDerived() {
+// CHECK:          swift::Int DerivedDerivedClass::getComputedPropInDerivedDerived() noexcept {
 // CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C014computedPropInbB0Sivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }

--- a/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-resilient-class-virtual-method-dispatch.swift
@@ -12,66 +12,66 @@
 // CHECK: SWIFT_EXTERN ptrdiff_t $s5Class04BaseA0C19virtualComputedPropSivg(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN ptrdiff_t $s5Class04BaseA0C19virtualComputedPropSivgTj(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // dispatch thunk for
 
-// CHECK:      void BaseClass::virtualMethod() {
+// CHECK:      void BaseClass::virtualMethod() noexcept {
 // CHECK-NEXT: _impl::$s5Class04BaseA0C13virtualMethodyyFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:  }
 
-// CHECK:      swift::Int BaseClass::virtualMethodIntInt(swift::Int x) {
+// CHECK:      swift::Int BaseClass::virtualMethodIntInt(swift::Int x) noexcept {
 // CHECK-NEXT: return Class::_impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iFTj(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        swift::Int BaseClass::finalMethodInBase(swift::Int x) {
+// CHECK:        swift::Int BaseClass::finalMethodInBase(swift::Int x) noexcept {
 // CHECK-NEXT:   return Class::_impl::$s5Class04BaseA0C013finalMethodInB0yS2iF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:         swift::Int BaseClass::getVirtualComputedProp() {
+// CHECK:         swift::Int BaseClass::getVirtualComputedProp() noexcept {
 // CHECK-NEXT:    _impl::$s5Class04BaseA0C19virtualComputedPropSivgTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:         int64_t BaseClass::getVirtualComputedGetSet() {
+// CHECK:         int64_t BaseClass::getVirtualComputedGetSet() noexcept {
 // CHECK-NEXT:    _impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64VvgTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:         void BaseClass::setVirtualComputedGetSet(int64_t newValue) {
+// CHECK:         void BaseClass::setVirtualComputedGetSet(int64_t newValue) noexcept {
 // CHECK-NEXT:    _impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64VvsTj(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:         swift::Int BaseClass::getStoredProp() {
+// CHECK:         swift::Int BaseClass::getStoredProp() noexcept {
 // CHECK-NEXT:    _impl::$s5Class04BaseA0C10storedPropSivgTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:         void BaseClass::setStoredProp(swift::Int value) {
+// CHECK:         void BaseClass::setStoredProp(swift::Int value) noexcept {
 // CHECK-NEXT:    _impl::$s5Class04BaseA0C10storedPropSivsTj(value, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
 // CHECK:           swift::Int BaseClass::operator [](swift::Int i) const
 // CHECK-NEXT:      return Class::_impl::$s5Class04BaseA0CyS2icigTj(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:        void DerivedClass::virtualMethod() {
+// CHECK:        void DerivedClass::virtualMethod() noexcept {
 // CHECK-NEXT:   _impl::$s5Class04BaseA0C13virtualMethodyyFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        swift::Int DerivedClass::virtualMethodIntInt(swift::Int x) {
+// CHECK:        swift::Int DerivedClass::virtualMethodIntInt(swift::Int x) noexcept {
 // CHECK-NEXT:   return Class::_impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iFTj(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
-// CHECK:        BaseClass DerivedClass::virtualMethodInDerived(const BaseClass& x) {
+// CHECK:        BaseClass DerivedClass::virtualMethodInDerived(const BaseClass& x) noexcept {
 // CHECK-NEXT:   return _impl::_impl_BaseClass::makeRetained(Class::_impl::$s5Class07DerivedA0C015virtualMethodInB0yAA04BaseA0CAFFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:   }
 
-// CHECK:         swift::Int DerivedClass::getVirtualComputedProp() {
+// CHECK:         swift::Int DerivedClass::getVirtualComputedProp() noexcept {
 // CHECK-NEXT:   Class::_impl::$s5Class04BaseA0C19virtualComputedPropSivgTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
 
-// CHECK:        void DerivedDerivedClass::virtualMethod() {
+// CHECK:        void DerivedDerivedClass::virtualMethod() noexcept {
 // CHECK-NEXT:     _impl::$s5Class07DerivedbA0C13virtualMethodyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:        BaseClass DerivedDerivedClass::virtualMethodInDerived(const BaseClass& x) {
+// CHECK:        BaseClass DerivedDerivedClass::virtualMethodInDerived(const BaseClass& x) noexcept {
 // CHECK-NEXT:     return _impl::_impl_BaseClass::makeRetained(Class::_impl::$s5Class07DerivedbA0C015virtualMethodInB0yAA04BaseA0CAFF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:     }
 
-// CHECK:        void DerivedDerivedClass::methodInDerivedDerived() {
+// CHECK:        void DerivedDerivedClass::methodInDerivedDerived() noexcept {
 // CHECK-NEXT:     _impl::$s5Class07DerivedbA0C08methodInbB0yyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
-// CHECK:         swift::Int DerivedDerivedClass::getStoredProp() {
+// CHECK:         swift::Int DerivedDerivedClass::getStoredProp() noexcept {
 // CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C10storedPropSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:          swift::Int DerivedDerivedClass::getComputedPropInDerivedDerived() {
+// CHECK:          swift::Int DerivedDerivedClass::getComputedPropInDerivedDerived() noexcept {
 // CHECK-NEXT:     return Class::_impl::$s5Class07DerivedbA0C014computedPropInbB0Sivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -83,10 +83,10 @@ public func createCrossModuleDerivedDerivedClass() -> CrossModuleDerivedDerivedC
 // CHECK-NEXT: SWIFT_EXTERN void $s8UseClass018CrossModuleDerivedB0C016virtualMethod2InE0yyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // virtualMethod2InDerived()
 
 
-// CHECK:      void CrossModuleDerivedClass::virtualMethod() {
+// CHECK:      void CrossModuleDerivedClass::virtualMethod() noexcept {
 // CHECK-NEXT: _impl::$s5Class04BaseA0C13virtualMethodyyFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
-// CHECK:      void CrossModuleDerivedClass::virtualMethodInDerived() {
+// CHECK:      void CrossModuleDerivedClass::virtualMethodInDerived() noexcept {
 // CHECK-NEXT: void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: #ifdef __arm64e__
 // CHECK-NEXT: void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
@@ -100,17 +100,17 @@ public func createCrossModuleDerivedDerivedClass() -> CrossModuleDerivedDerivedC
 // CHECK-NEXT: (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 
-// CHECK:      swift::Int CrossModuleDerivedClass::getDerivedComputedProp() {
+// CHECK:      swift::Int CrossModuleDerivedClass::getDerivedComputedProp() noexcept {
 // CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + [[#VM1:]]) / sizeof(void *));
 
-// CHECK:      void CrossModuleDerivedClass::virtualMethod2InDerived() {
+// CHECK:      void CrossModuleDerivedClass::virtualMethod2InDerived() noexcept {
 // CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + [[#VM2:]]) / sizeof(void *));
 
-// CHECK:      void CrossModuleDerivedDerivedClass::virtualMethodInDerived() {
+// CHECK:      void CrossModuleDerivedDerivedClass::virtualMethodInDerived() noexcept {
 // CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + 0) / sizeof(void *));
 
-// CHECK:      swift::Int CrossModuleDerivedDerivedClass::getDerivedComputedProp() {
+// CHECK:      swift::Int CrossModuleDerivedDerivedClass::getDerivedComputedProp() noexcept {
 // CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + [[#VM1]]) / sizeof(void *));
 
-// CHECK:      void CrossModuleDerivedDerivedClass::virtualMethod2InDerived() {
+// CHECK:      void CrossModuleDerivedDerivedClass::virtualMethod2InDerived() noexcept {
 // CHECK-NEXT: _impl::$s8UseClass018CrossModuleDerivedeB0C016virtualMethod2InE0yyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));

--- a/test/Interop/SwiftToCxx/core/set-min-access-level.swift
+++ b/test/Interop/SwiftToCxx/core/set-min-access-level.swift
@@ -53,7 +53,7 @@ public struct S {
 // CHECK-PUBLIC-NOT: packageFunc
 // CHECK-PUBLIC-NOT: privateFunc
 // CHECK-PUBLIC: SWIFT_INLINE_THUNK swift::Int publicFunc(swift::Int x) noexcept SWIFT_SYMBOL("s:4Core10publicFuncyS2iF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-PUBLIC: SWIFT_INLINE_THUNK swift::Int S::publicMethod(swift::Int x) const {
+// CHECK-PUBLIC: SWIFT_INLINE_THUNK swift::Int S::publicMethod(swift::Int x) const noexcept {
 // CHECK-PUBLIC-NOT: packageMethod
 // CHECK-PUBLIC-NOT: internalMethod
 // CHECK-PUBLIC-NOT: privateMethod
@@ -62,8 +62,8 @@ public struct S {
 // CHECK-PACKAGE: SWIFT_INLINE_THUNK swift::Int packageFunc(swift::Int x) noexcept SWIFT_SYMBOL("s:4Core11packageFuncyS2iF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-PACKAGE-NOT: privateFunc
 // CHECK-PACKAGE: SWIFT_INLINE_THUNK swift::Int publicFunc(swift::Int x) noexcept SWIFT_SYMBOL("s:4Core10publicFuncyS2iF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-PACKAGE: SWIFT_INLINE_THUNK swift::Int S::publicMethod(swift::Int x) const {
-// CHECK-PACKAGE: SWIFT_INLINE_THUNK swift::Int S::packageMethod(swift::Int x) const {
+// CHECK-PACKAGE: SWIFT_INLINE_THUNK swift::Int S::publicMethod(swift::Int x) const noexcept {
+// CHECK-PACKAGE: SWIFT_INLINE_THUNK swift::Int S::packageMethod(swift::Int x) const noexcept {
 // CHECK-PACKAGE-NOT: internalMethod
 // CHECK-PACKAGE-NOT: privateMethod
 
@@ -71,9 +71,9 @@ public struct S {
 // CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int packageFunc(swift::Int x) noexcept SWIFT_SYMBOL("s:4Core11packageFuncyS2iF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-INTERNAL-NOT: privateFunc
 // CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int publicFunc(swift::Int x) noexcept SWIFT_SYMBOL("s:4Core10publicFuncyS2iF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int S::publicMethod(swift::Int x) const {
-// CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int S::packageMethod(swift::Int x) const {
-// CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int S::internalMethod(swift::Int x) const {
+// CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int S::publicMethod(swift::Int x) const noexcept {
+// CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int S::packageMethod(swift::Int x) const noexcept {
+// CHECK-INTERNAL: SWIFT_INLINE_THUNK swift::Int S::internalMethod(swift::Int x) const noexcept {
 // CHECK-INTERNAL-NOT: privateMethod
 
 // CHECK-DIAGNOSTIC: error: invalid minimum clang header access level 'inernal'; chose from 'public'|'package'|'internal'

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
@@ -25,12 +25,12 @@ public func inoutLargeEnum(_ s: inout LargeEnum) {
 // CHECK-NEXT: _impl::$s9UsesEnums14inoutLargeEnumyy0B00dE0OzF(Enums::_impl::_impl_LargeEnum::getOpaquePointer(s));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK Enums::LargeEnum UsesEnumsLargeEnum::passThroughStructSeveralI64(const Enums::LargeEnum& y) const {
+// CHECK: SWIFT_INLINE_THUNK Enums::LargeEnum UsesEnumsLargeEnum::passThroughStructSeveralI64(const Enums::LargeEnum& y) const noexcept {
 // CHECK-NEXT: return Enums::_impl::_impl_LargeEnum::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s9UsesEnums0aB9LargeEnumV27passThroughStructSeveralI64y0B00cD0OAGF(result, Enums::_impl::_impl_LargeEnum::getOpaquePointer(y), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK Enums::LargeEnum UsesEnumsLargeEnum::getX() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK Enums::LargeEnum UsesEnumsLargeEnum::getX() const noexcept {
 // CHECK-NEXT: return Enums::_impl::_impl_LargeEnum::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s9UsesEnums0aB9LargeEnumV1x0B00cD0Ovg(result, _getOpaquePointer());
 // CHECK-NEXT: });

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -21,8 +21,8 @@ public struct UsesStructsStruct {
     public let x: StructSeveralI64
 }
 
-// CHECK:      SWIFT_INLINE_THUNK Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const SWIFT_SYMBOL("s:11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF");
-// CHECK-NEXT: SWIFT_INLINE_THUNK Structs::StructSeveralI64 getX() const SWIFT_SYMBOL("s:11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvp");
+// CHECK:      SWIFT_INLINE_THUNK Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const noexcept SWIFT_SYMBOL("s:11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK Structs::StructSeveralI64 getX() const noexcept SWIFT_SYMBOL("s:11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvp");
 
 
 public func passThroughStructSeveralI64(_ x: StructSeveralI64) -> StructSeveralI64 {
@@ -54,13 +54,13 @@ public func passThroughStructSmallDirect(_ x: SmallStructDirectPassing) -> Small
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const {
+// CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const noexcept {
 // CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   UsesStructs::_impl::$s11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(y), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::getX() const {
+// CHECK: SWIFT_INLINE_THUNK Structs::StructSeveralI64 UsesStructsStruct::getX() const noexcept {
 // CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   UsesStructs::_impl::$s11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvg(result, _getOpaquePointer());
 // CHECK-NEXT: });

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -52,7 +52,7 @@ public enum G<T> {
 // CHECK-NEXT:   return swift::_impl::implClassFor<C>::type::makeRetained(*reinterpret_cast<void **>(payloadFromDestruction));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK bool E::matchesIntValue(swift::Int value) const {
+// CHECK: SWIFT_INLINE_THUNK bool E::matchesIntValue(swift::Int value) const noexcept {
 // CHECK-NEXT: return Enums::_impl::$s5Enums1EO15matchesIntValueySbSiF(value, Enums::_impl::swift_interop_passDirect_Enums_{{.*}}(_getOpaquePointer()));
 
 // CHECK: SWIFT_INLINE_THUNK swift::Array<C> F::getB() const {

--- a/test/Interop/SwiftToCxx/enums/enum-member-param-no-shadow-case.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-member-param-no-shadow-case.swift
@@ -21,11 +21,11 @@ public enum E {
 // CHECK: SWIFT_INLINE_THUNK void takeParamA(swift::Int a_)
 // CHECK: static SWIFT_INLINE_THUNK void takeParamB(swift::Int b_)
 
-// CHECK: E E::init(swift::Int b_) {
+// CHECK: E E::init(swift::Int b_) noexcept {
 // CHECK: _impl::$s5Enums1EOyACSicfC(b_)
 
-// CHECK: void E::takeParamA(swift::Int a_) const {
+// CHECK: void E::takeParamA(swift::Int a_) const noexcept {
 // CHECK: _impl::$s5Enums1EO10takeParamAyySiF(a_,
 
-// CHECK: void E::takeParamB(swift::Int b_) {
+// CHECK: void E::takeParamB(swift::Int b_) noexcept {
 // CHECK: _impl::$s5Enums1EO10takeParamByySiFZ(b_);

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -125,9 +125,9 @@ public struct S {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-EMPTY:
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK E init() SWIFT_SYMBOL("s:5Enums1EOACycfc");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK swift::Int getTen() const SWIFT_SYMBOL("s:5Enums1EO3tenSivp");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void printSelf() const SWIFT_SYMBOL("s:5Enums1EO9printSelfyyF");
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK E init() noexcept SWIFT_SYMBOL("s:5Enums1EOACycfc");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK swift::Int getTen() const noexcept SWIFT_SYMBOL("s:5Enums1EO3tenSivp");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void printSelf() const noexcept SWIFT_SYMBOL("s:5Enums1EO9printSelfyyF");
 // CHECK-NEXT: private:
 // CHECK:        SWIFT_INLINE_THUNK char * _Nonnull _destructiveProjectEnumData() noexcept {
 // CHECK-NEXT:     auto metadata = _impl::$s5Enums1EOMa(0);
@@ -185,7 +185,7 @@ public struct S {
 // CHECK: }
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getHashValue() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getHashValue() const noexcept SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 // CHECK:      namespace Enums SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Enums") {
@@ -289,14 +289,14 @@ public struct S {
 // CHECK-NEXT:   SWIFT_INLINE_THUNK bool E::isFoobar() const {
 // CHECK-NEXT:     return *this == E::foobar;
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK E E::init() {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK E E::init() noexcept {
 // CHECK-NEXT:     return Enums::_impl::_impl_E::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:       Enums::_impl::swift_interop_returnDirect_Enums[[ENUMENCODING:[a-z0-9_]+]](result, Enums::_impl::$s5Enums1EOACycfC());
 // CHECK-NEXT:     });
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK swift::Int E::getTen() const {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK swift::Int E::getTen() const noexcept {
 // CHECK-NEXT:     return Enums::_impl::$s5Enums1EO3tenSivg(Enums::_impl::swift_interop_passDirect_Enums[[ENUMENCODING]](_getOpaquePointer()));
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void E::printSelf() const {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void E::printSelf() const noexcept {
 // CHECK-NEXT:     Enums::_impl::$s5Enums1EO9printSelfyyF(Enums::_impl::swift_interop_passDirect_Enums[[ENUMENCODING]](_getOpaquePointer()));
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
@@ -84,14 +84,14 @@ public final class ExposedClass {
 // CHECK: class SWIFT_SYMBOL("{{.*}}") ExposedStruct2 final {
 // CHECK: SWIFT_INLINE_THUNK ExposedStruct2 &operator =(const ExposedStruct2 &other) noexcept {
 // CHECK: }
-// CHECK-NEXT: swift::Int getY() const SWIFT_SYMBOL("{{.*}}");
-// CHECK-NEXT: void setY(swift::Int value) SWIFT_SYMBOL("{{.*}}");
-// CHECK-NEXT: static SWIFT_INLINE_THUNK ExposedStruct2 init() SWIFT_SYMBOL("{{.*}}");
-// CHECK-NEXT: static SWIFT_INLINE_THUNK ExposedStruct2 initWithValue(swift::Int x) SWIFT_SYMBOL("{{.*}}");
-// CHECK-NEXT: swift::Int getRenamedProp() const SWIFT_SYMBOL("{{.*}}");
-// CHECK-NEXT: void setRenamedProp(swift::Int value) SWIFT_SYMBOL("{{.*}}");
-// CHECK-NEXT: swift::Int getProp3() const SWIFT_SYMBOL("{{.*}}");
-// CHECK-NEXT: void renamedMethod() const SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: swift::Int getY() const noexcept SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: void setY(swift::Int value) noexcept SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: static SWIFT_INLINE_THUNK ExposedStruct2 init() noexcept SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: static SWIFT_INLINE_THUNK ExposedStruct2 initWithValue(swift::Int x) noexcept SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: swift::Int getRenamedProp() const noexcept SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: void setRenamedProp(swift::Int value) noexcept SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: swift::Int getProp3() const noexcept SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: void renamedMethod() const noexcept SWIFT_SYMBOL("{{.*}}");
 // CHECK-NEXT: private:
 
 // CHECK: SWIFT_INLINE_THUNK void exposed1() noexcept SWIFT_SYMBOL("{{.*}}") {
@@ -107,17 +107,17 @@ public final class ExposedClass {
 // CHECK-NEXT: }
 
 // CHECK: void ExposedClass::method()
-// CHECK: swift::Int ExposedStruct::getX() const {
-// CHECK: void ExposedStruct::setX(swift::Int value) {
-// CHECK: void ExposedStruct::method() const {
-// CHECK: swift::Int ExposedStruct2::getY() const {
-// CHECK: void ExposedStruct2::setY(swift::Int value) {
-// CHECK: ExposedStruct2 ExposedStruct2::init() {
-// CHECK: ExposedStruct2 ExposedStruct2::initWithValue(swift::Int x) {
-// CHECK: swift::Int ExposedStruct2::getRenamedProp() const {
-// CHECK: void ExposedStruct2::setRenamedProp(swift::Int value) {
-// CHECK: swift::Int ExposedStruct2::getProp3() const {
-// CHECK: void ExposedStruct2::renamedMethod() const {
+// CHECK: swift::Int ExposedStruct::getX() const noexcept {
+// CHECK: void ExposedStruct::setX(swift::Int value) noexcept {
+// CHECK: void ExposedStruct::method() const noexcept {
+// CHECK: swift::Int ExposedStruct2::getY() const noexcept {
+// CHECK: void ExposedStruct2::setY(swift::Int value) noexcept {
+// CHECK: ExposedStruct2 ExposedStruct2::init() noexcept {
+// CHECK: ExposedStruct2 ExposedStruct2::initWithValue(swift::Int x) noexcept {
+// CHECK: swift::Int ExposedStruct2::getRenamedProp() const noexcept {
+// CHECK: void ExposedStruct2::setRenamedProp(swift::Int value) noexcept {
+// CHECK: swift::Int ExposedStruct2::getProp3() const noexcept {
+// CHECK: void ExposedStruct2::renamedMethod() const noexcept {
 
 // CHECK-NOT: NonExposedStruct
 

--- a/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
@@ -21,6 +21,6 @@ extension Array {
 
 // CHECK: class SWIFT_SYMBOL("s:7Structs14TypeAfterArrayV") TypeAfterArray;
 // CHECK: class SWIFT_SYMBOL("s:7Structs5ArrayV") Array final {
-// CHECK:        swift::Int getX() const SWIFT_SYMBOL("s:7Structs5ArrayV1xSivp");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void setX(swift::Int value) SWIFT_SYMBOL("s:7Structs5ArrayV1xSivp");
-// CHECK-NEXT:   TypeAfterArray getVal() const SWIFT_SYMBOL("s:7Structs5ArrayV3valAA09TypeAfterB0Vvp");
+// CHECK:        swift::Int getX() const noexcept SWIFT_SYMBOL("s:7Structs5ArrayV1xSivp");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void setX(swift::Int value) noexcept SWIFT_SYMBOL("s:7Structs5ArrayV1xSivp");
+// CHECK-NEXT:   TypeAfterArray getVal() const noexcept SWIFT_SYMBOL("s:7Structs5ArrayV3valAA09TypeAfterB0Vvp");

--- a/test/Interop/SwiftToCxx/functions/Inputs/nonthrowing-noexcept.cpp
+++ b/test/Interop/SwiftToCxx/functions/Inputs/nonthrowing-noexcept.cpp
@@ -1,0 +1,31 @@
+#include "noexcept.h"
+#include <utility>
+
+using Noexcept::Reference;
+using Noexcept::Value;
+
+static_assert(noexcept(Noexcept::freeFunction()), "non-throwing free function");
+static_assert(noexcept(Noexcept::identity(std::declval<const swift::Int &>())),
+              "non-throwing generic free function");
+static_assert(noexcept(Value::init(0)), "non-throwing initializer");
+static_assert(noexcept(std::declval<const Value &>().read()), "const method");
+static_assert(noexcept(std::declval<Value &>().increment()), "mutating method");
+static_assert(noexcept(Value::make()), "static method");
+static_assert(noexcept(std::declval<const Value &>().identity(
+                  std::declval<const swift::Int &>())),
+              "generic method");
+static_assert(noexcept(std::declval<const Value &>().getNumber()), "getter");
+static_assert(noexcept(std::declval<Value &>().setNumber(0)), "setter");
+static_assert(noexcept(std::declval<const Value &>().isPositive()),
+              "bool getter");
+static_assert(noexcept(Value::getAnswer()), "static getter");
+static_assert(noexcept(std::declval<const Value &>()[0]), "subscript");
+static_assert(noexcept(Reference::init()), "class initializer");
+static_assert(noexcept(std::declval<Reference &>().read()), "class method");
+static_assert(noexcept(Reference::make()), "static class method");
+static_assert(noexcept(std::declval<Reference &>().getNumber()),
+              "class getter");
+static_assert(noexcept(std::declval<Reference &>().setNumber(0)),
+              "class setter");
+static_assert(noexcept(std::declval<const Reference &>()[0]),
+              "class subscript");

--- a/test/Interop/SwiftToCxx/functions/Inputs/throwing-noexcept.cpp
+++ b/test/Interop/SwiftToCxx/functions/Inputs/throwing-noexcept.cpp
@@ -1,0 +1,11 @@
+#include "throwing.h"
+#include <utility>
+
+using ThrowingNoexcept::Value;
+
+static_assert(!noexcept(ThrowingNoexcept::freeFunction()), "throwing function");
+static_assert(!noexcept(Value::init(0)), "throwing initializer");
+static_assert(!noexcept(std::declval<const Value &>().read()),
+              "throwing method");
+static_assert(!noexcept(std::declval<Value &>().update()), "throwing mutator");
+static_assert(!noexcept(Value::make()), "throwing static method");

--- a/test/Interop/SwiftToCxx/functions/lifetime-dependence-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/functions/lifetime-dependence-in-cxx.swift
@@ -61,9 +61,9 @@ extension Owner {
     }
 }
 
-// CHECK: SWIFT_INLINE_THUNK View borrowSelf() const SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK View borrowSelfMutating() SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK View getViewProperty() const SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK View borrowSelf() const noexcept SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK View borrowSelfMutating() noexcept SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK View getViewProperty() const noexcept SWIFT_SELF_LIFETIMEBOUND SWIFT_SYMBOL({{.*}});
 
 // CHECK: SWIFT_INLINE_THUNK View borrowBorrowingParam(const Owner& o SWIFT_LIFETIMEBOUND) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK: SWIFT_INLINE_THUNK View borrowDefaultParam(const Owner& o SWIFT_LIFETIMEBOUND) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
@@ -74,6 +74,6 @@ extension Owner {
 // CHECK: SWIFT_INLINE_THUNK View copyDefaultParam(const View& v) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 
 // The attribute is repeated on the out-of-line definitions of the members.
-// CHECK: SWIFT_INLINE_THUNK View Owner::borrowSelf() const SWIFT_SELF_LIFETIMEBOUND {
-// CHECK: SWIFT_INLINE_THUNK View Owner::borrowSelfMutating() SWIFT_SELF_LIFETIMEBOUND {
-// CHECK: SWIFT_INLINE_THUNK View Owner::getViewProperty() const SWIFT_SELF_LIFETIMEBOUND {
+// CHECK: SWIFT_INLINE_THUNK View Owner::borrowSelf() const noexcept SWIFT_SELF_LIFETIMEBOUND {
+// CHECK: SWIFT_INLINE_THUNK View Owner::borrowSelfMutating() noexcept SWIFT_SELF_LIFETIMEBOUND {
+// CHECK: SWIFT_INLINE_THUNK View Owner::getViewProperty() const noexcept SWIFT_SELF_LIFETIMEBOUND {

--- a/test/Interop/SwiftToCxx/functions/nonthrowing-noexcept.swift
+++ b/test/Interop/SwiftToCxx/functions/nonthrowing-noexcept.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Noexcept -clang-header-expose-decls=all-public -typecheck -emit-clang-header-path %t/noexcept.h
+// RUN: %target-interop-build-clangxx -std=c++14 -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t
+// RUN: %target-interop-build-clangxx -std=c++17 -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t
+// RUN: %target-interop-build-clangxx -std=c++20 -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t
+// RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t
+
+public func freeFunction() {}
+public func identity<T>(_ value: T) -> T { value }
+
+public struct Value {
+  public var number: Int
+  public init(_ number: Int) { self.number = number }
+  public func read() -> Int { number }
+  public mutating func increment() { number += 1 }
+  public static func make() -> Value { Value(42) }
+  public func identity<T>(_ value: T) -> T { value }
+  public var isPositive: Bool { number > 0 }
+  public static var answer: Int { 42 }
+  public subscript(index: Int) -> Int { number + index }
+}
+
+public class Reference {
+  public var number: Int = 0
+  public init() {}
+  public func read() -> Int { number }
+  public static func make() -> Reference { Reference() }
+  public subscript(index: Int) -> Int { number + index }
+}

--- a/test/Interop/SwiftToCxx/functions/nonthrowing-noexcept.swift
+++ b/test/Interop/SwiftToCxx/functions/nonthrowing-noexcept.swift
@@ -1,6 +1,5 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -module-name Noexcept -clang-header-expose-decls=all-public -typecheck -emit-clang-header-path %t/noexcept.h
-// RUN: %target-interop-build-clangxx -std=c++14 -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t
 // RUN: %target-interop-build-clangxx -std=c++17 -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t
 // RUN: %target-interop-build-clangxx -std=c++20 -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t
 // RUN: %target-interop-build-clangxx -std=c++17 -fno-exceptions -fsyntax-only %S/Inputs/nonthrowing-noexcept.cpp -I %t

--- a/test/Interop/SwiftToCxx/functions/swift-operators.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-operators.swift
@@ -39,7 +39,7 @@ public struct CustomArray<Element> where Element : ~Copyable {
 }
 
 // CHECK: #if __cplusplus >= 202302L
-// CHECK-NEXT: SWIFT_INLINE_THUNK int operator [](int x, int _2) const SWIFT_SYMBOL("s:9Operators6IntBoxVys5Int32VAE_AEtcig");
+// CHECK-NEXT: SWIFT_INLINE_THUNK int operator [](int x, int _2) const noexcept SWIFT_SYMBOL("s:9Operators6IntBoxVys5Int32VAE_AEtcig");
 // CHECK-NEXT: #endif // #if __cplusplus >= 202302L
 
 public func -(lhs: IntBox, rhs: IntBox) -> CInt {

--- a/test/Interop/SwiftToCxx/functions/throwing-noexcept.swift
+++ b/test/Interop/SwiftToCxx/functions/throwing-noexcept.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name ThrowingNoexcept -clang-header-expose-decls=all-public -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -typecheck -emit-clang-header-path %t/throwing.h
+// RUN: %target-interop-build-clangxx -std=c++17 -fsyntax-only %S/Inputs/throwing-noexcept.cpp -I %t -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+// REQUIRES: swift_feature_GenerateBindingsForThrowingFunctionsInCXX
+
+public func freeFunction() throws {}
+public struct Value {
+  public let number: Int
+  public init(_ number: Int) throws { self.number = number }
+  public func read() throws -> Int { number }
+  public mutating func update() throws {}
+  public static func make() throws -> Int { 42 }
+}

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -166,14 +166,14 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK void method() const SWIFT_SYMBOL("s:8Generics10GenericOptO6methodyyF");
-// CHECK-NEXT: SWIFT_INLINE_THUNK void reset() SWIFT_SYMBOL("s:8Generics10GenericOptO5resetyyF");
+// CHECK: SWIFT_INLINE_THUNK void method() const noexcept SWIFT_SYMBOL("s:8Generics10GenericOptO6methodyyF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK void reset() noexcept SWIFT_SYMBOL("s:8Generics10GenericOptO5resetyyF");
 // CHECK-NEXT: template<class T_1_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_1_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK T_1_0 genericMethod(const T_1_0& x) const SWIFT_SYMBOL("s:8Generics10GenericOptO13genericMethodyqd__qd__lF");
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getComputedProp() const SWIFT_SYMBOL("s:8Generics10GenericOptO12computedPropSivp");
+// CHECK-NEXT: SWIFT_INLINE_THUNK T_1_0 genericMethod(const T_1_0& x) const noexcept SWIFT_SYMBOL("s:8Generics10GenericOptO13genericMethodyqd__qd__lF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getComputedProp() const noexcept SWIFT_SYMBOL("s:8Generics10GenericOptO12computedPropSivp");
 
 
 // CHECK: SWIFT_INLINE_THUNK void inoutConcreteOpt(GenericOpt<uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF") {
@@ -310,7 +310,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericOpt<T_0_0>::method() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericOpt<T_0_0>::method() const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -331,13 +331,13 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_1_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK T_1_0 GenericOpt<T_0_0>::genericMethod(const T_1_0& x) const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK T_1_0 GenericOpt<T_0_0>::genericMethod(const T_1_0& x) const noexcept {
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int GenericOpt<T_0_0>::getComputedProp() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int GenericOpt<T_0_0>::getComputedProp() const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -114,12 +114,12 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK T_0_0 genericMethodPassThrough(const T_0_0& x) const SWIFT_SYMBOL("s:9Functions15TestSmallStructV24genericMethodPassThroughyxxlF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK T_0_0 genericMethodPassThrough(const T_0_0& x) const noexcept SWIFT_SYMBOL("s:9Functions15TestSmallStructV24genericMethodPassThroughyxxlF");
 // CHECK-NEXT: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void genericMethodMutTake(const T_0_0& x) SWIFT_SYMBOL("s:9Functions15TestSmallStructV20genericMethodMutTakeyyxlF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK void genericMethodMutTake(const T_0_0& x) noexcept SWIFT_SYMBOL("s:9Functions15TestSmallStructV20genericMethodMutTakeyyxlF");
 // CHECK:      template<class T>
 // CHECK-NEXT: returnNewValue
 
@@ -207,7 +207,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK T_0_0 TestSmallStruct::genericMethodPassThrough(const T_0_0& x) const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK T_0_0 TestSmallStruct::genericMethodPassThrough(const T_0_0& x) const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -239,7 +239,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void TestSmallStruct::genericMethodMutTake(const T_0_0& x) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void TestSmallStruct::genericMethodMutTake(const T_0_0& x) noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -371,7 +371,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK T_0_1 GenericPair<T_0_0, T_0_1>::getY() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK T_0_1 GenericPair<T_0_0, T_0_1>::getY() const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -398,7 +398,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::setY(const T_0_1& value) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::setY(const T_0_1& value) noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -412,7 +412,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> GenericPair<T_0_0, T_0_1>::init(const T_0_0& x, swift::Int i, const T_0_1& y) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK GenericPair<T_0_0, T_0_1> GenericPair<T_0_0, T_0_1>::init(const T_0_0& x, swift::Int i, const T_0_1& y) noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -431,7 +431,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::method() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::method() const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -442,7 +442,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::mutatingMethod(const GenericPair<T_0_1, T_0_0>& other) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::mutatingMethod(const GenericPair<T_0_1, T_0_0>& other) noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -457,7 +457,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_1_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK T_1_0 GenericPair<T_0_0, T_0_1>::genericMethod(const T_1_0& x, const T_0_1& y) const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK T_1_0 GenericPair<T_0_0, T_0_1>::genericMethod(const T_1_0& x, const T_0_1& y) const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -487,7 +487,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int GenericPair<T_0_0, T_0_1>::getComputedProp() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int GenericPair<T_0_0, T_0_1>::getComputedProp() const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -497,7 +497,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 
 // CHECK: SWIFT_INLINE_THUNK T_0_0 GenericPair<T_0_0, T_0_1>::getComputedVar()
 // CHECK: _impl::$s8Generics11GenericPairV11computedVarxvg(reinterpret_cast<void *>(&returnValue), swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
-// CHECK: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::setComputedVar(const T_0_0& newValue) {
+// CHECK: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::setComputedVar(const T_0_0& newValue) noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -146,14 +146,14 @@
 // CHECK-NEXT: _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK T_0_1 GenericPair<T_0_0, T_0_1>::getY() const {
+// CHECK: SWIFT_INLINE_THUNK T_0_1 GenericPair<T_0_0, T_0_1>::getY() const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
 // CHECK: _impl::$s8Generics11GenericPairV1yq_vg(reinterpret_cast<void *>(&returnValue), Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 
-// CHECK: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::setY(const T_0_1& newValue) {
+// CHECK: SWIFT_INLINE_THUNK void GenericPair<T_0_0, T_0_1>::setY(const T_0_1& newValue) noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -178,5 +178,5 @@
 // CHECK-NEXT: return Generics::_impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT: _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, Generics::_impl::$s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(swift::_impl::getOpaquePointer(consumedParamCopy_x), i, swift::_impl::getOpaquePointer(consumedParamCopy_y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
-// CHECK: SWIFT_INLINE_THUNK T_1_0 GenericPair<T_0_0, T_0_1>::genericMethod(const T_1_0& x, const T_0_1& y) const {
+// CHECK: SWIFT_INLINE_THUNK T_1_0 GenericPair<T_0_0, T_0_1>::genericMethod(const T_1_0& x, const T_0_1& y) const noexcept {
 // CHECK: _impl::$s8Generics11GenericPairV13genericMethodyqd__qd___q_tlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), Generics::_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata(), swift::TypeMetadataTrait<T_1_0>::getTypeMetadata());

--- a/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
@@ -37,7 +37,7 @@ public struct LaterGeneric<T> {
 // CHECK: inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstEnum> = true;
 
 // CHECK: class SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO") ComesFirstEnum final {
-// CHECK: LaterGeneric<ComesFirstEnum> returnsLaterOpt() const SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO15returnsLaterOptAA0F7GenericVyACGyF");
+// CHECK: LaterGeneric<ComesFirstEnum> returnsLaterOpt() const noexcept SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO15returnsLaterOptAA0F7GenericVyACGyF");
 
 // CHECK: namespace Generics SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("Generics") {
 // CHECK-EMPTY:
@@ -46,5 +46,5 @@ public struct LaterGeneric<T> {
 // CHECK-NEXT:  class _impl_ComesFirstStruct;
 
 // CHECK: class SWIFT_SYMBOL("s:8Generics16ComesFirstStructV") ComesFirstStruct final {
-// CHECK: LaterGeneric<ComesFirstStruct> returnsLaterOpt() const SWIFT_SYMBOL("s:8Generics16ComesFirstStructV15returnsLaterOptAA0F7GenericVyACGyF");
+// CHECK: LaterGeneric<ComesFirstStruct> returnsLaterOpt() const noexcept SWIFT_SYMBOL("s:8Generics16ComesFirstStructV15returnsLaterOptAA0F7GenericVyACGyF");
 // CHECK: class SWIFT_SYMBOL("s:8Generics12LaterGenericV") LaterGeneric final {

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -41,9 +41,9 @@ public struct FirstSmallStruct {
 // CHECK-NEXT: public:
 // CHECK: SWIFT_INLINE_THUNK FirstSmallStruct &operator =(const FirstSmallStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK uint32_t getX() const SWIFT_SYMBOL("s:4Init16FirstSmallStructV1xs6UInt32Vvp");
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK FirstSmallStruct init() SWIFT_SYMBOL("s:4Init16FirstSmallStructVACycfc");
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK FirstSmallStruct init(swift::Int x) SWIFT_SYMBOL("s:4Init16FirstSmallStructVyACSicfc");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK uint32_t getX() const noexcept SWIFT_SYMBOL("s:4Init16FirstSmallStructV1xs6UInt32Vvp");
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK FirstSmallStruct init() noexcept SWIFT_SYMBOL("s:4Init16FirstSmallStructVACycfc");
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK FirstSmallStruct init(swift::Int x) noexcept SWIFT_SYMBOL("s:4Init16FirstSmallStructVyACSicfc");
 // CHECK-NEXT: private:
 
 public struct LargeStruct {
@@ -69,9 +69,9 @@ public struct LargeStruct {
 }
 
 // CHECK: class SWIFT_SYMBOL("s:4Init11LargeStructV") LargeStruct final {
-// CHECK:       SWIFT_INLINE_THUNK swift::Int getX6() const SWIFT_SYMBOL("s:4Init11LargeStructV2x6Sivp");
-// CHECK-NEXT:  static SWIFT_INLINE_THUNK LargeStruct init() SWIFT_SYMBOL("s:4Init11LargeStructVACycfc");
-// CHECK-NEXT:  static SWIFT_INLINE_THUNK LargeStruct init(swift::Int x, const FirstSmallStruct& y) SWIFT_SYMBOL("s:4Init11LargeStructV1x1yACSi_AA010FirstSmallC0Vtcfc");
+// CHECK:       SWIFT_INLINE_THUNK swift::Int getX6() const noexcept SWIFT_SYMBOL("s:4Init11LargeStructV2x6Sivp");
+// CHECK-NEXT:  static SWIFT_INLINE_THUNK LargeStruct init() noexcept SWIFT_SYMBOL("s:4Init11LargeStructVACycfc");
+// CHECK-NEXT:  static SWIFT_INLINE_THUNK LargeStruct init(swift::Int x, const FirstSmallStruct& y) noexcept SWIFT_SYMBOL("s:4Init11LargeStructV1x1yACSi_AA010FirstSmallC0Vtcfc");
 // CHECK-NEXT: private:
 
 private class RefCountedClass {
@@ -98,8 +98,8 @@ public struct StructWithRefCountStoredProp {
     }
 }
 
-// CHECK:      static SWIFT_INLINE_THUNK StructWithRefCountStoredProp init() SWIFT_SYMBOL("s:4Init28StructWithRefCountStoredPropVACycfc");
-// CHECK-NEXT: static SWIFT_INLINE_THUNK StructWithRefCountStoredProp init(swift::Int x) SWIFT_SYMBOL("s:4Init28StructWithRefCountStoredPropV1xACSi_tcfc");
+// CHECK:      static SWIFT_INLINE_THUNK StructWithRefCountStoredProp init() noexcept SWIFT_SYMBOL("s:4Init28StructWithRefCountStoredPropVACycfc");
+// CHECK-NEXT: static SWIFT_INLINE_THUNK StructWithRefCountStoredProp init(swift::Int x) noexcept SWIFT_SYMBOL("s:4Init28StructWithRefCountStoredPropV1xACSi_tcfc");
 
 
 public final class FinalClass {
@@ -138,54 +138,54 @@ public struct WrapOverloadedInits {
     }
 }
 
-// CHECK: static SWIFT_INLINE_THUNK WrapOverloadedInits init(swift::Int x) SWIFT_SYMBOL("s:4Init19WrapOverloadedInitsVyACSicfc");
+// CHECK: static SWIFT_INLINE_THUNK WrapOverloadedInits init(swift::Int x) noexcept SWIFT_SYMBOL("s:4Init19WrapOverloadedInitsVyACSicfc");
 // CHECK-NEXT: static SWIFT_INLINE_THUNK WrapOverloadedInits init(float
 // CHECK-NOT: WrapOverloadedInits init(
 
-// CHECK: BaseClass BaseClass::init(swift::Int x, swift::Int y) {
+// CHECK: BaseClass BaseClass::init(swift::Int x, swift::Int y) noexcept {
 // CHECK-NEXT: return _impl::_impl_BaseClass::makeRetained(Init::_impl::$s4Init9BaseClassCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<BaseClass>::getTypeMetadata()));
 
-// CHECK: DerivedClass DerivedClass::init(swift::Int x, swift::Int y) {
+// CHECK: DerivedClass DerivedClass::init(swift::Int x, swift::Int y) noexcept {
 // CHECK-NEXT: _impl::_impl_DerivedClass::makeRetained(Init::_impl::$s4Init12DerivedClassCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<DerivedClass>::getTypeMetadata()));
 
-// CHECK: DerivedClassTwo DerivedClassTwo::init(swift::Int x, swift::Int y) {
+// CHECK: DerivedClassTwo DerivedClassTwo::init(swift::Int x, swift::Int y) noexcept {
 // CHECK-NEXT: return _impl::_impl_DerivedClassTwo::makeRetained(Init::_impl::$s4Init15DerivedClassTwoCyACSi_SitcfC(x, y, swift::TypeMetadataTrait<DerivedClassTwo>::getTypeMetadata()));
 
-// CHECK: FinalClass FinalClass::init(const FirstSmallStruct& prop) {
+// CHECK: FinalClass FinalClass::init(const FirstSmallStruct& prop) noexcept {
 // CHECK-NEXT: return _impl::_impl_FinalClass::makeRetained(Init::_impl::$s4Init10FinalClassCyAcA16FirstSmallStructVcfC(Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(Init::_impl::_impl_FirstSmallStruct::getOpaquePointer(prop)), swift::TypeMetadataTrait<FinalClass>::getTypeMetadata()));
 
 
-// CHECK:      SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
+// CHECK:      SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const noexcept {
 // CHECK-NEXT: return Init::_impl::$s4Init16FirstSmallStructV1xs6UInt32Vvg(Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct FirstSmallStruct::init() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct FirstSmallStruct::init() noexcept {
 // CHECK-NEXT: return Init::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, Init::_impl::$s4Init16FirstSmallStructVACycfC());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct FirstSmallStruct::init(swift::Int x) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct FirstSmallStruct::init(swift::Int x) noexcept {
 // CHECK-NEXT: return Init::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, Init::_impl::$s4Init16FirstSmallStructVyACSicfC(x));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK LargeStruct LargeStruct::init() {
+// CHECK:      SWIFT_INLINE_THUNK LargeStruct LargeStruct::init() noexcept {
 // CHECK-NEXT: return Init::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s4Init11LargeStructVACycfC(result);
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::init(swift::Int x, const FirstSmallStruct& y) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::init(swift::Int x, const FirstSmallStruct& y) noexcept {
 // CHECK-NEXT: return Init::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(result, x, Init::_impl::swift_interop_passDirect_Init_uint32_t_0_4(Init::_impl::_impl_FirstSmallStruct::getOpaquePointer(y)));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK StructWithRefCountStoredProp StructWithRefCountStoredProp::init() {
+// CHECK:      SWIFT_INLINE_THUNK StructWithRefCountStoredProp StructWithRefCountStoredProp::init() noexcept {
 // CHECK-NEXT: return Init::_impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, Init::_impl::$s4Init28StructWithRefCountStoredPropVACycfC());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK StructWithRefCountStoredProp StructWithRefCountStoredProp::init(swift::Int x) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK StructWithRefCountStoredProp StructWithRefCountStoredProp::init(swift::Int x) noexcept {
 // CHECK-NEXT: return Init::_impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, Init::_impl::$s4Init28StructWithRefCountStoredPropV1xACSi_tcfC(x));
 // CHECK-NEXT: });

--- a/test/Interop/SwiftToCxx/initializers/swift-init-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/swift-init-availability-in-cxx.swift
@@ -18,6 +18,6 @@ public struct Struct {
   }
 }
 
-// CHECK: static SWIFT_INLINE_THUNK Struct init(int16_t field) SWIFT_SYMBOL("s:7Methods6StructVyACs5Int16Vcfc") SWIFT_AVAILABILITY(macos,introduced=11);
+// CHECK: static SWIFT_INLINE_THUNK Struct init(int16_t field) noexcept SWIFT_SYMBOL("s:7Methods6StructVyACs5Int16Vcfc") SWIFT_AVAILABILITY(macos,introduced=11);
 
-// CHECK: SWIFT_INLINE_THUNK Struct Struct::init(int16_t field) SWIFT_AVAILABILITY(macos,introduced=11) {
+// CHECK: SWIFT_INLINE_THUNK Struct Struct::init(int16_t field) noexcept SWIFT_AVAILABILITY(macos,introduced=11) {

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -98,20 +98,20 @@ public final class PassStructInClassMethod {
 // CHECK: class SWIFT_SYMBOL("s:7Methods09ClassWithA0C") ClassWithMethods final : public swift::_impl::RefCountedClass {
 // CHECK:   using RefCountedClass::RefCountedClass;
 // CHECK-NEXT:   using RefCountedClass::operator=;
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void dump() SWIFT_SYMBOL("s:7Methods09ClassWithA0C4dumpyyF");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK ClassWithMethods sameRet() SWIFT_SYMBOL("s:7Methods09ClassWithA0C7sameRetACyF");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void mutate() SWIFT_SYMBOL("s:7Methods09ClassWithA0C6mutateyyF");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK ClassWithMethods deepCopy(swift::Int x) SWIFT_SYMBOL("s:7Methods09ClassWithA0C8deepCopyyACSiF");
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK LargeStruct staticFinalClassMethod(swift::Int x) SWIFT_SYMBOL("s:7Methods09ClassWithA0C011staticFinalB6Method1xAA11LargeStructVSi_tFZ");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void dump() noexcept SWIFT_SYMBOL("s:7Methods09ClassWithA0C4dumpyyF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK ClassWithMethods sameRet() noexcept SWIFT_SYMBOL("s:7Methods09ClassWithA0C7sameRetACyF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void mutate() noexcept SWIFT_SYMBOL("s:7Methods09ClassWithA0C6mutateyyF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK ClassWithMethods deepCopy(swift::Int x) noexcept SWIFT_SYMBOL("s:7Methods09ClassWithA0C8deepCopyyACSiF");
+// CHECK-NEXT:   static SWIFT_INLINE_THUNK LargeStruct staticFinalClassMethod(swift::Int x) noexcept SWIFT_SYMBOL("s:7Methods09ClassWithA0C011staticFinalB6Method1xAA11LargeStructVSi_tFZ");
 
 // CHECK: class SWIFT_SYMBOL("s:7Methods11LargeStructV") LargeStruct final {
 // CHECK: SWIFT_INLINE_THUNK LargeStruct &operator =(const LargeStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct doubled() const SWIFT_SYMBOL("s:7Methods11LargeStructV7doubledACyF");
-// CHECK-NEXT: SWIFT_INLINE_THUNK void dump() const SWIFT_SYMBOL("s:7Methods11LargeStructV4dumpyyF");
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct scaled(swift::Int x, swift::Int y) const SWIFT_SYMBOL("s:7Methods11LargeStructV6scaledyACSi_SitF");
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct added(const LargeStruct& x) const SWIFT_SYMBOL("s:7Methods11LargeStructV5addedyA2CF");
-// CHECK-NEXT: static SWIFT_INLINE_THUNK void staticMethod() SWIFT_SYMBOL("s:7Methods11LargeStructV12staticMethodyyFZ");
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct doubled() const noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV7doubledACyF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK void dump() const noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV4dumpyyF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct scaled(swift::Int x, swift::Int y) const noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV6scaledyACSi_SitF");
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct added(const LargeStruct& x) const noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV5addedyA2CF");
+// CHECK-NEXT: static SWIFT_INLINE_THUNK void staticMethod() noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV12staticMethodyyFZ");
 // CHECK-NEXT: private
 
 public struct WrapOverloadedMethods {
@@ -140,7 +140,7 @@ public struct WrapOverloadedMethodsSibling {
 
 // CHECK: WrapOverloadedMethodsSibling final {
 // CHECK: SWIFT_INLINE_THUNK void method
-// CHECK-SAME: (swift::Int x) const SWIFT_SYMBOL("s:7Methods014WrapOverloadedA7SiblingV6methodyySiF");
+// CHECK-SAME: (swift::Int x) const noexcept SWIFT_SYMBOL("s:7Methods014WrapOverloadedA7SiblingV6methodyySiF");
 // CHECK-NEXT: private:
 
 public func createClassWithMethods(_ x: Int) -> ClassWithMethods {
@@ -156,57 +156,57 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 }
 
 
-// CHECK: SWIFT_INLINE_THUNK void ClassWithMethods::dump() {
+// CHECK: SWIFT_INLINE_THUNK void ClassWithMethods::dump() noexcept {
 // CHECK-NEXT: _impl::$s7Methods09ClassWithA0C4dumpyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK ClassWithMethods ClassWithMethods::sameRet() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK ClassWithMethods ClassWithMethods::sameRet() noexcept {
 // CHECK-NEXT: return _impl::_impl_ClassWithMethods::makeRetained(Methods::_impl::$s7Methods09ClassWithA0C7sameRetACyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void ClassWithMethods::mutate() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void ClassWithMethods::mutate() noexcept {
 // CHECK-NEXT: _impl::$s7Methods09ClassWithA0C6mutateyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK ClassWithMethods ClassWithMethods::deepCopy(swift::Int x) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK ClassWithMethods ClassWithMethods::deepCopy(swift::Int x) noexcept {
 // CHECK-NEXT: return _impl::_impl_ClassWithMethods::makeRetained(Methods::_impl::$s7Methods09ClassWithA0C8deepCopyyACSiF(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct ClassWithMethods::staticFinalClassMethod(swift::Int x) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct ClassWithMethods::staticFinalClassMethod(swift::Int x) noexcept {
 // CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods09ClassWithA0C011staticFinalB6Method1xAA11LargeStructVSi_tFZ(result, x, swift::TypeMetadataTrait<ClassWithMethods>::getTypeMetadata());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int ClassWithNonFinalMethods::classClassMethod(swift::Int x) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int ClassWithNonFinalMethods::classClassMethod(swift::Int x) noexcept {
 // CHECK-NEXT: return Methods::_impl::$s7Methods017ClassWithNonFinalA0C05classB6Method1xS2i_tFZ(x, swift::TypeMetadataTrait<ClassWithNonFinalMethods>::getTypeMetadata());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void ClassWithNonFinalMethods::staticClassMethod() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void ClassWithNonFinalMethods::staticClassMethod() noexcept {
 // CHECK-NEXT: _impl::$s7Methods017ClassWithNonFinalA0C06staticB6MethodyyFZ(swift::TypeMetadataTrait<ClassWithNonFinalMethods>::getTypeMetadata());
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK LargeStruct LargeStruct::doubled() const {
+// CHECK:      SWIFT_INLINE_THUNK LargeStruct LargeStruct::doubled() const noexcept {
 // CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV7doubledACyF(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::dump() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::dump() const noexcept {
 // CHECK-NEXT: _impl::$s7Methods11LargeStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::scaled(swift::Int x, swift::Int y) const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::scaled(swift::Int x, swift::Int y) const noexcept {
 // CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV6scaledyACSi_SitF(result, x, y, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::added(const LargeStruct& x) const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::added(const LargeStruct& x) const noexcept {
 // CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV5addedyA2CF(result, Methods::_impl::_impl_LargeStruct::getOpaquePointer(x), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::staticMethod() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::staticMethod() noexcept {
 // CHECK-NEXT: _impl::$s7Methods11LargeStructV12staticMethodyyFZ();
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK LargeStruct PassStructInClassMethod::retStruct(swift::Int x) {
+// CHECK: SWIFT_INLINE_THUNK LargeStruct PassStructInClassMethod::retStruct(swift::Int x) noexcept {
 // CHECK-NEXT: return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   _impl::$s7Methods23PassStructInClassMethodC03retC0yAA05LargeC0VSiF(result, x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void PassStructInClassMethod::updateStruct(swift::Int x, const LargeStruct& y) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void PassStructInClassMethod::updateStruct(swift::Int x, const LargeStruct& y) noexcept {
 // CHECK-NEXT: _impl::$s7Methods23PassStructInClassMethodC06updateC0yySi_AA05LargeC0VtF(x, Methods::_impl::_impl_LargeStruct::getOpaquePointer(y), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
@@ -59,17 +59,17 @@ public struct SmallStruct {
 // CHECK: class SWIFT_SYMBOL("s:7Methods11LargeStructV") LargeStruct final {
 // CHECK: SWIFT_INLINE_THUNK LargeStruct &operator =(const LargeStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void dump() const SWIFT_SYMBOL("s:7Methods11LargeStructV4dumpyyF");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void double_() SWIFT_SYMBOL("s:7Methods11LargeStructV6doubleyyF");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK LargeStruct scale(swift::Int x, swift::Int y) SWIFT_SYMBOL("s:7Methods11LargeStructV5scaleyACSi_SitF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void dump() const noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV4dumpyyF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void double_() noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV6doubleyyF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK LargeStruct scale(swift::Int x, swift::Int y) noexcept SWIFT_SYMBOL("s:7Methods11LargeStructV5scaleyACSi_SitF");
 // CHECK-NEXT: private
 
 // CHECK: class SWIFT_SYMBOL("s:7Methods11SmallStructV") SmallStruct final {
 // CHECK: SWIFT_INLINE_THUNK SmallStruct &operator =(const SmallStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void dump() const SWIFT_SYMBOL("s:7Methods11SmallStructV4dumpyyF");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK SmallStruct scale(float y) SWIFT_SYMBOL("s:7Methods11SmallStructV5scaleyACSfF");
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void invert() SWIFT_SYMBOL("s:7Methods11SmallStructV6invertyyF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void dump() const noexcept SWIFT_SYMBOL("s:7Methods11SmallStructV4dumpyyF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK SmallStruct scale(float y) noexcept SWIFT_SYMBOL("s:7Methods11SmallStructV5scaleyACSfF");
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void invert() noexcept SWIFT_SYMBOL("s:7Methods11SmallStructV6invertyyF");
 // CHECK-NEXT: private:
 
 
@@ -81,26 +81,26 @@ public func createSmallStruct(x: Float) -> SmallStruct {
     return SmallStruct(x: x)
 }
 
-// CHECK:        SWIFT_INLINE_THUNK void LargeStruct::dump() const {
+// CHECK:        SWIFT_INLINE_THUNK void LargeStruct::dump() const noexcept {
 // CHECK-NEXT:   Methods::_impl::$s7Methods11LargeStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStruct::double_() {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStruct::double_() noexcept {
 // CHECK-NEXT:   Methods::_impl::$s7Methods11LargeStructV6doubleyyF(_getOpaquePointer());
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK LargeStruct LargeStruct::scale(swift::Int x, swift::Int y) {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK LargeStruct LargeStruct::scale(swift::Int x, swift::Int y) noexcept {
 // CHECK-NEXT:   return Methods::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     Methods::_impl::$s7Methods11LargeStructV5scaleyACSi_SitF(result, x, y, _getOpaquePointer());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 
-// CHECK:        SWIFT_INLINE_THUNK void SmallStruct::dump() const {
+// CHECK:        SWIFT_INLINE_THUNK void SmallStruct::dump() const noexcept {
 // CHECK-NEXT:   Methods::_impl::$s7Methods11SmallStructV4dumpyyF(Methods::_impl::swift_interop_passDirect_Methods_float_0_4(_getOpaquePointer()));
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK SmallStruct SmallStruct::scale(float y) {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK SmallStruct SmallStruct::scale(float y) noexcept {
 // CHECK-NEXT:   return Methods::_impl::_impl_SmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     Methods::_impl::swift_interop_returnDirect_Methods_float_0_4(result, Methods::_impl::$s7Methods11SmallStructV5scaleyACSfF(y, _getOpaquePointer()));
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void SmallStruct::invert() {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void SmallStruct::invert() noexcept {
 // CHECK-NEXT:   Methods::_impl::$s7Methods11SmallStructV6invertyyF(_getOpaquePointer());
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/methods/swift-method-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/swift-method-availability-in-cxx.swift
@@ -26,15 +26,15 @@ public struct Struct {
   }
 }
 
-// CHECK: SWIFT_INLINE_THUNK void method() const SWIFT_SYMBOL("s:7Methods6StructV6methodyyF") SWIFT_AVAILABILITY(macos,introduced=11);
-// CHECK: static SWIFT_INLINE_THUNK void staticMethod() SWIFT_SYMBOL("s:7Methods6StructV12staticMethodyyFZ") SWIFT_AVAILABILITY(macos,introduced=11);
-// CHECK: SWIFT_INLINE_THUNK void unavailableMethod() const SWIFT_SYMBOL("s:7Methods6StructV17unavailableMethodyyF") SWIFT_UNAVAILABLE_MSG("stuff happened");
-// CHECK: SWIFT_INLINE_THUNK swift::Int operator [](swift::Int x) const SWIFT_SYMBOL("s:7Methods6StructVyS2icig") SWIFT_AVAILABILITY(macos,introduced=11);
+// CHECK: SWIFT_INLINE_THUNK void method() const noexcept SWIFT_SYMBOL("s:7Methods6StructV6methodyyF") SWIFT_AVAILABILITY(macos,introduced=11);
+// CHECK: static SWIFT_INLINE_THUNK void staticMethod() noexcept SWIFT_SYMBOL("s:7Methods6StructV12staticMethodyyFZ") SWIFT_AVAILABILITY(macos,introduced=11);
+// CHECK: SWIFT_INLINE_THUNK void unavailableMethod() const noexcept SWIFT_SYMBOL("s:7Methods6StructV17unavailableMethodyyF") SWIFT_UNAVAILABLE_MSG("stuff happened");
+// CHECK: SWIFT_INLINE_THUNK swift::Int operator [](swift::Int x) const noexcept SWIFT_SYMBOL("s:7Methods6StructVyS2icig") SWIFT_AVAILABILITY(macos,introduced=11);
 
-// CHECK: SWIFT_INLINE_THUNK void Struct::method() const SWIFT_AVAILABILITY(macos,introduced=11) {
+// CHECK: SWIFT_INLINE_THUNK void Struct::method() const noexcept SWIFT_AVAILABILITY(macos,introduced=11) {
 
-// CHECK: SWIFT_INLINE_THUNK void Struct::staticMethod() SWIFT_AVAILABILITY(macos,introduced=11) {
+// CHECK: SWIFT_INLINE_THUNK void Struct::staticMethod() noexcept SWIFT_AVAILABILITY(macos,introduced=11) {
 
-// CHECK: SWIFT_INLINE_THUNK void Struct::unavailableMethod() const SWIFT_UNAVAILABLE_MSG("stuff happened") {
+// CHECK: SWIFT_INLINE_THUNK void Struct::unavailableMethod() const noexcept SWIFT_UNAVAILABLE_MSG("stuff happened") {
 
-// CHECK: SWIFT_INLINE_THUNK swift::Int Struct::operator [](swift::Int x) const SWIFT_SYMBOL("s:7Methods6StructVyS2icig") SWIFT_AVAILABILITY(macos,introduced=11)
+// CHECK: SWIFT_INLINE_THUNK swift::Int Struct::operator [](swift::Int x) const noexcept SWIFT_SYMBOL("s:7Methods6StructVyS2icig") SWIFT_AVAILABILITY(macos,introduced=11)

--- a/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/ownership/consuming-parameter-in-cxx.swift
@@ -102,38 +102,38 @@ public struct TheGenericContainerInitNonTriv {
     let x: Int
 }
 
-// CHECK: SWIFT_INLINE_THUNK void AKlass::takeKlass() {
+// CHECK: SWIFT_INLINE_THUNK void AKlass::takeKlass() noexcept {
 // CHECK-NEXT: alignas(alignof(AKlass)) char copyBuffer_consumedParamCopy_this[sizeof(AKlass)];
 // CHECK-NEXT: auto &consumedParamCopy_this = *(new(copyBuffer_consumedParamCopy_this) AKlass(*this));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<AKlass> storageGuard_consumedParamCopy_this(consumedParamCopy_this);
 // CHECK-NEXT: _impl::$s4Init6AKlassC9takeKlassyyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(consumedParamCopy_this));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK InitFromEnumNonTrivial InitFromEnumNonTrivial::init(const EnumNonTrivial& x) {
+// CHECK: SWIFT_INLINE_THUNK InitFromEnumNonTrivial InitFromEnumNonTrivial::init(const EnumNonTrivial& x) noexcept {
 // CHECK-NEXT: alignas(alignof(EnumNonTrivial)) char copyBuffer_consumedParamCopy_x[sizeof(EnumNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) EnumNonTrivial(x));
 // CHECK-NEXT: ConsumedValueStorageDestroyer<EnumNonTrivial> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 // CHECK-NEXT: returnNewValue
 // CHECK-NEXT: _impl::_impl_EnumNonTrivial::getOpaquePointer(consumedParamCopy_x)
 
-// CHECK: SWIFT_INLINE_THUNK InitFromKlass InitFromKlass::init(const AKlass& x) {
+// CHECK: SWIFT_INLINE_THUNK InitFromKlass InitFromKlass::init(const AKlass& x) noexcept {
 // CHECK-NEXT: alignas(alignof(AKlass)) char copyBuffer_consumedParamCopy_x[sizeof(AKlass)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) AKlass(x));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<AKlass> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 // CHECK-NEXT: returnNewValue
 // CHECK-NEXT: swift::_impl::_impl_RefCountedClass::getOpaquePointer(consumedParamCopy_x)
 
-// CHECK: SWIFT_INLINE_THUNK InitFromLargeStructNonTrivial InitFromLargeStructNonTrivial::init(const LargeStructNonTrivial& x) {
+// CHECK: SWIFT_INLINE_THUNK InitFromLargeStructNonTrivial InitFromLargeStructNonTrivial::init(const LargeStructNonTrivial& x) noexcept {
 // CHECK-NEXT: alignas(alignof(LargeStructNonTrivial)) char copyBuffer_consumedParamCopy_x[sizeof(LargeStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) LargeStructNonTrivial(x));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<LargeStructNonTrivial> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 
-// CHECK:  SWIFT_INLINE_THUNK InitFromSmall InitFromSmall::init(const SmallStructNonTrivial& x) {
+// CHECK:  SWIFT_INLINE_THUNK InitFromSmall InitFromSmall::init(const SmallStructNonTrivial& x) noexcept {
 // CHECK-NEXT: alignas(alignof(SmallStructNonTrivial)) char copyBuffer_consumedParamCopy_x[sizeof(SmallStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) SmallStructNonTrivial(x));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<SmallStructNonTrivial> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 
-// CHECK: SWIFT_INLINE_THUNK void InitFromSmall::takeSmallLarge(const SmallStructNonTrivial& _1, const LargeStructNonTrivial& _2) const {
+// CHECK: SWIFT_INLINE_THUNK void InitFromSmall::takeSmallLarge(const SmallStructNonTrivial& _1, const LargeStructNonTrivial& _2) const noexcept {
 // CHECK-NEXT: alignas(alignof(SmallStructNonTrivial)) char copyBuffer_consumedParamCopy_1[sizeof(SmallStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_1 = *(new(copyBuffer_consumedParamCopy_1) SmallStructNonTrivial(_1));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<SmallStructNonTrivial> storageGuard_consumedParamCopy_1(consumedParamCopy_1);
@@ -142,14 +142,14 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<LargeStructNonTrivial> storageGuard_consumedParamCopy_2(consumedParamCopy_2);
 // CHECK-NON_EVO-NEXT: Init::_impl::$s4Init0A9FromSmallV04takeC5LargeyyAA0C16StructNonTrivialVn_AA0efgH0VntF(Init::_impl::swift_interop_passDirect_Init_{{.*}}(Init::_impl::_impl_SmallStructNonTrivial::getOpaquePointer(consumedParamCopy_1)), Init::_impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_2), Init::_impl::swift_interop_passDirect_Init_{{.*}}(_getOpaquePointer()));
 
-// CHECK: SWIFT_INLINE_THUNK void LargeStructNonTrivial::takeMe() const {
+// CHECK: SWIFT_INLINE_THUNK void LargeStructNonTrivial::takeMe() const noexcept {
 // CHECK-NEXT: alignas(alignof(LargeStructNonTrivial)) char copyBuffer_consumedParamCopy_this[sizeof(LargeStructNonTrivial)];
 // CHECK-NEXT: auto &consumedParamCopy_this = *(new(copyBuffer_consumedParamCopy_this) LargeStructNonTrivial(*this));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<LargeStructNonTrivial> storageGuard_consumedParamCopy_this(consumedParamCopy_this);
 // CHECK-NEXT: Init::_impl::$s4Init21LargeStructNonTrivialV6takeMeyyF(Init::_impl::_impl_LargeStructNonTrivial::getOpaquePointer(consumedParamCopy_this));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK TheGenericContainer<T_0_0> TheGenericContainer<T_0_0>::init(const T_0_0& x) {
+// CHECK: SWIFT_INLINE_THUNK TheGenericContainer<T_0_0> TheGenericContainer<T_0_0>::init(const T_0_0& x) noexcept {
 //CHECK-NEXT:#ifndef __cpp_concepts
 //CHECK-NEXT: static_assert
 //CHECK-NEXT:#endif // __cpp_concepts
@@ -159,7 +159,7 @@ public struct TheGenericContainerInitNonTriv {
 //CHECK-NEXT: returnNewValue
 //CHECK-NEXT: swift::_impl::getOpaquePointer(consumedParamCopy_x)
 
-// CHECK: SWIFT_INLINE_THUNK void TheGenericContainer<T_0_0>::takeGenericContainer() const {
+// CHECK: SWIFT_INLINE_THUNK void TheGenericContainer<T_0_0>::takeGenericContainer() const noexcept {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert
 // CHECK-NEXT: #endif // __cpp_concepts
@@ -169,10 +169,10 @@ public struct TheGenericContainerInitNonTriv {
 // CHECK-NEXT: _impl::$s4Init19TheGenericContainerV04takecD0yyF(swift::TypeMetadataTrait<TheGenericContainer<T_0_0>>::getTypeMetadata(), Init::_impl::_impl_TheGenericContainer<T_0_0>::getOpaquePointer(consumedParamCopy_this));
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitNonTriv TheGenericContainerInitNonTriv::init(const TheGenericContainer<AKlass>& x) {
+// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitNonTriv TheGenericContainerInitNonTriv::init(const TheGenericContainer<AKlass>& x) noexcept {
 // CHECK-NEXT: alignas(alignof(TheGenericContainer<AKlass>)) char copyBuffer_consumedParamCopy_x[sizeof(TheGenericContainer<AKlass>)];
 // CHECK-NEXT: auto &consumedParamCopy_x = *(new(copyBuffer_consumedParamCopy_x) TheGenericContainer<AKlass>(x));
 // CHECK-NEXT: swift::_impl::ConsumedValueStorageDestroyer<TheGenericContainer<AKlass>> storageGuard_consumedParamCopy_x(consumedParamCopy_x);
 
-// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitTriv TheGenericContainerInitTriv::init(const TheGenericContainer<swift::Int>& x) {
+// CHECK: SWIFT_INLINE_THUNK TheGenericContainerInitTriv TheGenericContainerInitTriv::init(const TheGenericContainer<swift::Int>& x) noexcept {
 // CHECK-NON_EVO-NEXT: return

--- a/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
@@ -23,36 +23,36 @@ public struct IsHasProperties {
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) IsHasProperties
 
-// CHECK: SWIFT_INLINE_THUNK bool isEmpty() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool hasFlavor() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool isSolid() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setIsSolid(bool value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool getFlag() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setFlag(bool value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool getHas() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getIsOption() const SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK bool isEmpty() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool hasFlavor() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool isSolid() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setIsSolid(bool value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool getFlag() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setFlag(bool value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool getHas() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getIsOption() const noexcept SWIFT_SYMBOL({{.*}});
 
-// CHECK: SWIFT_INLINE_THUNK bool IsHasProperties::isEmpty() const {
+// CHECK: SWIFT_INLINE_THUNK bool IsHasProperties::isEmpty() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V7isEmptySbvg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::hasFlavor() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::hasFlavor() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V9hasFlavorSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::isSolid() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::isSolid() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V7isSolidSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void IsHasProperties::setIsSolid(bool value) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void IsHasProperties::setIsSolid(bool value) noexcept {
 // CHECK-NEXT: Properties::_impl::$s10Properties05IsHasA0V7isSolidSbvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::getFlag() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::getFlag() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V4flagSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void IsHasProperties::setFlag(bool value) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void IsHasProperties::setFlag(bool value) noexcept {
 // CHECK-NEXT: Properties::_impl::$s10Properties05IsHasA0V4flagSbvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::getHas() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK bool IsHasProperties::getHas() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V3hasSbvg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int IsHasProperties::getIsOption() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int IsHasProperties::getIsOption() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties05IsHasA0V8isOptionSivg(_getOpaquePointer());
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
@@ -12,7 +12,7 @@ public struct FirstSmallStruct {
 // CHECK: public:
 // CHECK:   SWIFT_INLINE_THUNK FirstSmallStruct &operator =(const FirstSmallStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK uint32_t getX() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   SWIFT_INLINE_THUNK uint32_t getX() const noexcept SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:   private:
 
 public struct LargeStruct {
@@ -39,16 +39,16 @@ public struct LargeStruct {
 // CHECK: public:
 // CHECK: SWIFT_INLINE_THUNK LargeStruct &operator =(const LargeStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX1() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX2() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX3() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX4() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX5() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX6() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct getAnotherLargeStruct() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct getFirstSmallStruct() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: static SWIFT_INLINE_THUNK swift::Int getStaticX() SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: static SWIFT_INLINE_THUNK FirstSmallStruct getStaticSmallStruct() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX1() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX2() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX3() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX4() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX5() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX6() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct getAnotherLargeStruct() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct getFirstSmallStruct() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static SWIFT_INLINE_THUNK swift::Int getStaticX() noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static SWIFT_INLINE_THUNK FirstSmallStruct getStaticSmallStruct() noexcept SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public final class PropertiesInClass {
@@ -69,9 +69,9 @@ public final class PropertiesInClass {
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) PropertiesInClass final : public swift::_impl::RefCountedClass {
 // CHECK: using RefCountedClass::operator=;
-// CHECK-NEXT: SWIFT_INLINE_THUNK int32_t getStoredInt() SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getComputedInt() SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct getSmallStruct() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK int32_t getStoredInt() noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getComputedInt() noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct getSmallStruct() noexcept SWIFT_SYMBOL({{.*}});
 
 public func createPropsInClass(_ x: Int32) -> PropertiesInClass {
     return PropertiesInClass(x)
@@ -96,10 +96,10 @@ public struct SmallStructWithGetters {
 // CHECK: public:
 // CHECK: SWIFT_INLINE_THUNK SmallStructWithGetters &operator =(const SmallStructWithGetters &other) noexcept {
 // CHECK: }
-// CHECK-NEXT:  SWIFT_INLINE_THUNK uint32_t getStoredInt() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK swift::Int getComputedInt() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK LargeStruct getLargeStruct() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK SmallStructWithGetters getSmallStruct() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  SWIFT_INLINE_THUNK uint32_t getStoredInt() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  SWIFT_INLINE_THUNK swift::Int getComputedInt() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  SWIFT_INLINE_THUNK LargeStruct getLargeStruct() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  SWIFT_INLINE_THUNK SmallStructWithGetters getSmallStruct() const noexcept SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public func createSmallStructWithGetter() -> SmallStructWithGetters {
@@ -134,71 +134,71 @@ public func createStructWithRefCountStoredProp() -> StructWithRefCountStoredProp
     return StructWithRefCountStoredProp(x: 0)
 }
 
-// CHECK: SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
+// CHECK: SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const {
+// CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x1Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX2() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX2() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x2Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX3() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX3() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x3Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX4() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX4() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x4Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX5() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX5() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x5Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX6() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getX6() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV2x6Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::getAnotherLargeStruct() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct LargeStruct::getAnotherLargeStruct() const noexcept {
 // CHECK-NEXT: return Properties::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   Properties::_impl::$s10Properties11LargeStructV07anotherbC0ACvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getFirstSmallStruct() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getFirstSmallStruct() const noexcept {
 // CHECK-NEXT: return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties11LargeStructV010firstSmallC0AA05FirsteC0Vvg(_getOpaquePointer()));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getStaticX() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int LargeStruct::getStaticX() noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV7staticXSivgZ();
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getStaticSmallStruct() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getStaticSmallStruct() noexcept {
 // CHECK-NEXT: return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties11LargeStructV011staticSmallC0AA05FirsteC0VvgZ());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_INLINE_THUNK int32_t PropertiesInClass::getStoredInt() {
+// CHECK: SWIFT_INLINE_THUNK int32_t PropertiesInClass::getStoredInt() noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC9storedInts5Int32Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int PropertiesInClass::getComputedInt() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int PropertiesInClass::getComputedInt() noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC11computedIntSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct PropertiesInClass::getSmallStruct() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct PropertiesInClass::getSmallStruct() noexcept {
 // CHECK-NEXT: return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties0A7InClassC11smallStructAA010FirstSmallE0Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK uint32_t SmallStructWithGetters::getStoredInt() const {
+// CHECK:      SWIFT_INLINE_THUNK uint32_t SmallStructWithGetters::getStoredInt() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties22SmallStructWithGettersV9storedInts6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int SmallStructWithGetters::getComputedInt() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int SmallStructWithGetters::getComputedInt() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties22SmallStructWithGettersV11computedIntSivg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct SmallStructWithGetters::getLargeStruct() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK LargeStruct SmallStructWithGetters::getLargeStruct() const noexcept {
 // CHECK-NEXT: return Properties::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   Properties::_impl::$s10Properties22SmallStructWithGettersV05largeC0AA05LargeC0Vvg(result, Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK SmallStructWithGetters SmallStructWithGetters::getSmallStruct() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK SmallStructWithGetters SmallStructWithGetters::getSmallStruct() const noexcept {
 // CHECK-NEXT: return Properties::_impl::_impl_SmallStructWithGetters::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   Properties::_impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties22SmallStructWithGettersV05smallC0ACvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer())));
 // CHECK-NEXT: });

--- a/test/Interop/SwiftToCxx/properties/name-collision.swift
+++ b/test/Interop/SwiftToCxx/properties/name-collision.swift
@@ -80,10 +80,10 @@ public struct S0 {
 // CHECK:};
 
 // Out-of-line definitions section.
-// CHECK: SWIFT_INLINE_THUNK swift::String C0::getDescription() {
+// CHECK: SWIFT_INLINE_THUNK swift::String C0::getDescription() noexcept {
 // CHECK: skip emitting accessor method for 'description'. 'getDescription' already declared.
 // CHECK-NOT: getDescription()
 // CHECK-NOT: getFeat()
-// CHECK: SWIFT_INLINE_THUNK swift::Int C1::getFeat() {
+// CHECK: SWIFT_INLINE_THUNK swift::Int C1::getFeat() noexcept {
 // CHECK: skip emitting accessor method for 'Feat'. 'getFeat' already declared.
 // CHECK-NOT: getFeat()

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
@@ -12,8 +12,8 @@ public struct FirstSmallStruct {
 // CHECK: public:
 // CHECK: SWIFT_INLINE_THUNK FirstSmallStruct &operator =(const FirstSmallStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK uint32_t getX() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void setX(uint32_t value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   SWIFT_INLINE_THUNK uint32_t getX() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void setX(uint32_t value) noexcept SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:   private:
 
 public struct LargeStruct {
@@ -34,20 +34,20 @@ public struct LargeStruct {
 // CHECK: public:
 // CHECK: SWIFT_INLINE_THUNK LargeStruct &operator =(const LargeStruct &other) noexcept {
 // CHECK: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX1() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setX1(swift::Int value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX2() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setX2(swift::Int value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX3() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setX3(swift::Int value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX4() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setX4(swift::Int value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX5() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setX5(swift::Int value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX6() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setX6(swift::Int value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: static SWIFT_INLINE_THUNK swift::Int getStaticX() SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: static SWIFT_INLINE_THUNK void setStaticX(swift::Int newValue) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX1() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setX1(swift::Int value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX2() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setX2(swift::Int value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX3() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setX3(swift::Int value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX4() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setX4(swift::Int value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX5() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setX5(swift::Int value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getX6() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setX6(swift::Int value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static SWIFT_INLINE_THUNK swift::Int getStaticX() noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static SWIFT_INLINE_THUNK void setStaticX(swift::Int newValue) noexcept SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public struct LargeStructWithProps {
@@ -57,10 +57,10 @@ public struct LargeStructWithProps {
 
 // CHECK:      class SWIFT_SYMBOL({{.*}}) LargeStructWithProps final {
 // CHECK-NEXT: public:
-// CHECK:      SWIFT_INLINE_THUNK LargeStruct getStoredLargeStruct() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredLargeStruct(const LargeStruct& value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct getStoredSmallStruct() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredSmallStruct(const FirstSmallStruct& value) SWIFT_SYMBOL({{.*}});
+// CHECK:      SWIFT_INLINE_THUNK LargeStruct getStoredLargeStruct() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredLargeStruct(const LargeStruct& value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct getStoredSmallStruct() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredSmallStruct(const FirstSmallStruct& value) noexcept SWIFT_SYMBOL({{.*}});
 
 public final class PropertiesInClass {
     public var storedInt: Int32
@@ -80,10 +80,10 @@ public final class PropertiesInClass {
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) PropertiesInClass final : public swift::_impl::RefCountedClass {
 // CHECK: using RefCountedClass::operator=;
-// CHECK-NEXT: SWIFT_INLINE_THUNK int32_t getStoredInt() SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredInt(int32_t value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getComputedInt() SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK void setComputedInt(swift::Int newValue) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK int32_t getStoredInt() noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setStoredInt(int32_t value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int getComputedInt() noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK void setComputedInt(swift::Int newValue) noexcept SWIFT_SYMBOL({{.*}});
 
 public func createPropsInClass(_ x: Int32) -> PropertiesInClass {
     return PropertiesInClass(x)
@@ -113,12 +113,12 @@ public struct SmallStructWithProps {
 // CHECK: public:
 // CHECK: SWIFT_INLINE_THUNK SmallStructWithProps &operator =(const SmallStructWithProps &other) noexcept {
 // CHECK: }
-// CHECK-NEXT:    SWIFT_INLINE_THUNK uint32_t getStoredInt() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:    SWIFT_INLINE_THUNK void setStoredInt(uint32_t value) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:    SWIFT_INLINE_THUNK swift::Int getComputedInt() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:    SWIFT_INLINE_THUNK void setComputedInt(swift::Int newValue) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:    SWIFT_INLINE_THUNK LargeStructWithProps getLargeStructWithProps() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:    SWIFT_INLINE_THUNK void setLargeStructWithProps(const LargeStructWithProps& newValue) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    SWIFT_INLINE_THUNK uint32_t getStoredInt() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    SWIFT_INLINE_THUNK void setStoredInt(uint32_t value) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    SWIFT_INLINE_THUNK swift::Int getComputedInt() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    SWIFT_INLINE_THUNK void setComputedInt(swift::Int newValue) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    SWIFT_INLINE_THUNK LargeStructWithProps getLargeStructWithProps() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    SWIFT_INLINE_THUNK void setLargeStructWithProps(const LargeStructWithProps& newValue) noexcept SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public func createSmallStructWithProps() -> SmallStructWithProps {
@@ -129,74 +129,74 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
     return FirstSmallStruct(x: x)
 }
 
-// CHECK: SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
+// CHECK: SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::setX(uint32_t value) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::setX(uint32_t value) noexcept {
 // CHECK-NEXT: _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
 
-// CHECK:        SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const {
+// CHECK:        SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const noexcept {
 // CHECK-NEXT:   return Properties::_impl::$s10Properties11LargeStructV2x1Sivg(_getOpaquePointer());
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStruct::setX1(swift::Int value) {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStruct::setX1(swift::Int value) noexcept {
 // CHECK-NEXT:   _impl::$s10Properties11LargeStructV2x1Sivs(value, _getOpaquePointer());
 // CHECK-NEXT:   }
 
-// CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getStaticX() {
+// CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getStaticX() noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties11LargeStructV7staticXSivgZ();
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::setStaticX(swift::Int newValue) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::setStaticX(swift::Int newValue) noexcept {
 // CHECK-NEXT: _impl::$s10Properties11LargeStructV7staticXSivsZ(newValue);
 // CHECK-NEXT: }
 
-// CHECK:        SWIFT_INLINE_THUNK LargeStruct LargeStructWithProps::getStoredLargeStruct() const {
+// CHECK:        SWIFT_INLINE_THUNK LargeStruct LargeStructWithProps::getStoredLargeStruct() const noexcept {
 // CHECK-NEXT:    return Properties::_impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvg(result, _getOpaquePointer());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredLargeStruct(const LargeStruct& value) {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredLargeStruct(const LargeStruct& value) noexcept {
 // CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvs(Properties::_impl::_impl_LargeStruct::getOpaquePointer(value), _getOpaquePointer());
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK FirstSmallStruct LargeStructWithProps::getStoredSmallStruct() const {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK FirstSmallStruct LargeStructWithProps::getStoredSmallStruct() const noexcept {
 // CHECK-NEXT:   return Properties::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, Properties::_impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvg(_getOpaquePointer()));
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
-// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredSmallStruct(const FirstSmallStruct& value) {
+// CHECK-NEXT:   SWIFT_INLINE_THUNK void LargeStructWithProps::setStoredSmallStruct(const FirstSmallStruct& value) noexcept {
 // CHECK-NEXT:   _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvs(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(Properties::_impl::_impl_FirstSmallStruct::getOpaquePointer(value)), _getOpaquePointer());
 // CHECK-NEXT:   }
 
-// CHECK: SWIFT_INLINE_THUNK int32_t PropertiesInClass::getStoredInt() {
+// CHECK: SWIFT_INLINE_THUNK int32_t PropertiesInClass::getStoredInt() noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC9storedInts5Int32Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void PropertiesInClass::setStoredInt(int32_t value) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void PropertiesInClass::setStoredInt(int32_t value) noexcept {
 // CHECK-NEXT: _impl::$s10Properties0A7InClassC9storedInts5Int32Vvs(value, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int PropertiesInClass::getComputedInt() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK swift::Int PropertiesInClass::getComputedInt() noexcept {
 // CHECK-NEXT: return Properties::_impl::$s10Properties0A7InClassC11computedIntSivg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void PropertiesInClass::setComputedInt(swift::Int newValue) {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void PropertiesInClass::setComputedInt(swift::Int newValue) noexcept {
 // CHECK-NEXT: _impl::$s10Properties0A7InClassC11computedIntSivs(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 
-// CHECK:        SWIFT_INLINE_THUNK uint32_t SmallStructWithProps::getStoredInt() const {
+// CHECK:        SWIFT_INLINE_THUNK uint32_t SmallStructWithProps::getStoredInt() const noexcept {
 // CHECK-NEXT:  return Properties::_impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  }
-// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setStoredInt(uint32_t value) {
+// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setStoredInt(uint32_t value) noexcept {
 // CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvs(value, _getOpaquePointer());
 // CHECK-NEXT:  }
-// CHECK-NEXT:  SWIFT_INLINE_THUNK swift::Int SmallStructWithProps::getComputedInt() const {
+// CHECK-NEXT:  SWIFT_INLINE_THUNK swift::Int SmallStructWithProps::getComputedInt() const noexcept {
 // CHECK-NEXT:  return Properties::_impl::$s10Properties20SmallStructWithPropsV11computedIntSivg(Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  }
-// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setComputedInt(swift::Int newValue) {
+// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setComputedInt(swift::Int newValue) noexcept {
 // CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV11computedIntSivs(newValue, _getOpaquePointer());
 // CHECK-NEXT:  }
-// CHECK-NEXT:  SWIFT_INLINE_THUNK LargeStructWithProps SmallStructWithProps::getLargeStructWithProps() const {
+// CHECK-NEXT:  SWIFT_INLINE_THUNK LargeStructWithProps SmallStructWithProps::getLargeStructWithProps() const noexcept {
 // CHECK-NEXT:  return Properties::_impl::_impl_LargeStructWithProps::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:    _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvg(result, Properties::_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  });
 // CHECK-NEXT:  }
-// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setLargeStructWithProps(const LargeStructWithProps& newValue) {
+// CHECK-NEXT:  SWIFT_INLINE_THUNK void SmallStructWithProps::setLargeStructWithProps(const LargeStructWithProps& newValue) noexcept {
 // CHECK-NEXT:  _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvs(Properties::_impl::_impl_LargeStructWithProps::getOpaquePointer(newValue), _getOpaquePointer());
 // CHECK-NEXT:  }

--- a/test/Interop/SwiftToCxx/properties/swift-property-availability-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/swift-property-availability-in-cxx.swift
@@ -22,9 +22,9 @@ public struct Struct {
   }
 }
 
-// CHECK:  SWIFT_INLINE_THUNK swift::Int getGetterOnly() const SWIFT_SYMBOL("s:7Methods6StructV10getterOnlySivp") SWIFT_AVAILABILITY(macos,introduced=11);
-// CHECK: static SWIFT_INLINE_THUNK swift::Int getStaticUnavailableProp() SWIFT_SYMBOL("s:7Methods6StructV21staticUnavailablePropSivpZ") SWIFT_UNAVAILABLE_MSG("stuff happened");
+// CHECK:  SWIFT_INLINE_THUNK swift::Int getGetterOnly() const noexcept SWIFT_SYMBOL("s:7Methods6StructV10getterOnlySivp") SWIFT_AVAILABILITY(macos,introduced=11);
+// CHECK: static SWIFT_INLINE_THUNK swift::Int getStaticUnavailableProp() noexcept SWIFT_SYMBOL("s:7Methods6StructV21staticUnavailablePropSivpZ") SWIFT_UNAVAILABLE_MSG("stuff happened");
 
-// CHECK: SWIFT_INLINE_THUNK swift::Int Struct::getGetterOnly() const SWIFT_AVAILABILITY(macos,introduced=11) {
+// CHECK: SWIFT_INLINE_THUNK swift::Int Struct::getGetterOnly() const noexcept SWIFT_AVAILABILITY(macos,introduced=11) {
 
-// CHECK: SWIFT_INLINE_THUNK swift::Int Struct::getStaticUnavailableProp() SWIFT_UNAVAILABLE_MSG("stuff happened") {
+// CHECK: SWIFT_INLINE_THUNK swift::Int Struct::getStaticUnavailableProp() noexcept SWIFT_UNAVAILABLE_MSG("stuff happened") {

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -40,12 +40,12 @@
 // CHECK: }
 // CHECK-NEXT: SWIFT_INLINE_THUNK Array(const Array &other) noexcept {
 // CHECK: }
-// CHECK: static SWIFT_INLINE_THUNK Array<T_0_0> init() SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK void append(const T_0_0& newElement) SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK T_0_0 removeAt(swift::Int index) SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK T_0_0 operator [](swift::Int index) const SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK swift::Int getCapacity() const SWIFT_SYMBOL({{.*}});
+// CHECK: static SWIFT_INLINE_THUNK Array<T_0_0> init() noexcept SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK void append(const T_0_0& newElement) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK T_0_0 removeAt(swift::Int index) noexcept SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK T_0_0 operator [](swift::Int index) const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK swift::Int getCount() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK swift::Int getCapacity() const noexcept SWIFT_SYMBOL({{.*}});
 
 // CHECK: template<class T_0_0>
 // CHECK: template<class T_0_0>
@@ -73,8 +73,8 @@
 // CHECK-NEXT: };
 // CHECK: SWIFT_INLINE_THUNK bool isSome() const;
 // CHECK: SWIFT_INLINE_THUNK bool isNone() const;
-// CHECK-DAG: SWIFT_INLINE_THUNK T_0_0 getUnsafelyUnwrapped() const SWIFT_SYMBOL({{.*}});
-// CHECK-DAG: SWIFT_INLINE_THUNK String getDebugDescription() const SWIFT_SYMBOL("s:Sq16debugDescriptionSSvp");
+// CHECK-DAG: SWIFT_INLINE_THUNK T_0_0 getUnsafelyUnwrapped() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-DAG: SWIFT_INLINE_THUNK String getDebugDescription() const noexcept SWIFT_SYMBOL("s:Sq16debugDescriptionSSvp");
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) String final {
 // CHECK-NEXT: public:
@@ -84,10 +84,10 @@
 // CHECK:  }
 // CHECK-NEXT:  SWIFT_INLINE_THUNK String &operator =(const String &other) noexcept {
 // CHECK:  }
-// CHECK-NEXT:  static SWIFT_INLINE_THUNK String init() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  static SWIFT_INLINE_THUNK String init() noexcept SWIFT_SYMBOL({{.*}});
 // CHECK:  SWIFT_INLINE_THUNK void append(const String& other)
-// CHECK:  SWIFT_INLINE_THUNK __StringNested::UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const __StringNested::UTF8View& newValue) SWIFT_SYMBOL({{.*}});
+// CHECK:  SWIFT_INLINE_THUNK __StringNested::UTF8View getUtf8() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const __StringNested::UTF8View& newValue) noexcept SWIFT_SYMBOL({{.*}});
 // CHECK:  SWIFT_INLINE_THUNK operator NSString * _Nonnull () const noexcept {
 // CHECK-NEXT:    return (__bridge_transfer NSString *)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(_impl::swift_interop_passDirect_Swift_String(_getOpaquePointer())));
 // CHECK-NEXT:   }
@@ -120,14 +120,14 @@
 // CHECK: class SWIFT_SYMBOL({{.*}}) UTF8View final {
 // CHECK: SWIFT_INLINE_THUNK UTF8View &operator =(const UTF8View &other) noexcept {
 // CHECK: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK __StringNested::Index getStartIndex() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:   SWIFT_INLINE_THUNK __StringNested::Index getEndIndex() const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK swift::Optional<__StringNested::Index> indexOffsetByLimitedBy(const __StringNested::Index& i, swift::Int n, const __StringNested::Index& limit) const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK swift::Int distanceFromTo(const __StringNested::Index& i, const __StringNested::Index& j) const SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK uint8_t operator [](const __StringNested::Index& i) const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK String getDescription() const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK bool isTriviallyIdenticalTo(const __StringNested::UTF8View& other) const SWIFT_SYMBOL({{.*}}){{.*}};
+// CHECK-NEXT: SWIFT_INLINE_THUNK __StringNested::Index getStartIndex() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   SWIFT_INLINE_THUNK __StringNested::Index getEndIndex() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Optional<__StringNested::Index> indexOffsetByLimitedBy(const __StringNested::Index& i, swift::Int n, const __StringNested::Index& limit) const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Int distanceFromTo(const __StringNested::Index& i, const __StringNested::Index& j) const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK uint8_t operator [](const __StringNested::Index& i) const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK String getDescription() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const noexcept SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK bool isTriviallyIdenticalTo(const __StringNested::UTF8View& other) const noexcept SWIFT_SYMBOL({{.*}}){{.*}};
 // CHECK-NEXT: private:
 
 // CHECK: class AnyKeyPath { } SWIFT_UNAVAILABLE_MSG("class 'AnyKeyPath' is not yet exposed to C++");

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -240,31 +240,31 @@ public func mutateSmall(_ x: inout FirstSmallStruct) {
 // CHECK-NEXT:   Structs::_impl::$s7Structs18printSmallAndLargeyyAA05FirstC6StructV_AA0eG0VtF(Structs::_impl::_impl_FirstSmallStruct::getOpaquePointer(x), Structs::_impl::_impl_LargeStruct::getOpaquePointer(y));
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const {
+// CHECK:      SWIFT_INLINE_THUNK uint32_t FirstSmallStruct::getX() const noexcept {
 // CHECK-NEXT:   return Structs::_impl::$s7Structs16FirstSmallStructV1xs6UInt32Vvg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK:      SWIFT_INLINE_THUNK void FirstSmallStruct::setX(uint32_t value) {
+// CHECK:      SWIFT_INLINE_THUNK void FirstSmallStruct::setX(uint32_t value) noexcept {
 // CHECK-NEXT:   Structs::_impl::$s7Structs16FirstSmallStructV1xs6UInt32Vvs(value, _getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::dump() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::dump() const noexcept {
 // CHECK-NEXT:   Structs::_impl::$s7Structs16FirstSmallStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::mutate() {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void FirstSmallStruct::mutate() noexcept {
 // CHECK-NEXT:   Structs::_impl::$s7Structs16FirstSmallStructV6mutateyyF(_getOpaquePointer());
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const {
+// CHECK:      SWIFT_INLINE_THUNK swift::Int LargeStruct::getX1() const noexcept {
 // CHECK-NEXT: return Structs::_impl::$s7Structs11LargeStructV2x1Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getFirstSmallStruct() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK FirstSmallStruct LargeStruct::getFirstSmallStruct() const noexcept {
 // CHECK-NEXT: return Structs::_impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) SWIFT_INLINE_THUNK_ATTRIBUTES {
 // CHECK-NEXT:   Structs::_impl::$s7Structs11LargeStructV010firstSmallC0AA05FirsteC0Vvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::dump() const {
+// CHECK-NEXT: SWIFT_INLINE_THUNK void LargeStruct::dump() const noexcept {
 // CHECK-NEXT: Structs::_impl::$s7Structs11LargeStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_INLINE_THUNK void StructWithRefCountStoredProp::dump() const {
+// CHECK:      SWIFT_INLINE_THUNK void StructWithRefCountStoredProp::dump() const noexcept {
 // CHECK-NEXT:   Structs::_impl::$s7Structs28StructWithRefCountStoredPropV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
@@ -32,7 +32,7 @@ public struct B {
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) A final {
 
-// CHECK: B returnsB() const SWIFT_SYMBOL({{.*}});
+// CHECK: B returnsB() const noexcept SWIFT_SYMBOL({{.*}});
 
 // CHECK: namespace _impl {
 // CHECK-EMPTY:
@@ -44,5 +44,5 @@ public struct B {
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) B final {
 
-// CHECK: SWIFT_INLINE_THUNK B A::returnsB() const {
-// CHECK: SWIFT_INLINE_THUNK A B::returnsA() const {
+// CHECK: SWIFT_INLINE_THUNK B A::returnsB() const noexcept {
+// CHECK: SWIFT_INLINE_THUNK A B::returnsA() const noexcept {

--- a/test/Macros/macro_generated_header_cxx.swift
+++ b/test/Macros/macro_generated_header_cxx.swift
@@ -23,7 +23,7 @@ public macro CxxFreestandingStruct() = #externalMacro(module: "MacroDefinition",
 // ---
 
 // CHECK:     class SWIFT_SYMBOL("s:9MacroUser0A14ExpandedStructV") MacroExpandedStruct final {
-// CHECK-DAG: SWIFT_INLINE_THUNK void member() const SWIFT_SYMBOL("s:9MacroUser0A14ExpandedStructV6memberyyF");
+// CHECK-DAG: SWIFT_INLINE_THUNK void member() const noexcept SWIFT_SYMBOL("s:9MacroUser0A14ExpandedStructV6memberyyF");
 #CxxFreestandingStruct
 
 // CHECK: class SWIFT_SYMBOL("s:9MacroUser10SomeStructV") SomeStruct final {
@@ -36,8 +36,8 @@ public struct SomeStruct {
 
   #CxxFreestandingFunc
 
-  // CHECK-DAG: SWIFT_INLINE_THUNK void peer_someMethod() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV15peer_someMethodyyF");
-  // CHECK-DAG: SWIFT_INLINE_THUNK void someMethod() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV10someMethodyyF");
-  // CHECK-DAG: SWIFT_INLINE_THUNK void cxxFreestanding() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV15cxxFreestandingyyF");
-  // CHECK-DAG: SWIFT_INLINE_THUNK void member_SomeStruct() const SWIFT_SYMBOL("s:9MacroUser10SomeStructV07member_cD0yyF");
+  // CHECK-DAG: SWIFT_INLINE_THUNK void peer_someMethod() const noexcept SWIFT_SYMBOL("s:9MacroUser10SomeStructV15peer_someMethodyyF");
+  // CHECK-DAG: SWIFT_INLINE_THUNK void someMethod() const noexcept SWIFT_SYMBOL("s:9MacroUser10SomeStructV10someMethodyyF");
+  // CHECK-DAG: SWIFT_INLINE_THUNK void cxxFreestanding() const noexcept SWIFT_SYMBOL("s:9MacroUser10SomeStructV15cxxFreestandingyyF");
+  // CHECK-DAG: SWIFT_INLINE_THUNK void member_SomeStruct() const noexcept SWIFT_SYMBOL("s:9MacroUser10SomeStructV07member_cD0yyF");
 }


### PR DESCRIPTION
Non-throwing free-function thunks already use `noexcept`, but member thunks omit it. Set the exception specification for methods, initializers, property accessors and subscript accessors, in both declarations and definitions. Throwing functions retain a potentially throwing C++ signature.

The implementation change is three modifier assignments. Most of the diff updates existing generated-header expectations. New compile-time assertions cover free/generic functions, struct/class initializers, instance/mutating/static/generic methods, getters/setters and subscripts in C++17/20 and with exceptions disabled. A separate test uses the existing `GenerateBindingsForThrowingFunctionsInCXX` experimental feature to check throwing signatures.

Split from #91112 in response to the request for smaller, independently reviewable PRs. Based on `main` at `cfbd3c5`.