### PR TITLE
[Platform] Guard Musl sys/io.h with x86 architecture check

### DIFF
--- a/stdlib/public/Platform/SwiftMusl.h
+++ b/stdlib/public/Platform/SwiftMusl.h
@@ -115,7 +115,9 @@
 #include <sys/fsuid.h>
 #include <sys/inotify.h>
 #include <sys/ioctl.h>
+#if defined(__x86_64__) || defined(__i386__)
 #include <sys/io.h>
+#endif
 #include <sys/klog.h>
 #include <sys/membarrier.h>
 #include <sys/mount.h>

--- a/stdlib/public/Platform/musl.modulemap
+++ b/stdlib/public/Platform/musl.modulemap
@@ -693,6 +693,7 @@ module sys_ioctl [system] {
   export *
 }
 module sys_io [system] {
+  requires x86
   header "sys/io.h"
   export *
 }


### PR DESCRIPTION
### Description
<sys/io.h> provides x86 port I/O routines and is architecture-specific.
On non-x86 architectures like aarch64, including this header causes module
build errors due to invalid x86 assembly constraints.

This guards `<sys/io.h>` in `SwiftMusl.h` under x86 architectures and adds
`requires x86` to `module sys_io` in `musl.modulemap`.

Resolves #91967
