### PR TITLE
[cxx-interop] Only emit reverse interop type metadata if the type is supported

### DIFF
--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -15,6 +15,8 @@
 #include "PrimitiveTypeMapping.h"
 #include "SwiftToClangInteropContext.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/AvailabilityInference.h"
+#include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/Assertions.h"
@@ -192,22 +194,6 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   // compilable everywhere while still supporting these types where possible.
   auto stdlibModule = astContext.getStdlibModule();
 
-  if (Type unicodeScalar =
-          astContext.getNamedSwiftType(stdlibModule, "CChar32"))
-    supportedPrimitiveTypes.push_back(unicodeScalar);
-
-  if (clangTI.hasInt128Type()) {
-    if (Type int128Ty = astContext.getInt128Type())
-      supportedPrimitiveTypes.push_back(int128Ty);
-    if (Type uint128Ty = astContext.getUInt128Type())
-      supportedPrimitiveTypes.push_back(uint128Ty);
-  }
-
-  if (clangTI.hasFloat16Type()) {
-    if (Type float16 = astContext.getNamedSwiftType(stdlibModule, "Float16"))
-      supportedPrimitiveTypes.push_back(float16);
-  }
-
   // We do not have metadata for primitive types in Embedded Swift.
   // As a result, the following features are not supported with primitive types in this mode:
   // - Dynamic casts
@@ -215,6 +201,34 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
   // - Generic requirement parameters
   // - Metadata source parameter
   bool embedded = astContext.LangOpts.hasFeature(Feature::Embedded);
+
+  // Some of these types were introduced after the oldest runtime that the
+  // deployment target supports. Referencing their type metadata from the
+  // generated header would make the C++ client fail to launch when back
+  // deployed.
+  auto isAvailableAtDeploymentTarget = [&](Type type) {
+    auto nominal = type->getNominalOrBoundGenericNominal();
+    if (!nominal)
+      return false;
+    if (embedded)
+      return true;
+    return AvailabilityRange::forDeploymentTarget(astContext)
+        .isContainedIn(AvailabilityInference::availableRange(nominal));
+  };
+  auto addIfAvailable = [&](Type type) {
+    if (type && isAvailableAtDeploymentTarget(type))
+      supportedPrimitiveTypes.push_back(type);
+  };
+
+  addIfAvailable(astContext.getNamedSwiftType(stdlibModule, "CChar32"));
+
+  if (clangTI.hasInt128Type()) {
+    addIfAvailable(astContext.getInt128Type());
+    addIfAvailable(astContext.getUInt128Type());
+  }
+
+  if (clangTI.hasFloat16Type())
+    addIfAvailable(astContext.getNamedSwiftType(stdlibModule, "Float16"));
 
   for (Type type : supportedPrimitiveTypes) {
     auto typeInfo = *typeMapping.getKnownCxxTypeInfo(
@@ -242,7 +256,10 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
 
     os << "template<>\nstruct TypeMetadataTrait<" << typeInfo.name << "> {\n"
        << "  static ";
-    ClangSyntaxPrinter(astContext, os).printInlineForThunk();
+    // This is deliberately not printed as an inline thunk: in debug mode
+    // inline thunks are marked as `used`, which would emit all of these
+    // accessors even when the program never uses the corresponding type.
+    ClangSyntaxPrinter(astContext, os).printInlineForHelperFunction();
     os << "void * _Nonnull getTypeMetadata() {\n"
        << "    return &" << cxx_synthesis::getCxxImplNamespaceName()
        << "::" << typeMetadataVarName << ";\n"

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx-darwin64bit.swift
@@ -52,7 +52,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<void *> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss13OpaquePointerVN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -62,7 +62,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<swift::Int> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$sSiN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -72,7 +72,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<swift::UInt> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$sSuN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -82,7 +82,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<char32_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss7UnicodeO6ScalarVN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -92,7 +92,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<__int128> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss6Int128VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -102,7 +102,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<unsigned __int128> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss7UInt128VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -112,7 +112,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<_Float16> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss7Float16VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -108,7 +108,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<bool> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$sSbN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -118,7 +118,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int8_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss4Int8VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -128,7 +128,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint8_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss5UInt8VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -138,7 +138,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int16_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss5Int16VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -148,7 +148,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint16_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss6UInt16VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -158,7 +158,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int32_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss5Int32VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -168,7 +168,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint32_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss6UInt32VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -178,7 +178,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<int64_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss5Int64VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -188,7 +188,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<uint64_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss6UInt64VN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -198,7 +198,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<float> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$sSfN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -208,7 +208,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<double> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$sSdN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -218,7 +218,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<void *> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss13OpaquePointerVN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
@@ -230,7 +230,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<char32_t> {
-// CHECK-NEXT:   static SWIFT_INLINE_THUNK void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:     return &_impl::$ss7UnicodeO6ScalarVN;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };

--- a/test/Interop/SwiftToCxx/core/type-metadata-deployment-target.swift
+++ b/test/Interop/SwiftToCxx/core/type-metadata-deployment-target.swift
@@ -1,0 +1,33 @@
+// Type metadata for standard library types that were introduced after the
+// deployment target must not be referenced from the generated header, as that
+// would prevent the C++ client from launching on an older runtime.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core-old.h -target %target-cpu-apple-macosx12
+// RUN: %FileCheck --check-prefix=OLD %s < %t/core-old.h
+
+// RUN: %target-swift-frontend %s -module-name Core -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/core-new.h -target %target-cpu-apple-macosx15
+// RUN: %FileCheck --check-prefix=NEW %s < %t/core-new.h
+
+// RUN: %target-interop-build-clangxx -x c++ %t/core-new.h -c -o %t/core-new.o -DDEBUG=1
+
+// REQUIRES: OS=macosx
+// REQUIRES: PTRSIZE=64
+
+public func takesInt(_ x: Int) {}
+
+// OLD-NOT: $ss6Int128VN
+// OLD-NOT: $ss7UInt128VN
+// OLD-NOT: isUsableInGenericContext<__int128>
+// OLD: // type metadata address for CChar32.
+// OLD: struct TypeMetadataTrait<char32_t> {
+// OLD-NOT: $ss6Int128VN
+// OLD-NOT: $ss7UInt128VN
+// OLD-NOT: isUsableInGenericContext<__int128>
+
+// NEW: // type metadata address for Int128.
+// NEW-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss6Int128VN;
+// NEW-NEXT: // type metadata address for UInt128.
+// NEW-NEXT: SWIFT_IMPORT_STDLIB_SYMBOL extern size_t $ss7UInt128VN;
+// NEW: struct TypeMetadataTrait<__int128> {


### PR DESCRIPTION
If a Swift type is restricted to a certain version of the OS, let's not emit type metadata for it in the generated reverse interop header when targeting an older OS version.

For example, `Int128` is not supported on macOS 10.15, so targeting that version causes the C++ program to fail to start.

rdar://184418028

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
