### PR TITLE
IRGen: zero-extend the result of the getEnumTag value witnesses

### DIFF
--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -179,15 +179,26 @@ static llvm::AttributeList getValueWitnessAttrs(IRGenModule &IGM,
   case ValueWitness::Destroy:
   case ValueWitness::DestructiveInjectEnumTag:
   case ValueWitness::DestructiveProjectEnumData:
-  case ValueWitness::GetEnumTag:
   case ValueWitness::StoreEnumTagSinglePayload:
     return attrs.addParamAttribute(ctx, 0, llvm::Attribute::NoAlias);
+
+  // getEnumTag returns the case index as an unsigned value.  Mark the result
+  // zeroext so that on targets which return sub-word integers in the low bits
+  // of a wider register without guaranteeing the high bits (e.g. PowerPC64,
+  // where a GPR is 64 bits and has no zeroing narrow sub-registers), the
+  // callee extends the result.  Otherwise callers that consume the tag as a
+  // full-width index read stale high bits and compute an out-of-bounds field
+  // record address.
+  case ValueWitness::GetEnumTag:
+    return attrs.addParamAttribute(ctx, 0, llvm::Attribute::NoAlias)
+        .addRetAttribute(ctx, llvm::Attribute::ZExt);
 
   case ValueWitness::GetEnumTagSinglePayload:
     return attrs
         .addFnAttribute(ctx, llvm::Attribute::getWithMemoryEffects(
                                  ctx, llvm::MemoryEffects::readOnly()))
-        .addParamAttribute(ctx, 0, llvm::Attribute::NoAlias);
+        .addParamAttribute(ctx, 0, llvm::Attribute::NoAlias)
+        .addRetAttribute(ctx, llvm::Attribute::ZExt);
 
   // These have two arguments and they don't alias each other.
   case ValueWitness::AssignWithTake:

--- a/test/IRGen/enum_value_witness_zeroext.swift
+++ b/test/IRGen/enum_value_witness_zeroext.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+
+// The getEnumTag value witness of a multi-payload enum returns the case index
+// as an unsigned tag.  It must carry the zeroext return attribute so that
+// targets which return sub-word integers in the low bits of a wider register
+// without clearing the high bits (e.g. PowerPC64) extend the result.  Without
+// it, swift_reflectionMirror_count() -> getFieldAt() consumes the tag as a
+// full-width index (index * sizeof(FieldRecord)), reads stale high bits, and
+// computes an out-of-bounds field-record address, crashing at -O when a
+// multi-payload enum is reflected.
+
+public class C {}
+
+public enum MultiPayload {
+  case none
+  case a(C)
+  case b(C)
+  case c
+}
+
+// The emitted getEnumTag witness ("...Owug") must return zeroext i32.
+// getEnumTagSinglePayload ("...Owet") receives the same attribute in
+// getValueWitnessAttrs().
+// CHECK: define {{.*}}zeroext i32 @"$s{{[0-9a-zA-Z_]*}}12MultiPayloadOwug"


### PR DESCRIPTION
The getEnumTag and getEnumTagSinglePayload value witnesses return the
enum case index as an unsigned 32-bit value.  Their signatures were built
as a bare `i32` return with no zeroext attribute.  On targets whose ABI
returns sub-word integers in the low bits of a wider register without
guaranteeing the high bits are cleared -- such as PowerPC64, where a GPR
is 64 bits wide and, unlike x86-64 (eax) or AArch64 (w-registers), has no
narrow sub-register that zeroes the upper half as a side effect -- the
generated witness leaves garbage in the high 32 bits of the result
register.

The extension kind (sign vs. zero) for a sub-word integer return is
source-level information that LLVM only carries via the zeroext/signext
return attribute; without it the backend any-extends and the high bits
are undefined.  This mirrors how Clang lowers unsigned-returning
functions for these targets.

Callers consume the tag as a full-width index.  swift_reflectionMirror_count()
passes the getEnumTag result straight to getFieldAt(), which indexes the
field-record array by index * sizeof(FieldRecord).  With stale high bits
the multiply overflows into a wild pointer and the process crashes --
reproducible on PowerPC64 by taking the Mirror of, or calling
String(describing:) on, any multi-payload enum under -O.

Mark the result of getEnumTag and getEnumTagSinglePayload zeroext.  The
tag is always a small non-negative value, so this is correct on every
target and a no-op where the result register is already extended.
