### PR TITLE
MemoryLifetimeVerifier: don't assume worst-case argument effects for callees without computed side effects

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -698,6 +698,10 @@ extension Function {
         let e = f.function.getSideEffects()
         return e.getMemBehavior(observeRetains: observeRetains)
       },
+      // hasComputedSideEffects  (used by the MemoryLifetimeVerifier)
+      { (f: BridgedFunction) -> Bool in
+        return f.function.effects.sideEffects != nil
+      },
       // argumentMayRead  (used by the MemoryLifetimeVerifier)
       { (f: BridgedFunction, bridgedArgOp: BridgedOperand, bridgedAddr: BridgedValue) -> Bool in
         let argOp = Operand(bridged: bridgedArgOp)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -660,6 +660,7 @@ struct BridgedFunction {
   typedef SwiftInt (* _Nonnull CopyEffectsFn)(BridgedFunction, BridgedFunction);
   typedef EffectInfo (* _Nonnull GetEffectInfoFn)(BridgedFunction, SwiftInt);
   typedef BridgedMemoryBehavior (* _Nonnull GetMemBehaviorFn)(BridgedFunction, bool);
+  typedef bool (* _Nonnull HasComputedSideEffectsFn)(BridgedFunction);
   typedef bool (* _Nonnull ArgumentMayReadFn)(BridgedFunction, BridgedOperand, BridgedValue);
   typedef bool (*_Nonnull ArgumentMayWriteFn)(BridgedFunction, BridgedOperand,
                                               BridgedValue);
@@ -670,6 +671,7 @@ struct BridgedFunction {
                                ParseFn parseFn, CopyEffectsFn copyEffectsFn,
                                GetEffectInfoFn effectInfoFn,
                                GetMemBehaviorFn memBehaviorFn,
+                               HasComputedSideEffectsFn hasComputedSideEffectsFn,
                                ArgumentMayReadFn argumentMayReadFn,
                                ArgumentMayWriteFn argumentMayWriteFn,
                                IsDeinitBarrierFn isDeinitBarrierFn);

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1311,6 +1311,13 @@ public:
   }
   void copyEffects(SILFunction *from);
   bool hasArgumentEffects() const;
+
+  /// True if the side effects of this function have been computed by the
+  /// ComputeSideEffects pass (as opposed to only having defined effects, like
+  /// escape effects, which can be copied from a generic function when
+  /// specializing it).
+  bool hasComputedSideEffects() const;
+
   void visitArgEffects(std::function<void(int, int, bool)> c) const;
   MemoryBehavior getMemoryBehavior(bool observeRetains);
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -217,6 +217,7 @@ static BridgedFunction::ParseFn parseFunction = nullptr;
 static BridgedFunction::CopyEffectsFn copyEffectsFunction = nullptr;
 static BridgedFunction::GetEffectInfoFn getEffectInfoFunction = nullptr;
 static BridgedFunction::GetMemBehaviorFn getMemBehvaiorFunction = nullptr;
+static BridgedFunction::HasComputedSideEffectsFn hasComputedSideEffectsFunction = nullptr;
 static BridgedFunction::ArgumentMayReadFn argumentMayReadFunction = nullptr;
 static BridgedFunction::ArgumentMayWriteFn argumentMayWriteFunction = nullptr;
 static BridgedFunction::IsDeinitBarrierFn isDeinitBarrierFunction = nullptr;
@@ -1376,6 +1377,7 @@ void BridgedFunction::registerBridging(
     SwiftMetatype metatype, RegisterFn initFn, RegisterFn destroyFn,
     WriteFn writeFn, ParseFn parseFn, CopyEffectsFn copyEffectsFn,
     GetEffectInfoFn effectInfoFn, GetMemBehaviorFn memBehaviorFn,
+    HasComputedSideEffectsFn hasComputedSideEffectsFn,
     ArgumentMayReadFn argumentMayReadFn, ArgumentMayWriteFn argumentMayWriteFn,
     IsDeinitBarrierFn isDeinitBarrierFn) {
   functionMetatype = metatype;
@@ -1386,6 +1388,7 @@ void BridgedFunction::registerBridging(
   copyEffectsFunction = copyEffectsFn;
   getEffectInfoFunction = effectInfoFn;
   getMemBehvaiorFunction = memBehaviorFn;
+  hasComputedSideEffectsFunction = hasComputedSideEffectsFn;
   argumentMayReadFunction = argumentMayReadFn;
   argumentMayWriteFunction = argumentMayWriteFn;
   isDeinitBarrierFunction = isDeinitBarrierFn;
@@ -1480,6 +1483,14 @@ MemoryBehavior SILFunction::getMemoryBehavior(bool observeRetains) {
 
   auto b = getMemBehvaiorFunction({this}, observeRetains);
   return (MemoryBehavior)b;
+}
+
+// Used by the MemoryLifetimeVerifier
+bool SILFunction::hasComputedSideEffects() const {
+  if (!hasComputedSideEffectsFunction)
+    return false;
+
+  return hasComputedSideEffectsFunction({const_cast<SILFunction *>(this)});
 }
 
 // Used by the MemoryLifetimeVerifier

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -406,7 +406,10 @@ bool MemoryLifetimeVerifier::applyMayRead(Operand *argOp, SILValue addr) {
         // This can happen if a store to an unused inout has been eliminated at
         // a call site and afterwards the callee is specialized and therefore
         // doesn't have the required side-effects computed, yet.
-        return callee->hasArgumentEffects() && callee->argumentMayRead(op, a);
+        // Note that this must not check `hasArgumentEffects()`: a specialized
+        // function can inherit _escape_ effects from its generic function
+        // without having any side-effects computed.
+        return callee->hasComputedSideEffects() && callee->argumentMayRead(op, a);
       });
 }
 
@@ -419,7 +422,7 @@ bool MemoryLifetimeVerifier::applyMayNotWrite(Operand *argOp, SILValue addr) {
       /*unknownCalleesResult=*/true,
       /*noAddressResult=*/true,
       [](SILFunction *callee, Operand *op, SILValue a) {
-        return !callee->hasArgumentEffects() || callee->argumentMayWrite(op, a);
+        return !callee->hasComputedSideEffects() || callee->argumentMayWrite(op, a);
       });
 }
 

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -974,6 +974,28 @@ bb0(%0 : $Int):
   return %9
 }
 
