### PR TITLE
[rebranch] [ClangImporter] Make ObjC types visible from redeclaring modules

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3512,8 +3512,10 @@ static bool isVisibleFromModule(const ClangModuleUnit *ModuleFilter,
 
   // Handle redeclarable Clang decls by checking each redeclaration.
   bool IsTagDecl = isa<clang::TagDecl>(D);
-  if (!(IsTagDecl || isa<clang::FunctionDecl, clang::VarDecl,
-                         clang::TypedefNameDecl, clang::NamespaceDecl>(D))) {
+  if (!(IsTagDecl ||
+        isa<clang::FunctionDecl, clang::VarDecl, clang::TypedefNameDecl,
+            clang::NamespaceDecl, clang::ObjCInterfaceDecl,
+            clang::ObjCProtocolDecl>(D))) {
     return false;
   }
 
@@ -3527,6 +3529,17 @@ static bool isVisibleFromModule(const ClangModuleUnit *ModuleFilter,
       auto TD = cast<clang::TagDecl>(Redeclaration);
       if (!TD->isCompleteDefinition() &&
           !TD->isThisDeclarationADemotedDefinition())
+        continue;
+    } else if (auto *OCD = dyn_cast<clang::ObjCContainerDecl>(Redeclaration)) {
+      // Likewise for ObjC interfaces and protocols. We're hampered here by the
+      // lack of a straightforward way to check whether the declaration had a
+      // body: `isThisDeclarationADefinition()` only returns true for the one
+      // specific decl that should be used as the definition, and there is
+      // nothing like `isThisDeclarationADemotedDefinition()` for ObjC type
+      // decls. Checking the source location of the `@end` keyword is hacky but
+      // I haven't found a better option.
+      if (!OCD->getAtEndRange().isValid() ||
+          OCD->getAtEndRange().getBegin() == OCD->getLocation())
         continue;
     }
 

--- a/test/ClangImporter/Inputs/objc_protocol_module_visibility/ModuleA.framework/Headers/ModuleA.h
+++ b/test/ClangImporter/Inputs/objc_protocol_module_visibility/ModuleA.framework/Headers/ModuleA.h
@@ -1,0 +1,11 @@
+#import <objc/NSObject.h>
+
+@protocol RedeclaredInModuleA <NSObject>
+@end
+
+@protocol ForwardRedeclaredInModuleA;
+
+@interface RedeclaredClassInModuleA : NSObject
+@end
+
+@class ForwardRedeclaredClassInModuleA;

--- a/test/ClangImporter/Inputs/objc_protocol_module_visibility/ModuleA.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/objc_protocol_module_visibility/ModuleA.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module ModuleA {
+  umbrella header "ModuleA.h"
+  export *
+}

--- a/test/ClangImporter/Inputs/objc_protocol_module_visibility/bridging.h
+++ b/test/ClangImporter/Inputs/objc_protocol_module_visibility/bridging.h
@@ -1,0 +1,15 @@
+#import <objc/NSObject.h>
+
+@protocol RedeclaredInModuleA <NSObject>
+@end
+
+@protocol ForwardRedeclaredInModuleA <NSObject>
+@end
+
+@interface RedeclaredClassInModuleA : NSObject
+@end
+
+@interface ForwardRedeclaredClassInModuleA : NSObject
+@end
+
+@import ModuleA;

--- a/test/ClangImporter/objc_protocol_module_visibility.swift
+++ b/test/ClangImporter/objc_protocol_module_visibility.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -verify -F %S/Inputs/objc_protocol_module_visibility -import-objc-header %S/Inputs/objc_protocol_module_visibility/bridging.h %s
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-pch -F %S/Inputs/objc_protocol_module_visibility -o %t.pch %S/Inputs/objc_protocol_module_visibility/bridging.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -verify -F %S/Inputs/objc_protocol_module_visibility -import-pch %t.pch %s
+
+// REQUIRES: objc_interop
+
+// An ObjC protocol or class redeclared both non-modularly (via the bridging
+// header) and inside a real framework module must still be found by a
+// module-qualified lookup into that framework, unless it is a forward
+// declaration.
+
+import ModuleA
+
+typealias X = ModuleA.RedeclaredInModuleA
+typealias Y = ModuleA.ForwardRedeclaredInModuleA // expected-error {{no type named 'ForwardRedeclaredInModuleA' in module 'ModuleA'}}
+
+typealias Z = ModuleA.RedeclaredClassInModuleA
+typealias W = ModuleA.ForwardRedeclaredClassInModuleA // expected-error {{no type named 'ForwardRedeclaredClassInModuleA' in module 'ModuleA'}}


### PR DESCRIPTION
Clang changes introduced during rebranch are sometimes causing the bridging header to “steal” types from their proper modules, which causes cross-references to not be resolved during deserialization. (I haven’t tracked down the precise cause, but it seems to have something to do with redeclarations; there have been a lot of subtle breaking changes to that in this rebranch.)

Adjust how `ClangModuleUnit::lookupValue()` computes visibility to ensure that ObjC protocols and classes, like many other clang declarations, are treated as visible in all modules that redeclare them, not just the one module whose declaration reached importDecl() first and therefore got cached.

Fixes rdar://185737901.

(**Note**: This feels a little risky since it makes types visible from more modules than before, but I haven't found a more conservative fix.)