### PR TITLE
Sema: validate COM interface requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2319,6 +2319,15 @@ ERROR(com_interface_refinement_requires_identity, none,
 ERROR(com_interface_repeated_iid, none,
       "COM interface %0 and inherited interface %1 use the same interface "
       "identifier '%2'", (DeclName, DeclName, StringRef))
+ERROR(com_interface_unsupported_requirement, none,
+      "requirement %1 cannot be %select{used|static|generic|async|throwing}0 in a COM interface",
+      (int, DeclName))
+ERROR(com_interface_unsupported_parameter, none,
+      "parameter %0 of COM interface requirement %1 cannot be represented in C",
+      (DeclName, DeclName))
+ERROR(com_interface_unsupported_type, none,
+      "type %0 of COM interface requirement %1 cannot be represented in C",
+      (Type, DeclName))
 ERROR(com_identity_existential, none,
       "'any %0' is invalid because '%0' describes a COM metatype identity",
       (StringRef))

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -630,12 +630,8 @@ void validateIdentityRequirement(ProtocolDecl *PD,
     PD->setInvalid();
   }
 }
-}
 
-void com::validateIdentityProtocol(ProtocolDecl *PD) {
-  if (!PD->isCOMIdentity())
-    return;
-
+void validateIdentityProtocol(ProtocolDecl *PD) {
   auto &context = PD->getASTContext();
   if (PD->isSpecificProtocol(KnownProtocolKind::COMInterface)) {
     validateIdentityRequirement(PD, COMIdentityRequirementKind::InterfaceID,
@@ -661,6 +657,90 @@ void com::validateIdentityProtocol(ProtocolDecl *PD) {
     return;
   }
   llvm_unreachable("unhandled COMInteropModel");
+}
+
+bool validateInterfaceMethod(AbstractFunctionDecl *AFD) {
+  bool invalid = false;
+  DeclName name = AFD->getName();
+  if (auto *accessor = dyn_cast<AccessorDecl>(AFD))
+    name = accessor->getStorage()->getName();
+
+  if (isa<ConstructorDecl>(AFD)) {
+    AFD->diagnose(diag::com_interface_unsupported_requirement, 0, name);
+    return true;
+  }
+
+  if (AFD->isStatic()) {
+    AFD->diagnose(diag::com_interface_unsupported_requirement, 1, name);
+    invalid = true;
+  }
+
+  if (AFD->hasGenericParamList()) {
+    AFD->diagnose(diag::com_interface_unsupported_requirement, 2, name);
+    invalid = true;
+  }
+
+  if (AFD->hasAsync()) {
+    AFD->diagnose(diag::com_interface_unsupported_requirement, 3, name);
+    invalid = true;
+  }
+
+  if (AFD->hasThrows()) {
+    AFD->diagnose(diag::com_interface_unsupported_requirement, 4, name);
+    invalid = true;
+  }
+
+  Type RTy = cast<FuncDecl>(AFD)->getResultInterfaceType();
+  if (!RTy->isVoid() && !RTy->isRepresentableIn(ForeignLanguage::C, AFD)) {
+    AFD->diagnose(diag::com_interface_unsupported_type, RTy, name);
+    invalid = true;
+  }
+
+  for (auto *P : *AFD->getParameters()) {
+    if (P->isVariadic() || P->getSpecifier() != ParamSpecifier::Default) {
+      AFD->diagnose(diag::com_interface_unsupported_parameter, P->getName(),
+                    name);
+      invalid = true;
+    }
+
+    Type PTy = P->getTypeInContext();
+    if (!PTy->isRepresentableIn(ForeignLanguage::C, AFD)) {
+      AFD->diagnose(diag::com_interface_unsupported_type, PTy, name);
+      invalid = true;
+    }
+  }
+
+  return invalid;
+}
+
+void validateInterfaceRequirements(ProtocolDecl *PD) {
+  bool invalid = false;
+  for (auto *member : PD->getProtocolRequirements()) {
+    if (auto *AT = dyn_cast<AssociatedTypeDecl>(member)) {
+      AT->diagnose(diag::com_interface_unsupported_requirement, 0,
+                   AT->getName());
+      invalid = true;
+    } else if (auto *AFD = dyn_cast<AbstractFunctionDecl>(member)) {
+      invalid |= validateInterfaceMethod(AFD);
+    } else if (auto *ASD = dyn_cast<AbstractStorageDecl>(member)) {
+      ASD->visitOpaqueAccessors([&](AccessorDecl *AFD) {
+        if (AFD->requiresNewWitnessTableEntry())
+          invalid |= validateInterfaceMethod(AFD);
+      });
+    }
+  }
+
+  if (invalid)
+    PD->setInvalid();
+}
+
+} // end anonymous namespace
+
+void com::validateProtocol(ProtocolDecl *PD) {
+  if (PD->isCOMIdentity())
+    validateIdentityProtocol(PD);
+  else if (PD->isCOMInterface())
+    validateInterfaceRequirements(PD);
 }
 
 ProtocolConformance *

--- a/lib/Sema/TypeCheckCOM.h
+++ b/lib/Sema/TypeCheckCOM.h
@@ -31,8 +31,8 @@ deriveImplicitConformance(NominalTypeDecl *NTD, KnownProtocolKind KP);
 /// Diagnose declaration-level restrictions on a native COM implementation.
 void validateImplementation(ClassDecl *CD);
 
-/// Validate the compiler-managed requirements of a COM identity protocol.
-void validateIdentityProtocol(ProtocolDecl *PD);
+/// Validate COM-specific rules for a protocol declaration.
+void validateProtocol(ProtocolDecl *PD);
 
 /// Diagnose restrictions on an explicitly declared COM conformance.
 void validateConformance(ProtocolConformance *conformance);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3653,7 +3653,7 @@ public:
       visit(Member);
 
     if (Ctx.LangOpts.EnableCOMInterop)
-      com::validateIdentityProtocol(PD);
+      com::validateProtocol(PD);
 
     checkDeclCommon(PD);
 

--- a/test/Sema/com-interface-requirements.swift
+++ b/test/Sema/com-interface-requirements.swift
@@ -1,0 +1,114 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/COM.swiftmodule -module-name COM -enable-experimental-com-interop %S/../Inputs/COM.swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-com-interop -I %t -D COM_INTEROP -verify-additional-prefix com-
+// RUN: %target-typecheck-verify-swift
+
+#if COM_INTEROP
+// Ordinary C-compatible methods and accessors remain valid. The imported
+// COMInterface identity requirement returns a GUID struct and is exempt from
+// these interface-vtable checks.
+@com(interface: "10000000-0000-0000-0000-000000000001")
+protocol IValid {
+  typealias Integer = Int32
+  func empty()
+  func explicitVoid() -> Void
+  func scalar(_ value: Int32) -> UInt32
+  func floating(_ value: Float) -> Double
+  func pointer(_ value: UnsafeRawPointer?) -> UnsafeMutableRawPointer?
+  func outParameter(_ value: UnsafeMutablePointer<Int32>?)
+  var readOnly: Int32 { get }
+  var readWrite: Int32 { get set }
+  subscript(index: Int32) -> Int32 { get set }
+}
+
+@com(interface: "10000000-0000-0000-0000-000000000002")
+protocol IRefined: IValid {
+  func another(_ value: UInt8)
+}
+
+// Extension members do not introduce COM vtable requirements.
+extension IValid {
+  static func helper<T>(_ value: T) -> T { value }
+  func asynchronousHelper() async throws {}
+  func swiftResult() -> [Int] { [] }
+}
+
+struct SwiftValue {}
+
+@com(interface: "20000000-0000-0000-0000-000000000001")
+protocol IAssociated {
+  associatedtype Element // expected-com-error {{requirement 'Element' cannot be used in a COM interface}}
+}
+
+// Initializers must be rejected without attempting to treat them as FuncDecls.
+@com(interface: "20000000-0000-0000-0000-000000000002")
+protocol IInitializer {
+  init() // expected-com-error {{requirement 'init()' cannot be used in a COM interface}}
+}
+
+@com(interface: "20000000-0000-0000-0000-000000000003")
+protocol IStatic {
+  static func create() // expected-com-error {{requirement 'create()' cannot be static in a COM interface}}
+}
+
+@com(interface: "20000000-0000-0000-0000-000000000004")
+protocol IGeneric {
+  func generic<T>(_ value: T) // expected-com-error {{requirement 'generic' cannot be generic in a COM interface}}
+  // expected-com-error@-1 {{type 'T' of COM interface requirement 'generic' cannot be represented in C}}
+}
+
+@com(interface: "20000000-0000-0000-0000-000000000005")
+protocol IEffects {
+  func asynchronous() async // expected-com-error {{requirement 'asynchronous()' cannot be async in a COM interface}}
+  func throwing() throws // expected-com-error {{requirement 'throwing()' cannot be throwing in a COM interface}}
+  func both() async throws // expected-com-error {{requirement 'both()' cannot be async in a COM interface}}
+  // expected-com-error@-1 {{requirement 'both()' cannot be throwing in a COM interface}}
+}
+
+@com(interface: "20000000-0000-0000-0000-000000000006")
+protocol ITypes {
+  func result() -> SwiftValue // expected-com-error {{type 'SwiftValue' of COM interface requirement 'result()' cannot be represented in C}}
+  func parameter(_ value: SwiftValue) // expected-com-error {{type 'SwiftValue' of COM interface requirement 'parameter' cannot be represented in C}}
+  func several(_ first: SwiftValue, _ second: SwiftValue) -> SwiftValue // expected-com-error 3 {{type 'SwiftValue' of COM interface requirement 'several' cannot be represented in C}}
+}
+
+@com(interface: "20000000-0000-0000-0000-000000000007")
+protocol IParameters {
+  func variadic(_ values: Int32...) // expected-com-error {{parameter 'values' of COM interface requirement 'variadic' cannot be represented in C}}
+  // expected-com-error@-1 {{type 'Int32...' of COM interface requirement 'variadic' cannot be represented in C}}
+  func modify(_ value: inout Int32) // expected-com-error {{parameter 'value' of COM interface requirement 'modify' cannot be represented in C}}
+  func borrow(_ value: borrowing Int32) // expected-com-error {{parameter 'value' of COM interface requirement 'borrow' cannot be represented in C}}
+  func consume(_ value: consuming Int32) // expected-com-error {{parameter 'value' of COM interface requirement 'consume' cannot be represented in C}}
+  func legacyBorrow(_ value: __shared Int32) // expected-com-error {{parameter 'value' of COM interface requirement 'legacyBorrow' cannot be represented in C}}
+  func legacyConsume(_ value: __owned Int32) // expected-com-error {{parameter 'value' of COM interface requirement 'legacyConsume' cannot be represented in C}}
+}
+
+@com(interface: "20000000-0000-0000-0000-000000000008")
+protocol IProperties {
+  static var staticProperty: Int32 { get } // expected-com-error {{requirement 'staticProperty' cannot be static in a COM interface}}
+  var effectful: Int32 { get async throws } // expected-com-error {{requirement 'effectful' cannot be async in a COM interface}}
+  // expected-com-error@-1 {{requirement 'effectful' cannot be throwing in a COM interface}}
+  var unsupported: SwiftValue { get set } // expected-com-error 2 {{type 'SwiftValue' of COM interface requirement 'unsupported' cannot be represented in C}}
+  // The index is also checked in the synthesized modify accessor.
+  subscript(value: SwiftValue) -> SwiftValue { get set } // expected-com-error 5 {{type 'SwiftValue' of COM interface requirement 'subscript(_:)' cannot be represented in C}}
+  subscript<T>(generic value: T) -> Int32 { get } // expected-com-error {{requirement 'subscript(generic:)' cannot be generic in a COM interface}}
+  // expected-com-error@-1 {{type 'T' of COM interface requirement 'subscript(generic:)' cannot be represented in C}}
+}
+#endif
+
+// The COM-specific restrictions must not affect ordinary Swift protocols,
+// whether COM interop is enabled or disabled.
+protocol Ordinary {
+  associatedtype Element
+  init()
+  static func factory()
+  func generic<T>(_ value: T) -> T
+  func asynchronous() async
+  func throwing() throws
+  func array(_ values: [Int]) -> [Int]
+  func variadic(_ values: Int...)
+  func modify(_ value: inout Int)
+  func borrow(_ value: borrowing Int)
+  func consume(_ value: consuming Int)
+  var effectful: Int { get async throws }
+}

--- a/test/Sema/metatype-extension-self.swift
+++ b/test/Sema/metatype-extension-self.swift
@@ -9,6 +9,7 @@ protocol IWidget: IUnknown { }
 
 @com(interface: "20000000-0000-0000-0000-000000000002")
 protocol IGizmo: IUnknown { associatedtype Element }
+// expected-error@-1{{requirement 'Element' cannot be used in a COM interface}}
 
 // A protocol metatype extension has no generic signature, and its members are
 // static members of the protocol metatype.  They cannot reference 'Self' or the


### PR DESCRIPTION
COM interface declarations currently accept Swift requirements that cannot be represented by the COM vtable ABI, such as associated types and generic methods.

Diagnose associated types, initializers, static and generic requirements, and async or throwing methods. Check parameter and result types for C representability, and reject variadic parameters and explicit parameter specifiers. Apply the same checks to property and subscript accessors.