### PR TITLE
docs: update BuiltinBorrow instructions

### DIFF
--- a/docs/SIL/Instructions.md
+++ b/docs/SIL/Instructions.md
@@ -5824,15 +5824,19 @@ location.
 The result `%borrow` has a lifetime dependency on the borrow stored
 at the memory location `%target`.
 
-### dereference_addr_borrow
+### dereference_borrow_addr
 
 ```none
-sil-instruction ::= 'dereference_addr_borrow' sil-value
+sil-instruction ::= 'dereference_borrow_addr' sil-value
 
-%target: $*T = dereference_addr_borrow %borrow: $Builtin.Borrow<T>
+%target: $*T = dereference_borrow_addr %borrow: $*Builtin.Borrow<T>
 ```
 
 Returns the address of the value referenced by a `Builtin.Borrow`.
+
+It takes the borrow operand indirectly by address, by contrast
+with `dereference_addr_borrow` below, which projects an address
+from a borrow value.
 
 ### init_borrow_addr
 
@@ -5856,7 +5860,8 @@ sil-instruction ::= 'dereference_addr_borrow' sil-value
 %target: $*T = dereference_addr_borrow %borrow: $Builtin.Borrow<T>
 ```
 
-Returns the address of the value referenced by a `Builtin.Borrow` in memory.
+Returns the address of the value referenced by a `Builtin.Borrow`, projecting
+it from the borrow value directly rather than from a borrow in memory.
 
 
 ## Miscellaneous instructions


### PR DESCRIPTION
The documentation for `dereference_addr_borrow` and `dereference_borrow_addr` is misleading. This PR aims to rectify that.