### PR TITLE
[SwiftCaching] Track macro plugins as dependencies when caching

### DIFF
--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -32,6 +32,11 @@ public:
   struct PluginEntry {
     StringRef libraryPath;
     StringRef executablePath;
+
+    /// The paths as passed to the frontend, before the loader unmapped them to
+    /// load the plugin from disk. Empty if no prefix mapping is in effect.
+    StringRef prefixMappedLibraryPath;
+    StringRef prefixMappedExecutablePath;
   };
 
 private:

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -86,7 +86,9 @@ PluginLoader::getPluginMap() {
   // Helper function to try inserting an entry if there's no existing entry
   // associated with the module name.
   auto try_emplace = [&](StringRef moduleName, StringRef libPath,
-                         StringRef execPath, bool overwrite = false) {
+                         StringRef execPath, bool overwrite = false,
+                         StringRef prefixMappedLibPath = "",
+                         StringRef prefixMappedExecPath = "") {
     auto moduleNameIdentifier = Ctx.getIdentifier(moduleName);
     if (map.find(moduleNameIdentifier) != map.end() && !overwrite) {
       // Specified module name is already in the map and no need to overwrite
@@ -94,9 +96,12 @@ PluginLoader::getPluginMap() {
       return;
     }
 
-    libPath = libPath.empty() ? "" : Ctx.AllocateCopy(libPath);
-    execPath = execPath.empty() ? "" : Ctx.AllocateCopy(execPath);
-    map[moduleNameIdentifier] = {libPath, execPath};
+    auto copy = [&](StringRef path) -> StringRef {
+      return path.empty() ? "" : Ctx.AllocateCopy(path);
+    };
+    map[moduleNameIdentifier] = {copy(libPath), copy(execPath),
+                                 copy(prefixMappedLibPath),
+                                 copy(prefixMappedExecPath)};
   };
 
   std::optional<llvm::PrefixMapper> mapper;
@@ -210,7 +215,7 @@ PluginLoader::getPluginMap() {
           continue;
         }
         try_emplace(moduleName, *libPath, remapPath(val.ExecutablePath),
-                    /*overwrite*/ true);
+                    /*overwrite*/ true, val.LibraryPath, val.ExecutablePath);
       }
       continue;
     }
