### PR TITLE
[Diagnostics] Fix unused variable fix-its for multi-condition statements

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4399,17 +4399,21 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
       //    if <expr> != nil {
       //
       if (auto SC = StmtConditionForVD[var]) {
-        // We only handle the "if let" case right now, since it is vastly the
-        // most common situation that people run into.
-        if (SC->getCond().size() == 1) {
-          auto pattern = SC->getCond()[0].getPattern();
+        bool handled = false;
+        for (const auto &cond : SC->getCond()) {
+          auto pattern = cond.getPattern();
+          if (!pattern || !pattern->containsVarDecl(var))
+            continue;
+
           if (auto OSP = dyn_cast<OptionalSomePattern>(pattern))
             if (auto LP = dyn_cast<BindingPattern>(OSP->getSubPattern()))
               if (isa<NamedPattern>(LP->getSubPattern())) {
-                auto initExpr = SC->getCond()[0].getInitializer();
+                auto initExpr = cond.getInitializer();
                 if (initExpr->getStartLoc().isValid()) {
-                  if (isUsedInInactive(var))
-                    continue;
+                  if (isUsedInInactive(var)) {
+                    handled = true;
+                    break;
+                  }
 
                   unsigned noParens = initExpr->canAppendPostfixExpression();
 
@@ -4443,7 +4447,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                   auto diagIF = Diags.diagnose(var->getLoc(),
                                                diag::pbd_never_used_stmtcond,
                                             var->getName());
-                  auto introducerLoc = SC->getCond()[0].getIntroducerLoc();
+                  auto introducerLoc = cond.getIntroducerLoc();
                   diagIF.fixItReplaceChars(introducerLoc,
                                            initExpr->getStartLoc(),
                                            &"("[noParens]);
@@ -4457,10 +4461,12 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                     diagIF.fixItInsertAfter(initExpr->getEndLoc(),
                                             &") != nil"[noParens]);
                   }
-                  continue;
+                  handled = true;
+                  break;
                 }
               }
         }
+        if (handled) continue;
       }
 
       // If the variable is defined in a pattern that isn't one of the usual

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -584,3 +584,13 @@ final class A {
 
  func f() {}
 }
+
+func issue89131() {
+  func sync() -> Int? { return nil }
+  
+  if let x = sync(), true {} 
+  // expected-warning@-1 {{value 'x' was defined but never used; consider replacing with boolean test}}
+  
+  if true, let x = sync() {} 
+  // expected-warning@-1 {{value 'x' was defined but never used; consider replacing with boolean test}}
+}


### PR DESCRIPTION
## Summary
Fixes missing boolean fix-its for unused optional bindings in multi-condition statements.

## Motivation
Previously, the diagnostics assumed an `if let` statement had only one condition when checking for unused bindings. Because of this, it would emit a generic `variable_never_used` warning for statements like `if let x = sync(), true` and suggest replacing `x` with `_`, instead of substituting the binding with a `!= nil` boolean check. This generalizes the logic to iterate through all condition elements, properly locating the binding.

## Implementation
Removed the hardcoded `SC->getCond().size() == 1` check in `lib/Sema/MiscDiagnostics.cpp`. We now iterate through all condition elements, check if the element's pattern defines the unused variable using `containsVarDecl(var)`, and correctly emit `pbd_never_used_stmtcond` for it.

## Testing
Added multi-condition unused optional binding tests to `test/decl/var/usage.swift` to verify the diagnostic message.

Resolves #89131.
