### PR TITLE
[test] Fix delimiter and mangling formatting for ignored inputs in Demangle test

### DIFF
--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -374,10 +374,10 @@ $sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specializat
 $s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> ()
 $sSD5IndexVy__GD ---> $sSD5IndexVy__GD
 $s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
-@$s8keypaths1KV3valACSi_tcfcACmTkmu : $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, K>)
-@$s8keypaths1KVACycfcACmTkMA : $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out K)
+@$s8keypaths1KV3valACSi_tcfcACmTkmu ---> $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, K>)
+@$s8keypaths1KVACycfcACmTkMA ---> $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out K)
 $s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq  ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
-$s18resilient_protocol24ResilientDerivedProtocolPxAA0c4BaseE0Tn --> associated conformance descriptor for resilient_protocol.ResilientDerivedProtocol.A: resilient_protocol.ResilientBaseProtocol
+$s18resilient_protocol24ResilientDerivedProtocolPxAA0c4BaseE0Tn ---> associated conformance descriptor for resilient_protocol.ResilientDerivedProtocol.A: resilient_protocol.ResilientBaseProtocol
 $s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF ---> red.test<A, B where B: Swift.Error>(red.Res<A, B>) -> red.Res<A, [B]>
 $s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type) -> red.OurType<them.TheirType<A.Assoc>>
 $s17property_wrappers10WithTuplesV9fractionsSd_S2dtvpfP ---> property wrapper backing initializer of property_wrappers.WithTuples.fractions : (Swift.Double, Swift.Double, Swift.Double)
@@ -397,10 +397,10 @@ $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee ---> $s0059xx
 $sx1td_t ---> (t: A...)
 $s7example1fyyYaF ---> example.f() async -> ()
 $s7example1fyyYaKF ---> example.f() async throws -> ()
-s7example1fyyYjfYaKF -> example.f@differentiable(_forward) () async throws -> ()
-s7example1fyyYjrYaKF -> example.f@differentiable(reverse) () async throws -> ()
-s7example1fyyYjdYaKF -> example.f@differentiable () async throws -> ()
-s7example1fyyYjlYaKF -> example.f@differentiable(_linear) () async throws -> ()
+$s7example1fyyYjfYaKF ---> example.f@differentiable(_forward) () async throws -> ()
+$s7example1fyyYjrYaKF ---> example.f@differentiable(reverse) () async throws -> ()
+$s7example1fyyYjdYaKF ---> example.f@differentiable () async throws -> ()
+$s7example1fyyYjlYaKF ---> example.f@differentiable(_linear) () async throws -> ()
 $s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> ()
 $s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE
 $s4main6testityyYaFTu ---> async function pointer to main.testit() async -> ()


### PR DESCRIPTION
### Motivation :- 

In `test/Demangle/demangle.swift`, the test runner extracts mangled test cases using `sed -ne '/--->/s/ *--->.*$//p'`.

Several test entries in `test/Demangle/Inputs/manglings.txt` were being silently ignored because of minor formatting discrepancies (such as `-->` with 2 dashes instead of 3, or missing `$s` prefixes and standard arrows). Resolves #67616.

### Modifications :-

Updated `test/Demangle/Inputs/manglings.txt`:
- Fixed delimiter on line 380 from `-->` to `--->`.
- Added missing `$s` prefixes and updated `->` to `--->` on lines 400-403 for differentiable function manglings.
- Fixed keypath accessor getter delimiter formatting on lines 377-378.

All 532 test cases in `manglings.txt` are now properly formatted with the `--->` delimiter.

### Checklist :- 
- [x] Code and documentation style followed.