### PR TITLE
Give Clang scanning workers the ClangImporter file system

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1080,6 +1080,11 @@ class SwiftDependencyScanningService {
   mutable llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
 
 public:
+  /// Builds the file system handed to each Clang scanning worker. Set by the
+  /// scanner so that workers see the ClangImporter's in-memory overlays.
+  std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()>
+      MakeScannerFileSystem;
+
   SwiftDependencyScanningService();
   SwiftDependencyScanningService(const SwiftDependencyScanningService &) =
       delete;

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -24,6 +24,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Strings.h"
 #include "clang/Lex/HeaderSearchOptions.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/Path.h"
@@ -543,12 +544,20 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
   // optimization. Clang needs to communicate with the build system to handle
   // the optimization safely. Swift can handle the working directory
   // optimizaiton already so it is safe to turn on all optimizations.
-  opts.OptimizeArgs = clang::dependencies::ScanningOptimizations::All;
+  // Not VFS: MakeVFS below substitutes the scanner's filesystem, so clang's VFS
+  // usage tracking no longer matches the invocation's -ivfsoverlay list.
+  opts.OptimizeArgs = static_cast<clang::dependencies::ScanningOptimizations>(
+      llvm::to_underlying(clang::dependencies::ScanningOptimizations::All) &
+      ~llvm::to_underlying(clang::dependencies::ScanningOptimizations::VFS));
   // The Swift scanner relies on the set of Clang modules visible from each
   // by-name module lookup to resolve Swift overlay and cross-import overlay
   // dependencies, so opt into having Clang report them.
   opts.ReportVisibleModules = true;
-  opts.MakeVFS = [] { return llvm::vfs::createPhysicalFileSystem(); };
+  opts.MakeVFS = [this]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+    if (MakeScannerFileSystem)
+      return MakeScannerFileSystem();
+    return llvm::vfs::createPhysicalFileSystem();
+  };
 
   ClangScanningService.emplace(std::move(opts));
 }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -212,6 +212,19 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
       CAS(CAS), ActionCache(ActionCache),
       diagnosticReporter(DiagnosticReporter),
       ShareClangCompilerInstance(ShareClangCompilerInstance) {
+  // Clang scanning workers get a physical file system by default, which lacks
+  // the files the ClangImporter injects in memory: the platform module maps,
+  // and the empty stubs standing in for headers the toolchain does not ship.
+  if (!globalScanningService.MakeScannerFileSystem) {
+    auto mapping = std::make_shared<ClangInvocationFileMapping>(
+        getClangInvocationFileMapping(ScanASTContext));
+    auto recipe =
+        ClangImporter::computeClangImporterVFSRecipe(ScanASTContext, *mapping);
+    globalScanningService.MakeScannerFileSystem = [mapping, recipe]() {
+      return ClangImporter::computeClangImporterFileSystem(
+          recipe, llvm::vfs::createPhysicalFileSystem());
+    };
+  }
   assert(globalScanningService.ClangScanningService->getCAS() == CAS &&
          "Need to be the same CAS instance");
   assert(globalScanningService.ClangScanningService->getActionCache() ==


### PR DESCRIPTION
Building Runtimes/Overlay on Windows with a VS toolset older than 17.13:

```
error: clang dependency scanning failure: .../vcruntime.modulemap:787:14: error: header '__msvc_ostream.hpp' not found
Z:\module-include.input:1:1: fatal error: could not build module 'std'
```

`vcruntime.modulemap` names `__msvc_ostream.hpp` unconditionally. That is meant to be fine. But the stubs live in the ClangImporter's in-memory VFS, and the dependency scanner never sees them.

# Why this is rebranch-only

main built the importer file system per worker and passed it to the scanning tool (getClangScanningFS). The LLVM rebase removed DependencyScanningTool's VFS parameter in favour of `DependencyScanningServiceOptions::MakeVFS`, and only half of `getClangScanningFS` came back: the CAS service got the importer file system, the non-CAS service got createPhysicalFileSystem(). Runtimes/Overlay uses -explicit-module-build without CAS.

Fix: a `MakeScannerFileSystem` hook on SwiftDependencyScanningService that MakeVFS consults, populated by the first ModuleDependencyScanningWorker.

# Trade-offs

Drops `ScanningOptimizations::VFS`. Substituting the file system desynchronizes Clang's VFS-usage tracking from the invocation's `-ivfsoverlay` list and trips the assert at `HeaderSearch.cpp:166`. That optimization prunes unused -`ivfsoverlay` arguments from reported module commands; without it those commands keep unused overlays, so they canonicalize less and modules differing only in unused overlays get separate PCMs. Not a correctness change. Small here (one or two overlays), larger for projects with many. main kept All because it substituted at tool construction, not via MakeVFS, the assert comes with the API change, not this patch. The proper fix is making the optimization aware of a substituted file system, which belongs in Clang and is well beyond unbreaking the build.

Lazy hook, not construction-time injection. ClangScanningService is emplaced before any worker or ASTContext exists, and MakeVFS runs per scan, so a std::function the first worker fills in suffices and keeps the service free of a ClangImporter include. Cost: a mutable public member whose contract lives in a comment.

# To reproduce

Toolset-independent reproducer: add a header that exists nowhere (`__msvc_bogus.hpp`) to both kInjectedHeaders and `vcruntime.modulemap`. main builds, rebranch fails to scan.