### PR TITLE
[test] Filter out misc output in macro plugin tests

### DIFF
--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -10,8 +10,9 @@
 // RUN:   -swift-version 5 \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -module-name MyApp \
-// RUN:   %t/test.swift \
-// RUN:   > %t/macro-expansions.txt 2>&1
+// RUN:   %t/test.swift 2>&1 \
+// RUN:   | grep "^[<-][->]" \
+// RUN:   > %t/macro-expansions.txt
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
 

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -27,7 +27,7 @@
 // RUN:   -Rmacro-loading -verify-ignore-unknown \
 // RUN:   -module-name MyApp \
 // RUN:   %s \
-// RUN:   2>&1 | tee %t/macro-expansions.txt
+// RUN:   2>&1 | grep "^[<-][->]" | tee %t/macro-expansions.txt
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
 
@@ -47,7 +47,7 @@
 // RUN:   -Rmacro-loading -verify-ignore-unknown \
 // RUN:   -module-name MyApp \
 // RUN:   %s \
-// RUN:   2>&1 | tee %t/macro-expansions-2.txt
+// RUN:   2>&1 | grep "^[<-][->]" | tee %t/macro-expansions-2.txt
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions-2.txt
 

--- a/test/Macros/macro_plugin_server_mod.swift
+++ b/test/Macros/macro_plugin_server_mod.swift
@@ -43,7 +43,8 @@
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
 // RUN:   -module-name MyApp \
 // RUN:   %t/app.swift \
-// RUN:   2>&1 | tee %t/macro-expansions.txt
+// RUN:   2>&1 | grep "^[<-][->]" \
+// RUN:        | tee %t/macro-expansions.txt
 
 // RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
 


### PR DESCRIPTION
For ASan bots we can end up with some notes being emitted that interfere with the matches here. Filter the output to only include `->`/`<-` lines.

rdar://183972126