### PR TITLE
[Concurrency] Reject 'isolated' in an inheritance clause

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5749,10 +5749,9 @@ TypeResolver::resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
 NeverNullType
 TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
                                       TypeResolutionOptions options) {
-  // isolated is only value for non-EnumCaseDecl parameters.
-  if ((!options.is(TypeResolverContext::FunctionInput) ||
-       options.hasBase(TypeResolverContext::EnumElementDecl)) &&
-      !options.is(TypeResolverContext::Inherited)) {
+  // isolated is only valid for non-EnumCaseDecl parameters.
+  if (!options.is(TypeResolverContext::FunctionInput) ||
+      options.hasBase(TypeResolverContext::EnumElementDecl)) {
     diagnoseInvalid(
         repr, repr->getSpecifierLoc(), diag::attr_only_on_parameters,
         "isolated");
@@ -5773,8 +5772,7 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
     unwrappedType = dynamicSelfType->getSelfType();
   }
 
-  if (inStage(TypeResolutionStage::Interface) &&
-      !options.is(TypeResolverContext::Inherited)) {
+  if (inStage(TypeResolutionStage::Interface)) {
     if (auto *env = resolution.getGenericSignature().getGenericEnvironment())
       unwrappedType = env->mapTypeIntoEnvironment(unwrappedType);
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -156,6 +156,13 @@ protocol R: SendableMetatype {
   func f() { }
 }
 
+// An isolated conformance is spelled with the global actor attribute, as in
+// '@MainActor P' above. 'isolated' is not accepted in an inheritance clause.
+// https://github.com/swiftlang/swift/issues/83538
+struct SIsolatedSpelling: isolated P { // expected-error{{'isolated' may only be used on parameters}}
+  func f() { }
+}
+
 // ----------------------------------------------------------------------------
 // Use checking of isolated conformances.
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #83538.

`struct S: isolated P {}` compiled without complaint, and the `isolated` was silently dropped.

`resolveIsolatedTypeRepr` guards against `isolated` outside a parameter position, but the guard carried `&& !options.is(TypeResolverContext::Inherited)`, so inheritance clauses were exempt from it. `git log -L` points at the commit that added the exemption, "Parsing and type checking for the definition of isolated conformances", so it looks like it was there for a spelling that didn't end up shipping: an isolated conformance is written with the global actor attribute, `struct S: @MainActor P {}`. That leaves nothing for `isolated` to mean in an inheritance clause, so the exemption can go.

Removing it also makes the `Inherited` check further down unreachable, so I dropped that one too.

After the change:

```
error: 'isolated' may only be used on parameters
```

on the line, and nothing cascading after it.

Nothing in `test/` used `isolated` in an inheritance clause, so there was nothing to update. I added a case to `test/Concurrency/isolated_conformance.swift` next to the other definition-side checks.

Test suites run locally against a `RelWithDebInfoAssert` build, all clean:

| suite | discovered | failures |
|---|---|---|
| Concurrency | 535 | 0 |
| Sema | 354 | 0 |
| decl | 374 | 0 |
| Parse | 266 | 0 |
| attr | 261 | 0 |
| type | 46 | 0 |

I also checked by hand that `isolated` parameters, `isolation: isolated (any Actor)? = #isolation`, and `struct S: @MainActor P {}` all still work.

Worth calling out that this is source-breaking in the strict sense: something that spelled `struct S: isolated P {}` compiled before and won't now. What that spelling bought was nothing, though. The specifier was resolved away and the declaration behaved exactly as if it read `struct S: P {}`, so any code leaning on it was leaning on an isolation that was never applied, and the fix on that end is deleting a word. That seems like the right trade for closing an accepts-invalid hole that silently discards what the author asked for, but if you'd rather stage it as a warning first I'm happy to do that instead.

This doesn't touch #86693 (`class Derived: @MainActor Base {}`), which is still accepted. That one is about a global actor attribute on a superclass entry rather than the `isolated` specifier, so it looks like a separate fix.
