### PR TITLE
[6.4.x] AST: Always print `@_originallyDefinedIn` attrs in swiftinterfaces

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1114,13 +1114,6 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     }
     break;
   }
-  case DeclAttrKind::OriginallyDefinedIn: {
-    auto Attr = cast<OriginallyDefinedInAttr>(this);
-    auto Name = D->getDeclContext()->getParentModule()->getName().str();
-    if (Options.IsForSwiftInterface && Attr->getManglingModuleName() == Name)
-      return false;
-    break;
-  }
   default:
     break;
   }

--- a/test/IRGen/backward_deploy_nominal.swift
+++ b/test/IRGen/backward_deploy_nominal.swift
@@ -4,9 +4,6 @@
 // RUN: %target-swift-frontend -emit-ir -parse-as-library -parse-stdlib %s -module-name Compatibility59 -module-abi-name Swift | %FileCheck %s --check-prefix=CHECK-SHIM
 // RUN: %target-swift-frontend -emit-ir -parse-as-library -parse-stdlib %s -module-name Compatibility59 -module-abi-name Swift | %FileCheck %s --check-prefix=ALSO-SHIM
 
-// RUN: %target-swift-emit-module-interface(%t/Swift.swiftinterface) %s -parse-as-library -parse-stdlib -module-name Swift
-// RUN: %FileCheck %s --check-prefix=CHECK-INTERFACE < %t/Swift.swiftinterface
-
 // REQUIRES: OS=macosx
 
 // Let's just pretend...
@@ -25,8 +22,3 @@ public struct Fridge<Contents> {}
 // The compatibility shim does not have any linker directives.
 // ALSO-SHIM-NOT: $ld$hide$
 // ALSO-SHIM-NOT: $ld$previous$
-
-// There is no @_originallyDefinedIn in the swiftinterface:
-// CHECK-INTERFACE-NOT: @_originallyDefinedIn
-// CHECK-INTERFACE: @available(macOS 13, *)
-// CHECK-INTERFACE-NEXT: public struct Fridge<Contents> {

--- a/test/ModuleInterface/originally-defined-attr.swift
+++ b/test/ModuleInterface/originally-defined-attr.swift
@@ -85,3 +85,9 @@ public struct SimpleThingInAlphabeticalOrderForMacros5_VersionsMappingTo27 {}
 @available(macOS 15, iOS 18, watchOS 11, tvOS 18, visionOS 2, *)
 @_originallyDefinedIn(module: "pre26", macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26)
 public struct SimpleThingInAlphabeticalOrderForMacros6_Version26 {}
+
+// CHECK: @_originallyDefinedIn(module: "Foo;FooCompatibility", macOS 13.13)
+// CHECK-LABEL: struct SimpleThingInAlphabeticalOrderForMacros8_DifferentLinkerModule
+@available(OSX 10.8, *)
+@_originallyDefinedIn(module: "Foo;FooCompatibility", OSX 13.13)
+public struct SimpleThingInAlphabeticalOrderForMacros8_DifferentLinkerModule {}


### PR DESCRIPTION
- **Explanation:** Don't skip printing them when the mangling module name is the same as the current module, since after https://github.com/swiftlang/swift/pull/91273 the linker module name can now carry semantic meaning for clients.
- **Scope:** Affects the attributes printed in the swiftinterface of the standard library and clients using the `-weak-link-span-compatibility-lib` flag introduced by https://github.com/swiftlang/swift/pull/91273.
- **Issue/Radar:** rdar://186673963
- **Original PR:** https://github.com/swiftlang/swift/pull/92049
- **Risk:** Low. Including these `@_originallyDefinedIn` attributes in the standard library `.swiftinterface` should have no effect on compilation for clients unless they use `-weak-link-span-compatibility-lib`.
- **Testing:** Updated compiler tests.
- **Reviewer:** @slavapestov 