### PR TITLE
[Sema] Treat member types of non-member bases as holes in diagnostic mode

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1723,11 +1723,19 @@ struct TypeSimplifier : public TypeTransform<TypeSimplifier> {
       if (auto selfType = lookupBaseType->getAs<DynamicSelfType>())
         lookupBaseType = selfType->getSelfType();
 
+      // Whether we have established that the base type cannot conform to
+      // the associated type's protocol.
+      bool cannotConform = false;
+
       if (lookupBaseType->mayHaveMembers() ||
           lookupBaseType->is<PackType>()) {
         auto *proto = assocType->getProtocol();
         auto conformance = CS.lookupConformance(lookupBaseType, proto);
-        if (!conformance) {
+        if (conformance) {
+          auto result = conformance.getTypeWitness(assocType);
+          if (result && !result->hasError())
+            return result;
+        } else {
           // Special case: When building slab literals, we go through the same
           // array literal machinery, so there will be a conversion constraint
           // for the element to ExpressibleByArrayLiteral.ArrayLiteralType.
@@ -1742,23 +1750,25 @@ struct TypeSimplifier : public TypeTransform<TypeSimplifier> {
             }
           }
 
-          // If the base type doesn't conform to the associatedtype's protocol,
-          // there will be a missing conformance fix applied in diagnostic mode,
-          // so the concrete dependent member type is considered a "hole" in
-          // order to continue solving.
-          auto memberTy = DependentMemberType::get(lookupBaseType, assocType);
-          if (CS.inSalvageMode())
-            return PlaceholderType::get(CS.getASTContext(), memberTy);
-
-          return memberTy;
+          cannotConform = true;
         }
-
-        auto result = conformance.getTypeWitness(assocType);
-        if (result && !result->hasError())
-          return result;
+      } else if (!lookupBaseType->isTypeVariableOrMember()) {
+        // The base is a type that cannot have members, such as a function
+        // or metatype type, so it cannot conform to the protocol either.
+        cannotConform = true;
       }
 
-      return DependentMemberType::get(lookupBaseType, assocType);
+      auto memberTy = DependentMemberType::get(lookupBaseType, assocType);
+
+      // If the base type doesn't conform to the associatedtype's protocol,
+      // there will be a missing conformance fix applied in diagnostic mode,
+      // so the concrete dependent member type is considered a "hole" in
+      // order to continue solving. Leaving a concrete dependent member type
+      // behind instead is not something the rest of the solver expects.
+      if (cannotConform && CS.inSalvageMode())
+        return PlaceholderType::get(CS.getASTContext(), memberTy);
+
+      return memberTy;
     }
 
     return std::nullopt;

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -978,13 +978,11 @@ do {
   func foo<T, U>(_: T, _: U) where T: Sequence, U: Sequence, T.Element == U.Element {}
   // expected-note@-1 {{required by local function 'foo' where 'T' = 'Set<Int>.Type'}}
   // expected-note@-2 {{required by local function 'foo' where 'U' = 'Array<String>.Type'}}
-  // expected-note@-3 {{where 'T.Element' = 'Set<Int>.Type.Element', 'U.Element' = 'Array<String>.Type.Element'}}
 
   foo(Set<Int>, Array<String>)
   // expected-error@-1 {{type 'Set<Int>.Type' cannot conform to 'Sequence'}}
   // expected-error@-2 {{type 'Array<String>.Type' cannot conform to 'Sequence'}}
-  // expected-error@-3 {{local function 'foo' requires the types 'Set<Int>.Type.Element' and 'Array<String>.Type.Element' be equivalent}}
-  // expected-note@-4 2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+  // expected-note@-3 2 {{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 // https://github.com/apple/swift/issues/56173

--- a/test/Constraints/issue-92020.swift
+++ b/test/Constraints/issue-92020.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/92020
+//
+// In diagnostic mode, the missing `Sequence` conformance on the function type
+// is fixed, and `((Int?) -> ()).Element` was left behind as a concrete
+// dependent member type instead of a hole, because a function type cannot
+// have members. It then ended up as an inferred collection element type and
+// tripped an assertion in the binding inference.
+
+func x(x: Int?) {}
+_ = (x + x) + (x + x)
+// expected-error@-1 {{binary operator '+' cannot be applied to two '(Int?) -> ()' operands}}
+
+func y(y: String?) {}
+_ = (y + y) + (y + y)
+// expected-error@-1 {{binary operator '+' cannot be applied to two '(String?) -> ()' operands}}
+
+// Metatypes cannot have members either. Make sure we only diagnose the
+// conformance failure and not a bogus follow-on about `Int.Type.Element`.
+func f<T: Sequence>(_: T) where T.Element == Int {}
+// expected-note@-1 {{required by global function 'f' where 'T' = 'Int.Type'}}
+f(Int.self)
+// expected-error@-1 {{type 'Int.Type' cannot conform to 'Sequence'}}
+// expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+
+func g<T: Sequence>(_: T, _: (T.Element) -> Void) {}
+// expected-note@-1 {{required by global function 'g' where 'T' = 'Int.Type'}}
+g(Int.self) { (_: Int) in }
+// expected-error@-1 {{type 'Int.Type' cannot conform to 'Sequence'}}
+// expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -129,9 +129,7 @@ func typeInExpression() {
 
   _ = X<(borrowing any ~Copyable) -> Void>()
 
-  _ = ~Copyable.self // expected-error{{type '(any Copyable).Type' cannot conform to 'BinaryInteger'}}
-  // expected-note@-1{{required by referencing operator function '~' on 'BinaryInteger' where 'Self' = '(any Copyable).Type'}}
-  // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+  _ = ~Copyable.self // expected-error{{unary operator '~' cannot be applied to an operand of type '(any Copyable).Type'}}
   _ = (any ~Copyable).self
 }
 

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -357,9 +357,7 @@ func compositionType() {
   _ = P1 & P2 // expected-error {{expected member name or initializer call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
   _ = any P1 & P1 // expected-error {{expected member name or initializer call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{18-18=).self}}
   _ = P1 & P2.self
-  // expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
-  // expected-note@-2 {{required by referencing operator function '&' on 'BinaryInteger' where 'Self' = 'any Any.Type'}}
-  // expected-error@-3 {{type 'any Any.Type' cannot conform to 'BinaryInteger'}}
+  // expected-error@-1 {{binary operator '&' cannot be applied to operands of type '(any P1).Type' and '(any P2).Type'}}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // Ok.
   _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(any P2, any P3)' cannot be used within a protocol-constrained type}}


### PR DESCRIPTION
A function type or metatype cannot have members, so it cannot conform to the associated type's protocol. Simplifying `$T.Element` for such a base produced a concrete dependent member type instead of a hole. That type later tripped an assertion in element type inference.

Return a placeholder in diagnostic mode, as we already do for a non-conforming nominal base.

Resolves https://github.com/swiftlang/swift/issues/92020
