### PR TITLE
Fix EagerSpecializer emitting unregistered "cmp_le" builtin

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -843,6 +843,13 @@ BuiltinInst *BuiltinInst::create(SILDebugLocation Loc, Identifier Name,
                                  SubstitutionMap Substitutions,
                                  ArrayRef<SILValue> Args,
                                  SILInstructionContext context) {
+  // A builtin must name either a registered Builtins.def builtin or an LLVM
+  // intrinsic.
+  ASSERT((context.getModule().getBuiltinInfo(Name).ID !=
+              BuiltinValueKind::None ||
+          context.getModule().getIntrinsicInfo(Name).ID !=
+              llvm::Intrinsic::not_intrinsic) &&
+         "BuiltinInst created with unregistered builtin or intrinsic name");
   SmallVector<SILValue, 32> allOperands;
   copy(Args, std::back_inserter(allOperands));
   collectTypeDependentOperands(allOperands, context, Substitutions);

--- a/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
@@ -566,7 +566,9 @@ void EagerDispatch::emitTrivialAndSizeCheck(SILBasicBlock *FailedTypeCheckBB,
                                          WordTy, SubMap, { GenericMT });
   auto LayoutSize =
       Builder.createIntegerLiteral(Loc, WordTy, Layout->getTrivialSizeInBytes());
-  const char *CmpOpName = Layout->isFixedSizeTrivial() ? "cmp_eq" : "cmp_le";
+  // Use cmp_ule for non LayoutConstraintKind::TrivialOfExactSize constraints,
+  // since the operands are non-negative Word sizes.
+  const char *CmpOpName = Layout->isFixedSizeTrivial() ? "cmp_eq" : "cmp_ule";
   auto Cmp =
     Builder.createBuiltinBinaryFunction(Loc, CmpOpName, WordTy,
                                         BoolTy,

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -267,6 +267,12 @@ public func copy2<S>(_ t: S, s: inout S) -> S where S: P{
   return s
 }
 
+@_specialize(where S: _TrivialAtMost(64))
+@inline(never)
+public func copy2NonExported<S>(_ s: S) -> S where S: P {
+  return s
+}
+
 // Check missing alignment.
 @_specialize(where S: _Trivial(64, )) // expected-error{{expected non-negative alignment to be specified in layout constraint}}
 // Check non-numeric size.


### PR DESCRIPTION
emitTrivialAndSizeCheck used "cmp_le" for a _TrivialAtMost(N) constraint, but only cmp_sle/cmp_ule are registered builtins. The malformed builtin caused a compiler crashed later. Use "cmp_ule" (operands are non-negative Word sizes) instead.

Resolves rdar://186660090

