### PR TITLE
[Windows] disable the MergeFunctions pass when building the compiler modules

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -220,6 +220,12 @@ function(add_swift_compiler_modules_library name)
     # Workaround for https://github.com/swiftlang/llvm-project/issues/7172
     list(APPEND swift_compile_options "-Xcc" "-Xclang" "-Xcc" "-fmodule-format=raw")
 
+    # FIXME: MergeFunctions privatizes the aliasee of clang's weak '??_E' vector
+    # deleting destructor alias, which COFF lowers to a per-object weak extern
+    # default, and lib.exe rejects the mismatch with LNK1227. Remove this once
+    # LLVM stops leaving weak aliases on private symbols.
+    list(APPEND swift_compile_options "-Xfrontend" "-disable-llvm-merge-functions-pass")
+
   elseif(swift_exec_bin_dir MATCHES ".*/swiftly/bin")
     # Detect and handle swiftly-managed hosts.
     execute_process(COMMAND swiftly use --print-location


### PR DESCRIPTION
## Problem

Stage2 Windows build fails archiving the compiler modules:

```
FAILED: [code=1227] lib/swiftCompilerModules.lib
SIL.o : fatal error LNK1227: conflicting weak extern definition for '??_Ebad_array_new_length@std@@UEAAPEAXI@Z'.
  New default '.weak.??_E...default.$s3SIL23ApplyOperandConventions...' conflicts with old default
  '.weak.??_E...default.$s3SIL7ContextP9OptimizerE...' in Optimizer.o
```

## Cause

clang emits the MS-ABI vector deleting destructor as `@"??_E<class>" = weak alias` to the external comdat `??_G`. At `-O`, MergeFunctions moves that body into a `private` unnamed function and the named thunk is later folded away, leaving a weak alias on a private symbol. COFF cannot express that, so MC synthesizes a **per-object-unique** `.weak.<sym>.default.<sym>`. `SIL.o` and `Optimizer.o` then disagree, and MSVC `lib.exe` rejects it (LNK1227). `lld-link`/`llvm-lib` do not.

## Fix

Disable MergeFunctions for the compiler modules on Windows.