### PR TITLE
🍒 [Windows] strip stray quotes from SKIP_TESTS before matching

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -64,7 +64,9 @@ set NINJA_STATUS=[%%f/%%t][%%p][%%es]
 :: Build the -Test argument, if any, by subtracting skipped tests
 set TestsList=lld,lldb,lldb-swift,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp
 set "TestArg="
-set "Skip=,%SKIP_TESTS%,"
+:: Strip stray double quotes from SKIP_TESTS so the substring match below still works.
+set "SkipTests=%SKIP_TESTS:"=%"
+set "Skip=,%SkipTests%,"
 for %%I in (%TestsList%) do (
   if "!Skip:,%%I,=!" == "!Skip!" (
       set "TestArg=!TestArg!%%I,"


### PR DESCRIPTION
- **Explanation**: On Windows, `SKIP_TESTS="lldb"` (quoted value) failed to skip tests because the quotes were included literally in the `%SKIP_TESTS%` batch variable, breaking the substring match against the comma-delimited test list. This strips stray double quotes from `SKIP_TESTS` before building the skip list in `build-windows-toolchain.bat`.
- **Scope**: Very narrow: affects only the Windows toolchain build script (`utils/build-windows-toolchain.bat`) used to determine which test suites to run.
- **Original PRs**: swiftlang/swift#92039
- **Risk**: Extremely low. The change only affects how the `SKIP_TESTS` environment variable is parsed in a build script; it does not touch compiler or runtime code.
- **Testing**: Verified manually that `SKIP_TESTS="lldb"` now correctly excludes `lldb` from the test argument list on Windows, whereas previously the quotes prevented the match.
- **Reviewers**: @compnerd (GitHub-approved the original PR)