### PR TITLE
[SILGen] Strip the move-only wrapper before reabstracting

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1340,6 +1340,17 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
                                         /*isResult*/ true);
 
   case Reabstract:
+    // A move-only wrapper isn't part of the Swift-level type system, so the
+    // reabstraction is described in terms of the bare type. Strip the wrapper
+    // off the value to match. This shows up for a 'borrowing' closure
+    // parameter reabstracted into a generic context.
+    if (value.getType().isMoveOnlyWrapped()) {
+      if (value.getOwnershipKind() == OwnershipKind::Guaranteed) {
+        value = SGF.B.createGuaranteedMoveOnlyWrapperToCopyableValue(loc, value);
+      } else {
+        value = SGF.B.createOwnedMoveOnlyWrapperToCopyableValue(loc, value);
+      }
+    }
     assert(value.getType().getObjectType() ==
            getReabstractionInputLoweredType().getObjectType());
     return SGF.emitTransformedValue(loc, value,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5863,6 +5863,19 @@ static ManagedValue createThunk(SILGenFunction &SGF,
                                 AbstractionPattern outputOrigType,
                                 CanAnyFunctionType outputSubstType,
                                 const TypeLowering &expectedTL) {
+  // A move-only wrapper isn't represented in the Swift-level type system, so
+  // the thunk below is built for the unwrapped function type. Strip the
+  // wrapper off the value as well, or the partial_apply won't line up. This
+  // shows up for a 'consuming' closure parameter, which is emitted into a
+  // move-only box and loaded back out still wrapped.
+  if (fn.getType().isMoveOnlyWrapped()) {
+    if (fn.getOwnershipKind() == OwnershipKind::Guaranteed) {
+      fn = SGF.B.createGuaranteedMoveOnlyWrapperToCopyableValue(loc, fn);
+    } else {
+      fn = SGF.B.createOwnedMoveOnlyWrapperToCopyableValue(loc, fn);
+    }
+  }
+
   auto substSourceType = fn.getType().castTo<SILFunctionType>();
   auto substExpectedType = expectedTL.getLoweredType().castTo<SILFunctionType>();
   

--- a/test/SILGen/consuming_parameter.swift
+++ b/test/SILGen/consuming_parameter.swift
@@ -73,3 +73,20 @@ struct Butt {
         return r
     }
 }
+
+// A consuming closure parameter is emitted into a move-only box. Reabstracting
+// it for a generic context has to strip the wrapper off the loaded value, or
+// the thunk's partial_apply gets a $@moveOnly operand where the thunk expects
+// the bare function type.
+// https://github.com/swiftlang/swift/issues/75188
+
+func genericTake<T>(_ t: T) {}
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}29passConsumingClosureToGeneric
+// CHECK:   [[LOAD:%.*]] = load [copy]
+// CHECK:   [[UNWRAP:%.*]] = moveonlywrapper_to_copyable [owned] [[LOAD]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$sIeg_ytIegr_TR
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK]]([[UNWRAP]])
+func passConsumingClosureToGeneric(fn: consuming @escaping () -> Void) {
+    genericTake(fn)
+}

--- a/test/SILOptimizer/noimplicitcopy_borrowing_parameters.swift
+++ b/test/SILOptimizer/noimplicitcopy_borrowing_parameters.swift
@@ -570,3 +570,16 @@ struct TrivialSelfTest {
 }
 
 func consumeTrivialSelfTest(_ x: consuming TrivialSelfTest) {}
+
+// Reabstracting a borrowing closure parameter into a generic context used to
+// crash in SILGenConvert rather than diagnosing the escape. The reabstraction
+// thunk's partial_apply is an escaping closure capturing the parameter, so the
+// code is invalid and this is the diagnostic it should get.
+// https://github.com/swiftlang/swift/issues/92048
+
+func genericTakeBorrowed<T>(_ t: T) {}
+
+func passBorrowingClosureToGeneric(fn: borrowing @escaping () -> Void) {
+    // expected-error @-1 {{'fn' cannot be captured by an escaping closure since it is a borrowed parameter}}
+    genericTakeBorrowed(fn) // expected-note {{closure capturing 'fn' here}}
+}


### PR DESCRIPTION
Fixes #75188. Also fixes #92048, which I ran into while reducing this one — see below.

Reduced from the report, which used SwiftUI and an array of `@MainActor` closures, down to:

```swift
func genericTake<T>(_ t: T) {}
func add(x: consuming @escaping () -> Void) { genericTake(x) }
```

```
SIL verification failed: applied argument types do not match suffix of function type's inputs
  $@moveOnly @Sendable @callee_guaranteed () -> ()
  $@Sendable @callee_guaranteed () -> ()
```

A `consuming` closure parameter is emitted into a move-only box, so reading it back gives a `$@moveOnly` function value. Reabstraction is described in terms of the bare function type, since the wrapper isn't part of the Swift-level type system, and the two disagree on the way into a generic context.

Narrowing, in case it's useful:

| | |
|---|---|
| `consuming` closure → generic context | crashes |
| `consuming` closure → non-generic context | fine, nothing to reabstract |
| `consuming Int` → generic context | fine, not a closure |
| `let y = x; genericTake(y)` | fine, the copy unwraps |
| no ownership modifier | fine |

The concurrency framing in the issue is incidental. It reproduces with no actor annotation at all — `@MainActor`, `@Sendable`, a custom global actor and a plain `() -> Void` all behave identically. The report saw it through SwiftUI, but nothing here is concurrency-specific.

### Two paths, one disagreement

While narrowing this I found that spelling the parameter `borrowing` crashes too, on a different path and a different assertion. It's the same disagreement about the wrapper, so this fixes both:

* **`createThunk` in `SILGenPoly`** builds the thunk from the unwrapped type — `castTo<SILFunctionType>()` looks through the wrapper — then applies it to the still-wrapped value. That's the `consuming` case and the verification failure above.
* **`Conversion::emit` in `SILGenConvert`** asserts the value's type matches the reabstraction's input type. That's the `borrowing` case. There the code is genuinely invalid: the thunk's `partial_apply` is an escaping closure capturing a borrowed parameter, so stripping the wrapper lets the existing diagnostic fire, `'x' cannot be captured by an escaping closure since it is a borrowed parameter`, instead of asserting.

Both follow the pattern `SILGenApply` already uses when an argument is move-only wrapped and the parameter type isn't. Filed the `borrowing` half separately as #92048 since it's a distinct crash; happy to split the patch too if you'd rather review them apart.

### What each case does on a release toolchain

Worth being precise, because the two differ:

* `consuming`: 6.3.3 compiles it quietly and produces the bad code, which is presumably the `EXC_BAD_ACCESS` #75188 describes. SIL verification only runs with assertions, so nothing catches it.
* `borrowing`: 6.3.3 emits the correct diagnostic. The assertion is asserts-only. That toolchain has assertions off, so it isn't evidence about when the assert started firing.

### Testing

* `test/SILGen/consuming_parameter.swift` — checks the unwrap lands before the thunk's `partial_apply`.
* `test/SILOptimizer/noimplicitcopy_borrowing_parameters.swift` — checks the borrowed-escape diagnostic comes out.

Both fail without the change and pass with it.

Suites run locally against a `RelWithDebInfoAssert` build, no failures:

| suite | discovered |
|---|---|
| SILOptimizer | 1332 |
| SILGen | 886 |
| Interpreter | 464 |
| Concurrency | 535 |
