### PR TITLE
[Windows] Stage GNU make for the lldb suites even with -Toolchain:$false

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1772,10 +1772,6 @@ function Get-Dependencies {
       Write-Success "WiX $($WiX.Version)"
     }
 
-    if (-not $Toolchain) { return }
-
-    DownloadAndVerify $PinnedBuild "$ArtifactCache\$PinnedToolchain.exe" $PinnedSHA256
-
     if ($Test -contains "lldb" -or $Test -contains "lldb-swift") {
       # The make tool isn't part of MSYS
       $GnuWin32MakeURL = "https://downloads.sourceforge.net/project/ezwinports/make-4.4.1-without-guile-w32-bin.zip"
@@ -1784,6 +1780,10 @@ function Get-Dependencies {
       Expand-ArtifactZip GnuWin32Make-4.4.1.zip GnuWin32Make-4.4.1
       Write-Success "GNUWin32 make 4.4.1"
     }
+
+    if (-not $Toolchain) { return }
+
+    DownloadAndVerify $PinnedBuild "$ArtifactCache\$PinnedToolchain.exe" $PinnedSHA256
 
     $ToolchainArtifact = "$ToolchainVersionIdentifier-$($BuildArchName.ToLowerInvariant())"
     Invoke-WithArtifactLock "SwiftToolchainExtraction" {


### PR DESCRIPTION
`Get-Dependencies` stages GNU make only for `-Test lldb`/`lldb-swift`, but that block sits after `if (-not $Toolchain) { return }`. Running the tests without rebuilding the toolchain - the documented `-Toolchain:$false -Test lldb-swift` combination - therefore never fetches it, and every API test fails to build its inferior:

```
File "...\subprocess.py", line 1435, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args, ...)
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

Move the staging above the toolchain early return.