### PR TITLE
[RemoteMirror] NUL-terminate the truncated output of swift_reflection_demangle.

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -346,11 +346,13 @@ void swift_reflection_dumpInfoForInstance(SwiftReflectionContextRef ContextRef,
 
 /// Demangle a type name.
 ///
-/// Copies at most `MaxLength` bytes from the demangled name string into
-/// `OutDemangledName`.
+/// Copies at most `MaxLength` bytes, including the terminating NUL, from the
+/// demangled name string into `OutDemangledName`. The result is always
+/// NUL-terminated when `MaxLength` is nonzero, truncating the name if
+/// necessary.
 ///
 /// Returns the length of the demangled string this function tried to copy
-/// into `OutDemangledName`.
+/// into `OutDemangledName`, not including the terminating NUL.
 SWIFT_REMOTE_MIRROR_LINKAGE
 size_t swift_reflection_demangle(const char *MangledName, size_t Length,
                                  char *OutDemangledName, size_t MaxLength);

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -890,6 +890,9 @@ size_t swift_reflection_demangle(const char *MangledName, size_t Length,
   static_cast<void>(err);
 #else
   strncpy(OutDemangledName, Demangled.c_str(), MaxLength);
+  // Always terminate the output string, as long as it has room for a NUL.
+  if (MaxLength > 0)
+    OutDemangledName[MaxLength - 1] = '\0';
 #endif
   return Demangled.size();
 }


### PR DESCRIPTION
We previously wrote out a truncated over-long string without a NUL terminator, which is dangerous for callers.

rdar://186317503