### PR TITLE
Derive `RawRepresentable` via macro

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -274,6 +274,7 @@ enum class BuiltinDerivedConformanceMacroKind : uint8_t {
   DeriveCaseIterable,
   DeriveEncodable,
   DeriveDecodable,
+  DeriveRawRepresentable,
 
   NumKinds,
 };

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1611,6 +1611,12 @@ MacroDecl *ASTContext::getBuiltinDerivedConformanceMacroDecl(
                       {stringParam("", "infos")},
                       MacroIntroducedDeclName::getArbitrary());
     break;
+  case BuiltinDerivedConformanceMacroKind::DeriveRawRepresentable:
+    macro = makeMacro("_deriveRawRepresentable", "DeriveRawRepresentableMacro",
+                      {stringParam("", "infos"), stringParam("", "witness"),
+                       boolParam("", "isStrictMemorySafety")},
+                      MacroIntroducedDeclName::getArbitrary());
+    break;
   case BuiltinDerivedConformanceMacroKind::NumKinds:
     llvm_unreachable("not a real kind");
   }

--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -19,6 +19,7 @@ add_swift_macro_library(SwiftMacros
   SwiftifyImportMacro.swift
   TypeInfoParser.swift
   DerivedConformances/DeriveCaseIterable.swift
+  DerivedConformances/DeriveRawRepresentable.swift
   DerivedConformances/DeriveEquatable.swift
   DerivedConformances/DeriveHashable.swift
   SWIFT_DEPENDENCIES

--- a/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveRawRepresentable.swift
+++ b/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveRawRepresentable.swift
@@ -1,0 +1,145 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Witness to derive for the `RawRepresentable` protocol.
+enum RawRepresentableWitness: TypeInfoProtocol {
+
+  /// The `rawValue` var
+  case varDef
+
+  /// The `init(rawValue:)` initializer
+  case initializer
+
+  /// Parsing utility
+  static func fromSyntax(node: ExprSyntax) throws -> RawRepresentableWitness {
+    switch node.trimmedDescription {
+    case "varDef": .varDef
+    case "initializer": .initializer
+    default:
+      fatalError(
+        "Expected `varDef` or `initializer` but got \(node.trimmedDescription)"
+      )
+    }
+  }
+
+  var syntax: ExprSyntax {
+    switch self {
+    case .varDef: "varDef"
+    case .initializer: "initializer"
+    }
+  }
+}
+
+public struct DeriveRawRepresentableMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Expecting #_deriveRawRepresentable(<type info>, <witness>, <isStrictMemorySafety>)
+
+    let (typeInfo, witnessKind, isStrictMemorySafety) = try node.arguments.expect(
+      .init(parser: NominalTypeInfo.fromStringLit),
+      .init(parser: RawRepresentableWitness.fromStringLit),
+      .boolArg(nil)
+    )
+    let enumInfo: EnumTypeInfo
+
+    switch typeInfo.kind {
+    case .enumLike(let info):
+      enumInfo = info
+    default: fatalError("Expected an enum")
+    }
+
+    // Derive the appropriate witness for the `witnessKind` requirement
+    let witness: DeclSyntax
+
+    switch witnessKind {
+    case .varDef:
+      witness = expandVarDef(enumInfo, isStrictMemorySafety: isStrictMemorySafety)
+    case .initializer:
+      witness = expandInitializer(enumInfo)
+    }
+
+    return [witness]
+  }
+
+  /// Expands the `rawValue` var declaration
+  static func expandVarDef(
+    _ enumInfo: EnumTypeInfo, isStrictMemorySafety: Bool
+  ) -> DeclSyntax {
+    let rawType = enumInfo.rawTypeName!
+
+    if enumInfo.isObjC {
+      // ObjC enums are represented by their raw value, so just use a bitcast.
+      let unsafePrefix = isStrictMemorySafety ? "unsafe " : ""
+      return
+        """
+        nonisolated var rawValue: \(raw: rawType) {
+          return \(raw: unsafePrefix)Swift::unsafeBitCast(self, to: \(raw: rawType).self)
+        }
+        """
+    }
+
+    let cases = enumInfo.cases.map { c in
+      "case .\(c.name): return \(c.rawValue!)"
+    }.joined(separator: "\n")
+
+    return
+      """
+      nonisolated var rawValue: \(raw: rawType) {
+        switch self {
+        \(raw: cases)
+        }
+      }
+      """
+  }
+
+  /// Expands the `init(rawValue:)` declaration
+  static func expandInitializer(_ enumInfo: EnumTypeInfo) -> DeclSyntax {
+    let rawType = enumInfo.rawTypeName!
+
+    let cases: [String] = enumInfo.cases.compactMap { c in
+      switch c.runtimeAvailability {
+      case .unavailable:
+        return nil
+      case .always:
+        return
+          """
+          case \(c.rawValue!):
+            self = .\(c.name)
+          """
+      case .conditional(let platform, let version):
+        return
+          """
+          case \(c.rawValue!):
+            guard #available(\(platform) \(version), *) else { return nil }
+            self = .\(c.name)
+          """
+      }
+    }
+
+    return
+      """
+      init?(rawValue: \(raw: rawType)) {
+        switch rawValue {
+        \(raw: cases.joined(separator: "\n"))
+        default:
+          return nil
+        }
+      }
+      """
+  }
+}

