### PR TITLE
[SIL] Treat non-consumed constant captures of nonescaping `@called(once)` closures as borrows

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -89,6 +89,10 @@ public:
     /// i.e. `[sending x]`. Such captures are only valid in a `@called(once)`
     /// closure.
     IsSending = 1 << 3,
+
+    /// IsCalledOnce is set when the closure directly capturing this value is
+    /// `@called(once)`.
+    IsCalledOnce = 1 << 4,
   };
 
   CapturedValue(ValueDecl *Val, unsigned Flags, SourceLoc Loc)
@@ -105,6 +109,7 @@ public:
   bool isNoEscape() const { return Flags & IsNoEscape; }
   bool isConsumed() const { return Flags & IsConsumed; }
   bool isSending() const { return Flags & IsSending; }
+  bool isCalledOnce() const { return Flags & IsCalledOnce; }
 
   bool isDynamicSelfMetadata() const { return !Value; }
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -146,11 +146,17 @@ TypeConverter::getDeclCaptureKind(CapturedValue capture,
                           expansion.getResilienceExpansion()));
 
   // If this is a noncopyable 'let' constant that is not a shared paramdecl or
-  // used by a noescape capture, then we know it is boxed and want to pass it in
-  // its boxed form so we can obey Swift's capture reference semantics.
+  // used by a noescape (excluding `@called(once)`) capture, then we know it is
+  // boxed and want to pass it in its boxed form so we can obey Swift's capture
+  // reference semantics.
+  //
+  // `@called(once)` is special here since capturing as a `Constant` is going
+  // to consume the value due to owned callee convention used for "at most once"
+  // enforcement. If the capture is not marked as "consuming" it should be boxed
+  // even if it's a `let`.
   if (!var->supportsMutation()
       && contextTy->isNoncopyable()
-      && !capture.isNoEscape()) {
+      && (!capture.isNoEscape() || capture.isCalledOnce())) {
       auto *param = dyn_cast<ParamDecl>(var);
       if (!param || (param->getValueOwnership() != ValueOwnership::Shared &&
                      !param->isSelfParameter())) {

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -422,8 +422,12 @@ public:
     if (NoEscape)
       Flags |= CapturedValue::IsNoEscape;
 
-    if (CalledOnce && ConsumedValues.count(D))
-      Flags |= CapturedValue::IsConsumed;
+    if (CalledOnce) {
+      Flags |= CapturedValue::IsCalledOnce;
+
+      if (ConsumedValues.count(D))
+        Flags |= CapturedValue::IsConsumed;
+    }
 
     addCapture(CapturedValue(D, Flags, DRE->getStartLoc()));
 
@@ -472,6 +476,8 @@ public:
         Flags &= ~CapturedValue::IsConsumed;
         // ... or have `sending` captures.
         Flags &= ~CapturedValue::IsSending;
+        // ... and aren't `@called(once)` themselves.
+        Flags &= ~CapturedValue::IsCalledOnce;
       }
 
       addCapture(capture.mergeFlags(Flags));

--- a/test/SIL/called_once_nonescaping_sending_captures.swift
+++ b/test/SIL/called_once_nonescaping_sending_captures.swift
@@ -152,15 +152,12 @@ func testNoncopyableRefAndUndo() {
     func test() {}
   }
 
-  // FIXME: There should be no errors here. This is currently considered to be
-  // a consuming use of `v` because `@called(once)` is never marked as `[on_stack]`.
-  // The move-only checker needs to be tought about non-escaping `@called(once)`.
-  let v = NCS() // expected-error {{'v' used after consume}}
-  calledOnce { // expected-note {{consumed here}}
+  let v = NCS()
+  calledOnce {
     v.test()
   }
 
-  _ = v // expected-note {{used here}}
+  _ = v // Ok
 }
 
 func testVarMutatedInClosure() {

--- a/test/SILGen/called_once_consuming_captures.swift
+++ b/test/SILGen/called_once_consuming_captures.swift
@@ -416,3 +416,32 @@ func testGenericEraseConsumesCapture<T: Usable & ~Copyable>(_ v: consuming T) {
   let fn = { @called(once) in v as any Usable & ~Copyable }
   _ = fn()
 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s30called_once_consuming_captures35testBorrowingUseOfLetDoesNotConsumeyyF : $@convention(thin) () -> () {
+// CHECK:  [[R_BOX:%.*]] = alloc_box ${ let Resource }, let, name "r"
+// CHECK:  [[R_BORROW:%.*]] = begin_borrow [lexical] [var_decl] [[R_BOX]] : ${ let Resource }
+// CHECK:  [[R_PROJ:%.*]] = project_box [[R_BORROW]] : ${ let Resource }, 0
+// CHECK:  [[CLOSURE_REF:%.*]] = function_ref @$s30called_once_consuming_captures35testBorrowingUseOfLetDoesNotConsumeyyFyyXEfU_
+// CHECK:  [[R_BORROW_COPY:%.*]] = copy_value [[R_BORROW]] : ${ let Resource }
+// CHECK:  partial_apply [called_once] [[CLOSURE_REF]]([[R_BORROW_COPY]]) : $@convention(thin) (@guaranteed { let Resource }) -> ()
+// CHECK:  [[R_READ_ADDR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[R_PROJ]] : $*Resource
+// CHECK:  {{.*}} = load_borrow [[R_READ_ADDR]] : $*Resource
+// CHECK: } // end sil function '$s30called_once_consuming_captures35testBorrowingUseOfLetDoesNotConsumeyyF'
+
+// CHECK-LABEL: sil private [ossa] @$s30called_once_consuming_captures35testBorrowingUseOfLetDoesNotConsumeyyFyyXEfU_ : $@convention(thin) (@guaranteed { let Resource }) -> () {
+// CHECK: bb0([[R_CAPTURE:%.*]] : @closureCapture @guaranteed ${ let Resource }):
+// CHECK:  [[R_PROJ:%.*]] = project_box [[R_CAPTURE]] : ${ let Resource }, 0
+// CHECK:  [[R_ADDR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[R_PROJ]] : $*Resource
+// CHECK:  [[R_BORROW:%.*]] = load_borrow [[R_ADDR]] : $*Resource
+// CHECK:  [[PEEK_REF:%.*]] = function_ref @$s30called_once_consuming_captures8ResourceV4peekyyF
+// CHECK:  apply [[PEEK_REF]]([[R_BORROW]]) : $@convention(method) (@guaranteed Resource) -> ()
+// CHECK: } // end sil function '$s30called_once_consuming_captures35testBorrowingUseOfLetDoesNotConsumeyyFyyXEfU_'
+func testBorrowingUseOfLetDoesNotConsume() {
+  func calledOnce(_: @called(once) () -> Void) {}
+
+  let r = Resource()
+  calledOnce {
+    r.peek()
+  }
+  _ = r
+}


### PR DESCRIPTION
Such values cannot be treated as constants because they'll be
consumed by the closure even though there are no consuming operations
in the body, so instead let's handle them via an immutable box.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
