### PR TITLE
[SILGen][Sema] Support key paths rooted at existential metatypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -734,9 +734,6 @@ ERROR(expr_keypath_application_root_type_mismatch, none,
       (Type, Type))
 ERROR(expr_swift_keypath_anyobject_root,none,
       "the root type of a Swift key path cannot be 'AnyObject'", ())
-ERROR(expr_keypath_protocol_metatype_static_member,none,
-      "key path cannot refer to static member %0 of protocol type %1",
-      (DeclNameRef, Type))
 ERROR(expr_keypath_multiparam_func_conversion, none,
       "cannot convert key path into a multi-argument function type %0", (Type))
 ERROR(cannot_convert_type_to_keypath_subscript_index,none,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2119,8 +2119,6 @@ class AllowInvalidRefInKeyPath final : public ConstraintFix {
   enum RefKind {
     // Allow invalid references to static members i.e. on instance of a type.
     StaticMember,
-    // Allow a reference to a static member through a protocol metatype root.
-    ProtocolMetatypeStaticMember,
     // Allow a reference to a static member as a key path component if it is
     // declared in a module with built with Swift 6.0 compiler version or older.
     UnsupportedStaticMember,
@@ -2156,9 +2154,6 @@ public:
     case RefKind::StaticMember:
       return "allow reference to a static member on invalid base in key path "
              "context";
-    case RefKind::ProtocolMetatypeStaticMember:
-      return "allow reference to a static member on a protocol metatype in "
-             "key path context";
     case RefKind::UnsupportedStaticMember:
       return "allow unsupported static member reference";
     case RefKind::MutatingGetter:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3616,25 +3616,35 @@ static ManagedValue emitKeyPathRValueBase(SILGenFunction &subSGF,
                                              AbstractionPattern::getOpaque(),
                                              baseType);
 
-  // If base is a metatype, it cannot be opened as an existential or upcasted
-  // from a class.
-  if (baseType->is<AnyMetatypeType>())
+  // If base is a concrete metatype, it cannot be opened as an existential or
+  // upcasted from a class.
+  if (baseType->is<MetatypeType>())
     return paramSubstValue;
   
   // Pop open an existential container base.
   if (baseType->isAnyExistentialType()) {
+    bool isMetatype = false;
+    CanType existentialType = baseType;
+    if (auto *metatype = baseType->getAs<ExistentialMetatypeType>()) {
+      isMetatype = true;
+      existentialType =
+          metatype->getExistentialInstanceType()->getCanonicalType();
+    }
+
     // Use the opened archetype from the AST for a protocol member, or make a
     // new one (which we'll upcast immediately below) for a class member.
     ExistentialArchetypeType *opened;
     if (storage->getDeclContext()->getSelfClassDecl()) {
-      opened = ExistentialArchetypeType::get(baseType);
+      opened = ExistentialArchetypeType::get(existentialType);
     } else {
       opened = subs.getReplacementTypes()[0]->castTo<ExistentialArchetypeType>();
     }
 
     FormalEvaluationScope scope(subSGF);
     
-    baseType = opened->getCanonicalType();
+    CanType openedType = opened->getCanonicalType();
+    baseType =
+        isMetatype ? CanType(CanMetatypeType::get(openedType)) : openedType;
     auto openedOpaqueValue = subSGF.emitOpenExistential(loc, paramSubstValue,
                                                         subSGF.getLoweredType(baseType),
                                                         AccessKind::Read);
@@ -3645,18 +3655,26 @@ static ManagedValue emitKeyPathRValueBase(SILGenFunction &subSGF,
   
   // Upcast a class instance to the property's declared type if necessary.
   if (auto propertyClass = storage->getDeclContext()->getSelfClassDecl()) {
-    if (auto selfType = baseType->getAs<DynamicSelfType>())
-      baseType = selfType->getSelfType()->getCanonicalType();
-    auto baseClass = baseType->getClassOrBoundGenericClass();
+    bool isMetatype = false;
+    CanType instanceType = baseType;
+    if (auto *metatype = baseType->getAs<MetatypeType>()) {
+      isMetatype = true;
+      instanceType = metatype->getInstanceType()->getCanonicalType();
+    }
+
+    if (auto selfType = instanceType->getAs<DynamicSelfType>())
+      instanceType = selfType->getSelfType()->getCanonicalType();
+    auto baseClass = instanceType->getClassOrBoundGenericClass();
 
     if (baseClass != propertyClass) {
-      baseType = baseType->getSuperclassForDecl(propertyClass)
-        ->getCanonicalType();
+      instanceType =
+          instanceType->getSuperclassForDecl(propertyClass)->getCanonicalType();
+      baseType = isMetatype ? CanType(CanMetatypeType::get(instanceType))
+                            : instanceType;
       paramSubstValue = subSGF.B.createUpcast(loc, paramSubstValue,
-                                     SILType::getPrimitiveObjectType(baseType));
+                                              subSGF.getLoweredType(baseType));
     }
   }
-  // …or pop open an existential container.
   return paramSubstValue;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6729,16 +6729,6 @@ bool InvalidStaticMemberRefInKeyPath::diagnoseAsError() {
   return true;
 }
 
-bool InvalidProtocolMetatypeStaticMemberRefInKeyPath::diagnoseAsError() {
-  auto baseType = BaseType;
-  if (auto *metatype = baseType->getAs<AnyMetatypeType>())
-    baseType = metatype->getInstanceType();
-
-  emitDiagnostic(diag::expr_keypath_protocol_metatype_static_member,
-                 DeclNameRef(getMember()->getName()), baseType);
-  return true;
-}
-
 bool UnsupportedStaticMemberRefInKeyPath::diagnoseAsError() {
   auto *member = getMember();
   auto *module = member->getDeclContext()->getParentModule();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1856,20 +1856,6 @@ public:
   bool diagnoseAsError() override;
 };
 
-class InvalidProtocolMetatypeStaticMemberRefInKeyPath final
-    : public InvalidMemberRefInKeyPath {
-  Type BaseType;
-
-public:
-  InvalidProtocolMetatypeStaticMemberRefInKeyPath(
-      const Solution &solution, Type baseType, ValueDecl *member,
-      ConstraintLocator *locator)
-      : InvalidMemberRefInKeyPath(solution, member, locator),
-        BaseType(resolveType(baseType)->getRValueType()) {}
-
-  bool diagnoseAsError() override;
-};
-
 /// Diagnose an attempt to reference a static member from an unsupported module.
 ///
 /// Only modules built either from source with 6.1+ compiler or

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1306,12 +1306,6 @@ bool AllowInvalidRefInKeyPath::diagnose(const Solution &solution,
     return failure.diagnose(asNote);
   }
 
-  case RefKind::ProtocolMetatypeStaticMember: {
-    InvalidProtocolMetatypeStaticMemberRefInKeyPath failure(
-        solution, BaseType, Member, getLocator());
-    return failure.diagnose(asNote);
-  }
-
   case RefKind::UnsupportedStaticMember: {
     UnsupportedStaticMemberRefInKeyPath failure(solution, BaseType, Member,
                                                 getLocator());
@@ -1390,17 +1384,9 @@ AllowInvalidRefInKeyPath::forRef(ConstraintSystem &cs, Type baseType,
       }
     }
 
-    auto baseRValueType = baseType->getRValueType();
-    if (auto *metatype = baseRValueType->getAs<AnyMetatypeType>()) {
-      if (metatype->getInstanceType()->isExistentialType()) {
-        return AllowInvalidRefInKeyPath::create(
-            cs, baseType, RefKind::ProtocolMetatypeStaticMember, member,
-            locator);
-      }
-    } else {
+    if (!baseType->getRValueType()->is<AnyMetatypeType>())
       return AllowInvalidRefInKeyPath::create(
           cs, baseType, RefKind::StaticMember, member, locator);
-    }
   }
 
   // Referencing enum cases in key path is not currently allowed.

--- a/test/Constraints/keypath_protocol_metatype.swift
+++ b/test/Constraints/keypath_protocol_metatype.swift
@@ -11,9 +11,52 @@ func ordinaryLookup(_ type: P.Type) -> Int {
 }
 
 let kp: KeyPath<P.Type, Int> = \.foo
-// expected-error@-1 {{key path cannot refer to static member 'foo' of protocol type 'P'}}
 
 func takesKeyPath(_ kp: KeyPath<P.Type, Int>) {}
 
 takesKeyPath(\.foo)
-// expected-error@-1 {{key path cannot refer to static member 'foo' of protocol type 'P'}}
+
+protocol Scope {
+  static var keys: [Int] { get }
+  static var counter: Int { get set }
+  static subscript(i: Int) -> Int { get }
+}
+extension Scope {
+  static var tag: Int { 0 }
+}
+protocol StaticY {
+  static var y: Int { get }
+}
+
+let _: KeyPath<any Scope.Type, [Int]> = \.keys
+let _: KeyPath<any Scope.Type, Int> = \.keys.count
+let _: KeyPath<any Scope.Type, Int> = \.tag
+let _: KeyPath<any Scope.Type, Int> = \.[0]
+
+let _: ReferenceWritableKeyPath<any Scope.Type, Int> = \.counter
+let _: PartialKeyPath<any Scope.Type> = \.keys
+let _: (any Scope.Type) -> [Int] = \.keys
+let _: KeyPath<any (Scope & StaticY).Type, Int> = \.y
+
+let _: KeyPath<any Scope.Type, Int> = \.keys
+// expected-error@-1 {{cannot assign value of type 'KeyPath<any Scope.Type, [Int]>' to type 'KeyPath<any Scope.Type, Int>'}}
+// expected-note@-2 {{arguments to generic parameter 'Value' ('[Int]' and 'Int') are expected to be equal}}
+let _: KeyPath<any Scope, [Int]> = \.keys
+// expected-error@-1 {{static member 'keys' cannot be used on instance of type 'any Scope'}}
+
+class Base {
+  static let staticN = 42
+  static var staticMutable = 0
+  class var overridable: Int { 1 }
+}
+protocol Derived: Base {
+  static var k: Int { get }
+}
+protocol Marker {}
+
+let _: KeyPath<any Derived.Type, Int> = \.staticN
+let _: ReferenceWritableKeyPath<any Derived.Type, Int> = \.staticMutable
+let _: KeyPath<any Derived.Type, Int> = \.overridable
+let _: KeyPath<any Derived.Type, Int> = \.k
+let _: KeyPath<any (Base & Marker).Type, Int> = \.staticN
+let _: KeyPath<any (Base & Marker).Type, Int> = \.overridable

--- a/test/Interpreter/keypath_protocol_metatype.swift
+++ b/test/Interpreter/keypath_protocol_metatype.swift
@@ -1,0 +1,83 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+// Key paths rooted at existential metatypes.
+
+protocol Scope {
+  static var keys: [Int] { get }
+  static var counter: Int { get set }
+  static subscript(i: Int) -> Int { get }
+}
+extension Scope {
+  static var tag: String { "\(Self.self)" }
+}
+
+struct A: Scope {
+  static var keys: [Int] { [1, 2, 3] }
+  static var counter = 0
+  static subscript(i: Int) -> Int { i * 10 }
+}
+struct B: Scope {
+  static var keys: [Int] { [4] }
+  static var counter = 100
+  static subscript(i: Int) -> Int { i * 20 }
+}
+
+let keys: KeyPath<any Scope.Type, [Int]> = \.keys
+let count: KeyPath<any Scope.Type, Int> = \.keys.count
+let tag: KeyPath<any Scope.Type, String> = \.tag
+let sub: KeyPath<any Scope.Type, Int> = \.[2]
+let counter: ReferenceWritableKeyPath<any Scope.Type, Int> = \.counter
+let identity: KeyPath<any Scope.Type, any Scope.Type> = \.self
+
+for m: any Scope.Type in [A.self, B.self] {
+  print(m[keyPath: keys], m[keyPath: count], m[keyPath: tag], m[keyPath: sub],
+        m[keyPath: identity])
+}
+// CHECK: [1, 2, 3] 3 A 20 A
+// CHECK: [4] 1 B 40 B
+
+let scopeA: any Scope.Type = A.self
+scopeA[keyPath: counter] += 5
+// CHECK: 5 100
+print(A.counter, B.counter)
+
+let keysAgain: KeyPath<any Scope.Type, [Int]> = \.keys
+// CHECK: true true
+print(keys == keysAgain, keys.hashValue == keysAgain.hashValue)
+
+let keysFn: (any Scope.Type) -> [Int] = \.keys
+// CHECK: [4]
+print(keysFn(B.self))
+
+// MARK: - Class-constrained existential metatype root
+
+class C {
+  static let staticN = 42
+  static var staticMutable = 0
+  class var overridable: Int { 1 }
+}
+protocol P: C {
+  static var k: Int { get }
+}
+final class D: C, P {
+  override class var overridable: Int { 2 }
+  static var k: Int { 7 }
+}
+
+let staticN: KeyPath<any P.Type, Int> = \.staticN
+let staticMutable: ReferenceWritableKeyPath<any P.Type, Int> = \.staticMutable
+let overridable: KeyPath<any P.Type, Int> = \.overridable
+let k: KeyPath<any P.Type, Int> = \.k
+
+let dType: any P.Type = D.self
+dType[keyPath: staticMutable] = 11
+// CHECK: 42 11 2 7
+print(dType[keyPath: staticN], dType[keyPath: staticMutable],
+      dType[keyPath: overridable], dType[keyPath: k])
+
+protocol Marker {}
+extension D: Marker {}
+let composed: KeyPath<any (C & Marker).Type, Int> = \.overridable
+// CHECK: 2
+print((D.self as any (C & Marker).Type)[keyPath: composed])

--- a/test/Interpreter/keypath_protocol_metatype_objc.swift
+++ b/test/Interpreter/keypath_protocol_metatype_objc.swift
@@ -1,0 +1,31 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+// Key paths rooted at @objc protocol existentials and existential metatypes.
+
+@objc protocol OP {
+  var v: Int { get }
+  static var sv: Int { get }
+}
+
+class C1: NSObject, OP {
+  var v: Int { 1 }
+  static var sv: Int { 10 }
+}
+class C2: NSObject, OP {
+  var v: Int { 2 }
+  static var sv: Int { 20 }
+}
+
+let iv: KeyPath<any OP, Int> = \.v
+let sv: KeyPath<any OP.Type, Int> = \.sv
+
+let pairs: [(any OP, any OP.Type)] = [(C1(), C1.self), (C2(), C2.self)]
+for (e, m) in pairs {
+  print(e[keyPath: iv], m[keyPath: sv])
+}
+// CHECK: 1 10
+// CHECK: 2 20

--- a/test/SILGen/keypath_protocol_metatype.swift
+++ b/test/SILGen/keypath_protocol_metatype.swift
@@ -1,15 +1,57 @@
-// RUN: not %target-swift-emit-silgen %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol P {
   static var foo: Int { get }
+  static var counter: Int { get set }
 }
 
 struct S {
   init(_ kp: KeyPath<P.Type, Int>) {}
 }
 
+// CHECK-LABEL: sil hidden [ossa] @$s25keypath_protocol_metatype4testyyF
 func test() {
+  // CHECK: keypath $KeyPath<any P.Type, Int>, (root $any P.Type; gettable_property $Int, id #P.foo!getter{{.*}}getter @$s25keypath_protocol_metatype1PP3fooSivpZAaB_pXpTK : $@convention(keypath_accessor_getter) (@in_guaranteed @thick any P.Type) -> @out Int)
   S(\.foo)
 }
 
-// CHECK: error: key path cannot refer to static member 'foo' of protocol type 'P'
+// The getter thunk opens the existential metatype and dispatches through the
+// witness table of the dynamic type.
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s25keypath_protocol_metatype1PP3fooSivpZAaB_pXpTK : $@convention(keypath_accessor_getter) (@in_guaranteed @thick any P.Type) -> @out Int
+// CHECK: [[OPENED:%.*]] = open_existential_metatype %{{.*}} to $@thick (@opened({{.*}}, any P) Self).Type
+// CHECK: witness_method $@opened({{.*}}, any P) Self, #P.foo!getter{{.*}}, [[OPENED]]
+
+// CHECK-LABEL: sil hidden [ossa] @$s25keypath_protocol_metatype12testSettableyyF
+func testSettable() {
+  // CHECK: keypath $ReferenceWritableKeyPath<any P.Type, Int>, (root $any P.Type; settable_property $Int, id #P.counter!getter{{.*}}getter @$s25keypath_protocol_metatype1PP7counterSivpZAaB_pXpTK : $@convention(keypath_accessor_getter) (@in_guaranteed @thick any P.Type) -> @out Int, setter @$s25keypath_protocol_metatype1PP7counterSivpZAaB_pXpTk : $@convention(keypath_accessor_setter) (@in_guaranteed Int, @in_guaranteed @thick any P.Type) -> ())
+  let _: ReferenceWritableKeyPath<any P.Type, Int> = \.counter
+}
+
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s25keypath_protocol_metatype1PP7counterSivpZAaB_pXpTk : $@convention(keypath_accessor_setter) (@in_guaranteed Int, @in_guaranteed @thick any P.Type) -> ()
+// CHECK: [[OPENED:%.*]] = open_existential_metatype %{{.*}} to $@thick (@opened({{.*}}, any P) Self).Type
+// CHECK: witness_method $@opened({{.*}}, any P) Self, #P.counter!setter{{.*}}, [[OPENED]]
+
+class Base {
+  class var overridable: Int { 1 }
+}
+protocol Derived: Base {
+  static var k: Int { get }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s25keypath_protocol_metatype20testClassConstrainedyyF
+func testClassConstrained() {
+  // CHECK: keypath $KeyPath<any Derived.Type, Int>, (root $any Derived.Type; gettable_property $Int, id #Derived.k!getter{{.*}}getter @$s25keypath_protocol_metatype7DerivedP1kSivpZAaB_pXpTK : $@convention(keypath_accessor_getter) (@in_guaranteed @thick any Derived.Type) -> @out Int)
+  let _: KeyPath<any Derived.Type, Int> = \.k
+  // CHECK: keypath $KeyPath<any Derived.Type, Int>, (root $any Derived.Type; gettable_property $Int, id #Base.overridable!getter{{.*}}getter @$s25keypath_protocol_metatype4BaseC11overridableSivpZAA7Derived_pXpTK : $@convention(keypath_accessor_getter) (@in_guaranteed @thick any Derived.Type) -> @out Int)
+  let _: KeyPath<any Derived.Type, Int> = \.overridable
+}
+
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s25keypath_protocol_metatype7DerivedP1kSivpZAaB_pXpTK : $@convention(keypath_accessor_getter) (@in_guaranteed @thick any Derived.Type) -> @out Int
+// CHECK: open_existential_metatype
+// CHECK: witness_method $@opened({{.*}}, any Derived) Self, #Derived.k!getter
+
+// A member of the superclass bound is reached by upcasting the opened metatype.
+// CHECK-LABEL: sil shared [thunk] [ossa] @$s25keypath_protocol_metatype4BaseC11overridableSivpZAA7Derived_pXpTK : $@convention(keypath_accessor_getter) (@in_guaranteed @thick any Derived.Type) -> @out Int
+// CHECK: [[OPENED:%.*]] = open_existential_metatype %{{.*}} to $@thick (@opened({{.*}}, any Derived) Self).Type
+// CHECK: [[CLASS:%.*]] = upcast [[OPENED]] to $@thick Base.Type
+// CHECK: class_method [[CLASS]], #Base.overridable!getter

--- a/validation-test/compiler_crashers_fixed/Transform-transform-c18626.swift
+++ b/validation-test/compiler_crashers_fixed/Transform-transform-c18626.swift
@@ -6,5 +6,5 @@ protocol a {
   }
 }
 func c(d: [a.Type]) {
-  d.map(\.b) // expected-error {{key path cannot refer to static member 'b' of protocol type 'a'}}
+  _ = d.map(\.b)
 }


### PR DESCRIPTION
A key path rooted at `any P.Type` that refers to a static member of `P` type-checks, but SILGen could not lower it and crashed. #88474 turned that crash into a diagnostic, rejecting every static member through an existential metatype root. This PR lowers these key paths instead and removes the diagnostic and its fix kind.

| Root type | Instance (`T`) | Metatype (`T.Type`) |
| - | - | - |
| Concrete (`S`) | Supported | Supported (SE-0438) |
| Existential (`any P`) | Supported (see #63155) | Rejected (#88474) |

Only key paths with existential metatype roots are missing, so I thought it'd make sense to support them.

Since the diagnostic is gone, the following two cases crash again as they did before #88474:

* static members whose type mentions `Self` or an associated type, same as instance existential roots (#63155)
* `AnyObject.Type` roots

Tested with `test` and `validation-test` on macOS, and there were no relevant failures. All 5 tests this PR touches / adds passed.

Fixes #82898.

It's my first time contributing to the Swift project, so I'd appreciate any feedback (and a CI run). Thanks!