### PR TITLE
[Sema] Reject \isolated\ keyword in inheritance clauses

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5749,10 +5749,9 @@ TypeResolver::resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
 NeverNullType
 TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
                                       TypeResolutionOptions options) {
-  // isolated is only value for non-EnumCaseDecl parameters.
-  if ((!options.is(TypeResolverContext::FunctionInput) ||
-       options.hasBase(TypeResolverContext::EnumElementDecl)) &&
-      !options.is(TypeResolverContext::Inherited)) {
+  // isolated is only valid for non-EnumCaseDecl parameters.
+  if (!options.is(TypeResolverContext::FunctionInput) ||
+      options.hasBase(TypeResolverContext::EnumElementDecl)) {
     diagnoseInvalid(
         repr, repr->getSpecifierLoc(), diag::attr_only_on_parameters,
         "isolated");

--- a/test/Concurrency/issue_83538.swift
+++ b/test/Concurrency/issue_83538.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+protocol P {}
+struct S: isolated P {} // expected-error {{'isolated' may only be used on parameters}}


### PR DESCRIPTION
## Summary
Properly rejects the `isolated` keyword in inheritance clauses, fixing an oversight where it was incorrectly permitted.

## Motivation
Previously, `struct S: isolated P {}` would compile without errors because the compiler had a specific exception allowing the `isolated` keyword in inheritance contexts. This exception was likely left over from early SE-0470 proposals before `isolated` conformances were changed to be inferred or explicit `nonisolated` conformances via `nonisolated P`.

## Implementation
Removed the `options.is(TypeResolverContext::Inherited)` exception in `lib/Sema/TypeCheckType.cpp`'s `resolveIsolatedTypeRepr`. Now, using `isolated` in an inheritance clause correctly emits the `attr_only_on_parameters` diagnostic.

## Testing
Added a negative test case in `test/Concurrency/issue_83538.swift` to verify the diagnostic.

Resolves #83538.
