### PR TITLE
[Sema] Check all generic substitutions for isolated conformances

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -9336,6 +9336,10 @@ namespace {
     // or will be lazy loaded from the 'fromDC' context otherwise.
     mutable std::optional<ActorIsolation> isolation;
 
+    // Tracks the isolated global actor seen in a nonisolated(nonsending) context,
+    // to detect conflicting isolated conformances.
+    mutable std::optional<ActorIsolation> nonisolatedNonsendingIsolation;
+
   public:
     MismatchedIsolatedConformances(const DeclContext *fromDC,
                                    HandleConformanceIsolationFn handleBad)
@@ -9377,12 +9381,19 @@ namespace {
       auto conformanceIsolation = concrete->getIsolation();
       if (!conformanceIsolation.isGlobalActor() ||
           conformanceIsolation == getIsolation())
-        return true;
+        return false;
 
       // In a nonisolated(nonsending) context the conformance is valid because
       // effectively always is on the caller's isolation.
-      if (getIsolation().isNonisolatedNonsending())
-        return true;
+      if (getIsolation().isNonisolatedNonsending()) {
+        if (!nonisolatedNonsendingIsolation) {
+          nonisolatedNonsendingIsolation = conformanceIsolation;
+          return false;
+        }
+
+        if (*nonisolatedNonsendingIsolation == conformanceIsolation)
+          return false;
+      }
 
       badIsolatedConformances.push_back(concrete);
       return false;
@@ -9405,14 +9416,24 @@ namespace {
       }
 
       ASTContext &ctx = fromDC->getASTContext();
-      auto firstConformance = badIsolatedConformances.front();
-      ctx.Diags
-          .diagnose(
-              loc, diag::isolated_conformance_wrong_domain,
-              firstConformance->getIsolation(), firstConformance->getType(),
-              firstConformance->getProtocol()->getName(),
-              getIsolation())
-          .warnUntilLanguageMode(LanguageMode::v6);
+      auto targetDomain = (getIsolation().isNonisolatedNonsending() &&
+                           nonisolatedNonsendingIsolation)
+                              ? *nonisolatedNonsendingIsolation
+                              : getIsolation();
+
+      llvm::SmallPtrSet<ProtocolConformance *, 4> diagnosed;
+      for (auto *conformance : badIsolatedConformances) {
+        if (!diagnosed.insert(conformance).second)
+          continue;
+
+        ctx.Diags
+            .diagnose(
+                loc, diag::isolated_conformance_wrong_domain,
+                conformance->getIsolation(), conformance->getType(),
+                conformance->getProtocol()->getName(),
+                targetDomain)
+            .warnUntilLanguageMode(LanguageMode::v6);
+      }
       return true;
     }
   };

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -185,9 +185,19 @@ func acceptSendableP<T: Sendable & P>(_: T) { }
 func acceptSendableMetaP<T: SendableMetatype & P>(_: T) { }
 // expected-note@-1 3{{'acceptSendableMetaP' declared here}}
 
+func acceptMultipleP<T: P, U: P>(_: T, _: U) { }
+
+struct NonisolatedP: P {
+  func f() { }
+}
+
 @MainActor
 func testIsolationConformancesInCall(c: C) {
   acceptP(c) // okay
+  acceptMultipleP(c, c) // okay
+  acceptMultipleP(c, CMismatchedIsolation()) // expected-warning{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot be used in main actor-isolated context}}
+  acceptMultipleP(CMismatchedIsolation(), c) // expected-warning{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot be used in main actor-isolated context}}
+  acceptMultipleP(NonisolatedP(), CMismatchedIsolation()) // expected-warning{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot be used in main actor-isolated context}}
 
   acceptSendableP(c) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a 'Sendable' type parameter}}
   acceptSendableMetaP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a 'Sendable' type parameter}}
@@ -202,11 +212,17 @@ func testIsolatedConformancesOfActor(a: SomeActor) {
 @SomeGlobalActor
 func testIsolatedConformancesOfOtherGlobalActor(c: CMismatchedIsolation) {
   acceptP(c)
+  acceptMultipleP(c, c) // okay
+  acceptMultipleP(c, C()) // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in global actor 'SomeGlobalActor'-isolated context}}
+  acceptMultipleP(C(), c) // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in global actor 'SomeGlobalActor'-isolated context}}
   acceptSendableMetaP(c)  // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot satisfy conformance requirement for a 'Sendable' type parameter}}
 }
 
 func testIsolationConformancesFromOutside(c: C) {
   acceptP(c) // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  acceptMultipleP(c, CMismatchedIsolation())
+  // expected-warning@-1{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  // expected-warning@-2{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot be used in nonisolated context}}
   let _: any P = c // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
   let _ = PWrapper<C>() // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
 }

--- a/test/Concurrency/isolated_conformance_6.swift
+++ b/test/Concurrency/isolated_conformance_6.swift
@@ -20,3 +20,30 @@ protocol Q: SendableMetatype {
 @MainActor struct QSendableSMainActor: @MainActor Q {
   func f() { }
 }
+
+protocol Proto {
+  func doThing()
+}
+
+actor OtherActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = OtherActor()
+}
+
+struct MainType: @MainActor Proto {
+  func doThing() { }
+}
+
+struct OtherType: @SomeGlobalActor Proto {
+  func doThing() { }
+}
+
+func acceptTwo<T: Proto, U: Proto>(_ v1: T, _ v2: U) { }
+
+@MainActor func testMultipleIsolatedGenericArgs() {
+  acceptTwo(MainType(), MainType()) // okay
+  acceptTwo(MainType(), OtherType()) // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'OtherType' to 'Proto' cannot be used in main actor-isolated context}}
+  acceptTwo(OtherType(), MainType()) // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'OtherType' to 'Proto' cannot be used in main actor-isolated context}}
+}


### PR DESCRIPTION
When checking a declaration reference for isolated conformances matching the context isolation, `MismatchedIsolatedConformances::operator()` previously returned `true` upon finding a matching or non-isolated conformance.

Because `forEachConformance` stops traversal whenever its callback returns `true`, only generic arguments up to the first matching conformance were checked. Any subsequent generic arguments with conflicting or mismatched isolated conformances were skipped and left undiagnosed, which could lead to running isolated requirements on the wrong executor.

This PR updates `MismatchedIsolatedConformances` to continue traversal across all generic substitutions, correctly detecting mismatches in subsequent arguments and diagnosing them.

Resolves #92004
