### PR TITLE
ModuleInterface: preserve COM implementation identities

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1424,7 +1424,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     if (!Attr->IID.empty()) {
       Printer << "(interface: \"" << Attr->IID << "\")";
     } else if (!Attr->CLSID->empty()) {
-      Printer << "(implementation: " << Attr->CLSID.value() << ", threading: .";
+      Printer << "(implementation: \"" << Attr->CLSID.value()
+              << "\", threading: .";
       switch (Attr->getThreadingModel()) {
       case COMThreadingModel::Single:
         Printer << "single";

--- a/test/ModuleInterface/com-class-identity.swift
+++ b/test/ModuleInterface/com-class-identity.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-com-interop -com-interop-model=microsoft -module-name COM -emit-module-path %t/COM.swiftmodule %S/../Inputs/COM.swift
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) -enable-experimental-com-interop -com-interop-model=microsoft -module-name Library -I %t %s
+// RUN: %FileCheck %s --input-file %t/Library.swiftinterface
+// RUN: %target-swift-frontend -enable-experimental-com-interop -com-interop-model=microsoft -module-name Library -I %t -compile-module-from-interface %t/Library.swiftinterface -o %t/Library.swiftmodule
+
+@com(implementation: "20000000-0000-0000-0000-000000000002",
+     threading: .both)
+public class Widget: IUnknown { }
+
+// CHECK: @com(implementation: "20000000-0000-0000-0000-000000000002", threading: .both)
+// CHECK: public class Widget : COM::IUnknown


### PR DESCRIPTION
Public @com classes expose activation identities through their metatypes. Quote the implementation UUID so textual interfaces remain valid Swift.

Exercise interface printing, rebuilding, and CLSID lookup in a client.