### PR TITLE
SIL: don't treat debug uses of interior pointers as lifetime uses in the verifier

### DIFF
--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -453,9 +453,23 @@ bool SILValueOwnershipChecker::gatherUsers(
                          << "Address User: " << *op->getUser();
           });
         };
+        SmallVector<Operand *, 8> interiorPointerUses;
         foundError |= (interiorPointerOperand.findTransitiveUses(
-                           &nonLifetimeEndingUsers, &onError)
+                           &interiorPointerUses, &onError)
                        == AddressUseKind::Unknown);
+        // A debug use does not require its operand to be alive, so it must not
+        // become an implicit regular user of the borrow scope. Filter such uses
+        // out here just like we do for the direct uses gathered above: the
+        // transitive address walk reports both debug uses of the projected
+        // address and, via findInnerTransitiveGuaranteedUses, debug uses of the
+        // values loaded from it.
+        for (auto *interiorPointerUse : interiorPointerUses) {
+          auto ownership = interiorPointerUse->getOperandOwnership();
+          if (ownership == OperandOwnership::NonUse ||
+              ownership == OperandOwnership::DebugUse)
+            continue;
+          nonLifetimeEndingUsers.push_back(interiorPointerUse);
+        }
       }
 
       // Finally add the op to the non lifetime ending user list.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3212,6 +3212,11 @@ public:
       if (deadEndBlocks && deadEndBlocks->isDeadEnd(user->getParent())) {
         continue;
       }
+      // A debug use does not require its operand to be alive, so it is allowed
+      // to be outside of the scope.
+      if (use->getOperandOwnership() == OperandOwnership::DebugUse) {
+        continue;
+      }
       if (scopedAddress.isScopeEndingUse(use)) {
         continue;
       }

--- a/test/SIL/OwnershipVerifier/interior_pointer.sil
+++ b/test/SIL/OwnershipVerifier/interior_pointer.sil
@@ -152,3 +152,28 @@ bb0(%0 : @owned $Error):
   %result = apply %m<@opened(1, Error) Self>(%2) : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
   return %result : $Int
 }
+
+// A non-debug use of a value load_borrow'd from an interior pointer must still
+// be diagnosed if it is outside of the base's borrow scope. Only debug uses are
+// exempt.
+sil @use_klass_guaranteed : $@convention(thin) (@guaranteed Klass) -> ()
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'load_borrow_use_outside_of_interior_pointer_lifetime'
+// CHECK-NEXT: Found outside of lifetime use?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $KlassUser               // users: %5, %2
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $KlassUser                      // id: %5
+// CHECK-NEXT: Non Consuming User:   %7 = apply %6(%3) : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK-NEXT: Block: bb0
+sil [ossa] @load_borrow_use_outside_of_interior_pointer_lifetime : $@convention(thin) (@owned KlassUser) -> () {
+bb0(%0 : @owned $KlassUser):
+  %1 = begin_borrow %0 : $KlassUser
+  %2 = ref_element_addr %1 : $KlassUser, #KlassUser.field
+  %3 = load_borrow %2 : $*Klass
+  end_borrow %3 : $Klass
+  end_borrow %1 : $KlassUser
+  %func = function_ref @use_klass_guaranteed : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %func(%3) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %0 : $KlassUser
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/OwnershipVerifier/interior_pointer_debug_use.sil
+++ b/test/SIL/OwnershipVerifier/interior_pointer_debug_use.sil
@@ -1,0 +1,79 @@
+// RUN: %target-sil-opt -enable-sil-verify-all=0 -o /dev/null %s 2>&1
+
+// REQUIRES: asserts
+
+// A debug_value does not require its operand to be alive. So debug uses which
+// are reached through an interior pointer must not be treated as implicit
+// regular users of the enclosing borrow scope. This file has patterns in it
+// that should not trigger the ownership verifier.
+
+import Builtin
+
+class Klass {}
+
+struct KlassWrapper {
+  var k: Klass
+}
+
+class KlassUser {
+  var field: Klass
+  var wrapper: KlassWrapper
+}
+
+// A debug_value of the interior pointer itself.
+sil [ossa] @debug_use_of_interior_pointer_after_end_borrow : $@convention(thin) (@owned KlassUser) -> () {
+bb0(%0 : @owned $KlassUser):
+  %1 = begin_borrow %0
+  %2 = ref_element_addr %1, #KlassUser.field
+  end_borrow %1
+  debug_value %2, let, name "x", expr op_deref
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// A debug_value of a value load_borrow'd from an interior pointer.
+sil [ossa] @debug_use_of_load_borrow_after_end_borrow : $@convention(thin) (@owned KlassUser) -> () {
+bb0(%0 : @owned $KlassUser):
+  %1 = begin_borrow %0
+  %2 = ref_element_addr %1, #KlassUser.wrapper
+  %3 = load_borrow %2
+  end_borrow %3
+  end_borrow %1
+  debug_value %3, let, name "x"
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// A debug_value of a guaranteed value forwarded from a load_borrow of an
+// interior pointer.
+sil [ossa] @debug_use_of_forwarded_load_borrow_after_end_borrow : $@convention(thin) (@owned KlassUser) -> () {
+bb0(%0 : @owned $KlassUser):
+  %1 = begin_borrow %0
+  %2 = ref_element_addr %1, #KlassUser.wrapper
+  %3 = load_borrow %2
+  %4 = struct_extract %3, #KlassWrapper.k
+  end_borrow %3
+  end_borrow %1
+  debug_value %4, let, name "x"
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// A debug_value of a store_borrow destination, checked by the store_borrow
+// scope verification rather than by the ownership verifier.
+sil [ossa] @debug_use_of_store_borrow_after_end_borrow : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = begin_borrow %0
+  %2 = alloc_stack $Klass
+  %3 = store_borrow %1 to %2
+  end_borrow %3
+  debug_value %3, let, name "x", expr op_deref
+  dealloc_stack %2
+  end_borrow %1
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}


### PR DESCRIPTION
The ownership verifier adds the transitive uses of an interior pointer as implicit regular users of the enclosing borrow scope. Those uses come from `findInnerTransitiveGuaranteedUses`, which reports `DebugUse` operands as leaf use points, so a `debug_value` outside the borrow scope was diagnosed as "Found outside of lifetime use". A debug use does not require its operand to be alive, and the verifier already filters `DebugUse` from the uses it gathers directly.
`checkScopedAddressUses` had the same hole for `store_borrow` scopes.

Fixes a false ownership verifier error which was triggered by https://github.com/swiftlang/swift/pull/91922