### PR TITLE
AST,SIL: model the COM method calling convention

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -257,6 +257,7 @@ extension TypeProperties {
       case .ObjCMethod:            return .objCMethod
       case .WitnessMethod:         return .witnessMethod
       case .Closure:               return .closure
+      case .COMMethod:             return .comMethod
       case .CXXMethod:             return .cxxMethod
       case .KeyPathAccessorGetter: return .keyPathAccessorGetter
       case .KeyPathAccessorSetter: return .keyPathAccessorSetter
@@ -377,6 +378,9 @@ public enum FunctionTypeRepresentation {
   /// A closure invocation function that has not been bound to a context.
   case closure
 
+  /// A COM interface method with a foreign self-first calling convention.
+  case comMethod
+
   /// A C++ method that takes a "this" argument (not a static C++ method or constructor).
   /// Except for handling the "this" argument, has the same behavior as "CFunctionPointer".
   case cxxMethod
@@ -396,6 +400,7 @@ public enum FunctionTypeRepresentation {
       case .objCMethod:            return .ObjCMethod
       case .witnessMethod:         return .WitnessMethod
       case .closure:               return .Closure
+      case .comMethod:             return .COMMethod
       case .cxxMethod:             return .CXXMethod
       case .keyPathAccessorGetter: return .KeyPathAccessorGetter
       case .keyPathAccessorSetter: return .KeyPathAccessorSetter

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -3140,7 +3140,8 @@ struct BridgedASTType {
     KeyPathAccessorGetter,
     KeyPathAccessorSetter,
     KeyPathAccessorEquals,
-    KeyPathAccessorHash
+    KeyPathAccessorHash,
+    COMMethod,
   };
 
   swift::TypeBase * _Nullable type;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -807,6 +807,8 @@ BridgedASTType::FunctionTypeRepresentation BridgedASTType::getFunctionTypeRepres
   static_assert((int)FunctionTypeRepresentation::KeyPathAccessorSetter == (int)swift::SILFunctionTypeRepresentation::KeyPathAccessorSetter);
   static_assert((int)FunctionTypeRepresentation::KeyPathAccessorEquals == (int)swift::SILFunctionTypeRepresentation::KeyPathAccessorEquals);
   static_assert((int)FunctionTypeRepresentation::KeyPathAccessorHash == (int)swift::SILFunctionTypeRepresentation::KeyPathAccessorHash);
+  static_assert((int)FunctionTypeRepresentation::COMMethod ==
+                (int)swift::SILFunctionTypeRepresentation::COMMethod);
 
   auto fnType = unbridged()->castTo<swift::SILFunctionType>();
   return (FunctionTypeRepresentation)(fnType->getRepresentation());

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -380,6 +380,10 @@ enum class SILFunctionTypeRepresentation : uint8_t {
   KeyPathAccessorSetter,
   KeyPathAccessorEquals,
   KeyPathAccessorHash,
+
+  /// A COM interface method. The interface pointer is passed as the first
+  /// argument using the foreign calling convention.
+  COMMethod,
 };
 
 /// Returns true if the function with this convention doesn't carry a context.
@@ -409,6 +413,7 @@ isThinRepresentation(SILFunctionTypeRepresentation rep) {
   case SILFunctionTypeRepresentation::WitnessMethod:
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Closure:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
   case SILFunctionTypeRepresentation::KeyPathAccessorGetter:
   case SILFunctionTypeRepresentation::KeyPathAccessorSetter:
@@ -445,6 +450,7 @@ isKeyPathAccessorRepresentation(SILFunctionTypeRepresentation rep) {
     case SILFunctionTypeRepresentation::CFunctionPointer:
     case SILFunctionTypeRepresentation::Closure:
     case SILFunctionTypeRepresentation::CXXMethod:
+    case SILFunctionTypeRepresentation::COMMethod:
       return false;
   }
   llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
@@ -475,6 +481,7 @@ convertRepresentation(SILFunctionTypeRepresentation rep) {
     return {FunctionTypeRepresentation::Block};
   case SILFunctionTypeRepresentation::Thin:
     return {FunctionTypeRepresentation::Thin};
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
   case SILFunctionTypeRepresentation::CFunctionPointer:
     return {FunctionTypeRepresentation::CFunctionPointer};
@@ -500,6 +507,7 @@ constexpr bool canBeCalledIndirectly(SILFunctionTypeRepresentation rep) {
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Block:
   case SILFunctionTypeRepresentation::Closure:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
     return false;
   case SILFunctionTypeRepresentation::ObjCMethod:
@@ -524,6 +532,7 @@ template <typename Repr> constexpr bool shouldStoreClangType(Repr repr) {
   case SILFunctionTypeRepresentation::Block:
   case SILFunctionTypeRepresentation::CXXMethod:
     return true;
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::ObjCMethod:
   case SILFunctionTypeRepresentation::Thick:
   case SILFunctionTypeRepresentation::Thin:
@@ -734,6 +743,7 @@ public:
     case SILFunctionTypeRepresentation::ObjCMethod:
     case SILFunctionTypeRepresentation::Method:
     case SILFunctionTypeRepresentation::WitnessMethod:
+    case SILFunctionTypeRepresentation::COMMethod:
     case SILFunctionTypeRepresentation::CXXMethod:
       return true;
     }
@@ -1112,6 +1122,7 @@ SILFunctionLanguage getSILFunctionLanguage(SILFunctionTypeRepresentation rep) {
   case SILFunctionTypeRepresentation::ObjCMethod:
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Block:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
     return SILFunctionLanguage::C;
   case SILFunctionTypeRepresentation::Thick:
@@ -1308,6 +1319,7 @@ public:
     case Representation::ObjCMethod:
     case Representation::Method:
     case Representation::WitnessMethod:
+    case Representation::COMMethod:
     case SILFunctionTypeRepresentation::CXXMethod:
       return true;
     }
@@ -1326,6 +1338,7 @@ public:
     case Representation::Method:
     case Representation::WitnessMethod:
     case Representation::Closure:
+    case Representation::COMMethod:
     case SILFunctionTypeRepresentation::CXXMethod:
     case Representation::KeyPathAccessorGetter:
     case Representation::KeyPathAccessorSetter:

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -264,6 +264,7 @@ public:
   bool isCalleeThin() const {
     switch (getSubstCalleeType()->getRepresentation()) {
     case SILFunctionTypeRepresentation::CFunctionPointer:
+    case SILFunctionTypeRepresentation::COMMethod:
     case SILFunctionTypeRepresentation::CXXMethod:
     case SILFunctionTypeRepresentation::Thin:
     case SILFunctionTypeRepresentation::Method:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -307,6 +307,8 @@ static StringRef getDumpString(SILFunctionType::Representation value) {
   case SILFunctionType::Representation::Thick: return "thick";
   case SILFunctionType::Representation::Block: return "block";
   case SILFunctionType::Representation::CFunctionPointer: return "c";
+  case SILFunctionType::Representation::COMMethod:
+    return "com_method";
   case SILFunctionType::Representation::CXXMethod:
     return "cxx_method";
   case SILFunctionType::Representation::Thin: return "thin";

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2410,6 +2410,9 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
     case SILFunctionTypeRepresentation::WitnessMethod:
       OpArgs.push_back('W');
       break;
+    case SILFunctionTypeRepresentation::COMMethod:
+      OpArgs.push_back('V');
+      break;
     case SILFunctionTypeRepresentation::KeyPathAccessorGetter:
     case SILFunctionTypeRepresentation::KeyPathAccessorSetter:
     case SILFunctionTypeRepresentation::KeyPathAccessorEquals:

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7287,6 +7287,9 @@ public:
       case SILFunctionType::Representation::Method:
         Printer << "method";
         break;
+      case SILFunctionType::Representation::COMMethod:
+        Printer << "com_method";
+        break;
       case SILFunctionType::Representation::CXXMethod:
         Printer << "cxx_method";
         break;
@@ -7379,6 +7382,9 @@ public:
         break;
       case SILFunctionType::Representation::Method:
         Printer << "method";
+        break;
+      case SILFunctionType::Representation::COMMethod:
+        Printer << "com_method";
         break;
       case SILFunctionType::Representation::CXXMethod:
         Printer << "cxx_method";

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -217,6 +217,7 @@ ClangTypeConverter::getFunctionType(ArrayRef<SILParameterInfo> params,
     return nullptr;
 
   switch (repr) {
+  case SILFunctionType::Representation::COMMethod:
   case SILFunctionType::Representation::CXXMethod:
   case SILFunctionType::Representation::CFunctionPointer:
     return ClangASTContext.getPointerType(fn).getTypePtr();

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -370,6 +370,7 @@ static bool isBitwiseCopyableFunctionType(EitherFunctionType eitherFnTy) {
   case SILFunctionTypeRepresentation::Block:
     return false;
   case SILFunctionTypeRepresentation::Thin:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Method:

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2549,6 +2549,9 @@ NodePointer Demangler::demangleImplFunctionType() {
   case 'O': FConv = "objc_method"; break;
   case 'K': FConv = "closure"; break;
   case 'W': FConv = "witness_method"; break;
+  case 'V':
+    FConv = "com_method";
+    break;
   default: pushBack(); break;
   }
   if (FConv) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2084,6 +2084,7 @@ ManglingError Remangler::mangleImplFunctionConvention(Node *node,
                       .Case("objc_method", 'O')
                       .Case("closure", 'K')
                       .Case("witness_method", 'W')
+                      .Case("com_method", 'V')
                       .Default(0);
   DEMANGLER_ASSERT(FuncAttr && "invalid impl function convention", node);
   if ((FuncAttr == 'B' || FuncAttr == 'C') && node->getNumChildren() > 1 &&

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4579,23 +4579,27 @@ void CallEmission::externalizeArguments(IRGenFunction &IGF, const Callee &callee
   unsigned firstParam = 0;
   unsigned paramEnd = FI.arg_size();
 
-  // Handle the ObjC prefix.
-  if (callee.getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod) {
+  switch (callee.getRepresentation()) {
+  case SILFunctionTypeRepresentation::ObjCMethod:
     // Ignore both the logical and the physical parameters associated
     // with self and (if not objc_direct) _cmd.
     firstParam += callee.isDirectObjCMethod() ? 1 :  2;
     params = params.drop_back();
+    break;
 
-  // Or the block prefix.
-  } else if (fnType->getRepresentation()
-                == SILFunctionTypeRepresentation::Block) {
+  case SILFunctionTypeRepresentation::Block:
     // Ignore the physical block-object parameter.
     firstParam += 1;
-  } else if (callee.getRepresentation() ==
-             SILFunctionTypeRepresentation::CXXMethod) {
+    break;
+
+  case SILFunctionTypeRepresentation::CXXMethod:
     // Skip the "self" param.
     firstParam += 1;
     params = params.drop_back();
+    break;
+
+  default:
+    break;
   }
 
   bool formalIndirectResult = fnType->getNumResults() > 0 &&

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -379,6 +379,10 @@ irgen::expandCallingConv(IRGenModule &IGM,
                          SILFunctionTypeRepresentation convention, bool isAsync,
                          bool isCalleeAllocatedCoro) {
   switch (convention) {
+  case SILFunctionTypeRepresentation::COMMethod:
+    llvm_unreachable(
+        "COM method calling convention lowering is not implemented");
+
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::ObjCMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
@@ -1590,6 +1594,9 @@ void SignatureExpansion::expandExternalSignatureTypes() {
     paramTys.push_back(clangCtx.VoidPtrTy);
     break;
 
+  case SILFunctionTypeRepresentation::COMMethod:
+    llvm_unreachable("COM method signature lowering is not implemented");
+
   case SILFunctionTypeRepresentation::CXXMethod: {
     // Cxx methods take their 'self' argument first.
     auto &self = params.back();
@@ -1968,6 +1975,7 @@ void SignatureExpansion::expandKeyPathAccessorParameters() {
   case SILFunctionTypeRepresentation::WitnessMethod:
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Closure:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
     llvm_unreachable("non keypath accessor convention");
   }
@@ -2062,6 +2070,8 @@ void SignatureExpansion::expandParameters(
   } else {
     auto needsContext = [=]() -> bool {
       switch (FnType->getRepresentation()) {
+      case SILFunctionType::Representation::COMMethod:
+        llvm_unreachable("calling COM method in Swift CC expansion?");
       case SILFunctionType::Representation::Block:
         llvm_unreachable("adding block parameter in Swift CC expansion?");
 
@@ -2340,6 +2350,8 @@ void SignatureExpansion::expandAsyncEntryType() {
   } else {
     auto needsContext = [=]() -> bool {
       switch (FnType->getRepresentation()) {
+      case SILFunctionType::Representation::COMMethod:
+        llvm_unreachable("calling COM method in Swift CC expansion?");
       case SILFunctionType::Representation::Block:
         llvm_unreachable("adding block parameter in Swift CC expansion?");
 
@@ -2966,6 +2978,9 @@ public:
                            isOutlined);
       break;
 
+    case SILFunctionTypeRepresentation::COMMethod:
+      llvm_unreachable("COM method argument lowering is not implemented");
+
     case SILFunctionTypeRepresentation::Block:
     case SILFunctionTypeRepresentation::CXXMethod:
       if (getCallee().getRepresentation() == SILFunctionTypeRepresentation::Block) {
@@ -3346,6 +3361,7 @@ public:
     case SILFunctionTypeRepresentation::ObjCMethod:
     case SILFunctionTypeRepresentation::Block:
     case SILFunctionTypeRepresentation::CFunctionPointer:
+    case SILFunctionTypeRepresentation::COMMethod:
     case SILFunctionTypeRepresentation::CXXMethod:
     case SILFunctionTypeRepresentation::KeyPathAccessorGetter:
     case SILFunctionTypeRepresentation::KeyPathAccessorSetter:
@@ -4188,6 +4204,7 @@ Callee::Callee(CalleeInfo &&info, const FunctionPointer &fn,
   case SILFunctionTypeRepresentation::KeyPathAccessorHash:
     assert(!FirstData && !SecondData);
     break;
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
     assert(FirstData && !SecondData);
     break;
@@ -4203,6 +4220,7 @@ llvm::Value *Callee::getSwiftContext() const {
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Thin:
   case SILFunctionTypeRepresentation::Closure:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
   case SILFunctionTypeRepresentation::KeyPathAccessorGetter:
   case SILFunctionTypeRepresentation::KeyPathAccessorSetter:

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -627,6 +627,7 @@ const TypeInfo *TypeConverter::convertFunctionType(SILFunctionType *T) {
       
   case SILFunctionType::Representation::Thin:
   case SILFunctionType::Representation::Method:
+  case SILFunctionType::Representation::COMMethod:
   case SILFunctionType::Representation::CXXMethod:
   case SILFunctionType::Representation::WitnessMethod:
   case SILFunctionType::Representation::CFunctionPointer:
@@ -719,6 +720,7 @@ getFuncSignatureInfoForLowered(IRGenModule &IGM, CanSILFunctionType type) {
   case SILFunctionType::Representation::Thin:
   case SILFunctionType::Representation::CFunctionPointer:
   case SILFunctionType::Representation::Method:
+  case SILFunctionType::Representation::COMMethod:
   case SILFunctionType::Representation::CXXMethod:
   case SILFunctionType::Representation::WitnessMethod:
   case SILFunctionType::Representation::Closure:

--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -179,6 +179,7 @@ static const PointerAuthSchema &getFunctionPointerSchema(IRGenModule &IGM,
                                                    CanSILFunctionType fnType) {
   auto &options = IGM.getOptions().PointerAuth;
   switch (fnType->getRepresentation()) {
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
   case SILFunctionTypeRepresentation::CFunctionPointer:
     return options.FunctionPointers;
@@ -512,6 +513,7 @@ PointerAuthEntity::getTypeDiscriminator(IRGenModule &IGM) const {
     }
     
     // C function pointers are undiscriminated.
+    case SILFunctionTypeRepresentation::COMMethod:
     case SILFunctionTypeRepresentation::CXXMethod:
     case SILFunctionTypeRepresentation::CFunctionPointer:
       return llvm::ConstantInt::get(IGM.Int64Ty, 0);

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2928,6 +2928,7 @@ bool irgen::hasPolymorphicParameters(CanSILFunctionType ty) {
 
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
     // May be polymorphic at the SIL level, but no type metadata is actually
     // passed.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3614,6 +3614,7 @@ Callee LoweredValue::getCallee(IRGenFunction &IGF,
       return getBlockPointerCallee(IGF, functionValue, std::move(calleeInfo));
 
     case SILFunctionType::Representation::ObjCMethod:
+    case SILFunctionType::Representation::COMMethod:
     case SILFunctionType::Representation::CXXMethod:
     case SILFunctionType::Representation::Thick:
       llvm_unreachable("unexpected function with singleton representation");
@@ -3681,6 +3682,7 @@ static std::unique_ptr<CallEmission> getCallEmissionForLoweredValue(
   }
 
   case SILFunctionType::Representation::ObjCMethod:
+  case SILFunctionType::Representation::COMMethod:
   case SILFunctionType::Representation::CXXMethod:
   case SILFunctionType::Representation::Thick:
   case SILFunctionType::Representation::Block:
@@ -4229,6 +4231,7 @@ getPartialApplicationFunction(IRGenSILFunction &IGF, SILValue v,
     case SILFunctionTypeRepresentation::CFunctionPointer:
     case SILFunctionTypeRepresentation::Block:
     case SILFunctionTypeRepresentation::ObjCMethod:
+    case SILFunctionTypeRepresentation::COMMethod:
     case SILFunctionTypeRepresentation::CXXMethod:
       llvm_unreachable("partial_apply of foreign functions not implemented");
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3578,6 +3578,7 @@ public:
     case SILFunctionType::Representation::Method:
     case SILFunctionType::Representation::WitnessMethod:
     case SILFunctionType::Representation::ObjCMethod:
+    case SILFunctionType::Representation::COMMethod:
     case SILFunctionType::Representation::CXXMethod:
     case SILFunctionType::Representation::CFunctionPointer:
     case SILFunctionType::Representation::Closure:
@@ -3763,6 +3764,7 @@ namespace {
       case SILFunctionType::Representation::Method:
       case SILFunctionType::Representation::WitnessMethod:
       case SILFunctionType::Representation::ObjCMethod:
+      case SILFunctionType::Representation::COMMethod:
       case SILFunctionType::Representation::CXXMethod:
       case SILFunctionType::Representation::CFunctionPointer:
       case SILFunctionType::Representation::Closure:

--- a/lib/SIL/IR/Bridging.cpp
+++ b/lib/SIL/IR/Bridging.cpp
@@ -127,6 +127,7 @@ Type TypeConverter::getLoweredBridgedType(AbstractionPattern pattern,
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::ObjCMethod:
   case SILFunctionTypeRepresentation::Block:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
     // Map native types back to bridged types.
 
@@ -213,7 +214,8 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
     case SILFunctionType::Representation::Thin:
     case SILFunctionType::Representation::Method:
     case SILFunctionType::Representation::ObjCMethod:
-    case SILFunctionTypeRepresentation::CXXMethod:
+    case SILFunctionType::Representation::COMMethod:
+    case SILFunctionType::Representation::CXXMethod:
     case SILFunctionType::Representation::WitnessMethod:
     case SILFunctionType::Representation::Closure:
     case SILFunctionType::Representation::KeyPathAccessorGetter:

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3578,6 +3578,7 @@ static CanSILFunctionType getNativeSILFunctionType(
         TC, origType, substInterfaceType, extInfoBuilder, constant);
 
   case SILFunctionType::Representation::Thin:
+  case SILFunctionType::Representation::COMMethod:
   case SILFunctionType::Representation::ObjCMethod:
   case SILFunctionType::Representation::Thick:
   case SILFunctionType::Representation::Method:
@@ -5438,6 +5439,7 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
     bridgedResultType = resultType;
     break;
 
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
   case SILFunctionTypeRepresentation::ObjCMethod:
   case SILFunctionTypeRepresentation::CFunctionPointer: {

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -1046,6 +1046,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     }
     case SILFunctionTypeRepresentation::CFunctionPointer:
     case SILFunctionTypeRepresentation::CXXMethod:
+    case SILFunctionTypeRepresentation::COMMethod:
     case SILFunctionTypeRepresentation::Thin:
     case SILFunctionTypeRepresentation::Method:
     case SILFunctionTypeRepresentation::Closure:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1942,6 +1942,7 @@ static ManagedValue convertFunctionRepresentation(SILGenFunction &SGF,
     case SILFunctionType::Representation::Closure:
     case SILFunctionType::Representation::ObjCMethod:
     case SILFunctionType::Representation::WitnessMethod:
+    case SILFunctionType::Representation::COMMethod:
     case SILFunctionType::Representation::CXXMethod:
     case SILFunctionType::Representation::KeyPathAccessorGetter:
     case SILFunctionType::Representation::KeyPathAccessorSetter:
@@ -1976,6 +1977,7 @@ static ManagedValue convertFunctionRepresentation(SILGenFunction &SGF,
     case SILFunctionType::Representation::Closure:
     case SILFunctionType::Representation::ObjCMethod:
     case SILFunctionType::Representation::WitnessMethod:
+    case SILFunctionType::Representation::COMMethod:
     case SILFunctionType::Representation::CXXMethod:
     case SILFunctionType::Representation::KeyPathAccessorGetter:
     case SILFunctionType::Representation::KeyPathAccessorSetter:

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -96,6 +96,7 @@ static bool isSpecializableRepresentation(SILFunctionTypeRepresentation Rep,
   case SILFunctionTypeRepresentation::WitnessMethod:
     return OptForPartialApply;
   case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::Block:
     return false;
   }

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -767,8 +767,9 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
   case SILFunctionTypeRepresentation::KeyPathAccessorEquals:
   case SILFunctionTypeRepresentation::KeyPathAccessorHash:
     break;
-    
+
   case SILFunctionTypeRepresentation::CFunctionPointer:
+  case SILFunctionTypeRepresentation::COMMethod:
   case SILFunctionTypeRepresentation::CXXMethod:
   case SILFunctionTypeRepresentation::ObjCMethod:
   case SILFunctionTypeRepresentation::Block:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4964,26 +4964,26 @@ NeverNullType TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
   auto conventionAttr = claim<ConventionTypeAttr>(attrs);
   if (conventionAttr) {
     auto parsedRep =
-      llvm::StringSwitch<std::optional<SILFunctionType::Representation>>(
+        llvm::StringSwitch<std::optional<SILFunctionType::Representation>>(
             conventionAttr->getConventionName())
-        .Case("thick", SILFunctionType::Representation::Thick)
-        .Case("block", SILFunctionType::Representation::Block)
-        .Case("thin", SILFunctionType::Representation::Thin)
-        .Case("c", SILFunctionType::Representation::CFunctionPointer)
-        .Case("method", SILFunctionType::Representation::Method)
-        .Case("objc_method",
-              SILFunctionType::Representation::ObjCMethod)
-        .Case("witness_method",
-              SILFunctionType::Representation::WitnessMethod)
-        .Case("keypath_accessor_getter",
-              SILFunctionType::Representation::KeyPathAccessorGetter)
-        .Case("keypath_accessor_setter",
-              SILFunctionType::Representation::KeyPathAccessorSetter)
-        .Case("keypath_accessor_equals",
-              SILFunctionType::Representation::KeyPathAccessorEquals)
-        .Case("keypath_accessor_hash",
-              SILFunctionType::Representation::KeyPathAccessorHash)
-        .Default(std::nullopt);
+            .Case("thick", SILFunctionType::Representation::Thick)
+            .Case("block", SILFunctionType::Representation::Block)
+            .Case("thin", SILFunctionType::Representation::Thin)
+            .Case("c", SILFunctionType::Representation::CFunctionPointer)
+            .Case("method", SILFunctionType::Representation::Method)
+            .Case("com_method", SILFunctionType::Representation::COMMethod)
+            .Case("objc_method", SILFunctionType::Representation::ObjCMethod)
+            .Case("witness_method",
+                  SILFunctionType::Representation::WitnessMethod)
+            .Case("keypath_accessor_getter",
+                  SILFunctionType::Representation::KeyPathAccessorGetter)
+            .Case("keypath_accessor_setter",
+                  SILFunctionType::Representation::KeyPathAccessorSetter)
+            .Case("keypath_accessor_equals",
+                  SILFunctionType::Representation::KeyPathAccessorEquals)
+            .Case("keypath_accessor_hash",
+                  SILFunctionType::Representation::KeyPathAccessorHash)
+            .Default(std::nullopt);
     if (!parsedRep) {
       conventionAttr->setInvalid();
       diagnoseInvalid(repr, conventionAttr->getAtLoc(),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7079,6 +7079,7 @@ getActualSILFunctionTypeRepresentation(uint8_t rep) {
   CASE(Method)
   CASE(ObjCMethod)
   CASE(WitnessMethod)
+  CASE(COMMethod)
   CASE(CXXMethod)
   CASE(KeyPathAccessorGetter)
   CASE(KeyPathAccessorSetter)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1022; // @_target attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1023; // COMMethod
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -318,6 +318,7 @@ enum class SILFunctionTypeRepresentation : uint8_t {
   KeyPathAccessorSetter,
   KeyPathAccessorEquals,
   KeyPathAccessorHash,
+  COMMethod,
 };
 using SILFunctionTypeRepresentationField = BCFixed<5>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5665,6 +5665,7 @@ static uint8_t getRawStableSILFunctionTypeRepresentation(
   SIMPLE_CASE(SILFunctionTypeRepresentation, ObjCMethod)
   SIMPLE_CASE(SILFunctionTypeRepresentation, WitnessMethod)
   SIMPLE_CASE(SILFunctionTypeRepresentation, Closure)
+  SIMPLE_CASE(SILFunctionTypeRepresentation, COMMethod)
   SIMPLE_CASE(SILFunctionTypeRepresentation, CXXMethod)
   SIMPLE_CASE(SILFunctionTypeRepresentation, KeyPathAccessorGetter)
   SIMPLE_CASE(SILFunctionTypeRepresentation, KeyPathAccessorSetter)

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -391,6 +391,7 @@ $sxq_Irgnr_D ---> @differentiable(reverse) @callee_guaranteed (@in_guaranteed A)
 $sxq_Idgnr_D ---> @differentiable @callee_guaranteed (@in_guaranteed A) -> (@out B)
 $sxq_Ilgnr_D ---> @differentiable(_linear) @callee_guaranteed (@in_guaranteed A) -> (@out B)
 $sS3fIedgyywd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float)
+$sBpIetVy_D ---> @escaping @convention(thin) @convention(com_method) (@unowned Builtin.RawPointer) -> ()
 $sS5fIertyyywddw_D ---> @escaping @differentiable(reverse) @convention(thin) (@unowned Swift.Float, @unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float, @unowned @noDerivative Swift.Float)
 $syQo ---> $syQo
 $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee ---> $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1560,6 +1560,8 @@ sil @c_convention : $@convention(c) () -> ()
 sil @method_convention : $@convention(method) (Int) -> ()
 sil @objc_method_convention : $@convention(objc_method) (Int) -> ()
 sil @witness_method_convention : $@convention(witness_method: Bendable) (Fork) -> ()
+// CHECK-LABEL: sil @com_method_convention : $@convention(com_method) (Builtin.RawPointer) -> ()
+sil @com_method_convention : $@convention(com_method) (Builtin.RawPointer) -> ()
 
 // CHECK-LABEL: sil @conventions : $@convention(thin) (() -> (), @convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(method) () -> (), @convention(objc_method) () -> (), @convention(witness_method: Bendable) (Fork) -> ()) -> () {
 sil @conventions : $@convention(thin) (@convention(thick) () -> (),

--- a/test/Serialization/com-method-convention.sil
+++ b/test/Serialization/com-method-convention.sil
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-stdlib -emit-sil -emit-sorted-sil -sil-verify-all -module-name COMConvention %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -emit-sib -sil-verify-all -module-name COMConvention %s -o %t/COMConvention.sib
+// RUN: %target-swift-frontend -parse-stdlib -emit-sil -emit-sorted-sil -sil-verify-all -module-name COMConvention %t/COMConvention.sib | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -use-clang-function-types -emit-sil -emit-sorted-sil -sil-verify-all -module-name COMConvention %t/COMConvention.sib | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+// Preserve the convention on a function definition and on a function value.
+// COM methods do not require a stored Clang function type.
+
+// CHECK-LABEL: sil @method : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32 {
+// CHECK: return %0
+sil @method : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32 {
+bb0(%value : $Builtin.Int32, %self : $Builtin.RawPointer):
+  return %value : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil @reference : $@convention(thin) () -> @convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32 {
+// CHECK: [[METHOD:%.*]] = function_ref @method : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32
+// CHECK: return [[METHOD]]
+sil @reference : $@convention(thin) () -> @convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32 {
+bb0:
+  %method = function_ref @method : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32
+  return %method : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32
+}
+
+// The SIL self argument remains last; moving it to the physical first argument
+// belongs to IRGen.
+// CHECK-LABEL: sil @use : $@convention(thin) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32 {
+// CHECK: [[METHOD:%.*]] = function_ref @method : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32
+// CHECK: [[RESULT:%.*]] = apply [[METHOD]](%0, %1) : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32
+// CHECK: return [[RESULT]]
+sil @use : $@convention(thin) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32 {
+bb0(%value : $Builtin.Int32, %self : $Builtin.RawPointer):
+  %method = function_ref @method : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32
+  %result = apply %method(%value, %self) : $@convention(com_method) (Builtin.Int32, Builtin.RawPointer) -> Builtin.Int32
+  return %result : $Builtin.Int32
+}

--- a/test/attr/attr_convention.swift
+++ b/test/attr/attr_convention.swift
@@ -11,6 +11,9 @@ let f4c: @convention(c, cType: "int (*)(int)") (Int32) -> Int32 = { $0 }
 
 let f5: @convention(INTERCAL) (Int) -> Int = { $0 } // expected-error{{convention 'INTERCAL' not supported}}
 
+// COM method conventions are only spelled in SIL.
+let comMethod: @convention(com_method) (Int) -> Int = { $0 } // expected-error{{convention 'com_method' not supported}}
+
 // https://github.com/apple/swift/issues/53417
 
 do {

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_unittest(SwiftASTTests
   DiagnosticFormattingTests.cpp
   DiagnosticInfoTests.cpp
   SourceLocTests.cpp
+  SILFunctionTypeTests.cpp
   TestContext.cpp
   TypeMatchTests.cpp
   VersionRangeTests.cpp

--- a/unittests/AST/SILFunctionTypeTests.cpp
+++ b/unittests/AST/SILFunctionTypeTests.cpp
@@ -1,0 +1,48 @@
+//===--- SILFunctionTypeTests.cpp - SIL function type tests --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestContext.h"
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/Types.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::unittest;
+
+TEST(SILFunctionType, COMMethod) {
+  TestContext C;
+  auto makeType = [&](SILFunctionTypeRepresentation representation) {
+    auto extInfo =
+        SILExtInfoBuilder().withRepresentation(representation).build();
+    SILParameterInfo self(C.Ctx.TheRawPointerType,
+                          ParameterConvention::Direct_Unowned);
+    return SILFunctionType::get(nullptr, extInfo, SILCoroutineKind::None,
+                                ParameterConvention::Direct_Unowned, {self}, {},
+                                {}, std::nullopt, {}, {}, C.Ctx);
+  };
+
+  auto method = makeType(SILFunctionTypeRepresentation::COMMethod);
+  EXPECT_TRUE(method->hasSelfParam());
+  EXPECT_FALSE(method->getExtInfo().hasContext());
+  EXPECT_EQ(method->getLanguage(), SILFunctionLanguage::C);
+  EXPECT_FALSE(shouldStoreClangType(method->getRepresentation()));
+
+  // Although both are foreign function pointers, the COM method's implicit
+  // self parameter requires a distinct type and mangling.
+  auto function = makeType(SILFunctionTypeRepresentation::CFunctionPointer);
+  EXPECT_NE(method, function);
+  EXPECT_FALSE(function->hasSelfParam());
+
+  Mangle::ASTMangler mangler(C.Ctx);
+  EXPECT_EQ(mangler.mangleTypeForTypeName(method), "BpIetVy_");
+  EXPECT_EQ(mangler.mangleTypeForTypeName(function), "BpIetCy_");
+}


### PR DESCRIPTION
This pull request introduces support for a new function type representation for COM interface methods throughout the Swift compiler codebase. The changes add the `COMMethod` representation to various enums, type systems, and supporting logic, laying the groundwork for handling COM interface method conventions. However, actual lowering and code generation for COM methods is not yet implemented; attempts to use these paths will result in `llvm_unreachable` assertions.

The most important changes are:

**1. Type System and Enum Additions**
- Added `COMMethod` as a new case to function type representation enums in `SILFunctionTypeRepresentation`, `FunctionTypeRepresentation`, and related bridging enums, enabling the type system to recognize COM interface methods. [[1]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR383-R386) [[2]](diffhunk://#diff-dc24ce8e9a12cf9b197541be1bfcca8e07a4b43a96276aa118f55f2f1ab80740R381-R383) [[3]](diffhunk://#diff-835bf87ae30b4064ff7fd7a32011f46fd58a338e55e02de34674f7a11b87cf25L3143-R3144)

**2. Bridging and Type Conversion**
- Updated bridging code and type conversion logic to handle the new `COMMethod` representation, including static assertions and switch cases to ensure correct enum value mapping between Swift and bridging layers. [[1]](diffhunk://#diff-3c437251edae6d22f43faa12137879a582ee5482690489aa32f96a5e5a9c00f5R810-R811) [[2]](diffhunk://#diff-dc24ce8e9a12cf9b197541be1bfcca8e07a4b43a96276aa118f55f2f1ab80740R260) [[3]](diffhunk://#diff-dc24ce8e9a12cf9b197541be1bfcca8e07a4b43a96276aa118f55f2f1ab80740R403) [[4]](diffhunk://#diff-f626e11fb8d3587deded0ff6ebdd036e7edc85cf08e254a4f141e644b6fd86e3R220)

**3. Code Generation and Lowering Stubs**
- Inserted `llvm_unreachable` stubs in the IRGen (code generation) layer for all code paths related to lowering, signature expansion, and argument handling for COM methods, clearly marking these as not yet implemented. [[1]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R382-R385) [[2]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R1597-R1599) [[3]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R1978) [[4]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R2073-R2074) [[5]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R2353-R2354) [[6]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R2981-R2983)

**4. Printing, Mangling, and Demangling**
- Updated AST printing, mangling, and demangling logic to recognize and correctly display or encode/decode the `COMMethod` representation, ensuring tooling and diagnostics can handle this new case. [[1]](diffhunk://#diff-0dfba48d1a4f467a4fde650be96ca9e7f4b53234055ccdbdd0ce0734e6d822a9R310-R311) [[2]](diffhunk://#diff-a51b503c668714235cef4196e235630d73ce361068e1cd149faf92499744604bR7290-R7292) [[3]](diffhunk://#diff-a51b503c668714235cef4196e235630d73ce361068e1cd149faf92499744604bR7386-R7388) [[4]](diffhunk://#diff-7ea4597449ccdb47c742e03aaf22e581efb4e18c7240047645ced5ea3ede7855R2413-R2415) [[5]](diffhunk://#diff-0f15599ed4c17e8194c4a77516293879416f64361f7f960f8b4a8b044a980fdfR2552-R2554) [[6]](diffhunk://#diff-94eb69d908be3bca240d3318868026d4be647faec057abdb36f3f5fc144e28a7R2087)

**5. Supporting Logic and Utilities**
- Updated various utility functions and logic (e.g., context checks, indirect callability, language inference, etc.) to account for the new `COMMethod` representation, ensuring consistent handling across the codebase. [[1]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR416) [[2]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR453) [[3]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR484) [[4]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR510) [[5]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR535) [[6]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR746) [[7]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR1125) [[8]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR1322) [[9]](diffhunk://#diff-da64f67a05bcc9f586b637faaa6d9e73e0e3e90b4657b36c70d8d26f029ffa6cR1341) [[10]](diffhunk://#diff-28f0eb58279ef4c55b7953cd2fdfdd70d6ec9a56e2bdea40f0c01fff9a4e732aR267) [[11]](diffhunk://#diff-5e3c624d440ee19cdc8e908dddd0fc64abd4732f295238ca5450ddbe232f70d5R373) [[12]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R3364) [[13]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R4207) [[14]](diffhunk://#diff-e3cb1b9416734345839b90f1c5ec26d9173d335e687abb007c9ec0b332b3d3e4R4223)

These changes collectively prepare the compiler to recognize and describe COM interface methods, even though full support for code generation is not yet present.