### PR TITLE
[6.4] SILGen: initialize init-accessor-subsumed storage through its accessor cross-file

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1606,17 +1606,19 @@ void SILGenFunction::emitMemberInitializationViaInitAccessor(
     B.createEndAccess(loc, selfRef.getValue(), /*aborted=*/false);
 }
 
-void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
-                                           PatternBindingDecl *field,
-                                           SubstitutionMap substitutions) {
+void SILGenFunction::emitMemberInitializer(
+    DeclContext *dc, VarDecl *selfDecl, PatternBindingDecl *field,
+    SubstitutionMap substitutions,
+    const llvm::SmallPtrSetImpl<VarDecl *> &initAccessorSubsumedStorage) {
   assert(!field->isStatic());
 
   for (auto i : range(field->getNumPatternEntries())) {
-    if (auto *var = field->getAnchoringVarDecl(i))
+    auto *var = field->getAnchoringVarDecl(i);
+    if (var)
       (void)var->getImplInfo(); // trigger expansion of attached accessor macros
 
     auto init = field->getExecutableInit(i);
-    if (!init)
+    if (!init || (var && initAccessorSubsumedStorage.count(var)))
       continue;
 
     // Member initializer expressions are only used in a constructor with
@@ -1624,7 +1626,6 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     // initializer from being evaluated synchronously (or propagating required
     // isolation through closure bodies), then the default value cannot be used
     // and the member must be explicitly initialized in the constructor.
-    auto *var = field->getAnchoringVarDecl(i);
     auto requiredIsolation = var->getInitializerIsolation();
     auto contextIsolation = getActorIsolationOfContext(dc);
     switch (requiredIsolation) {
@@ -1717,10 +1718,38 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
   }
 }
 
+/// The stored properties of \p nominal whose own initializer is subsumed by an
+/// init accessor on another property. This is recomputing a fact that should
+/// be answered via some requestified bit of code that determine whether to call
+/// `setInitializerSubsumed`. That code in Sema is currently only run during
+/// primary-file type checking.
+static void collectInitAccessorSubsumedStorage(
+    NominalTypeDecl *nominal, llvm::SmallPtrSetImpl<VarDecl *> &subsumed) {
+  std::multimap<VarDecl *, VarDecl *> initializedViaAccessor;
+  nominal->collectPropertiesInitializableByInitAccessors(initializedViaAccessor);
+
+  for (auto &pair : initializedViaAccessor) {
+    VarDecl *backing = pair.first;
+    VarDecl *accessorProp = pair.second;
+    auto *pbd = accessorProp->getParentPatternBinding();
+    if (!pbd)
+      continue;
+    auto idx = pbd->getPatternEntryIndexForVarDecl(accessorProp);
+    // Subsumed only if the accessor has an initializer of its own; force its
+    // possibly synthesized default (e.g., an Optional's 'nil').
+    (void)pbd->getCheckedPatternBindingEntry(idx);
+    if (pbd->isInitialized(idx))
+      subsumed.insert(backing);
+  }
+}
+
 void SILGenFunction::emitMemberInitializers(DeclContext *dc,
                                             VarDecl *selfDecl,
                                             NominalTypeDecl *nominal) {
   auto subs = getSubstitutionsForPropertyInitializer(dc, nominal);
+
+  llvm::SmallPtrSet<VarDecl *, 4> initAccessorSubsumedStorage;
+  collectInitAccessorSubsumedStorage(nominal, initAccessorSubsumedStorage);
 
   llvm::SmallPtrSet<PatternBindingDecl *, 4> alreadyInitialized;
   for (auto member : nominal->getImplementationContext()->getAllMembers()) {
@@ -1741,7 +1770,8 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
           for (auto *property : initAccessor->getAccessedProperties()) {
             auto *PBD = property->getParentPatternBinding();
             if (alreadyInitialized.insert(PBD).second)
-              emitMemberInitializer(dc, selfDecl, PBD, subs);
+              emitMemberInitializer(dc, selfDecl, PBD, subs,
+                                    initAccessorSubsumedStorage);
           }
 
           emitMemberInitializationViaInitAccessor(dc, selfDecl, pbd, subs);
@@ -1749,7 +1779,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         }
       }
 
-      emitMemberInitializer(dc, selfDecl, pbd, subs);
+      emitMemberInitializer(dc, selfDecl, pbd, subs, initAccessorSubsumedStorage);
     }
   }
 }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1064,9 +1064,12 @@ public:
   /// \param selfDecl The 'self' declaration within the current function.
   /// \param field The stored property that has to be initialized.
   /// \param substitutions The substitutions to apply to initializer and setter.
