### PR TITLE
Don't assert when trying to specialize witness tables for abstract conformances.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -224,15 +224,15 @@ private func specializeDeinit(forType type: Type,
 
 /// Specializes a witness table of `conformance` for the concrete type of the conformance.
 func specializeWitnessTable(for conformance: Conformance, _ context: ModulePassContext) {
-  if let existingSpecialization = context.lookupWitnessTable(for: conformance),
-         existingSpecialization.isSpecialized
-  {
-    return
-  }
-
   guard conformance.isConcrete else {
     // If the conformance is abstract the witness table is specialized elsewhere - at the
     // place where the concrete conformance is referenced.
+    return
+  }
+
+  if let existingSpecialization = context.lookupWitnessTable(for: conformance),
+         existingSpecialization.isSpecialized
+  {
     return
   }
 


### PR DESCRIPTION
Right now, `specializeWitnessTable()` reads `existingSpecialization.isSpecialized` before reading `conformance.isConcrete`. Unfortunately, the former asserts if the latter is `false`, leading to a crash and the check for `conformance.isConcrete` being dead code. Move the check for `conformance.isConcrete` up to avoid the assert.

Resolves rdar://186615041.