### PR TITLE
[Concurrency] Fix crash on 'isolated' in an enum case payload

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2714,6 +2714,16 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       SmallVector<AnyFunctionType::Param, 4> argTy;
       PL->getParams(argTy);
 
+      // An enum case payload cannot be isolated, and Sema diagnoses the
+      // 'isolated' specifier separately. The flag is derived from the type
+      // repr, though, so drop it here: the type below is built with a default
+      // ExtInfo, which cannot record parameter isolation, and a payload
+      // carrying the flag would break FunctionType's isolation invariant.
+      for (auto &param : argTy) {
+        if (param.isIsolated())
+          param = param.withFlags(param.getParameterFlags().withIsolated(false));
+      }
+
       // FIXME: Verify ExtInfo state is correct, not working by accident.
       FunctionType::ExtInfo info;
       resultTy = FunctionType::get(argTy, resultTy, info);

--- a/test/Concurrency/isolated_enum_payload.swift
+++ b/test/Concurrency/isolated_enum_payload.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 %s
+
+// REQUIRES: concurrency
+
+// 'isolated' is not allowed on an enum case payload. Building the element's
+// constructor type used to trip FunctionType's isolation invariant and crash
+// before any of these diagnostics could be emitted.
+// https://github.com/swiftlang/swift/issues/86007
+
+enum E {
+  case beforeName(isolated Int)
+  // expected-error@-1 {{'isolated' before a parameter name is not allowed, place it before the parameter type instead}}
+  // expected-error@-2 {{'isolated' may only be used on parameters}}
+
+  case inTypePosition(x: isolated Int)
+  // expected-error@-1 {{'isolated' may only be used on parameters}}
+
+  case actorPayload(isolated any Actor)
+  // expected-error@-1 {{'isolated' before a parameter name is not allowed, place it before the parameter type instead}}
+  // expected-error@-2 {{'isolated' may only be used on parameters}}
+
+  case ok(Int)
+}


### PR DESCRIPTION
Fixes #86007.

```swift
enum E {
  case iso(isolated Int)
}
```

crashes on an assertions build:

```
Assertion failed: (isConsistentAboutIsolation(info, params)), function FunctionType, file ASTContext.cpp
```

That invariant says a function type has an isolated parameter exactly when its `ExtInfo` records parameter isolation. An enum element's constructor type is built straight from the parameter list with a default-constructed `ExtInfo`:

```cpp
PL->getParams(argTy);
FunctionType::ExtInfo info;
resultTy = FunctionType::get(argTy, resultTy, info);
```

and `ParamDecl` picks up its isolated flag by walking the type repr in `setTypeRepr`, so the payload arrives flagged while the `ExtInfo` stays empty. Functions don't hit this because their interface type builds an `ExtInfo` with parameter isolation to match.

`isolated` isn't valid on an enum case payload and is already diagnosed, so this drops the flag when building the element's type rather than teaching the `ExtInfo` to carry it. Worth noting the diagnostics were never missing, just unreachable: the assertion fired first. With the type consistent they come out normally, including `'isolated' may only be used on parameters` for `case iso(x: isolated Int)`, which goes through `resolveIsolatedTypeRepr`'s existing enum-element check.

The crash reproduces in both Swift 5 and Swift 6 language modes. On a build without assertions there's presumably no crash, just an internally inconsistent function type, so this may be worth looking at beyond the assert.

Added `test/Concurrency/isolated_enum_payload.swift`. It fails (crashes) without the change and passes with it, so it does pin the behaviour down.

Test suites run locally against a `RelWithDebInfoAssert` build, no failures:

| suite | discovered |
|---|---|
| SILGen | 886 |
| Concurrency | 536 |
| decl | 374 |
| Sema | 354 |
| Parse | 266 |
| attr | 261 |
| expr | 118 |
| type | 46 |

Stripping the flag can only affect a payload that was already diagnosed as invalid, since a valid enum case never has an isolated parameter, but the SILGen run seemed worth doing given where the change sits.
