### PR TITLE
[Demangling] Reject a SILBox substitution count mismatch.

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -1568,6 +1568,16 @@ protected:
             Builder);
 
         // Decode substitutions.
+        //
+        // The substitution list length and the generic signature's parameter
+        // counts are independent fields of the mangled name. Reject any
+        // mismatch.
+        if (substNode->getNumChildren() != genericParams.size())
+          return MAKE_NODE_TYPE_ERROR(
+              substNode,
+              "substitution count (%zu) does not match the generic "
+              "signature's parameter count (%zu)",
+              substNode->getNumChildren(), (size_t)genericParams.size());
         for (unsigned i = 0, e = substNode->getNumChildren(); i < e; ++i) {
           auto *subst = substNode->getChild(i);
           auto substTy = decodeMangledType(subst, depth + 1,

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -1145,3 +1145,26 @@ TEST(TypeRefTest, ReadTypeRefRemoteAddressWraparound) {
 
   munmap(pages, pageSize * 2);
 }
+
+// A SILBoxTypeWithLayout mangling carries the generic signature's parameter
+// counts and the substitution list length as independent fields, so a mangled
+// name can declare zero parameters and still supply substitutions. Decoding
+// must reject the mismatch instead of indexing past the end of the decoded
+// parameter list.
+TEST(TypeRefTest, SILBoxSubstitutionCountMismatchIsRejected) {
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
+  Demangle::Demangler Dem;
+
+  // One mutable field of the generic parameter, one Builtin.Int32
+  // substitution, and a signature declaring one parameter at depth 0.
+  auto *WellFormed = Dem.demangleType("xz_Bi32__lXX");
+  ASSERT_NE(WellFormed, nullptr);
+  EXPECT_NE(Builder.decodeMangledType(WellFormed), nullptr);
+
+  // Same, but the signature declares zero generic parameters while the
+  // substitution list still holds one type.
+  Demangle::Demangler Dem2;
+  auto *Mismatched = Dem2.demangleType("xz_Bi32__rzlXX");
+  ASSERT_NE(Mismatched, nullptr);
+  EXPECT_EQ(Builder.decodeMangledType(Mismatched), nullptr);
+}


### PR DESCRIPTION
A SILBoxTypeWithLayout mangling carries the generic signature's parameter counts and the substitution list length as independent fields. Make sure they match.

rdar://185698551