### PR TITLE
[IRGen] Preserve concurrency references in reflection manglings

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -95,6 +95,9 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
     AllowSymbolicReferencesLocally(AllowSymbolicReferences);
   llvm::SaveAndRestore<std::function<bool (SymbolicReferent)>>
     CanSymbolicReferenceLocally(CanSymbolicReference);
+  llvm::SaveAndRestore<bool>
+    AllowConcurrencyStandardSubstitutionsLocally(
+        AllowConcurrencyStandardSubstitutions, false);
 
   AllowSymbolicReferences = true;
   CanSymbolicReference = [&](SymbolicReferent s) -> bool {

--- a/test/IRGen/reflection_metadata_mainactor.swift
+++ b/test/IRGen/reflection_metadata_mainactor.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir -target %target-swift-6.0-abi-triple %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: concurrency
+// UNSUPPORTED: CPU=arm64e
+
+// Reflection metadata for a concurrency type must retain a symbolic reference
+// to its descriptor. Otherwise, the linker can dead-strip libswift_Concurrency
+// and runtime metadata lookup will return null.
+
+public struct MainActorFunction {
+  let function: @MainActor () -> Void
+}
+
+// CHECK: @"got.$sScMMn"


### PR DESCRIPTION
Fixes #91945.

Reflection metadata for `@MainActor` function types can use the `_Concurrency` short substitution `ScM` without retaining a linker-visible reference to `libswift_Concurrency`. With dead stripping, a program that only boxes or reflects such a function type can omit the runtime library and crash when metadata lookup returns null.

This change disables concurrency short substitutions while emitting symbolic reflection manglings. `_Concurrency` types therefore use a symbolic reference such as `got.$sScMMn`, preserving the runtime descriptor reference and the library link. The change is scoped to symbolic mangling and is ABI-neutral.

Added an IRGen regression test checking that the MainActor descriptor reference is emitted.

Testing: `git diff --check`; full Swift compiler tests were not run because this checkout does not contain a built `swift-frontend`.