### PR TITLE
embedded: fix some problems with witness table specialization for opaque result types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -706,6 +706,10 @@ extension FunctionWorklist {
                                                      visited: inout Set<Conformance>,
                                                      _ context: ModulePassContext)
   {
+    // If an associated type is an opaque result type the conformance is abstract. The witness
+    // methods of the underlying type's conformance still need to be optimized, because IRGen
+    // looks through the opaque type when it emits the witness table entry.
+    let conformance = conformance.lookingThroughOpaqueTypes(context)
     guard conformance.isConcrete,
           visited.insert(conformance).inserted
     else {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -282,8 +282,12 @@ func specializeWitnessTable(for conformance: Conformance, _ context: ModulePassC
       //       let concreteAssociateConf = assocConf.subst(with: conformance.specializedSubstitutions)
       let concreteAssociateConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.rawType,
                                                                        to: assocConf.protocol)
-      if concreteAssociateConf.isSpecialized {
-        specializeWitnessTable(for: concreteAssociateConf, context)
+      // The associated conformance is abstract if the associated type is an opaque result
+      // type. Keep the abstract conformance in the entry - IRGen looks through the opaque
+      // type - but make sure the underlying type's witness table exists.
+      let underlyingConf = concreteAssociateConf.lookingThroughOpaqueTypes(context)
+      if underlyingConf.isConcrete, underlyingConf.isSpecialized {
+        specializeWitnessTable(for: underlyingConf, context)
       }
       return .associatedConformance(requirement: requirement,
                                     witness: concreteAssociateConf)
@@ -302,7 +306,8 @@ private func specializeDefaultMethods(for conformance: Conformance,
                                       _ context: ModulePassContext)
 {
   // Avoid infinite recursion, which may happen if an associated conformance is the conformance itself.
-  guard visited.insert(conformance).inserted,
+  guard conformance.isConcrete,
+        visited.insert(conformance).inserted,
         let witnessTable = context.lookupWitnessTable(for: conformance.rootConformance)
   else {
     return
@@ -336,13 +341,17 @@ private func specializeDefaultMethods(for conformance: Conformance,
       }
       specialized = true
       return .method(requirement: requirement, witness: specializedMethod)
-    case .baseProtocol(_, let witness):
-      specializeDefaultMethods(for: witness, visited: &visited, context)
+    case .baseProtocol(let requirement, _):
+      let baseConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.selfInterfaceType,
+                                                          to: requirement)
+      specializeNestedConformance(baseConf, visited: &visited, context)
       return origEntry
     case .associatedType:
       return origEntry
-    case .associatedConformance(_, let assocConf):
-      specializeDefaultMethods(for: assocConf, visited: &visited, context)
+    case .associatedConformance(let requirement, let assocConf):
+      let concreteAssocConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.rawType,
+                                                                   to: assocConf.protocol)
+      specializeNestedConformance(concreteAssocConf, visited: &visited, context)
       return origEntry
     }
   }
@@ -351,6 +360,42 @@ private func specializeDefaultMethods(for conformance: Conformance,
   if specialized {
     context.createSpecializedWitnessTable(entries: newEntries,conformance: conformance,
                                           linkage: .shared, serialized: false)
+  }
+}
+
+/// Handles a base-protocol or associated conformance of a non-generic witness table.
+///
+/// If the nested conformance is specialized it needs a specialized witness table: in Embedded
+/// Swift such a witness table entry directly points to the witness table of the nested
+/// conformance. Nothing else creates it, because the outer conformance is not specialized.
+private func specializeNestedConformance(_ conformance: Conformance,
+                                         visited: inout Set<Conformance>,
+                                         _ context: ModulePassContext)
+{
+  // If the associated type is an opaque result type the conformance is abstract. The witness
+  // table of the opaque type's underlying type is still needed, because IRGen looks through
+  // the opaque type when it emits the entry.
+  let conformance = conformance.lookingThroughOpaqueTypes(context)
+  guard conformance.isConcrete else {
+    return
+  }
+  let baseConf = conformance.isInherited ? conformance.inheritedConformance : conformance
+  if baseConf.isSpecialized {
+    specializeWitnessTable(for: conformance, context)
+  } else {
+    specializeDefaultMethods(for: conformance, visited: &visited, context)
+  }
+}
+
+extension Conformance {
+  /// If an associated type is an opaque result type, the associated conformance is abstract.
+  /// In that case return the concrete conformance of the opaque type's underlying type, which
+  /// is always known in Embedded Swift.
+  func lookingThroughOpaqueTypes(_ context: ModulePassContext) -> Conformance {
+    if isConcrete {
+      return self
+    }
+    return context.substituteOpaqueTypes(in: self)
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -106,6 +106,15 @@ extension Context {
     return _bridged.lookupWitnessTable(conformance.bridged).witnessTable
   }
 
+  /// Replaces opaque result types in `conformance` with their underlying types.
+  ///
+  /// If an associated type is an opaque result type, the associated conformance is abstract.
+  /// This returns the concrete conformance of the opaque type's underlying type - if it is
+  /// known in the current type expansion context.
+  public func substituteOpaqueTypes(in conformance: Conformance) -> Conformance {
+    return _bridged.substOpaqueTypesWithUnderlyingTypes(conformance.bridged).conformance
+  }
+
   public func lookupVTable(for classDecl: NominalTypeDecl) -> VTable? {
     return _bridged.lookupVTable(classDecl.bridged).vTable
   }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1647,6 +1647,8 @@ struct BridgedContext {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue getSILUndef(BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   OptionalBridgedWitnessTable lookupWitnessTable(BridgedConformance conformance) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
+  BridgedConformance substOpaqueTypesWithUnderlyingTypes(BridgedConformance conformance) const;
   BRIDGED_INLINE bool calleesAreStaticallyKnowable(BridgedDeclRef method) const;
 
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -3616,6 +3616,12 @@ OptionalBridgedWitnessTable BridgedContext::lookupWitnessTable(BridgedConformanc
   return {context->getModule()->lookUpWitnessTable(ref.getConcrete())};
 }
 
+BridgedConformance BridgedContext::substOpaqueTypesWithUnderlyingTypes(BridgedConformance conformance) const {
+  swift::SILModule *mod = context->getModule();
+  return {swift::substOpaqueTypesWithUnderlyingTypes(conformance.unbridged(),
+                                                     mod->getMaximalTypeExpansionContext())};
+}
+
 bool BridgedContext::calleesAreStaticallyKnowable(BridgedDeclRef method) const {
   return swift::calleesAreStaticallyKnowable(*context->getModule(), method.unbridged());
 }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1210,6 +1210,13 @@ static bool hasConditionalConformances(IRGenModule &IGM,
 /// tables to be dependently-generated?
 bool IRGenModule::isDependentConformance(
     const RootProtocolConformance *conformance) {
+  // A dependent conformance requires its witness table to be instantiated at runtime.
+  // This is not possible in Embedded Swift, which has no such runtime. It's also not
+  // needed: the mandatory pipeline specializes all witness tables, so that every
+  // conformance which is used at runtime is fully concrete.
+  if (Context.LangOpts.hasFeature(Feature::Embedded))
+    return false;
+
   llvm::SmallPtrSet<const NormalProtocolConformance *, 4> visited;
   return ::isDependentConformance(
       *this, conformance,
@@ -1772,8 +1779,12 @@ static bool isSpecializedConformance(ProtocolConformance *c) {
 
       if (IGM.isEmbeddedWithExistentials()) {
         // In Embedded Swift associated type witness point to the metadata.
-        llvm::Constant *witnessEntry = IGM.getAddrOfTypeMetadata(
-          typeWitness->getCanonicalType());
+        // The type witness can be an opaque result type, which has no metadata of its
+        // own. Its underlying type is always known in Embedded Swift.
+        CanType canTypeWitness = typeWitness->getCanonicalType();
+        if (canTypeWitness->hasOpaqueArchetype())
+          canTypeWitness = IGM.substOpaqueTypesWithUnderlyingTypes(canTypeWitness);
+        llvm::Constant *witnessEntry = IGM.getAddrOfTypeMetadata(canTypeWitness);
         auto &schema = IGM.getOptions().PointerAuth
                           .ProtocolAssociatedTypeAccessFunctions;
         Table.addSignedPointer(witnessEntry, schema, assocType);
@@ -1843,7 +1854,15 @@ static bool isSpecializedConformance(ProtocolConformance *c) {
       if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
         // In Embedded Swift associated-conformance entries simply point to the witness table
         // of the associated conformance.
-        ProtocolConformance *assocConf = associatedWitness.Witness.getConcrete();
+        ProtocolConformanceRef assocConfRef = associatedWitness.Witness;
+        // An associated type which is an opaque result type has an abstract conformance.
+        // In Embedded Swift the underlying type of an opaque type is always known, so
+        // replace the opaque type to get the concrete conformance.
+        if (assocConfRef.isAbstract() &&
+            assocConfRef.getType()->hasOpaqueArchetype()) {
+          assocConfRef = IGM.substOpaqueTypesWithUnderlyingTypes(assocConfRef);
+        }
+        ProtocolConformance *assocConf = assocConfRef.getConcrete();
         llvm::Constant *witnessEntry = IGM.getAddrOfWitnessTable(assocConf);
         auto &schema = IGM.getOptions().PointerAuth
                           .ProtocolAssociatedTypeWitnessTableAccessFunctions;

--- a/test/embedded/nested-opaque-associated-conformance.swift
+++ b/test/embedded/nested-opaque-associated-conformance.swift
@@ -1,0 +1,79 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -Onone -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: OS=macosx
+
+// A conformance whose associated type is an opaque result type of a generic type looks
+// "dependent" to IRGen, which would need to instantiate the witness table at runtime.
+// That's not possible in Embedded Swift - and not needed, because the mandatory pipeline
+// specializes all witness tables.
+
+protocol R {
+  func r()
+}
+
+struct PlainR: R {
+  func r() { print("PlainR.r") }
+}
+
+struct WrapperR<T>: R {
+  var t: T
+  func r() { print("WrapperR.r") }
+}
+
+protocol Q {
+  associatedtype B: R
+  func makeB() -> B
+}
+
+// The nested opaque type does not depend on `T`.
+struct IndependentQ<T>: Q {
+  func makeB() -> some R { PlainR() }
+}
+
+// The nested opaque type depends on `T`.
+struct DependentQ<T>: Q {
+  var t: T
+  func makeB() -> some R { WrapperR(t: t) }
+}
+
+protocol P: AnyObject {
+  associatedtype A: Q
+  func make() -> A
+}
+
+final class C1: P {
+  func make() -> some Q { IndependentQ<Int>() }
+}
+
+final class C2: P {
+  func make() -> some Q { DependentQ(t: 27) }
+}
+
+final class C3<T>: P {
+  var t: T
+  init(t: T) { self.t = t }
+  func make() -> some Q { DependentQ(t: t) }
+}
+
+@inline(never)
+func callThroughExistential(_ p: any P) {
+  p.make().makeB().r()
+}
+
+@main
+struct Main {
+  static func main() {
+    // CHECK: PlainR.r
+    callThroughExistential(C1())
+    // CHECK: WrapperR.r
+    callThroughExistential(C2())
+    // CHECK: WrapperR.r
+    callThroughExistential(C3(t: true))
+  }
+}

--- a/test/embedded/opaque-associated-conformance-exec.swift
+++ b/test/embedded/opaque-associated-conformance-exec.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -Onone -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: OS=macosx
+
+// If an associated type is an opaque result type, the associated conformance is abstract.
+// In Embedded Swift the underlying type is always known, so both the witness table
+// specialization and IRGen have to look through the opaque type.
+
+protocol Q {
+  func q()
+}
+
+struct PlainQ: Q {
+  func q() { print("PlainQ.q") }
+}
+
+struct GenericQ<T>: Q {
+  var t: T
+  func q() { print("GenericQ.q") }
+}
+
+protocol P: AnyObject {
+  associatedtype A: Q
+  func make() -> A
+}
+
+// The underlying type of the opaque type is not generic.
+final class OpaquePlain: P {
+  func make() -> some Q { PlainQ() }
+}
+
+// The underlying type of the opaque type is generic, so it needs a specialized witness
+// table which nothing else creates.
+final class OpaqueGeneric: P {
+  func make() -> some Q { GenericQ(t: 27) }
+}
+
+// The same, from a generic class.
+final class OpaqueFromGenericClass<T>: P {
+  var t: T
+  init(t: T) { self.t = t }
+  func make() -> some Q { GenericQ(t: t) }
+}
+
+@inline(never)
+func callThroughExistential(_ p: any P) {
+  p.make().q()
+}
+
+@main
+struct Main {
+  static func main() {
+    // CHECK: PlainQ.q
+    callThroughExistential(OpaquePlain())
+    // CHECK: GenericQ.q
+    callThroughExistential(OpaqueGeneric())
+    // CHECK: GenericQ.q
+    callThroughExistential(OpaqueFromGenericClass(t: true))
+  }
+}

--- a/test/embedded/opaque-associated-conformance-irgen.swift
+++ b/test/embedded/opaque-associated-conformance-irgen.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -module-name test | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+// Check that IRGen looks through opaque result types when it emits the
+// associated-conformance entry of a witness table. In Embedded Swift such an entry
+// directly points to the witness table of the associated conformance, so the abstract
+// conformance of an opaque type has to be resolved to its underlying type.
+
+public protocol R {
+  func r()
+}
+
+struct TheR: R {
+  func r() {}
+}
+
+public protocol Q {
+  associatedtype B: R
+  func q()
+  func makeR() -> B
+}
+
+struct SomeQ: Q {
+  func q() {}
+  func makeR() -> some R { TheR() }
+}
+
+public protocol P: AnyObject {
+  associatedtype A: Q
+  func make() -> A
+}
+
+public final class C: P {
+  public func make() -> some Q { SomeQ() }
+}
+
+public func createExistential() -> any P {
+  return C()
+}
+
+// Both associated-conformance entries are resolved through an opaque type:
+// `C.A` -> `SomeQ` and `SomeQ.B` -> `TheR`.
+
+// CHECK-DAG: @"$e4test4TheRVAA1RAAWP" = {{.*}}[2 x ptr] [ptr null, ptr @"$e4test4TheRVAA1RA2aDP1ryyFTW"]
+// CHECK-DAG: @"$e4test5SomeQVAA1QAAWP" = {{.*}}[5 x ptr] [ptr null, ptr @"$e4test4TheRVAA1RAAWP",
+// CHECK-DAG: @"$e4test1CCAA1PAAWP" = {{.*}}[4 x ptr] [ptr null, ptr @"$e4test5SomeQVAA1QAAWP",

--- a/test/embedded/opaque-associated-conformance.swift
+++ b/test/embedded/opaque-associated-conformance.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -wmo -module-name test | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+// If an associated type is an opaque result type, the associated conformance is
+// abstract. Witness table specialization in the mandatory pipeline must not treat such
+// a conformance as concrete.
+
+public protocol Q {
+  func g()
+}
+
+struct SomeQ: Q {
+  func g() {}
+}
+
+public protocol P: AnyObject {
+  associatedtype A: Q
+  func make() -> A
+}
+
+public protocol P2: P {}
+
+public final class GenericClass<T>: P2 {
+  public func make() -> some Q { SomeQ() }
+}
+
+public final class NonGenericClass: P2 {
+  public func make() -> some Q { SomeQ() }
+}
+
+public func testGeneric() -> any P2 {
+  return GenericClass<Int>()
+}
+
+public func testNonGeneric() -> any P2 {
+  return NonGenericClass()
+}
+
+// The specialized witness table is created and keeps the abstract associated conformance
+// of the opaque type. IRGen resolves it to the underlying type's conformance.
+
+// CHECK-LABEL: sil_witness_table shared [specialized] GenericClass<Int>: specialize <Int> (<T> GenericClass<T>: P module test) {
+// CHECK-NEXT:    associated_conformance (A: Q): dependent @_opaqueReturnTypeOf("$e4test12GenericClassC4makeQryF", 0) __<Int>
+// CHECK-NEXT:    associated_type A: @_opaqueReturnTypeOf("$e4test12GenericClassC4makeQryF", 0) __<Int>
+// CHECK-NEXT:    method #P.make{{.*}}: @$e4test12GenericClassCyxGAA1PA2aEP4make1AQzyFTWSi_Tgq5
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_witness_table shared [specialized] GenericClass<Int>: specialize <Int> (<T> GenericClass<T>: P2 module test) {
+// CHECK-NEXT:    base_protocol P: GenericClass<Int>: specialize <Int> (<T> GenericClass<T>: P module test)
+// CHECK-NEXT:  }

--- a/test/embedded/specialized-associated-conformance.swift
+++ b/test/embedded/specialized-associated-conformance.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -Onone -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: OS=macosx
+
+// A witness table which is not specialized itself can still have a specialized associated
+// conformance. In Embedded Swift the associated-conformance entry directly points to the
+// witness table of that conformance, so it has to be specialized here - nothing else does
+// it, because the outer conformance is not specialized.
+
+protocol Q {
+  func q()
+}
+
+struct GenericQ<T>: Q {
+  var t: T
+  func q() { print("GenericQ.q") }
+}
+
+protocol P: AnyObject {
+  associatedtype A: Q
+  func make() -> A
+}
+
+final class NonGenericClass: P {
+  func make() -> GenericQ<Int> { GenericQ(t: 27) }
+}
+
+// The same via a base protocol, so that the base-protocol entry is covered, too.
+protocol P2: P {}
+
+final class ViaBaseProtocol: P2 {
+  func make() -> GenericQ<Bool> { GenericQ(t: true) }
+}
+
+@inline(never)
+func callThroughExistential(_ p: any P) {
+  p.make().q()
+}
+
+@main
+struct Main {
+  static func main() {
+    // CHECK: GenericQ.q
+    callThroughExistential(NonGenericClass())
+    // CHECK: GenericQ.q
+    callThroughExistential(ViaBaseProtocol())
+  }
+}


### PR DESCRIPTION
* If an associated type is an opaque result type, the associated conformance is
  abstract. Treating it as concrete crashed the compiler with an assert in
  `Conformance.isSpecialized`.

* A witness table which is not specialized itself can still have a specialized
  associated (or base protocol) conformance. Nothing created its specialized witness
  table, which resulted in an undefined symbol at link time.

* The witness methods of an opaque type's underlying conformance were not added to the
  function worklist, so they were not specialized.

* IRGen: if an associated type is an opaque result type, the associated conformance is abstract
and the type witness has no metadata of its own. In Embedded Swift the underlying type
is always known, so look through the opaque type when emitting both entries.

* IRGen: a conformance is never dependent in Embedded Swift: a dependent conformance
requires its witness table to be instantiated at runtime, which is not possible without
a runtime - and not needed, because the mandatory pipeline specializes all witness
tables. Without this, an opaque associated type of a generic type made the conformance
look dependent, resulting in an undefined `swift_getWitnessTable` at link time.

rdar://186615041