### PR TITLE
[Diagnostics] Clarify error for type attributes outside inheritance clauses

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6507,13 +6507,13 @@ ERROR(sendable_raw_storage,none,
       "protocol", (DeclName))
 
 ERROR(typeattr_not_inheritance_clause,none,
-      "%0 only applies in inheritance clauses",
+      "%0 can only be used as a type attribute in inheritance clauses",
       (const TypeAttribute *))
 ERROR(typeattr_not_extension_inheritance_clause,none,
-      "%0 only applies in inheritance clauses in extensions",
+      "%0 can only be used as a type attribute in inheritance clauses in extensions",
       (const TypeAttribute *))
 ERROR(typeattr_not_protocol_inheritance_clause,none,
-      "%0 only applies in inheritance clause of a protocol extension",
+      "%0 can only be used as a type attribute in inheritance clause of a protocol extension",
       (const TypeAttribute *))
 ERROR(typeattr_not_existential,none,
       "%0 cannot apply to non-protocol type %1",

--- a/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
+++ b/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
@@ -62,6 +62,6 @@ class C12: @unchecked C11 { } // expected-error {{'@unchecked' cannot apply to n
 
 protocol P { }
 
-protocol Q: @unchecked Sendable { } // expected-error {{'@unchecked' only applies in inheritance clauses}}
+protocol Q: @unchecked Sendable { } // expected-error {{'@unchecked' can only be used as a type attribute in inheritance clauses}}
 
-typealias TypeAlias1 = @unchecked P // expected-error {{'@unchecked' only applies in inheritance clauses}}
+typealias TypeAlias1 = @unchecked P // expected-error {{'@unchecked' can only be used as a type attribute in inheritance clauses}}

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -15,18 +15,18 @@ do {
   struct B : @preconcurrency K {
     // expected-error@-1 {{'@preconcurrency' cannot apply to non-protocol type 'K'}}
     var x: @preconcurrency Int
-    // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+    // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
   }
 
   typealias T = @preconcurrency Q
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
 
   func test(_: @preconcurrency K) {}
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
 }
 
 protocol InvalidUseOfPreconcurrencyAttr : @preconcurrency Q {
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
 }
 
 struct TestPreconcurrencyAttr {}

--- a/test/Sema/extension_retroactive_conformances.swift
+++ b/test/Sema/extension_retroactive_conformances.swift
@@ -162,15 +162,15 @@ protocol ClientProtocol {}
 // ok, conforming a type from another module to a protocol within this module is totally fine
 extension Sample1: ClientProtocol {}
 
-struct MySample7: @retroactive SampleProtocol1 {} // expected-error {{'@retroactive' only applies in inheritance clauses in extensions}}{{19-32=}}
+struct MySample7: @retroactive SampleProtocol1 {} // expected-error {{'@retroactive' can only be used as a type attribute in inheritance clauses in extensions}}{{19-32=}}
 
 extension MySample7: @retroactive ClientProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'MySample7' is declared in this module}}{{22-35=}}
 
 extension Int: @retroactive ClientProtocol {} // expected-warning {{'retroactive' attribute does not apply; 'ClientProtocol' is declared in this module}}{{16-29=}}
 
-func f(_ x: @retroactive Int) {} // expected-error {{'@retroactive' only applies in inheritance clauses in extensions}}
+func f(_ x: @retroactive Int) {} // expected-error {{'@retroactive' can only be used as a type attribute in inheritance clauses in extensions}}
 
-var x: @retroactive Int { 0 } // expected-error {{'@retroactive' only applies in inheritance clauses in extensions}}
+var x: @retroactive Int { 0 } // expected-error {{'@retroactive' can only be used as a type attribute in inheritance clauses in extensions}}
 
 #if os(macOS)
 


### PR DESCRIPTION
## Summary
Clarifies the error messages for type attributes used outside of inheritance clauses.

## Motivation
Previously, the diagnostics stated that the attribute "only applies in inheritance clauses". This was misleading for attributes like `@preconcurrency`, which are perfectly valid as declaration or import attributes. Issue #88338 pointed out that the error should specifically mention it is restricted when used as a *type attribute*.

## Implementation
Updated `typeattr_not_inheritance_clause`, `typeattr_not_extension_inheritance_clause`, and `typeattr_not_protocol_inheritance_clause` in `include/swift/AST/DiagnosticsSema.def` to state that they "can only be used as a type attribute in..." rather than "only applies in...".

## Testing
Updated the diagnostic expectation strings in:
- `test/Concurrency/concurrent_value_checking_typechecker_errors.swift`
- `test/Concurrency/preconcurrency_conformances.swift`
- `test/Sema/extension_retroactive_conformances.swift`

Resolves #88338.
