### PR TITLE
[RemoteMirror] Check readInteger result in ObjectiveCProtocol case in MetadataReader.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -543,8 +543,9 @@ public:
         // without symbolic references.
 
         auto addr = resolved.getResolvedAddress() + sizeof(int32_t);
-        int32_t offset;
-        Reader->readInteger(addr, &offset);
+        int32_t offset = 0;
+        if (!Reader->readInteger(addr, &offset))
+          return nullptr;
         auto addrOfTypeRef = addr + offset;
         resolved = Reader->getSymbol(addrOfTypeRef);
 


### PR DESCRIPTION
readInteger can fail. Check the return value and return nullptr if it fails rather than using an uninitialized variable.

rdar://186609648