@@ -285,15 +290,29 @@ void PluginLoader::recordDependency(const PluginEntry &plugin,
   // libraryPath: non-nil, executablePath: nil: in-process library plugin.
   // libraryPath: non-nil, executablePath: non-nil: external library plugin.
   // libraryPath: nil, executablePath: non-nil: executable plugin.
-  StringRef path =
-      !plugin.libraryPath.empty() ? plugin.libraryPath : plugin.executablePath;
+  bool useLibraryPath = !plugin.libraryPath.empty();
+  StringRef path = useLibraryPath ? plugin.libraryPath : plugin.executablePath;
+  StringRef prefixMappedPath = useLibraryPath
+                                   ? plugin.prefixMappedLibraryPath
+                                   : plugin.prefixMappedExecutablePath;
 
   // NOTE: We don't track plugin-server path as a dependency because it doesn't
   // provide much value.
 
   assert(!path.empty());
+
+  // Record the path as it was passed to the frontend. The dependency file
+  // emitter applies the same prefix map, like it does for every other
+  // dependency.
+  if (!prefixMappedPath.empty() && prefixMappedPath != path) {
+    DepTracker->addMacroPluginDependency(prefixMappedPath, moduleName);
+    return;
+  }
+
   SmallString<128> resolvedPath;
-  auto fs = Ctx.SourceMgr.getFileSystem();
+  // The plugin is not in the CAS file system, so resolve it against the file
+  // system it is actually loaded from.
+  auto fs = getPluginLoadingFS(Ctx);
   if (auto err = fs->getRealPath(path, resolvedPath)) {
     return;
   }

--- a/lib/Frontend/MakeStyleDependencies.cpp
+++ b/lib/Frontend/MakeStyleDependencies.cpp
@@ -92,7 +92,7 @@ reversePathSortedFilenames(const Container &elts) {
   return tmp;
 }
 
-static void emitMakeDependenciesFile(std::vector<std::string> &dependencies,
+static void emitMakeDependenciesFile(std::vector<std::string> dependencies,
                                      const FrontendOptions &opts,
                                      const InputFile &input,
                                      const std::vector<std::pair<std::string, std::string>> &prefixMap,

--- a/test/CAS/macro_plugin.swift
+++ b/test/CAS/macro_plugin.swift
@@ -34,6 +34,33 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %s @%t/MyApp.cmd
 
+/// The plugin is an input to the compilation, so it has to appear in the
+/// make-style dependencies, both when produced and when replayed from the CAS.
+// RUN: %target-swift-frontend-plain \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -module-name MyApp -O \
+// RUN:   -resolved-plugin-verification -Rcache-compile-job \
+// RUN:   -emit-dependencies -emit-dependencies-path %t/deps.d \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %s @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=MISS
+// MISS: remark: cache miss
+
+// RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/deps.d -DLIB=%target-library-name(MacroDefinition)
+
+// RUN: rm %t/deps.d
+// RUN: %target-swift-frontend-plain \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -module-name MyApp -O \
+// RUN:   -resolved-plugin-verification -Rcache-compile-job \
+// RUN:   -emit-dependencies -emit-dependencies-path %t/deps.d \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %s @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=REPLAY
+// REPLAY: remark: replay output file '{{.*}}deps.d'
+
+// RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/deps.d -DLIB=%target-library-name(MacroDefinition)
+
+// DEPS: plugins{{/|\\}}[[LIB]]
+
 @attached(extension, conformances: P, names: named(requirement))
 macro DelegatedConformance() = #externalMacro(module: "MacroDefinition", type: "DelegatedConformanceViaExtensionMacro")
 

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -41,6 +41,31 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/macro.swift @%t/MyApp.cmd
 
+/// The plugin is an input to the compilation, so it has to appear in the
+/// make-style dependencies, both when produced and when replayed from the CAS.
+// RUN: %target-swift-frontend-plain \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
+// RUN:   -swift-version 5 -module-name MyApp \
+// RUN:   -emit-dependencies -emit-dependencies-path %t/deps.d \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/macro.swift @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=MISS
+// MISS: remark: cache miss
+
+// RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/deps.d -DLIB=%target-library-name(MacroDefinition)
+
+// RUN: rm %t/deps.d
+// RUN: %target-swift-frontend-plain \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas -Rcache-compile-job \
+// RUN:   -swift-version 5 -module-name MyApp \
+// RUN:   -emit-dependencies -emit-dependencies-path %t/deps.d \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/macro.swift @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix=REPLAY
+// REPLAY: remark: replay output file '{{.*}}deps.d'
+
+// RUN: %FileCheck %s --check-prefix=DEPS --input-file=%t/deps.d -DLIB=%target-library-name(MacroDefinition)
+
+// DEPS: plugins{{/|\\}}[[LIB]]
+
 // RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/macro.swift -o %t/deps2.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t/plugins#%swift-plugin-server \
@@ -70,6 +95,35 @@
 // RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test %t -cache-replay-prefix-map /^bin %swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=REMARK
 // REMAKR: remark: cache miss
 // REMARK: remark: loaded macro implementation module 'MacroDefinition' from compiler plugin server
+
+/// The plugin is tracked using the prefix mapped path passed to the frontend,
+/// so the dependency file maps it back to the local path.
+// RUN: %target-swift-frontend-plain \
+// RUN:   -emit-module -o %t/Macro2.swiftmodule -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -O -module-name MyApp -Rcache-compile-job \
+// RUN:   -emit-dependencies -emit-dependencies-path %t/deps2.d \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test %t -cache-replay-prefix-map /^bin %swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=MISS-REMAP
+// MISS-REMAP: remark: cache miss
+
+// RUN: %FileCheck %s --check-prefix=DEPS-LOCAL --input-file=%t/deps2.d -DLIB=%target-library-name(MacroDefinition) -DTMP=%t
+// DEPS-LOCAL-DAG: [[TMP]]{{/|\\}}macro.swift
+// DEPS-LOCAL-DAG: [[TMP]]{{/|\\}}plugins{{/|\\}}[[LIB]]
+
+/// Replaying the same key with a different prefix map moves the plugin to the
+/// new location along with the source file.
+// RUN: rm %t/deps2.d
+// RUN: %target-swift-frontend-plain \
+// RUN:   -emit-module -o %t/Macro2.swiftmodule -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -O -module-name MyApp -Rcache-compile-job \
+// RUN:   -emit-dependencies -emit-dependencies-path %t/deps2.d \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test /^relocated -cache-replay-prefix-map /^bin %swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=REPLAY-REMAP
+// REPLAY-REMAP: remark: replay output file '{{.*}}deps2.d'
+
+// RUN: %FileCheck %s --check-prefix=DEPS-REMAP --input-file=%t/deps2.d -DLIB=%target-library-name(MacroDefinition)
+// DEPS-REMAP-DAG: /^relocated{{/|\\}}macro.swift
+// DEPS-REMAP-DAG: /^relocated{{/|\\}}plugins{{/|\\}}[[LIB]]
 
 /// Encoded PLUGIN_SEARCH_OPTION is remapped.
 // RUN: %llvm-bcanalyzer -dump %t/Macro.swiftmodule | %FileCheck %s --check-prefix=MOD -DLIB=%target-library-name(MacroDefinition)


### PR DESCRIPTION
`PluginLoader::recordDependency` resolved the plugin path against the source manager's file system. Under compilation caching that is the CAS file system, which does not contain the plugin, so `getRealPath` failed and the dependency was silently dropped: `-emit-dependencies` left the macro plugin out of the depfile and build systems kept stale macro expansions. Resolve against the file system the plugin is actually loaded from instead.

When the paths are prefix mapped, record the path as it was passed to the frontend rather than the one the loader unmapped to load the plugin from disk, so the plugin is tracked like every other dependency.

Emitting the dependency file no longer mutates the dependency list it is given, so the copy stored in the CAS keeps the prefix mapped paths and a replay elsewhere can map them to its own locations.

rdar://186890751

