### PR TITLE
[AST] Correctly handle synthetic macros in `getUnexpandedMacroRange`

### DIFF
--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -174,11 +174,14 @@ SourceRange swift::getUnexpandedMacroRange(const SourceManager &SM,
             ASTNode::getFromOpaqueValue(info->astNode).getSourceRange();
       bufferID = SM.findBufferContainingLoc(outerRange.Start);
       continue;
+    case GeneratedSourceInfo::SyntheticMacro:
+      outerRange = SourceRange(info->originalSourceRange.getStart());
+      bufferID = SM.findBufferContainingLoc(outerRange.Start);
+      continue;
     case GeneratedSourceInfo::ReplacedFunctionBody:
     case GeneratedSourceInfo::PrettyPrinted:
     case GeneratedSourceInfo::DefaultArgument:
     case GeneratedSourceInfo::AttributeFromClang:
-    case GeneratedSourceInfo::SyntheticMacro:
       return SourceRange();
     }
   }


### PR DESCRIPTION
`getUnexpandedMacroRange` grouped `SyntheticMacro` buffers with the kinds that have no way back to real source, so it returned an empty range for them. 
It now returns the correct `originalSourceRange`