### PR TITLE
[android][test] Reenable C++ bridging test that was only failing since NDK 29, now fixed in LTS NDK 30

### DIFF
--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -21,9 +21,6 @@
 // RUN: %target-interop-build-clangxx -fsyntax-only -x c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++17 -c -fmodules -fcxx-modules -I %t 
 // FIXME: test c++20 (rdar://117419434)
 
-// Failing for Android since NDK 29, android/ndk#2242
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
-
 //--- header.h
 
 struct Trivial {


### PR DESCRIPTION
See NDK modification made in NDK 30 RC1 upstream referenced in android/ndk#2242 that fixed this test again.