### PR TITLE
[Backtracing] [Testing] Add extra debug logging for async bt tests

### DIFF
--- a/test/Backtracing/CrashAsync.test
+++ b/test/Backtracing/CrashAsync.test
@@ -5,7 +5,7 @@
 // Demangling is disabled for now because older macOS can't demangle async
 // function names.  We test demangling elsewhere, so this is no big deal.
 
-// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s
+// RUN: not --crash env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/JSONAsync.swift
+++ b/test/Backtracing/JSONAsync.swift
@@ -3,7 +3,7 @@
 // RUN: %target-codesign %t/JSONAsync
 
 // RUN: env %env-SWIFT_BACKTRACE=enable=yes,demangle=no,cache=no,format=json,output-to=%t/crash.json %target-run %t/JSONAsync %t/JSONAsync.dSYM 2>&1 || true
-// RUN: %validate-json %t/crash.json | %FileCheck %s
+// RUN: %validate-json %t/crash.json | %FileCheck %s -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Backtracing/SimpleAsyncBacktrace.swift
+++ b/test/Backtracing/SimpleAsyncBacktrace.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -g -parse-as-library -Xfrontend -disable-availability-checking -Onone -o %t/SimpleAsyncBacktrace
 // RUN: %target-codesign %t/SimpleAsyncBacktrace
-// RUN: %target-run %t/SimpleAsyncBacktrace | %FileCheck %s
+// RUN: %target-run %t/SimpleAsyncBacktrace | %FileCheck %s -dump-input-filter=all
 
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime

--- a/test/Backtracing/WithSourceCode/CrashAsyncFriendly.test
+++ b/test/Backtracing/WithSourceCode/CrashAsyncFriendly.test
@@ -5,7 +5,7 @@
 // Demangling is disabled for now because older macOS can't demangle async
 // function names.  We test demangling elsewhere, so this is no big deal.
 
-// RUN: not --crash env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s --check-prefix FRIENDLY
+// RUN: not --crash env %env-SWIFT_BACKTRACE=preset=friendly,enable=yes,demangle=no,cache=no %target-run %t/CrashAsync 2>&1 | %FileCheck %s --check-prefix FRIENDLY -dump-input-filter=all
 
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime


### PR DESCRIPTION
We have seen rare, intermittent failures on async backtracing tests in particular, most seem to be on containerised Linux builds and similar, probably when the system is under duress. The problem is the backtraces we get don't contain enough context to debug this and it's so intermittent we cannot reproduce it locally.

This PR is to add more logging so that we can get a better idea what's going on if this fails again.

rdar://187030690
