### PR TITLE
[DependencyScan] Give the Clang scanner ClangImporter's in-memory files

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1072,7 +1072,10 @@ class SwiftDependencyScanningService {
   /// The CAS configuration created the Scanning Service if used.
   std::optional<llvm::cas::CASConfiguration> CASConfig;
 
-  /// The persistent Clang dependency scanner service
+  /// The persistent Clang dependency scanner service.
+  ///
+  /// Created by the first scan (see \c setupDependencyScanningService), which
+  /// is also what lets this double as the "already configured" flag.
   std::optional<clang::dependencies::DependencyScanningService>
       ClangScanningService;
 
@@ -1080,24 +1083,48 @@ class SwiftDependencyScanningService {
   mutable llvm::sys::SmartMutex<true> ScanningServiceGlobalLock;
 
 public:
-  SwiftDependencyScanningService();
+  SwiftDependencyScanningService() : Alloc(), Saver(Alloc) {}
   SwiftDependencyScanningService(const SwiftDependencyScanningService &) =
       delete;
   SwiftDependencyScanningService &
   operator=(const SwiftDependencyScanningService &) = delete;
   virtual ~SwiftDependencyScanningService() {}
 
-  /// Setup caching service.
-  bool setupCachingDependencyScanningService(CompilerInstance &Instance);
+  /// Create the Clang dependency scanning service from \p Instance: the base
+  /// file system of its workers, and compiler caching if \p Instance requires
+  /// it.
+  ///
+  /// The service is created by the first scan and reused by every scan after
+  /// it, because re-creating it would drop its caches and dangle the references
+  /// held by an in-flight scan's workers. Creation must therefore happen before
+  /// any worker exists, which is why \c performModuleScan and
+  /// \c performModulePrescan call this before creating their
+  /// \c ModuleDependencyScanner; later calls are no-ops.
+  ///
+  /// \returns true if an error was diagnosed, which happens when \p Instance
+  /// asks for a CAS configuration the existing service cannot provide.
+  bool setupDependencyScanningService(CompilerInstance &Instance);
+
+  /// The CAS the Clang dependency scanning service was created with, or null if
+  /// it has not been created yet or does not use caching.
+  std::shared_ptr<llvm::cas::ObjectStore> getCAS() const {
+    return ClangScanningService ? ClangScanningService->getCAS() : nullptr;
+  }
+
+  /// The action cache the Clang dependency scanning service was created with,
+  /// or null if it has not been created yet or does not use caching.
+  std::shared_ptr<llvm::cas::ActionCache> getActionCache() const {
+    return ClangScanningService ? ClangScanningService->getActionCache()
+                                : nullptr;
+  }
 
   /// Allocate string inside ScanningService.
   StringRef save(StringRef str);
 
-  /// Get clang scanning service.
-  const clang::dependencies::DependencyScanningService &
-  getClangScanningService() const {
-    assert(ClangScanningService);
-    return *ClangScanningService;
+  /// Whether the Clang dependency scanning service has been created; see
+  /// \c setupDependencyScanningService.
+  bool hasClangScanningService() const {
+    return ClangScanningService.has_value();
   }
 
 private:

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -675,6 +675,15 @@ makeClangScanningVFSFactory(
 
 bool SwiftDependencyScanningService::setupDependencyScanningService(
     CompilerInstance &Instance) {
+  // Serialize the check-and-create below. Several scans can start concurrently
+  // on a fresh service, and creating the Clang scanning service twice would
+  // dangle the references held by the workers of whichever scan got there
+  // first.
+  //
+  // Note that this lock must stay recursive: \c save() takes it too, and is
+  // reached from \c makeClangScanningVFSFactory below.
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
+
   const auto &invocation = Instance.getInvocation();
 
   if (ClangScanningService) {

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/PluginLoader.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Strings.h"
 #include "clang/Lex/HeaderSearchOptions.h"
@@ -536,23 +537,6 @@ void ModuleDependencyInfo::setOutputPathAndHash(StringRef outputPath,
   }
 }
 
-SwiftDependencyScanningService::SwiftDependencyScanningService()
-    : Alloc(), Saver(Alloc) {
-  clang::dependencies::DependencyScanningServiceOptions opts;
-  // ScanningOptimizations::Default excludes the current working directory
-  // optimization. Clang needs to communicate with the build system to handle
-  // the optimization safely. Swift can handle the working directory
-  // optimizaiton already so it is safe to turn on all optimizations.
-  opts.OptimizeArgs = clang::dependencies::ScanningOptimizations::All;
-  // The Swift scanner relies on the set of Clang modules visible from each
-  // by-name module lookup to resolve Swift overlay and cross-import overlay
-  // dependencies, so opt into having Clang report them.
-  opts.ReportVisibleModules = true;
-  opts.MakeVFS = [] { return llvm::vfs::createPhysicalFileSystem(); };
-
-  ClangScanningService.emplace(std::move(opts));
-}
-
 bool
 swift::dependencies::checkImportNotTautological(const ImportPath::Module modulePath,
                                                 const SourceLoc importLoc,
@@ -655,70 +639,91 @@ swift::dependencies::registerBackDeployLibraries(
   #include "swift/Frontend/BackDeploymentLibs.def"
 }
 
-bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
-    CompilerInstance &Instance) {
-  if (!Instance.getInvocation().requiresCAS())
-    return false;
+/// Build the callback to install as
+/// \c DependencyScanningServiceOptions::MakeVFS, capturing a snapshot of the
+/// ClangImporter file system of \p ctx.
+///
+/// The Clang scanner command line refers to ClangImporter's in-memory files
+/// with plain '-ivfsoverlay' arguments -- notably the system VFS overlay on
+/// non-Darwin platforms. A worker that cannot see them ends up with fewer
+/// \c RedirectingFileSystem s than '-ivfsoverlay' options and trips an
+/// assertion in Clang's \c HeaderSearch::collectVFSUsageAndClear.
+static std::function<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>()>
+makeClangScanningVFSFactory(
+    const ASTContext &ctx, std::shared_ptr<llvm::cas::ObjectStore> cas,
+    llvm::function_ref<StringRef(StringRef)> allocateString) {
+  // Snapshot the ClangImporter file system into an owning recipe rather than
+  // capturing the ASTContext: the callback outlives the per-query
+  // CompilerInstance this came from. The overriden files' contents are
+  // allocated by \p allocateString for the same reason.
+  auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+  auto recipe = ClangImporter::computeClangImporterVFSRecipe(
+      ctx, importer->getClangFileMapping(), allocateString);
 
-  if (CASConfig) {
-    // If CASOption matches, the service is initialized already.
-    if (*CASConfig == Instance.getInvocation().getCASOptions().Config)
-      return false;
-
-    // CASOption mismatch, return error.
-    Instance.getDiags().diagnose(SourceLoc(), diag::error_cas_conflict_options);
-    return true;
-  }
-
-  // Setup CAS.
-  CASConfig = Instance.getInvocation().getCASOptions().Config;
-
-  clang::CASOptions CASOpts;
-  CASOpts.CASPath = CASConfig->CASPath;
-  CASOpts.PluginPath = CASConfig->PluginPath;
-  CASOpts.PluginOptions = CASConfig->PluginOptions;
-
-  {
-    clang::dependencies::DependencyScanningServiceOptions opts;
-    // The current working directory optimization (off by default) should not
-    // impact CAS. We set the optization to all to be consistent with the
-    // non-CAS case.
-    opts.OptimizeArgs = clang::dependencies::ScanningOptimizations::All;
-    // See the non-CAS case above.
-    opts.ReportVisibleModules = true;
-    opts.Compilation = clang::dependencies::IncludeTreeCompilation{
-        CASOpts, Instance.getSharedCASInstance(),
-        Instance.getSharedCacheInstance()};
-
-    // The base VFS is derived from the ClangImporter of the first invocation.
-    // This is usually fine since the base VFS should be the same for the same
-    // platform.
-    //
-    // Snapshot it into an owning recipe rather than capturing the ASTContext:
-    // the callback is owned by the scanning service and outlives this
-    // per-query CompilerInstance. Just as importantly, the callback must build a
-    // *separate* file system on every call -- the Clang scanner calls
+  return [recipe = std::move(recipe), cas = std::move(cas)]()
+             -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+    // Build a *separate* file system on every call: the Clang scanner calls
     // setCurrentWorkingDirectory on the file system it is handed, and several
     // workers do so concurrently (rdar://184810704).
-    auto &ctx = Instance.getASTContext();
-    auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-    auto recipe = ClangImporter::computeClangImporterVFSRecipe(
-        ctx, importer->getClangFileMapping(),
-        [&](StringRef str) { return save(str); });
-    auto cas = Instance.getSharedCASInstance();
+    auto fs = ClangImporter::computeClangImporterFileSystem(
+        recipe, llvm::vfs::createPhysicalFileSystem());
+    if (cas)
+      return llvm::cas::createCASProvidingFileSystem(cas, std::move(fs));
+    return fs;
+  };
+}
 
-    opts.MakeVFS = [recipe = std::move(recipe),
-                    cas]() -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
-      auto fs = ClangImporter::computeClangImporterFileSystem(
-          recipe, llvm::vfs::createPhysicalFileSystem());
-      if (cas)
-        return llvm::cas::createCASProvidingFileSystem(cas, std::move(fs));
-      return fs;
-    };
+bool SwiftDependencyScanningService::setupDependencyScanningService(
+    CompilerInstance &Instance) {
+  const auto &invocation = Instance.getInvocation();
 
-    ClangScanningService.emplace(std::move(opts));
+  if (ClangScanningService) {
+    // The service is reused as-is. Its base file system is not rebuilt, which
+    // is usually fine since it should be the same for the same platform, but a
+    // conflicting CAS configuration cannot be honored.
+    if (invocation.requiresCAS() &&
+        (!CASConfig || *CASConfig != invocation.getCASOptions().Config)) {
+      Instance.getDiags().diagnose(SourceLoc(),
+                                  diag::error_cas_conflict_options);
+      return true;
+    }
+    return false;
   }
 
+  clang::dependencies::DependencyScanningServiceOptions opts;
+  // ScanningOptimizations::Default excludes the current working directory
+  // optimization. Clang needs to communicate with the build system to handle
+  // the optimization safely. Swift can handle the working directory
+  // optimizaiton already so it is safe to turn on all optimizations. This also
+  // keeps the caching and non-caching cases consistent; the optimization should
+  // not impact CAS either way.
+  opts.OptimizeArgs = clang::dependencies::ScanningOptimizations::All;
+  // The Swift scanner relies on the set of Clang modules visible from each
+  // by-name module lookup to resolve Swift overlay and cross-import overlay
+  // dependencies, so opt into having Clang report them.
+  opts.ReportVisibleModules = true;
+
+  std::shared_ptr<llvm::cas::ObjectStore> cas;
+  if (invocation.requiresCAS()) {
+    CASConfig = invocation.getCASOptions().Config;
+
+    clang::CASOptions CASOpts;
+    CASOpts.CASPath = CASConfig->CASPath;
+    CASOpts.PluginPath = CASConfig->PluginPath;
+    CASOpts.PluginOptions = CASConfig->PluginOptions;
+
+    cas = Instance.getSharedCASInstance();
+    opts.Compilation = clang::dependencies::IncludeTreeCompilation{
+        CASOpts, cas, Instance.getSharedCacheInstance()};
+  }
+
+  // The base VFS is derived from the ClangImporter of this invocation, which is
+  // usually fine since it should be the same for the same platform.
+  opts.MakeVFS = makeClangScanningVFSFactory(
+      Instance.getASTContext(), std::move(cas),
+      [this](StringRef str) { return save(str); });
+
+  ClangScanningService.emplace(std::move(opts));
   return false;
 }
 

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -409,10 +409,6 @@ llvm::ErrorOr<ScanQueryContext> DependencyScanningTool::createScanQueryContext(
 
     Invocation->getFrontendOptions().LLVMArgs.clear();
 
-    // Setup the scanning service after the instance finishes setup.
-    if (ScanningService->setupDependencyScanningService(*Instance))
-      return std::make_error_code(std::errc::invalid_argument);
-
     (void)Instance->getMainModule();
   }
 

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -399,9 +399,8 @@ llvm::ErrorOr<ScanQueryContext> DependencyScanningTool::createScanQueryContext(
 
     // Setup the CAS instance from scanning service if applicable.
     if (Invocation->requiresCAS())
-      Instance->setSharedCASInstances(
-          ScanningService->getClangScanningService().getCAS(),
-          ScanningService->getClangScanningService().getActionCache());
+      Instance->setSharedCASInstances(ScanningService->getCAS(),
+                                      ScanningService->getActionCache());
 
     // Setup the instance
     std::string InstanceSetupError;
@@ -410,8 +409,8 @@ llvm::ErrorOr<ScanQueryContext> DependencyScanningTool::createScanQueryContext(
 
     Invocation->getFrontendOptions().LLVMArgs.clear();
 
-    // Setup the caching service after the instance finishes setup.
-    if (ScanningService->setupCachingDependencyScanningService(*Instance))
+    // Setup the scanning service after the instance finishes setup.
+    if (ScanningService->setupDependencyScanningService(*Instance))
       return std::make_error_code(std::errc::invalid_argument);
 
     (void)Instance->getMainModule();

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -561,6 +561,11 @@ llvm::ErrorOr<std::unique_ptr<ModuleDependencyScanner>>
 ModuleDependencyScanner::create(SwiftDependencyScanningService &service,
                                 CompilerInstance *instance,
                                 ModuleDependenciesCache &cache) {
+  // The workers created below build their file systems from the Clang scanning
+  // service, so it must exist by now.
+  assert(service.hasClangScanningService() &&
+         "dependency scanning service was not set up");
+
   auto scanner =
       std::unique_ptr<ModuleDependencyScanner>(new ModuleDependencyScanner(
           service, cache, instance->getInvocation(), instance->getSILOptions(),

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1394,6 +1394,11 @@ performModuleScanImpl(
     SwiftDependencyScanningService &service, CompilerInstance *instance,
     ModuleDependenciesCache &cache,
     DepScanInMemoryDiagnosticCollector *diagnosticCollector) {
+  // Configure the scanning service before creating the scanner, and therefore
+  // before any Clang scanning worker builds its file system.
+  if (service.setupDependencyScanningService(*instance))
+    return std::make_error_code(std::errc::invalid_argument);
+
   const ASTContext &ctx = instance->getASTContext();
   const FrontendOptions &opts = instance->getInvocation().getFrontendOptions();
   // Load the dependency cache if -reuse-dependency-scan-cache
@@ -1481,6 +1486,11 @@ static llvm::ErrorOr<swiftscan_import_set_t> performModulePrescanImpl(
     SwiftDependencyScanningService &service, CompilerInstance *instance,
     ModuleDependenciesCache &cache,
     DepScanInMemoryDiagnosticCollector *diagnosticCollector) {
+  // Configure the scanning service before creating the scanner, and therefore
+  // before any Clang scanning worker builds its file system.
+  if (service.setupDependencyScanningService(*instance))
+    return std::make_error_code(std::errc::invalid_argument);
+
   // Setup the scanner
   auto expectedScannerPtr =
       ModuleDependencyScanner::create(service, instance, cache);
@@ -1529,8 +1539,6 @@ bool swift::dependencies::scanDependencies(CompilerInstance &CI) {
       ctx.Allocate<SwiftDependencyScanningService>();
   ModuleDependenciesCache cache(CI.getMainModule()->getNameStr().str(),
                                 CI.getInvocation().getModuleScanningHash());
-  if (service->setupCachingDependencyScanningService(CI))
-    return true;
 
   // Execute scan
   llvm::ErrorOr<swiftscan_dependency_graph_t> dependenciesOrErr =

--- a/test/ScanDependencies/clang-system-vfs-overlay-in-scanner.swift
+++ b/test/ScanDependencies/clang-system-vfs-overlay-in-scanner.swift
@@ -1,0 +1,77 @@
+/// Regression test for the Clang dependency scanner losing ClangImporter's
+/// in-memory file system.
+///
+/// On non-Darwin targets `ClangImporter` injects a system VFS overlay
+/// (`<resource-dir>/<clang-system-vfs-overlay>`) that redirects the platform
+/// libc `module.modulemap` at the Swift-provided one. That YAML file exists
+/// *only* in the `InMemoryFileSystem` built by
+/// `ClangImporter::computeClangImporterFileSystem`, yet it is handed to Clang
+/// as a plain `-ivfsoverlay` argument on the scanner command line.
+///
+/// If the Clang scanning workers' base file system does not contain that
+/// in-memory file, `createVFSFromOverlayFiles` cannot open it, reports
+/// `err_missing_vfs_overlay_file` and skips it. Clang then ends up with fewer
+/// `RedirectingFileSystem`s than `HeaderSearchOpts::VFSOverlayFiles` entries,
+/// and `HeaderSearch::collectVFSUsageAndClear` asserts while the scanner writes
+/// a PCM:
+///
+///   Assertion `VFSUsage.size() == getHeaderSearchOpts().VFSOverlayFiles.size()
+///   && "A different number of RedirectingFileSystem's were present than
+///   -ivfsoverlay options passed to Clang!"' failed.
+///
+/// The target is pinned to Linux so that this reproduces from any host; no
+/// target stdlib is needed because of `-parse-stdlib`.
+///
+/// rdar://184810704
+
+// REQUIRES: asserts
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// A fake Linux sysroot: enough libc headers for
+/// `getLibcFileMapping`'s `findFirstIncludeDir` probe, and a Swift-provided
+/// glibc.modulemap for it to redirect `usr/include/module.modulemap` to.
+// RUN: mkdir -p %t/sdk/usr/include
+// RUN: touch %t/sdk/usr/include/inttypes.h %t/sdk/usr/include/unistd.h %t/sdk/usr/include/stdint.h
+// RUN: mkdir -p %t/sdk/usr/lib/swift/linux/x86_64
+// RUN: cp %t/glibc.modulemap %t/sdk/usr/lib/swift/linux/x86_64/glibc.modulemap
+// RUN: touch %t/sdk/usr/lib/swift/linux/x86_64/SwiftGlibc.h
+
+/// Sanity check: the scanner command line really does carry the in-memory-only
+/// overlay. Without this the test could silently stop covering the bug.
+// RUN: %swift_frontend_plain -frontend -scan-dependencies -parse-stdlib \
+// RUN:   -target x86_64-unknown-linux-gnu -sdk %t/sdk -module-name repro \
+// RUN:   -Xcc -I%t/include -module-cache-path %t/mcp \
+// RUN:   -dump-clang-diagnostics %t/main.swift -o %t/deps.json 2>&1 \
+// RUN:   | %FileCheck --check-prefix=ARGS %s
+// ARGS: clang importer driver args:
+// ARGS-SAME: '-ivfsoverlay' '{{.*}}<clang-system-vfs-overlay>'
+
+/// The scan itself must not crash, and must still resolve the Clang module.
+/// Scanning `CRepro` makes the scanner write a PCM, which is where
+/// `collectVFSUsageAndClear` runs.
+// RUN: %swift_frontend_plain -frontend -scan-dependencies -parse-stdlib \
+// RUN:   -target x86_64-unknown-linux-gnu -sdk %t/sdk -module-name repro \
+// RUN:   -Xcc -I%t/include -module-cache-path %t/mcp \
+// RUN:   %t/main.swift -o %t/deps.json
+// RUN: %FileCheck --check-prefix=DEPS %s < %t/deps.json
+// DEPS: "clang": "CRepro"
+
+//--- glibc.modulemap
+module SwiftGlibc [system] {
+  header "SwiftGlibc.h"
+  export *
+}
+
+//--- include/module.modulemap
+module CRepro {
+  header "CRepro.h"
+  export *
+}
+
+//--- include/CRepro.h
+int repro(void);
+
+//--- main.swift
+import CRepro


### PR DESCRIPTION
On non-Darwin platforms ClangImporter redirects the platform libc `module.modulemap` at the Swift-provided one via a VFS overlay YAML that exists only in an `InMemoryFileSystem`, and hands Clang its path as a plain `-ivfsoverlay` argument. The Clang dependency scanning workers therefore need that in-memory file in their base file system.

2bb398029f7 replaced the per-worker factory that built it with a bare `createPhysicalFileSystem()`, so `createVFSFromOverlayFiles` could no longer open the overlay, reported `err_missing_vfs_overlay_file` and skipped it. Clang then ended up with fewer `RedirectingFileSystem`s than `HeaderSearchOpts::VFSOverlayFiles` entries and asserted in `HeaderSearch::collectVFSUsageAndClear` while writing a scanner PCM:

```
  Assertion `VFSUsage.size() == getHeaderSearchOpts().VFSOverlayFiles.size()
  && "A different number of RedirectingFileSystem's were present than
  -ivfsoverlay options passed to Clang!"' failed.
```

e801e26 rebuilt the callback around an owning `ClangImporterVFSRecipe`, but only in `setupCachingDependencyScanningService`, which is gated on `requiresCAS()`. Non-caching scans kept the bare physical file system.

Deriving that callback needs an `ASTContext`, which the `SwiftDependencyScanningService` constructor does not have, so stop creating the Clang scanning service there and let the first scan create it instead. `setupCachingDependencyScanningService` becomes `setupDependencyScanningService`, builds the service whether or not caching is involved, and uses the engaged-ness of the optional as its own "already created" check. The service is now created exactly once, which also removes the previous ability to re-create it underneath an in-flight scan's workers.

Call it from `performModuleScanImpl` and `performModulePrescanImpl` rather than from each of their callers. Those are the points where a service and a `CompilerInstance` first come together to create a `ModuleDependencyScanner`, so this covers the import prescan and the unit tests, neither of which configured the service at all.

Behavior change: a scan that requires CAS now diagnoses `error_cas_conflict_options` if the service was already created without it, rather than re-creating the service. Mixing caching and non-caching scans over one service was never sound.

Note that the recipe cannot hold a ready-made `InMemoryFileSystem` for the workers to share: `OverlayFileSystem` forwards `setCurrentWorkingDirectory` to all of its overlays, so sharing one would only move the race from `RealFileSystem`'s working directory to `InMemoryFileSystem`'s.

rdar://184810704