### PR TITLE
[Windows] honour the SDK architecture flags in Get-SelectedSDKBuilds

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4152,13 +4152,10 @@ function Write-PlatformInfoPlist($PlatformOrOS) {
 }
 
 function Get-SelectedSDKBuilds() {
-  return $KnownPlatforms.Values | Where-Object {
-    switch ($_.OS) {
-      Windows { $Windows }
-      Android { $Android }
-      default { $false }
-    }
-  }
+  $Builds = @()
+  if ($Windows) { $Builds += $WindowsSDKBuilds }
+  if ($Android) { $Builds += $AndroidSDKBuilds }
+  return $Builds
 }
 
 # Promotes C module header directories that libdispatch and Foundation install


### PR DESCRIPTION
`Get-SelectedSDKBuilds` returned every Windows/Android entry in `$KnownPlatforms`, ignoring `-WindowsSDKArchitectures` and `-AndroidSDKArchitectures`. Every other SDK loop uses `$WindowsSDKBuilds` / `$AndroidSDKBuilds`, which do honour them.

Its two callers build and clean the Clang compiler runtimes, so `'-Windows -WindowsSDKArchitectures X64'` still built compiler-rt for i686 and aarch64, and failed when the host lacked the ARM64 MSVC libraries:

```
lld-link: error: could not open 'msvcrtd.lib': no such file or directory
```

The default is all three Windows architectures, so a caller that passes no architecture flags is unaffected.