### PR TITLE
[rebranch] Accept both x86_fp80 printing forms in FileCheck patterns

### DIFF
--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -113,7 +113,7 @@ sil_global @static_aligned_array : $TestArrayStorage = {
   %initval = object $TestArrayStorage (%3 : $Int32, [tail_elems] %4 : $Float80)
 }
 // CHECK-SYSV-arm64: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef }> }, align 8
-// CHECK-SYSV-x86_64: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [2 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [12 x i8] undef, %Ts7Float80V <{ x86_fp80 0xK3FFE8000000000000000 }> }> }, align 16
+// CHECK-SYSV-x86_64: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [2 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [12 x i8] undef, %Ts7Float80V <{ x86_fp80 {{(5\.000000e-01|0xK3FFE8000000000000000)}} }> }> }, align 16
 // CHECK-WIN-x86_64: @static_aligned_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems1c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems1 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef }> }, align 8
 
 final class ClassWithEmptyField {

--- a/test/stdlib/FloatingPointIR_FP80.swift
+++ b/test/stdlib/FloatingPointIR_FP80.swift
@@ -18,5 +18,5 @@ func testConstantFoldFloatLiterals() {
   acceptFloat80(1.0)
 }
 
-// i386: call swiftcc void @"$s20FloatingPointIR_FP8013acceptFloat80yys0F0VF{{.*}}"(x86_fp80 0xK3FFF8000000000000000)
-// x86_64: call swiftcc void @"$s20FloatingPointIR_FP8013acceptFloat80yys0F0VF{{.*}}"(x86_fp80 0xK3FFF8000000000000000)
+// i386: call swiftcc void @"$s20FloatingPointIR_FP8013acceptFloat80yys0F0VF{{.*}}"(x86_fp80 {{(1\.000000e\+00|0xK3FFF8000000000000000)}})
+// x86_64: call swiftcc void @"$s20FloatingPointIR_FP8013acceptFloat80yys0F0VF{{.*}}"(x86_fp80 {{(1\.000000e\+00|0xK3FFF8000000000000000)}})


### PR DESCRIPTION
LLVM 41c214f0b115 ("[AsmWriter] Change the output syntax of floating-point literals", #190649, present in LLVM 23 but not yet in LLVM 21) no longer prints FP constants in the legacy hexadecimal format; x87-extended values that are exactly representable in 6 decimal digits now print as decimals.

Rather than pin the expectation to one LLVM version's output (tests cannot do C preprocessor version checks), make the two affected patterns accept either form:

- IRGen/static_initializer.sil: x86_fp80 0xK3FFE8000000000000000 (0.5) -> x86_fp80 {{(5\.000000e-01|0xK3FFE8000000000000000)}}
- stdlib/FloatingPointIR_FP80.swift: x86_fp80 0xK3FFF8000000000000000 (1.0) -> x86_fp80 {{(1\.000000e\+00|0xK3FFF8000000000000000)}}

Both forms verified against the toolchain's actual -emit-ir output.