+// The callee only has escape effects, but no computed side effects. In this case
+// the verifier must not assume the worst case - that the callee reads the
+// uninitialized `Inner.b` - because the escape effects can be inherited from a
+// generic function when specializing it, without any side effects being computed.
+sil [ossa] @only_escape_effects : $@convention(thin) (@inout Inner) -> () {
+[%0: noescape **]
+}
+
+sil [ossa] @callee_without_computed_side_effects : $@convention(thin) (@owned T) -> () {
+bb0(%0 : @owned $T):
+  %1 = alloc_stack $Inner
+  %2 = struct_element_addr %1, #Inner.a
+  %3 = struct_element_addr %1, #Inner.b
+  store %0 to [init] %2
+  %5 = function_ref @only_escape_effects : $@convention(thin) (@inout Inner) -> ()
+  %6 = apply %5(%1) : $@convention(thin) (@inout Inner) -> ()
+  destroy_addr %2
+  dealloc_stack %1
+  %9 = tuple ()
+  return %9
+}
+
 sil @dont_read_from_inout : $@convention(thin) (@inout Bool) -> ()
 
 sil [ossa] @no_read_from_inout : $@convention(thin) (Bool) -> () {


### PR DESCRIPTION
`applyMayRead` and `applyMayNotWrite` already skip callees whose side effects have not been computed yet - which happens if a store to an unused inout was eliminated in one module and the callee is specialized in another module, where `ComputeSideEffects` did not run (yet).

But the check used `hasArgumentEffects()`, which is also true if the function only has _escape_ effects. A specialized function inherits the escape effects of its generic function via `copyEffects`, so the guard didn't fire and `argumentMayRead` fell back to the worst-case defined effects. This caused a spurious "argument memory is not initialized, but should be" failure.

Fixes a false alarm of the MemoryLifetimeVerifier
