### PR TITLE
[Concurrency] Add regression test for actor-instance-isolated default values

### DIFF
--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -332,3 +332,22 @@ class PreconcurrencyInit {
 
 // expected-warning@+1 {{main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 func downgrade(_: PreconcurrencyInit = .init()) {}
+
+// https://github.com/swiftlang/swift/issues/77985
+// An actor-instance-isolated default value in an actor-isolated context does
+// not cross an isolation boundary, including when the initializer is an
+// immediately-applied closure whose type must be inferred, or which
+// forward-references a member declared later in the actor.
+actor DefaultValueActor {
+  var name = "foo"
+
+  lazy var inferredFromClosure = {
+    name + name
+  }()
+
+  lazy var forwardReferencing: String = {
+    later + later
+  }()
+
+  var later = "bar"
+}


### PR DESCRIPTION
Adds a regression test for #77985.

`test/Concurrency/isolated_default_arguments.swift` doesn't currently cover actor-instance isolation. The only actors in it are the `SomeGlobalActor` global actor and an empty `actor A {}`, and the `lazy var` cases that are there are global-actor isolated with an explicit type and a plain expression.

The issue still reproduces on 6.3.3 and is already fixed on `main`, but as far as I can tell nothing in the test suite pins that behavior down. This adds the two shapes that used to fail: an immediately-applied closure initializer whose type has to be inferred, and one that forward-references a member declared further down the actor.

I ran it both ways to make sure it isn't a test that would pass either way:

* `swift-DEVELOPMENT-SNAPSHOT-2026-09-05-a` (6.5-dev): passes, no diagnostics
* Apple Swift 6.3.3 (`swiftlang-6.3.3.1.3`): fails with two `unexpected warning produced`, so it does catch the original bug

I didn't bisect, so I can't say which change fixed it.
