### PR TITLE
[DebugInfo] Use deterministic reverse order deletion in DiagnoseUnreachable

### DIFF
--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -451,6 +451,10 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
   llvm::SmallPtrSet<SILInstruction *, 8> nextInsts;
   while (!deadInsts.empty()) {
     for (auto inst : deadInsts) {
+      // Salvaging debug info may delete and rewrite queued instructions.
+      if (inst->isDeleted())
+        continue;
+
       // Call the callback before we mutate the to be deleted instruction in any
       // way, and salvage debug info while it's meaningful.
       callbacks.notifyWillBeDeleted(inst);
@@ -482,6 +486,8 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
     }
 
     for (auto inst : deadInsts) {
+      if (inst->isDeleted())
+        continue;
       // This will remove this instruction and all its uses.
       eraseFromParentWithDebugInsts(inst, callbacks);
     }

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -442,13 +442,14 @@ void swift::eliminateDeadInstruction(SILInstruction *inst,
 void swift::recursivelyDeleteTriviallyDeadInstructions(
     ArrayRef<SILInstruction *> ia, bool force, InstModCallbacks callbacks) {
   // Delete these instruction and others that become dead after it's deleted.
-  llvm::SmallPtrSet<SILInstruction *, 8> deadInsts;
-  for (auto *inst : ia) {
+  llvm::SmallSetVector<SILInstruction *, 8> deadInsts;
+  // Salvage debug info needs deletion to be in reverse order.
+  for (auto *inst : llvm::reverse(ia)) {
     // If the instruction is not dead and force is false, do nothing.
     if (force || isInstructionTriviallyDead(inst))
       deadInsts.insert(inst);
   }
-  llvm::SmallPtrSet<SILInstruction *, 8> nextInsts;
+  llvm::SmallSetVector<SILInstruction *, 8> nextInsts;
   while (!deadInsts.empty()) {
     for (auto inst : deadInsts) {
       // Salvaging debug info may delete and rewrite queued instructions.


### PR DESCRIPTION
The recursivelyDeleteTriviallyDeadInstructions function, which is only
used with multiple instructions by DiagnoseUnreachable, would delete
instructions in a non-deterministic order as it was using a SmallPtrSet
for iteration.

This leads to random crashes if salvageDebugInfo rewrites an instruction
when the operand has already been dropped. Instead, instructions now use
a strict reverse order for safe salvaging.

Additionally, it correctly handles instructions being deleted by salvageDebugInfo during iteration.