### PR TITLE
[Tools] Fix swift-reflection-fuzzer build and bound its reads

### DIFF
--- a/tools/swift-reflection-fuzzer/CMakeLists.txt
+++ b/tools/swift-reflection-fuzzer/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_fuzzer_host_tool(swift-reflection-fuzzer
   swift-reflection-fuzzer.cpp
-  LLVM_LINK_COMPONENTS support
+  LLVM_LINK_COMPONENTS binaryformat support
   SWIFT_COMPONENT testsuite-tools
   )
 target_link_libraries(swift-reflection-fuzzer

--- a/tools/swift-reflection-fuzzer/swift-reflection-fuzzer.cpp
+++ b/tools/swift-reflection-fuzzer/swift-reflection-fuzzer.cpp
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 
 #if defined(__APPLE__) && defined(__MACH__)
@@ -53,8 +54,12 @@ template <typename T> static T unwrap(llvm::Expected<T> value) {
 }
 
 class ObjectMemoryReader : public MemoryReader {
+  const uint8_t *Start;
+  const uint8_t *End;
+
 public:
-  ObjectMemoryReader() {}
+  ObjectMemoryReader(const uint8_t *Data, size_t Size)
+      : Start(Data), End(Data + Size) {}
 
   bool queryDataLayout(DataLayoutQueryType type, void *inBuffer,
                        void *outBuffer) override {
@@ -123,9 +128,15 @@ public:
     return RemoteAddress();
   }
 
-  bool isAddressValid(RemoteAddress addr, uint64_t size) const { return true; }
+  bool isAddressValid(RemoteAddress addr, uint64_t size) const {
+    auto *p = (const uint8_t *)addr.getRawAddress();
+    // Compare as sizes to avoid overflowing the pointer arithmetic.
+    return p >= Start && p <= End && size <= (uint64_t)(End - p);
+  }
 
   ReadBytesResult readBytes(RemoteAddress address, uint64_t size) override {
+    if (!isAddressValid(address, size))
+      return ReadBytesResult();
     return ReadBytesResult((const void *)address.getRawAddress(),
                            [](const void *) {});
   }
@@ -133,14 +144,18 @@ public:
   bool readString(RemoteAddress address, std::string &dest) override {
     if (!isAddressValid(address, 1))
       return false;
-    auto cString = StringRef((const char *)address.getRawAddress());
-    dest.append(cString.begin(), cString.end());
+    auto *p = (const char *)address.getRawAddress();
+    size_t maxLen = (const char *)End - p;
+    size_t len = strnlen(p, maxLen);
+    if (len == maxLen)
+      return false; // Unterminated: the string runs off the end of the input.
+    dest.append(p, p + len);
     return true;
   }
 };
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-  auto reader = std::make_shared<ObjectMemoryReader>();
+  auto reader = std::make_shared<ObjectMemoryReader>(Data, Size);
   NativeReflectionContext context(std::move(reader));
   context.addImage(
       RemoteAddress((uint64_t)Data, RemoteAddress::DefaultAddressSpace));


### PR DESCRIPTION
`swift-reflection-fuzzer` fails to link once a fuzzing engine is configured
(`add_swift_fuzzer_host_tool` only creates the target then, so this goes
unnoticed in a normal build):

```
Undefined symbols for architecture arm64:
  "llvm::wasm::sectionTypeToString(unsigned int)", referenced from:
      swift::reflection::ReflectionContext<...>::readWasm(...) in swift-reflection-fuzzer.cpp.o
ld: symbol(s) not found for architecture arm64
```

`ReflectionContext::readWasm` (`include/swift/RemoteInspection/ReflectionContext.h`)
calls `llvm::wasm::sectionTypeToString`, which lives in LLVM's `BinaryFormat`
component. The fuzzer's `CMakeLists.txt` only lists `support` in
`LLVM_LINK_COMPONENTS`, so that library was never linked in. The first commit
adds `binaryformat`, the same component `llvm-readobj` and `llvm/lib/Object`
list for the same symbol.

While fixing the build, the fuzz harness's `ObjectMemoryReader` turned out to
read without any bound on the fuzzer's actual input: `isAddressValid` always
returned `true`, and `readString` scanned for a NUL terminator with no limit,
so malformed input can walk it past the end of the libFuzzer-owned
allocation. The second commit tracks the input buffer's range at construction
and bounds every read (`isAddressValid`, `readBytes`, `readString`) to it.

Two commits, independent of each other:
1. Link `swift-reflection-fuzzer` against `BinaryFormat` (the actual build fix).
2. Bound the fuzz harness's memory reader to its input buffer (hardening).

Assisted-by: claude
