### PR TITLE
[rebranch][irgen] Assign GUIDs before writing summary-index bitcode on Linux

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -98,6 +98,9 @@
 #include "llvm/Transforms/ObjCARC.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Scalar/DCE.h"
+#if LLVM_VERSION_MAJOR >= 23
+#include "llvm/Transforms/Utils/AssignGUID.h"
+#endif
 #include "llvm/Transforms/Utils/Instrumentation.h"
 
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
@@ -614,6 +617,12 @@ void swift::performLLVMOptimizations(
         TargetMachine->getTargetTriple().getVendor() != llvm::Triple::Apple;
 
     if (Opts.LLVMLTOKind == IRGenLLVMLTOKind::Thin) {
+#if LLVM_VERSION_MAJOR >= 23
+      // ThinLTOBitcodeWriterPass requests ModuleSummaryIndexAnalysis, which
+      // requires a GUID to be assigned to every GlobalValue. The LTO prelink
+      // pipelines do that via AssignGUIDPass, but the O0 pipeline does not.
+      MPM.addPass(AssignGUIDPass());
+#endif
       MPM.addPass(ThinLTOBitcodeWriterPass(*out, nullptr));
     } else {
       if (EmitRegularLTOSummary) {
@@ -623,6 +632,12 @@ void swift::performLLVMOptimizations(
         // lto summary.)
         Module->addModuleFlag(llvm::Module::Error, "EnableSplitLTOUnit",
                               uint32_t(1));
+#if LLVM_VERSION_MAJOR >= 23
+        // BitcodeWriterPass with EmitSummaryIndex requests
+        // ModuleSummaryIndexAnalysis, which requires a GUID to be assigned to
+        // every GlobalValue; the per-module/O0 pipelines do not do that.
+        MPM.addPass(AssignGUIDPass());
+#endif
       }
       MPM.addPass(BitcodeWriterPass(
           *out, /*ShouldPreserveUseListOrder*/ false, EmitRegularLTOSummary));


### PR DESCRIPTION
BitcodeWriterPass/ThinLTOBitcodeWriterPass request ModuleSummaryIndexAnalysis, which since the GUID-metadata reland in LLVM requires a GUID to be assigned to every GlobalValue before use (getGUID() now asserts instead of computing one on the fly). The LTO prelink pipelines assign GUIDs via AssignGUIDPass, but the per-module and O0 pipelines do not, so plain -emit-bc on non-Apple triples (where a regular LTO summary is emitted by default) crashed with:

  Assertion 'MaybeGUID.has_value() && "GUID was not assigned before
  calling GetGUID()" failed (Globals.cpp:106)

Run AssignGUIDPass before the bitcode writer in those cases. It is deterministic (MD5 of the global identifier) and re-running it after an LTO pipeline that already assigned GUIDs is harmless.

Adaptation for main: guarded with LLVM_VERSION_MAJOR >= 23. On LLVM 21 GlobalValue::getGUID() still computes a GUID on the fly (no assert) and the AssignGUIDPass itself does not exist, so plain -emit-bc works without this; the guarded pipeline changes only take effect on the newer LLVM.
