### PR TITLE
[ASTGen] Build ExportedSourceFile's SourceLocationConverter lazily

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -197,7 +197,7 @@ extension swift.DiagnosticKind {
 public func addQueuedSourceFile(
   queuedDiagnosticsPtr: UnsafeMutableRawPointer,
   bufferID: Int,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   displayNamePtr: UnsafePointer<UInt8>,
   displayNameLength: Int,
   parentID: Int,

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -35,9 +35,10 @@ public struct ExportedSourceFile {
   public let syntax: Syntax
 
   /// A source location converter to convert `AbsolutePosition`s in `syntax` to line/column locations.
-  ///
-  /// Cached so we don't need to re-build the line table every time we need to convert a position.
-  public let sourceLocationConverter: SourceLocationConverter
+  public lazy var sourceLocationConverter: SourceLocationConverter = SourceLocationConverter(
+    fileName: fileName,
+    tree: syntax
+  )
 
   /// Configured regions for this source file.
   ///
@@ -184,8 +185,7 @@ public func parseSourceFile(
       buffer: buffer,
       moduleName: moduleName,
       fileName: fileName,
-      syntax: parsed,
-      sourceLocationConverter: SourceLocationConverter(fileName: fileName, tree: parsed)
+      syntax: parsed
     )
   )
 

--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -424,7 +424,7 @@ func expandFreestandingMacro(
   macroPtr: UnsafeRawPointer,
   discriminatorText: UnsafePointer<CChar>,
   rawMacroRole: UInt8,
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafeMutableRawPointer,
   sourceLocationPtr: UnsafePointer<UInt8>?,
   expandedSourceOutPtr: UnsafeMutablePointer<BridgedStringRef>
 ) -> Int {
@@ -479,7 +479,7 @@ func expandFreestandingMacroImpl(
   macroRole: MacroRole,
   cContext: BridgedASTContext,
   expansionSyntax: FreestandingMacroExpansionSyntax,
-  sourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  sourceFilePtr: UnsafeMutablePointer<ExportedSourceFile>,
   discriminator: String
 ) -> String? {
 
@@ -565,11 +565,11 @@ func expandAttachedMacro(
   qualifiedTypeText: UnsafePointer<CChar>,
   conformanceListText: UnsafePointer<CChar>,
   rawMacroRole: UInt8,
-  customAttrSourceFilePtr: UnsafeRawPointer,
+  customAttrSourceFilePtr: UnsafeMutableRawPointer,
   customAttrSourceLocPointer: UnsafePointer<UInt8>?,
-  declarationSourceFilePtr: UnsafeRawPointer,
+  declarationSourceFilePtr: UnsafeMutableRawPointer,
   attachedTo declarationSourceLocPointer: UnsafePointer<UInt8>?,
-  parentDeclSourceFilePtr: UnsafeRawPointer?,
+  parentDeclSourceFilePtr: UnsafeMutableRawPointer?,
   parentDeclSourceLocPointer: UnsafePointer<UInt8>?,
   expandedSourceOutPtr: UnsafeMutablePointer<BridgedStringRef>
 ) -> Int {
@@ -660,11 +660,11 @@ func expandAttachedMacroImpl(
   discriminator: String,
   qualifiedType: String,
   conformanceList: String,
-  customAttrSourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  customAttrSourceFilePtr: UnsafeMutablePointer<ExportedSourceFile>,
   customAttrNode: AttributeSyntax,
-  declarationSourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  declarationSourceFilePtr: UnsafeMutablePointer<ExportedSourceFile>,
   attachedTo declarationNode: Syntax,
-  parentDeclSourceFilePtr: UnsafePointer<ExportedSourceFile>?,
+  parentDeclSourceFilePtr: UnsafeMutablePointer<ExportedSourceFile>?,
   parentDeclNode: DeclSyntax?
 ) -> String? {
   let macroName: String = customAttrNode.attributeName.description

--- a/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
@@ -393,7 +393,7 @@ extension String {
 }
 
 extension PluginMessage.Syntax {
-  init?(syntax: Syntax, in sourceFilePtr: UnsafePointer<ExportedSourceFile>, pluginProtocolVersion: Int = PluginMessage.PROTOCOL_VERSION_NUMBER) {
+  init?(syntax: Syntax, in sourceFilePtr: UnsafeMutablePointer<ExportedSourceFile>, pluginProtocolVersion: Int = PluginMessage.PROTOCOL_VERSION_NUMBER) {
     let kind: PluginMessage.Syntax.Kind
     switch true {
     case syntax.is(AccessorDeclSyntax.self): kind = pluginProtocolVersion >= 8 ? .accessor : .declaration


### PR DESCRIPTION
Constructing a `SourceLocationConverter` is not free and builds a line table spanning the whole file, but only macro expansion, grouped diagnostic rendering, virtual file collection, and unqualified lookup validation need line/column info. `#if` clause ranges, `@diagnose` warning control, Embedded checks, fingerprinting, and name matching all don't use it. Make the property `lazy` so the line table is built on first use.

Reading a `lazy` property needs mutable access, so this widens the pointer types on the two call chains that reach it (`swift_Macros_expandFreestandingMacro`, `swift_Macros_expandAttachedMacro`, `swift_ASTGen_addQueuedSourceFile`). The matching C++ declarations already pass non-const `void *`, so no C++ change is needed.