### PR TITLE
[Sema] Fix optional Objective-C bridging coercion

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7021,6 +7021,20 @@ Expr *ExprRewriter::buildObjCBridgeExpr(Expr *expr, Type toType,
                                         ConstraintLocatorBuilder locator) {
   Type fromType = cs.getType(expr);
 
+  // Bridge to the object type before injecting into an optional. Otherwise,
+  // the optional destination is mistaken for a Swift type to bridge from.
+  if (auto optionalObjectType = toType->getOptionalObjectType()) {
+    if (optionalObjectType->isAnyObject() ||
+        optionalObjectType->isBridgeableObjectType()) {
+      auto bridgedExpr =
+          buildObjCBridgeExpr(expr, optionalObjectType, locator);
+      if (!bridgedExpr)
+        return nullptr;
+      return cs.cacheType(
+          new (ctx) InjectIntoOptionalExpr(bridgedExpr, toType));
+    }
+  }
+
   // Bridged collection casts always succeed, so we treat them as
   // collection "upcasts".
   if ((fromType->isArray() && toType->isArray())

--- a/test/expr/cast/objc_coerce_array.swift
+++ b/test/expr/cast/objc_coerce_array.swift
@@ -5,6 +5,7 @@ import Foundation
 var x = 1
 
 _ = [x] as [NSNumber]
+_ = [x] as [NSNumber?]
 
 _ = ["x":["y":"z","a":1]] as [String : [String : AnyObject]]
 _ = ["x":["z",1]] as [String : [AnyObject]]


### PR DESCRIPTION
Fix collection bridging coercions when the destination element is an optional Objective-C type.

`[Int] as [NSNumber?]` now bridges each native `Int` to `NSNumber` before injecting it into `Optional`, instead of selecting the Objective-C-to-Swift bridge path and producing an invalid SIL enum payload.

Adds a regression case to `test/expr/cast/objc_coerce_array.swift`.

Fixes #83201