### PR TITLE
[Do Not Merge] Re-create all debug instructions within salvageDebugInfo

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2209,6 +2209,16 @@ void swift::salvageDebugInfo(SILInstruction *I) {
   // Instructions with type dependent operands cannot be salvaged.
   if (I->getNumTypeDependentOperands() != 0)
     return;
+  
+  // TESTING: RECREATE DEBUG VALUES
+  if (auto *SVI = dyn_cast<SingleValueInstruction>(I)) {
+    llvm::SmallVector<Operand *> uses(getDebugUses(SVI));
+    for (auto *use : uses) {
+      auto *DVI = cast<DebugValueInst>(use->getUser());
+      DVI->clone(DVI);
+      DVI->eraseFromParent();
+    }
+  }
 
   if (auto *SI = dyn_cast<StoreInst>(I)) {
     if (SILValue DestVal = SI->getDest())

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -451,6 +451,10 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
   llvm::SmallPtrSet<SILInstruction *, 8> nextInsts;
   while (!deadInsts.empty()) {
     for (auto inst : deadInsts) {
+      // Salvaging debug info may delete and rewrite queued instructions.
+      if (inst->isDeleted())
+        continue;
+
       // Call the callback before we mutate the to be deleted instruction in any
       // way, and salvage debug info while it's meaningful.
       callbacks.notifyWillBeDeleted(inst);
@@ -482,6 +486,8 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
     }
 
     for (auto inst : deadInsts) {
+      if (inst->isDeleted())
+        continue;
       // This will remove this instruction and all its uses.
       eraseFromParentWithDebugInsts(inst, callbacks);
     }

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -442,13 +442,14 @@ void swift::eliminateDeadInstruction(SILInstruction *inst,
 void swift::recursivelyDeleteTriviallyDeadInstructions(
     ArrayRef<SILInstruction *> ia, bool force, InstModCallbacks callbacks) {
   // Delete these instruction and others that become dead after it's deleted.
-  llvm::SmallPtrSet<SILInstruction *, 8> deadInsts;
-  for (auto *inst : ia) {
+  llvm::SmallSetVector<SILInstruction *, 8> deadInsts;
+  // Salvage debug info needs reverse iteration to work.
+  for (auto *inst : llvm::reverse(ia)) {
     // If the instruction is not dead and force is false, do nothing.
     if (force || isInstructionTriviallyDead(inst))
       deadInsts.insert(inst);
   }
-  llvm::SmallPtrSet<SILInstruction *, 8> nextInsts;
+  llvm::SmallSetVector<SILInstruction *, 8> nextInsts;
   while (!deadInsts.empty()) {
     for (auto inst : deadInsts) {
       // Salvaging debug info may delete and rewrite queued instructions.

--- a/test/SILOptimizer/simplify_struct.sil
+++ b/test/SILOptimizer/simplify_struct.sil
@@ -14,10 +14,10 @@ struct Outer {
 
 // CHECK-LABEL: sil [ossa] @simple_delay_struct :
 // CHECK:       bb0
-// CHECK-NEXT:    debug_value %0, var, name "y", type $S, expr op_fragment:#S.a
-// CHECK-NEXT:    debug_value %1, var, name "y", type $S, expr op_fragment:#S.b
 // CHECK-NEXT:    debug_value %0, var, name "x", type $S, expr op_fragment:#S.a
 // CHECK-NEXT:    debug_value %1, var, name "x", type $S, expr op_fragment:#S.b
+// CHECK-NEXT:    debug_value %0, var, name "y", type $S, expr op_fragment:#S.a
+// CHECK-NEXT:    debug_value %1, var, name "y", type $S, expr op_fragment:#S.b
 // CHECK-NEXT:    [[B:%.*]] = begin_borrow %0
 // CHECK-NEXT:    fix_lifetime [[B]]
 // CHECK-NEXT:    fix_lifetime %1


### PR DESCRIPTION
PR for testing purposes only.
Checking for double deletes that might be caused by salvageDebugInfo if it starts deleting instructions