### PR TITLE
[DependencyScan] Give non-caching scan workers a recipe-based base VFS

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -42,6 +42,11 @@
 namespace swift {
 
 class ClangModuleDependenciesCacheImpl;
+#if LLVM_VERSION_MAJOR >= 23
+// Defined in ClangImporter.h; only passed by value here (complete type is
+// required at the call/definition site, not in this declaration).
+struct ClangImporterVFSRecipe;
+#endif
 class SourceFile;
 class ASTContext;
 class Identifier;
@@ -1089,6 +1094,16 @@ public:
 
   /// Setup caching service.
   bool setupCachingDependencyScanningService(CompilerInstance &Instance);
+
+#if LLVM_VERSION_MAJOR >= 23
+  /// Replace the MakeVFS callback used by non-caching scans with one that builds
+  /// each worker's VFS from a snapshot of the ClangImporter file mapping. Needed
+  /// because the scan invocation references the in-memory clang system VFS overlay
+  /// (see ClangImporter::getClangSystemOverlayFile), which a plain physical FS
+  /// cannot serve. Mirrors setupCachingDependencyScanningService for the caching
+  /// path. Must be called before any scanning workers run.
+  void setNonCachingClangVFSFactory(ClangImporterVFSRecipe &&recipe);
+#endif
 
   /// Allocate string inside ScanningService.
   StringRef save(StringRef str);

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -22,6 +22,9 @@
 #include "swift/AST/PluginLoader.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Frontend/Frontend.h"
+#if LLVM_VERSION_MAJOR >= 23
+#include "swift/ClangImporter/ClangImporter.h"
+#endif
 #include "swift/Strings.h"
 #include "clang/Lex/HeaderSearchOptions.h"
 #include "llvm/Config/config.h"
@@ -550,6 +553,22 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
       // already so it is safe to turn on all optimizations.
       clang::dependencies::ScanningOptimizations::All);
 }
+
+#if LLVM_VERSION_MAJOR >= 23
+void SwiftDependencyScanningService::setNonCachingClangVFSFactory(
+    ClangImporterVFSRecipe &&recipe) {
+  llvm::sys::SmartScopedLock<true> Lock(ScanningServiceGlobalLock);
+  clang::dependencies::DependencyScanningServiceOptions opts =
+      ClangScanningService->getOpts();
+  auto r = std::move(recipe);
+  // Dependency scanner needs to create its own file system per worker.
+  opts.MakeVFS = [r = std::move(r)]() mutable {
+    return ClangImporter::computeClangImporterFileSystem(
+        r, llvm::vfs::createPhysicalFileSystem());
+  };
+  ClangScanningService.emplace(std::move(opts));
+}
+#endif
 
 bool
 swift::dependencies::checkImportNotTautological(const ImportPath::Module modulePath,

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -632,6 +632,26 @@ ModuleDependencyScanner::ModuleDependencyScanner(
         llvm::cas::createCASProvidingFileSystem(
             CAS, ScanASTContext.SourceMgr.getFileSystem()));
 
+#if LLVM_VERSION_MAJOR >= 23
+  if (!CAS) {
+    // The non-caching MakeVFS default on this LLVM is a plain physical FS,
+    // which cannot serve the in-memory clang system VFS overlay that
+    // -ivfsoverlay in the scan invocation references (ClangImporter adds it
+    // when libc headers are redirected, e.g. glibc on Linux). Snapshot the
+    // importer file mapping into a recipe and build each worker's VFS from it,
+    // mirroring the caching path (setupCachingDependencyScanningService; see
+    // 94a4cd860ec). Older LLVMs build worker VFSes via getClangScanningFS,
+    // which already serves the overlay, so this is only needed here.
+    auto *importer = static_cast<ClangImporter *>(
+        ScanASTContext.getClangModuleLoader());
+    ClangImporterVFSRecipe recipe =
+        ClangImporter::computeClangImporterVFSRecipe(
+            ScanASTContext, importer->getClangFileMapping(),
+            [&](StringRef str) { return ScanningService.save(str); });
+    ScanningService.setNonCachingClangVFSFactory(std::move(recipe));
+  }
+#endif
+
   // TODO: Make num threads configurable
   for (size_t i = 0; i < NumThreads; ++i)
     Workers.emplace_front(std::make_unique<ModuleDependencyScanningWorker>(


### PR DESCRIPTION
The non-caching MakeVFS default (plain physical FS, left behind by 2bb398029f7) cannot serve the in-memory clang system VFS overlay that -ivfsoverlay in the scan invocation references (ClangImporter adds it when libc headers are redirected, e.g. glibc on Linux). Scan workers that build a PCH (clang compileModule path) then fail the HeaderSearch assert 'VFSUsage.size() == VFSOverlayFiles.size()' because no RedirectingFileSystem layer is created for the overlay file.

Snapshot the importer file mapping into a ClangImporterVFSRecipe in ModuleDependencyScanner's constructor (before workers start) and install it as the non-caching MakeVFS, mirroring setupCachingDependencyScanningService (94a4cd860ec).

Adaptation for main: guarded with LLVM_VERSION_MAJOR >= 23. On LLVM 21 the scan service builds each worker's VFS via getClangScanningFS, which already layers the ClangImporter file mapping and serves the overlay, so the bug does not manifest there; only LLVM 23's MakeVFS-based service needs this. The guarded code uses the rebranch ClangImporter recipe APIs (which do not exist in LLVM 21's DependencyScanningService).