--- a/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveRawRepresentable.swift
+++ b/lib/Macros/Sources/SwiftMacros/DerivedConformances/DeriveRawRepresentable.swift
@@ -111,24 +111,14 @@ public struct DeriveRawRepresentableMacro: DeclarationMacro {
   static func expandInitializer(_ enumInfo: EnumTypeInfo) -> DeclSyntax {
     let rawType = enumInfo.rawTypeName!
 
-    let cases: [String] = enumInfo.cases.compactMap { c in
-      switch c.runtimeAvailability {
-      case .unavailable:
-        return nil
-      case .always:
-        return
-          """
-          case \(c.rawValue!):
-            self = .\(c.name)
-          """
-      case .conditional(let platform, let version):
-        return
-          """
-          case \(c.rawValue!):
-            guard #available(\(platform) \(version), *) else { return nil }
-            self = .\(c.name)
-          """
-      }
+    let cases: [String] = enumInfo.cases.compactMap { c -> String? in
+      guard let guards = c.constructionGuards() else { return nil }
+      let body = (guards + ["self = .\(c.name)"]).joined(separator: "\n  ")
+      return
+        """
+        case \(c.rawValue!):
+          \(body)
+        """
     }
 
     return

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -56,6 +56,10 @@ public struct EnumCaseInfo {
   /// appear in Swift source) and `nil` if there isn't one
   var associatedValueLabels: [String?]
 
+  /// The textual representation of the case's raw value literal, `nil` if it
+  /// does not have one.
+  var rawValue: String?
+
   /// Whether a value of this case can exist at runtime. False only when the
   /// case is unavailable in every execution context the code may run in, so a
   /// switch over `self` may treat it as unreachable.
@@ -82,6 +86,45 @@ public struct AvailabilityQuery {
   /// Whether this is an `#unavailable` query rather than an `#available` one.
   var isUnavailability: Bool
   var constantResult: Bool?
+}
+
+extension AvailabilityQuery {
+  /// The `#available` or `#unavailable` condition that this query spells in
+  /// source.
+  var condition: String {
+    var spec = domain
+    if let primaryRange {
+      spec += " \(primaryRange)"
+    }
+    var specs = [spec]
+    if !isUnavailability && primaryRange != nil {
+      specs.append("*")
+    }
+
+    let keyword = isUnavailability ? "#unavailable" : "#available"
+    return "\(keyword)(\(specs.joined(separator: ", ")))"
+  }
+}
+
+extension EnumCaseInfo {
+  /// The `guard` statements that must precede a reference constructing this
+  /// case, each returning `nil` when its condition fails, or `nil` if the case
+  /// can never be constructed and must be left out of the initializer.
+  func constructionGuards() -> [String]? {
+    guard isConstructible else { return nil }
+
+    var guards: [String] = []
+    for query in runtimeAvailabilityQueries {
+      if let constantResult = query.constantResult {
+        if !constantResult {
+          return nil
+        }
+        continue
+      }
+      guards.append("guard \(query.condition) else { return nil }")
+    }
+    return guards
+  }
 }
 
 public struct StructTypeInfo {
@@ -337,6 +380,25 @@ extension LabeledExprListSyntax {
       try e.expect(arg: lst[4])
     )
   }
+
+  /// Parses six labelled arguments from the argument list.
+  func expect<A, B, C, D, E, F>(
+    _ a: ArgParser<A>, _ b: ArgParser<B>, _ c: ArgParser<C>, _ d: ArgParser<D>,
+    _ e: ArgParser<E>, _ f: ArgParser<F>
+  ) throws -> (A, B, C, D, E, F) {
+    guard count == 6 else {
+      throw TypeInfoParseError.argCountMismatch(expected: 6, args: self)
+    }
+    let lst = Array(self)
+    return (
+      try a.expect(arg: lst[0]),
+      try b.expect(arg: lst[1]),
+      try c.expect(arg: lst[2]),
+      try d.expect(arg: lst[3]),
+      try e.expect(arg: lst[4]),
+      try f.expect(arg: lst[5])
+    )
+  }
 }
 
 /// Protocol for `NominalTypeInfo` and associated types to conform to.
@@ -535,11 +597,12 @@ extension EnumCaseInfo: TypeInfoProtocol {
     // Expecting:
     //   EnumCaseInfo(name: <String>,
     //                associatedValueLabels: <[String?]>,
+    //                rawValue: <String?>,
     //                isReachable: <Bool>,
     //                isConstructible: <Bool>,
     //                runtimeAvailabilityQueries: <[AvailabilityQuery]>)
 
-    let (name, associatedValueLabels, isReachable, isConstructible,
+    let (name, associatedValueLabels, rawValue, isReachable, isConstructible,
          runtimeAvailabilityQueries) =
       try getNamedFuncallArgs(
         node: node,
@@ -547,6 +610,7 @@ extension EnumCaseInfo: TypeInfoProtocol {
       ).expect(
         .stringArg("name"),
         .stringArg("associatedValueLabels").toOptional().toArray(),
+        .stringArg("rawValue").toOptional(),
         .boolArg("isReachable"),
         .boolArg("isConstructible"),
         .arrayArg("runtimeAvailabilityQueries", parser: AvailabilityQuery.fromSyntax)
@@ -555,6 +619,7 @@ extension EnumCaseInfo: TypeInfoProtocol {
     return Self(
       name: name,
       associatedValueLabels: associatedValueLabels,
+      rawValue: rawValue,
       isReachable: isReachable,
       isConstructible: isConstructible,
       runtimeAvailabilityQueries: runtimeAvailabilityQueries)
@@ -562,7 +627,7 @@ extension EnumCaseInfo: TypeInfoProtocol {
 
   public var syntax: ExprSyntax {
     """
-    EnumCaseInfo(name: \(stringlit(name)), associatedValueLabels: \(arraySyntax(associatedValueLabels, {optionalSyntax($0, stringlit)})), isReachable: \(boollit(isReachable)), isConstructible: \(boollit(isConstructible)), runtimeAvailabilityQueries: \(arraySyntax(runtimeAvailabilityQueries, \.syntax)))
+    EnumCaseInfo(name: \(stringlit(name)), associatedValueLabels: \(arraySyntax(associatedValueLabels, {optionalSyntax($0, stringlit)})), rawValue: \(optionalSyntax(rawValue, stringlit)), isReachable: \(boollit(isReachable)), isConstructible: \(boollit(isConstructible)), runtimeAvailabilityQueries: \(arraySyntax(runtimeAvailabilityQueries, \.syntax)))
     """
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -41,6 +41,10 @@ public struct EnumTypeInfo {
 
   /// Information on all its cases
   var cases: [EnumCaseInfo]
+
+  /// The textual representation of the enum's raw type, `nil` if it does not
+  /// declare one.
+  var rawTypeName: String?
 }
 
 /// Represents information on a single case of an enumeration.
@@ -462,14 +466,16 @@ extension StructTypeInfo: TypeInfoProtocol {
 extension EnumTypeInfo: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
-    //   EnumTypeInfo(isObjC: <Bool>, cases: <[EnumCaseInfo]>)
-    let (isObjC, cases) = try getNamedFuncallArgs(
+    //   EnumTypeInfo(isObjC: <Bool>, cases: <[EnumCaseInfo]>,
+    //                rawTypeName: <String?>)
+    let (isObjC, cases, rawTypeName) = try getNamedFuncallArgs(
       node: node,
       name: "EnumTypeInfo"
     )
     .expect(
       .boolArg("isObjC"),
-      .arrayArg("cases", parser: EnumCaseInfo.fromSyntax)
+      .arrayArg("cases", parser: EnumCaseInfo.fromSyntax),
+      .stringArg("rawTypeName").toOptional()
     )
 
     // Enum cases can be overloaded, letting several cases can share a name. Name lookup
@@ -477,12 +483,12 @@ extension EnumTypeInfo: TypeInfoProtocol {
     // case with a name we have already seen.
     var seen: Set<String> = Set()
     let uniqueCases = cases.reversed().filter { seen.insert($0.name).inserted }.reversed()
-    return Self(isObjC: isObjC, cases: Array(uniqueCases))
+    return Self(isObjC: isObjC, cases: Array(uniqueCases), rawTypeName: rawTypeName)
   }
 
   public var syntax: ExprSyntax {
     """
-    EnumTypeInfo(isObjC: \(boollit(isObjC)), cases: \(arraySyntax(cases)))
+    EnumTypeInfo(isObjC: \(boollit(isObjC)), cases: \(arraySyntax(cases)), rawTypeName: \(optionalSyntax(rawTypeName, stringlit)))
     """
   }
 }

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1245,6 +1245,29 @@ static void printAvailabilityQuery(llvm::raw_ostream &out,
   out << ")";
 }
 
+/// Prints the Swift source text of an enum case's raw value literal
+/// expression \p raw to \p out.
+static void printRawValueLiteral(llvm::raw_ostream &out,
+                                 const LiteralExpr *raw) {
+  if (auto *intLit = dyn_cast<IntegerLiteralExpr>(raw)) {
+    if (intLit->isNegative())
+      out << "-";
+    out << intLit->getDigitsText();
+  } else if (isa<NilLiteralExpr>(raw)) {
+    out << "nil";
+  } else if (auto *stringLit = dyn_cast<StringLiteralExpr>(raw)) {
+    out << QuotedString(stringLit->getValue());
+  } else if (auto *floatLit = dyn_cast<FloatLiteralExpr>(raw)) {
+    if (floatLit->isNegative())
+      out << "-";
+    out << floatLit->getDigitsText();
+  } else if (auto *boolLit = dyn_cast<BooleanLiteralExpr>(raw)) {
+    out << (boolLit->getValue() ? "true" : "false");
+  } else {
+    llvm_unreachable("invalid raw literal expr");
+  }
+}
+
 /// Prints a string containing swift syntax describing the case \p  decl with
 /// relevant information to \p out.
 static void printEnumCaseInfo(llvm::raw_ostream &out,
@@ -1275,7 +1298,16 @@ static void printEnumCaseInfo(llvm::raw_ostream &out,
   bool isReachable = !decl->isUnreachableAtRuntime() ||
                      decl->getParentEnum()->isUnreachableAtRuntime();
 
-  out << "], isReachable: " << (isReachable ? "true" : "false")
+  out << "], rawValue: ";
+  if (auto *raw = decl->getRawValueExpr()) {
+    std::string literalText;
+    auto litOut = llvm::raw_string_ostream(literalText);
+    printRawValueLiteral(litOut, raw);
+    out << QuotedString(litOut.str());
+  } else {
+    out << "nil";
+  }
+  out << ", isReachable: " << (isReachable ? "true" : "false")
       << ", isConstructible: " << (isConstructible ? "true" : "false")
       << ", runtimeAvailabilityQueries: [";
   llvm::interleaveComma(availabilityQueries, out,

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1293,7 +1293,13 @@ static void printEnumTypeKind(llvm::raw_ostream &out, EnumDecl *decl) {
   llvm::interleaveComma(
       decl->getAllElements(), out,
       [&](const EnumElementDecl *elem) { printEnumCaseInfo(out, elem); });
-  out << "]))";
+  out << "], rawTypeName: ";
+  if (Type rawType = decl->getRawType()) {
+    out << QuotedString(rawType->getString());
+  } else {
+    out << "nil";
+  }
+  out << "))";
 }
 
 /// Prints a string containing swift syntax describing the stored property \p

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -26,7 +26,6 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
-#include "swift/AST/PluginLoader.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
@@ -498,31 +497,31 @@ ValueDecl *DerivedConformance::deriveRawRepresentable(ValueDecl *requirement) {
   if (!canDeriveRawRepresentable(cast<DeclContext>(ConformanceDecl), Nominal))
     return nullptr;
 
-  auto &pluginLoader = Context.getPluginLoader();
-  auto &entry = pluginLoader.lookupPluginByModuleName(
-      Context.getIdentifier("SwiftMacros"));
-  if (!entry.libraryPath.empty() && !::getenv("DONT_DERIVE_VIA_MACROS")) {
-    if (requirement->getBaseName() == Context.Id_rawValue) {
-      auto *witness = deriveRawRepresentableViaMacros(*this, requirement);
-      maybeMarkAsInlinable(*this,
-                           cast<VarDecl>(witness)->getAccessor(AccessorKind::Get));
-      return witness;
-    }
-    if (requirement->getBaseName().isConstructor()) {
-      auto *witness = deriveRawRepresentableViaMacros(*this, requirement);
-      maybeMarkAsInlinable(*this, cast<AbstractFunctionDecl>(witness));
-      return witness;
-    }
-    Context.Diags.diagnose(requirement->getLoc(),
-                           diag::broken_raw_representable_requirement);
-    return nullptr;
+  bool viaMacros =
+      Context.LangOpts.hasFeature(Feature::DeriveConformancesViaMacros);
+
+  if (requirement->getBaseName() == Context.Id_rawValue) {
+    if (!viaMacros)
+      return deriveRawRepresentable_raw(*this);
+
+    auto *witness = deriveRawRepresentableViaMacros(*this, requirement);
+    if (!witness)
+      return nullptr;
+    maybeMarkAsInlinable(
+        *this, cast<VarDecl>(witness)->getAccessor(AccessorKind::Get));
+    return witness;
   }
 
-  if (requirement->getBaseName() == Context.Id_rawValue)
-    return deriveRawRepresentable_raw(*this);
+  if (requirement->getBaseName().isConstructor()) {
+    if (!viaMacros)
+      return deriveRawRepresentable_init(*this);
 
-  if (requirement->getBaseName().isConstructor())
-    return deriveRawRepresentable_init(*this);
+    auto *witness = deriveRawRepresentableViaMacros(*this, requirement);
+    if (!witness)
+      return nullptr;
+    maybeMarkAsInlinable(*this, cast<AbstractFunctionDecl>(witness));
+    return witness;
+  }
 
   Context.Diags.diagnose(requirement->getLoc(),
                          diag::broken_raw_representable_requirement);

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -26,9 +26,11 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/QuotedString.h"
 #include "llvm/ADT/APInt.h"
 
 using namespace swift;
@@ -405,6 +407,29 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
   return initDecl;
 }
 
+static ValueDecl *deriveRawRepresentableViaMacros(DerivedConformance &derived,
+                                                  ValueDecl *requirement) {
+  auto &C = requirement->getASTContext();
+  bool isStrictMemorySafety = C.LangOpts.hasFeature(
+      Feature::StrictMemorySafety, /*allowMigration=*/true);
+
+  std::string macro = "#_deriveRawRepresentable(";
+  auto os = llvm::raw_string_ostream(macro);
+  os << QuotedString(getNominalTypeInfoString(derived)) << ", ";
+
+  if (requirement->getBaseName() == C.Id_rawValue) {
+    os << QuotedString("varDef");
+  } else {
+    ASSERT(requirement->getBaseName().isConstructor());
+    os << QuotedString("initializer");
+  }
+  os << ", " << (isStrictMemorySafety ? "true" : "false") << ")";
+  os.flush();
+  return deriveRequirementViaMacro(
+      derived, requirement, macro,
+      BuiltinDerivedConformanceMacroKind::DeriveRawRepresentable);
+}
+
 bool DerivedConformance::canDeriveRawRepresentable(DeclContext *DC,
                                                    NominalTypeDecl *type) {
   auto enumDecl = dyn_cast<EnumDecl>(type);
@@ -472,6 +497,26 @@ ValueDecl *DerivedConformance::deriveRawRepresentable(ValueDecl *requirement) {
   // Check preconditions for synthesized conformance.
   if (!canDeriveRawRepresentable(cast<DeclContext>(ConformanceDecl), Nominal))
     return nullptr;
+
+  auto &pluginLoader = Context.getPluginLoader();
+  auto &entry = pluginLoader.lookupPluginByModuleName(
+      Context.getIdentifier("SwiftMacros"));
+  if (!entry.libraryPath.empty() && !::getenv("DONT_DERIVE_VIA_MACROS")) {
+    if (requirement->getBaseName() == Context.Id_rawValue) {
+      auto *witness = deriveRawRepresentableViaMacros(*this, requirement);
+      maybeMarkAsInlinable(*this,
+                           cast<VarDecl>(witness)->getAccessor(AccessorKind::Get));
+      return witness;
+    }
+    if (requirement->getBaseName().isConstructor()) {
+      auto *witness = deriveRawRepresentableViaMacros(*this, requirement);
+      maybeMarkAsInlinable(*this, cast<AbstractFunctionDecl>(witness));
+      return witness;
+    }
+    Context.Diags.diagnose(requirement->getLoc(),
+                           diag::broken_raw_representable_requirement);
+    return nullptr;
+  }
 
   if (requirement->getBaseName() == Context.Id_rawValue)
     return deriveRawRepresentable_raw(*this);

--- a/test/Availability/availability_derived_conformances_macros.swift
+++ b/test/Availability/availability_derived_conformances_macros.swift
@@ -1,0 +1,271 @@
+// DEFINE: %{args} = -module-name main -parse-as-library -swift-version 5 \
+// DEFINE:   -target %target-cpu-apple-macosx10.52 \
+// DEFINE:   -enable-experimental-feature CustomAvailability \
+// DEFINE:   -define-enabled-availability-domain EnabledDomain \
+// DEFINE:   -define-always-enabled-availability-domain AlwaysEnabledDomain \
+// DEFINE:   -define-disabled-availability-domain DisabledDomain \
+// DEFINE:   -define-dynamic-availability-domain DynamicDomain \
+// DEFINE:   -define-dynamic-availability-domain OtherDynamicDomain \
+// DEFINE:   -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) \
+// DEFINE:   -enable-experimental-feature DeriveConformancesViaMacros
+
+// RUN: %target-swift-frontend -print-ast %s -verify %{args} \
+// RUN:   | %FileCheck %s --check-prefixes=CHECK,NOEXT
+// RUN: %target-swift-frontend -print-ast %s -verify %{args} -application-extension \
+// RUN:   | %FileCheck %s --check-prefixes=CHECK,EXT
+
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -verify %{args}
+// RUN: %target-swift-frontend -emit-sil -o /dev/null %s -verify %{args} -enable-library-evolution
+
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_CustomAvailability
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+// CHECK-LABEL:  public enum PlatformEnum : Int {
+public enum PlatformEnum: Int {
+  case alwaysAvailable = 0
+
+  @available(macOS 10.51, *)
+  case introducedBeforeDeployment = 1
+
+  @available(macOS 10.55, *)
+  case introducedAfterDeployment = 2
+
+  @available(macOSApplicationExtension 10.56, *)
+  case introducedAfterDeploymentForAppExtensions = 3
+
+  @available(macOS, unavailable)
+  case unavailableOnMacOS = 4
+
+  @available(macOSApplicationExtension, unavailable)
+  case unavailableForAppExtensions = 5
+
+  @available(*, unavailable)
+  case universallyUnavailable = 6
+
+  @available(macOS, obsoleted: 10.99)
+  case notObsoleteYet = 7
+
+  @available(macOS, obsoleted: 10.51)
+  case alreadyObsolete = 8
+
+  @available(macOS, deprecated: 10.51)
+  case alreadyDeprecated = 9
+
+  @available(macOS, introduced: 10.55, deprecated: 99.0)
+  case introducedAfterDeploymentAndDeprecated = 10
+
+  @available(iOS 18.0, *)
+  case introducedOnOtherPlatform = 11
+
+  // CHECK-LABEL:   var rawValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .alwaysAvailable:
+  // CHECK-NEXT:         return 0
+  // CHECK-NEXT:       case .introducedBeforeDeployment:
+  // CHECK-NEXT:         return 1
+  // CHECK-NEXT:       case .introducedAfterDeployment:
+  // CHECK-NEXT:         return 2
+  // CHECK-NEXT:       case .introducedAfterDeploymentForAppExtensions:
+  // CHECK-NEXT:         return 3
+  // CHECK-NEXT:       case .unavailableOnMacOS:
+  // CHECK-NEXT:         return 4
+  // CHECK-NEXT:       case .unavailableForAppExtensions:
+  // CHECK-NEXT:         return 5
+  // CHECK-NEXT:       case .universallyUnavailable:
+  // CHECK-NEXT:         return 6
+  // CHECK-NEXT:       case .notObsoleteYet:
+  // CHECK-NEXT:         return 7
+  // CHECK-NEXT:       case .alreadyObsolete:
+  // CHECK-NEXT:         return 8
+  // CHECK-NEXT:       case .alreadyDeprecated:
+  // CHECK-NEXT:         return 9
+  // CHECK-NEXT:       case .introducedAfterDeploymentAndDeprecated:
+  // CHECK-NEXT:         return 10
+  // CHECK-NEXT:       case .introducedOnOtherPlatform:
+  // CHECK-NEXT:         return 11
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // NOEXT-LABEL:   init?(rawValue: Int) {
+  // NOEXT-NEXT:     switch rawValue {
+  // NOEXT-NEXT:     case 0:
+  // NOEXT-NEXT:       self = .alwaysAvailable
+  // NOEXT-NEXT:     case 1:
+  // NOEXT-NEXT:       self = .introducedBeforeDeployment
+  // NOEXT-NEXT:     case 2:
+  // NOEXT-NEXT:       guard #available(macOS 10.55, *) else {
+  // NOEXT-NEXT:         return nil
+  // NOEXT-NEXT:       }
+  // NOEXT-NEXT:       self = .introducedAfterDeployment
+  // NOEXT-NEXT:     case 3:
+  // NOEXT-NEXT:       self = .introducedAfterDeploymentForAppExtensions
+  // NOEXT-NEXT:     case 5:
+  // NOEXT-NEXT:       self = .unavailableForAppExtensions
+  // NOEXT-NEXT:     case 7:
+  // NOEXT-NEXT:       self = .notObsoleteYet
+  // NOEXT-NEXT:     case 9:
+  // NOEXT-NEXT:       self = .alreadyDeprecated
+  // NOEXT-NEXT:     case 10:
+  // NOEXT-NEXT:       guard #available(macOS 10.55, *) else {
+  // NOEXT-NEXT:         return nil
+  // NOEXT-NEXT:       }
+  // NOEXT-NEXT:       self = .introducedAfterDeploymentAndDeprecated
+  // NOEXT-NEXT:     case 11:
+  // NOEXT-NEXT:       self = .introducedOnOtherPlatform
+  // NOEXT-NEXT:     default:
+  // NOEXT-NEXT:       return nil
+  // NOEXT-NEXT:     }
+  // NOEXT-NEXT:   }
+
+  // EXT-LABEL:   init?(rawValue: Int) {
+  // EXT-NEXT:     switch rawValue {
+  // EXT-NEXT:     case 0:
+  // EXT-NEXT:       self = .alwaysAvailable
+  // EXT-NEXT:     case 1:
+  // EXT-NEXT:       self = .introducedBeforeDeployment
+  // EXT-NEXT:     case 2:
+  // EXT-NEXT:       guard #available(macOS 10.55, *) else {
+  // EXT-NEXT:         return nil
+  // EXT-NEXT:       }
+  // EXT-NEXT:       self = .introducedAfterDeployment
+  // EXT-NEXT:     case 3:
+  // EXT-NEXT:       guard #available(macOSApplicationExtension 10.56, *) else {
+  // EXT-NEXT:         return nil
+  // EXT-NEXT:       }
+  // EXT-NEXT:       self = .introducedAfterDeploymentForAppExtensions
+  // EXT-NEXT:     case 7:
+  // EXT-NEXT:       self = .notObsoleteYet
+  // EXT-NEXT:     case 9:
+  // EXT-NEXT:       self = .alreadyDeprecated
+  // EXT-NEXT:     case 10:
+  // EXT-NEXT:       guard #available(macOS 10.55, *) else {
+  // EXT-NEXT:         return nil
+  // EXT-NEXT:       }
+  // EXT-NEXT:       self = .introducedAfterDeploymentAndDeprecated
+  // EXT-NEXT:     case 11:
+  // EXT-NEXT:       self = .introducedOnOtherPlatform
+  // EXT-NEXT:     default:
+  // EXT-NEXT:       return nil
+  // EXT-NEXT:     }
+  // EXT-NEXT:   }
+}
+
+// CHECK-LABEL:  public enum CustomDomainEnum : Int {
+public enum CustomDomainEnum: Int {
+  @available(EnabledDomain)
+  case availableInEnabledDomain = 0
+
+  @available(EnabledDomain, unavailable)
+  case unavailableInEnabledDomain = 1
+
+  @available(DisabledDomain)
+  case availableInDisabledDomain = 2
+
+  @available(DisabledDomain, unavailable)
+  case unavailableInDisabledDomain = 3
+
+  @available(DynamicDomain)
+  case availableInDynamicDomain = 4
+
+  @available(DynamicDomain, unavailable)
+  case unavailableInDynamicDomain = 5
+
+  @available(DynamicDomain)
+  @available(OtherDynamicDomain)
+  case availableInTwoDynamicDomains = 6
+
+  @available(DynamicDomain, deprecated, message: "use something else")
+  case deprecatedInDynamicDomain = 7
+
+  // CHECK-LABEL:   var rawValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .availableInEnabledDomain:
+  // CHECK-NEXT:         return 0
+  // CHECK-NEXT:       case .unavailableInEnabledDomain:
+  // CHECK-NEXT:         return 1
+  // CHECK-NEXT:       case .availableInDisabledDomain:
+  // CHECK-NEXT:         return 2
+  // CHECK-NEXT:       case .unavailableInDisabledDomain:
+  // CHECK-NEXT:         return 3
+  // CHECK-NEXT:       case .availableInDynamicDomain:
+  // CHECK-NEXT:         return 4
+  // CHECK-NEXT:       case .unavailableInDynamicDomain:
+  // CHECK-NEXT:         return 5
+  // CHECK-NEXT:       case .availableInTwoDynamicDomains:
+  // CHECK-NEXT:         return 6
+  // CHECK-NEXT:       case .deprecatedInDynamicDomain:
+  // CHECK-NEXT:         return 7
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK-LABEL:   init?(rawValue: Int) {
+  // CHECK-NEXT:     switch rawValue {
+  // CHECK-NEXT:     case 0:
+  // CHECK-NEXT:       self = .availableInEnabledDomain
+  // CHECK-NEXT:     case 3:
+  // CHECK-NEXT:       self = .unavailableInDisabledDomain
+  // CHECK-NEXT:     case 4:
+  // CHECK-NEXT:       guard #available(DynamicDomain) else {
+  // CHECK-NEXT:         return nil
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       self = .availableInDynamicDomain
+  // CHECK-NEXT:     case 5:
+  // CHECK-NEXT:       guard #unavailable(DynamicDomain) else {
+  // CHECK-NEXT:         return nil
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       self = .unavailableInDynamicDomain
+  // CHECK-NEXT:     case 6:
+  // CHECK-NEXT:       guard #available(OtherDynamicDomain) else {
+  // CHECK-NEXT:         return nil
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       guard #available(DynamicDomain) else {
+  // CHECK-NEXT:         return nil
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       self = .availableInTwoDynamicDomains
+  // CHECK-NEXT:     case 7:
+  // CHECK-NEXT:       self = .deprecatedInDynamicDomain
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}
+
+// CHECK-LABEL:  public enum UnavailableEnum : Int {
+
+@available(*, unavailable)
+public enum UnavailableEnum: Int {
+  case a = 0
+
+  @available(*, unavailable)
+  case b = 1
+
+  @available(swift, obsoleted: 4)
+  case c = 2
+
+  // CHECK-LABEL:   var rawValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return 0
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return 1
+  // CHECK-NEXT:       case .c:
+  // CHECK-NEXT:         return 2
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+
+  // CHECK-LABEL:   init?(rawValue: Int) {
+  // CHECK-NEXT:     switch rawValue {
+  // CHECK-NEXT:     case 0:
+  // CHECK-NEXT:       self = .a
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+}

--- a/test/Sema/enum_raw_representable_explicit.swift
+++ b/test/Sema/enum_raw_representable_explicit.swift
@@ -1,4 +1,7 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros
+
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
 
 enum Foo: Int, RawRepresentable { case A }
 

--- a/test/decl/enum/derived_rawrepresentable_macros.swift
+++ b/test/decl/enum/derived_rawrepresentable_macros.swift
@@ -1,0 +1,104 @@
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -print-ast %s | %FileCheck %s
+
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -emit-sil -o /dev/null %s
+// RUN: %target-swift-frontend -load-plugin-library %swift-plugin-dir/%target-library-name(SwiftMacros) -enable-experimental-feature DeriveConformancesViaMacros -emit-sil -o /dev/null %s -enable-library-evolution
+
+// REQUIRES: swift_feature_DeriveConformancesViaMacros
+
+// CHECK-LABEL: internal enum Simple : Int {
+enum Simple: Int {
+  // CHECK-NEXT:   nonisolated internal var rawValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return 0
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return 1
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   internal init?(rawValue: Int) {
+  // CHECK-NEXT:     switch rawValue {
+  // CHECK-NEXT:     case 0:
+  // CHECK-NEXT:       self = .a
+  // CHECK-NEXT:     case 1:
+  // CHECK-NEXT:       self = .b
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   case a
+  case a
+  // CHECK-NEXT:   case b
+  case b
+  // CHECK-NEXT:   internal typealias RawValue = Int
+}
+
+// CHECK-LABEL: internal enum Strings : String {
+enum Strings: String {
+  // CHECK-NEXT:   nonisolated internal var rawValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .a:
+  // CHECK-NEXT:         return "a"
+  // CHECK-NEXT:       case .b:
+  // CHECK-NEXT:         return "bee"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   internal init?(rawValue: String) {
+  // CHECK-NEXT:     switch rawValue {
+  // CHECK-NEXT:     case "a":
+  // CHECK-NEXT:       self = .a
+  // CHECK-NEXT:     case "bee":
+  // CHECK-NEXT:       self = .b
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  case a
+  case b = "bee"
+}
+
+// CHECK-LABEL: internal enum EscapedNames : String {
+enum EscapedNames: String {
+  // CHECK-NEXT:   nonisolated internal var rawValue: String {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       switch self {
+  // CHECK-NEXT:       case .default:
+  // CHECK-NEXT:         return "default"
+  // CHECK-NEXT:       case .foo bar:
+  // CHECK-NEXT:         return "foo bar"
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   internal init?(rawValue: String) {
+  // CHECK-NEXT:     switch rawValue {
+  // CHECK-NEXT:     case "default":
+  // CHECK-NEXT:       self = .default
+  // CHECK-NEXT:     case "foo bar":
+  // CHECK-NEXT:       self = .foo bar
+  // CHECK-NEXT:     default:
+  // CHECK-NEXT:       return nil
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  case `default`
+  case `foo bar`
+}
+
+// CHECK-LABEL: internal enum ExplicitRawValue : Int, RawRepresentable {
+enum ExplicitRawValue: Int, RawRepresentable {
+  // CHECK-NEXT:   case a
+  case a = 0
+
+  // CHECK-NEXT:   internal var rawValue: Int {
+  // CHECK-NEXT:     get {
+  // CHECK-NEXT:       return 42
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  var rawValue: Int { return 42 }
+
+  // CHECK:        internal init?(rawValue: Int) {
+  // CHECK-NEXT:     self = ExplicitRawValue.a
+  init?(rawValue: Int) { self = .a }
+}


### PR DESCRIPTION
Move `RawRepresentable` derivation to a macro under a feature flag

Adds a `DeriveConformancesViaMacros` feature flag path for deriving `rawValue` and `init?(rawValue:)` on raw-value enums. When enabled, `DerivedConformance::deriveRawRepresentable` builds a `#_deriveRawRepresentable(...)` macro call instead of hand-crafting the AST nodes, and the new `DeriveRawRepresentableMacro` (in `SwiftMacros`) expands it. The `RawValue` associated type is not concerned by this.

The requirement being derived is passed to the macro as a string-encoded argument. Type info is encoded the same way as for `Equatable`, extended with the enum's raw type and each case's raw value literal.

The non-macro path is untouched. This is opt-in via the feature flag.