### PR TITLE
[AsyncStream] Avoid using Disconnected where not necessary

### DIFF
--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -52,24 +52,6 @@ func _lock(_ ptr: UnsafeRawPointer)
 func _unlock(_ ptr: UnsafeRawPointer)
 #endif
 
-fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, @unchecked Sendable {
-  private var value: Value?
-
-  private init() {
-    self.value = nil
-  }
-
-  init(_ value: consuming sending Value) {
-    self.value = consume value
-  }
-
-  mutating func take() -> sending Value {
-    let oldValue = consume value
-    self = .init()
-    return oldValue!
-  }
-}
-
 /// The state machine backing the continuation-based variant of `Async{Throwing}Stream`.
 ///
 /// States:
@@ -750,10 +732,9 @@ extension _AsyncStreamStorage {
   }
 
   func yield(_ value: consuming sending Element) -> Continuation.YieldResult {
-    var disconnected = Disconnected(value)
-    let action = withLock { state in
-      return unsafe state.yield(disconnected.take())
-    }
+    unsafe _lock(self.lock)
+    let action = unsafe self.stateMachine.yield(value)
+    unsafe _unlock(self.lock)
 
     switch unsafe action {
     case .resume(let consumer, let element, let yieldResult):


### PR DESCRIPTION
Having a tough time reproducing an issue but this disconnected makes me concerned anyway, we don't need it.

Either way this is a nice cleanup

Refs rdar://184370075