-  void emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
-                             PatternBindingDecl *field,
-                             SubstitutionMap substitutions);
+  /// \param initAccessorSubsumedStorage Stored properties set up through an init
+  /// accessor on another property; their own initializer is skipped.
+  void emitMemberInitializer(
+      DeclContext *dc, VarDecl *selfDecl, PatternBindingDecl *field,
+      SubstitutionMap substitutions,
+      const llvm::SmallPtrSetImpl<VarDecl *> &initAccessorSubsumedStorage);
 
   void emitMemberInitializationViaInitAccessor(DeclContext *dc,
                                                VarDecl *selfDecl,

--- a/test/Interpreter/init_accessor_crossfile_subsumption.swift
+++ b/test/Interpreter/init_accessor_crossfile_subsumption.swift
@@ -1,0 +1,118 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// This test builds a module consisting of two files. One declares the type, and another
+// declares extensions of those types containing initializers.
+// https://github.com/swiftlang/swift/issues/91700
+
+// RUN: %target-build-swift %t/Types.swift %t/Inits.swift -module-name Lib \
+// RUN:   -emit-module -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-library -static -o %t/%target-static-library-name(Lib)
+// RUN: %target-build-swift %t/main.swift -I %t -L %t -l Lib -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Init accessors are not fully supported yet under SIL opaque values
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
+
+//--- Types.swift
+
+// 'facade' has a synthesized 'nil' default (it is Optional); it subsumes
+// 'storage', so a cross-file init must yield nil, not storage's own 7.
+public struct ImplicitDefault {
+  var storage: Int? = 7
+  var facade: Int? {
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+  }
+  public var read: Int? { storage }
+}
+
+// Two accessors initialize the same storage, both with defaults: the last wins.
+public struct TwoDefaults {
+  var storage = 0
+  var facade1: Int = 520 {
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+  var facade2: Int = 42 {
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+  public var read: Int { storage }
+}
+
+// A class extension can only add a delegating convenience init cross-file, so the
+// member initializers are emitted in the designated 'init()'; the
+// synthesized-'nil' default of 'facade' still subsumes the default of 'storage'.
+public class ImplicitDefaultClass {
+  var storage: Int? = 7
+  var facade: Int? {
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+  }
+  public init() {}
+  public var read: Int? { storage }
+}
+
+public struct GenericHolder<T> {
+  var tag: T
+  var storage: Int? = 7
+  var facade: Int? {
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+  }
+  public var read: Int? { storage }
+}
+
+// Non-subsumed control: 'facade' has no default, so it does NOT subsume
+// 'storage'. The storage's own default value 99 is expected.
+public struct NoDefault {
+  var storage = 99
+  var facade: Int {
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+  public var read: Int { storage }
+}
+
+//--- Inits.swift
+
+extension ImplicitDefault { public init(other: Int) {} }
+extension TwoDefaults { public init(other: Int) {} }
+extension ImplicitDefaultClass {
+  public convenience init(other: Int) { self.init() }
+}
+// A non-delegating cross-file initializer: 'tag' is set explicitly and the
+// member initializers must set up 'storage' through the accessor.
+extension GenericHolder { public init(tag: T) { self.tag = tag } }
+extension NoDefault { public init(other: Int) {} }
+
+//--- main.swift
+
+import Lib
+
+print("ImplicitDefault:", ImplicitDefault(other: 0).read as Any)
+// CHECK: ImplicitDefault: nil
+
+print("TwoDefaults:", TwoDefaults(other: 0).read)
+// CHECK: TwoDefaults: 42
+
+print("ImplicitDefaultClass:", ImplicitDefaultClass(other: 0).read as Any)
+// CHECK: ImplicitDefaultClass: nil
+
+print("GenericHolder:", GenericHolder(tag: "x").read as Any)
+// CHECK: GenericHolder: nil
+
+print("NoDefault:", NoDefault(other: 0).read)
+// CHECK: NoDefault: 99

--- a/test/SILGen/other-file-extension-defining-init.swift
+++ b/test/SILGen/other-file-extension-defining-init.swift
@@ -1,0 +1,209 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Stored properties with default initialization expressions can have those expressions be "subsumed" by other
+// computed properties that define an init accessor that itself has a default value.
+//
+// This test specifically exercises the case where the type is defined in a secondary file, while the initializer
+// is defined in a separate file designated as primary during compilation. This normally shouldn't matter, but due
+// to some quirks with accessors and how Sema treats types in secondary files, we can see incorrect answers in SILGen.
+// https://github.com/swiftlang/swift/issues/91700
+
+// RUN: %target-swift-emit-silgen -primary-file %t/Extension.swift %t/Test.swift -module-name initaccessors > %t/output.silgen
+// RUN: %FileCheck %s < %t/output.silgen
+// RUN: %target-swift-emit-sil -sil-verify-all -primary-file %t/Extension.swift %t/Test.swift -module-name initaccessors > /dev/null
+
+//--- Test.swift
+
+// The names of the structs below refer to whether 'facade' has a default initial value or not.
+
+// Control: just an ordinary stored property.
+public struct Control {
+  var storage = 7
+}
+
+public struct NoDefault {
+  var storage = 7
+
+  var facade: Int { // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+}
+
+public struct ExplicitDefault {
+  var storage = 1
+
+  var facade: Int = 2 { // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+}
+
+// facade's default initialization expression is synthesized (an implicit 'nil' assignment),
+// and it still subsumes 'storage', so a cross-file initializer must route through the accessor.
+public struct ImplicitDefault {
+  var storage: Int? = 7
+
+  var facade: Int? {  // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+  }
+}
+
+// Two init accessors initializing the same storage.
+// One that does have a default and thus subsumes, and the other without.
+public struct TwoAccessorsOneDefault {
+  var storage = 0
+
+  var facade_noDefault: Int { // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+
+  var facade_withDefault: Int = 42 { // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+}
+
+public struct TwoAccessorsTwoDefaults {
+  var storage = 0
+
+  var facade1: Int = 520 { // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+
+  var facade2: Int = 42 { // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+}
+
+// A generic type: same secondary-file subsumption, exercising the generic path.
+public struct GenericExplicitDefault<T> {
+  var value: T
+
+  var storage = 1
+
+  var facade: Int = 2 { // <--
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+}
+
+// An init accessor that *accesses* a stored property subsumed by another accessor.
+public struct AccessesSubsumed {
+  var storage = 1
+
+  var facade: Int = 2 { // <-- subsumes storage
+    @storageRestrictions(initializes: storage)
+    init(initialValue) { storage = initialValue }
+    get { storage }
+    set { storage = newValue }
+  }
+
+  var reader: Int = 0 { // <-- accesses (reads) storage; declared after facade
+    @storageRestrictions(accesses: storage)
+    init(initialValue) {}
+    get { storage }
+    set {}
+  }
+}
+
+//--- Extension.swift
+
+// Without any init accessors, we trigger the initialization of the storage across files.
+extension Control { init(other: Int) {} }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors7ControlV5otherACSi_tcfC :
+// CHECK-NOT:     assign_or_init
+// CHECK:         struct_element_addr {{.*}}, #Control.storage
+// CHECK:         function_ref @$s13initaccessors7ControlV7storageSivpfi
+// CHECK-NOT:     assign_or_init
+// CHECK:       } // end sil function '$s13initaccessors7ControlV5otherACSi_tcfC'
+
+
+// facade has no default of its own, so storage's initialization is not 'subsumed',
+// meaning we trigger the storage's initialization expression.
+extension NoDefault { init(other: Int) {} }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors9NoDefaultV5otherACSi_tcfC :
+// CHECK-NOT:     assign_or_init
+// CHECK:         struct_element_addr {{.*}}, #NoDefault.storage
+// CHECK:         function_ref @$s13initaccessors9NoDefaultV7storageSivpfi
+// CHECK-NOT:     assign_or_init
+// CHECK:       } // end sil function '$s13initaccessors9NoDefaultV5otherACSi_tcfC'
+
+
+// For all the rest, the storage' initialization expression is subsumed by the accessor,
+// so expect to see no mention of the storage, and only assign_or_init of the facades.
+
+extension ExplicitDefault { init(other: Int) {} }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors15ExplicitDefaultV5otherACSi_tcfC  :
+// CHECK-NOT:     storage
+// CHECK:         assign_or_init #ExplicitDefault.facade
+// CHECK-NOT:     storage
+// CHECK:       } // end sil function '$s13initaccessors15ExplicitDefaultV5otherACSi_tcfC'
+
+extension ImplicitDefault { init(other: Int) {} }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors15ImplicitDefaultV5otherACSi_tcfC :
+// CHECK-NOT:     storage
+// CHECK:         assign_or_init #ImplicitDefault.facade
+// CHECK-NOT:     storage
+// CHECK:       } // end sil function '$s13initaccessors15ImplicitDefaultV5otherACSi_tcfC'
+
+// Two accessors, but only one had a default. Storage's init is subsumed and we trigger only one accessor's initialization.
+extension TwoAccessorsOneDefault { init(other: Int) {} }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors22TwoAccessorsOneDefaultV5otherACSi_tcfC :
+// CHECK-NOT:     assign_or_init
+// CHECK:         assign_or_init #TwoAccessorsOneDefault.facade_withDefault
+// CHECK-NOT:     assign_or_init
+// CHECK:       } // end sil function '$s13initaccessors22TwoAccessorsOneDefaultV5otherACSi_tcfC'
+
+// Two accessors had defaults, so we get two assign_or_inits in sequence.
+extension TwoAccessorsTwoDefaults { init(other: Int) {} }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors012TwoAccessorsB8DefaultsV5otherACSi_tcfC :
+// CHECK-NOT:     storage
+// CHECK:         [[ONE_INIT:%[0-9]+]] = function_ref @$s13initaccessors012TwoAccessorsB8DefaultsV7facade1Sivi
+// CHECK:         [[ONE_INIT_PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] [[ONE_INIT]](
+// CHECK:         assign_or_init #TwoAccessorsTwoDefaults.facade1, self {{.*}}, value {{.*}}, init [[ONE_INIT_PA]]
+// CHECK-NOT:     assign_or_init
+// CHECK:         [[TWO_INIT:%[0-9]+]] = function_ref @$s13initaccessors012TwoAccessorsB8DefaultsV7facade2Sivi
+// CHECK:         [[TWO_INIT_PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] [[TWO_INIT]](
+// CHECK:         assign_or_init #TwoAccessorsTwoDefaults.facade2, self {{.*}}, value {{.*}}, init [[TWO_INIT_PA]]
+// CHECK-NOT:     assign_or_init
+// CHECK:       } // end sil function '$s13initaccessors012TwoAccessorsB8DefaultsV5otherACSi_tcfC'
+
+// A generic type: facade's default subsumes storage, so the cross-file init
+// routes through the accessor with no mention of storage.
+extension GenericExplicitDefault { init(other: T) { value = other } }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors22GenericExplicitDefaultV5otherACyxGx_tcfC :
+// CHECK-NOT:     storage
+// CHECK:         assign_or_init #GenericExplicitDefault.facade
+// CHECK-NOT:     storage
+// CHECK:       } // end sil function '$s13initaccessors22GenericExplicitDefaultV5otherACyxGx_tcfC'
+
+// The 'reader' accessor accesses 'storage', but 'storage' is subsumed by 'facade'.
+extension AccessesSubsumed { init(other: Int) {} }
+// CHECK-LABEL: sil hidden [ossa] @$s13initaccessors16AccessesSubsumedV5otherACSi_tcfC :
+// CHECK-NOT:     storage
+// CHECK:         assign_or_init #AccessesSubsumed.facade
+// CHECK-NOT:     storage
+// CHECK:         assign_or_init #AccessesSubsumed.reader
+// CHECK-NOT:     storage
+// CHECK:       } // end sil function '$s13initaccessors16AccessesSubsumedV5otherACSi_tcfC'


### PR DESCRIPTION
Explanation: A stored property's default initialization expression is considered "subsumed" by an init accessor's if it contains such an expression. The fact that a stored property is subsumed was only being computed when type checking the nominal type containing that property. Suppose that type is defined in a file called `A.swift`. If you defined an initializer of that type in an extension within _another_ file, `B.swift`, then SILGen would not think there was a subsumption. Instead, it'd try to emit code within that initializer that invokes the stored property's initialization expression function. Problem is that `A.swift` doesn't emit that function symbol, as when _it_ was built, it thought it was subsumed. This leads to a "missing symbol" linker error.

Issue: https://github.com/swiftlang/swift/issues/91700 / rdar://181667352

Cherry-picked from: https://github.com/swiftlang/swift/pull/91895

Scope: SILGen

Testing: CI and tests extracted from bug reports

Risk: Low. This is an extra layer computing whether the subsumption happened, which only kicks-in for properties initialized by an init accessor.

Reviewed by: @xedin 