### PR TITLE
CMake: Expose `LLVM_VERSION_MAJOR` to Swift sources in the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,16 @@ if(BRIDGING_MODE STREQUAL "DEFAULT" OR NOT BRIDGING_MODE)
   endif()
 endif()
 
+# LLVM_VERSION_MAJOR for Swift sources in the compiler, should they ever
+# need it.
+set(SWIFT_LLVM_VERSION_MAJOR_SWIFT_COMPILE_DEFINITIONS)
+foreach(version 23 24 25)
+  if(LLVM_VERSION_MAJOR GREATER_EQUAL ${version})
+    list(APPEND SWIFT_LLVM_VERSION_MAJOR_SWIFT_COMPILE_DEFINITIONS
+      "LLVM_VERSION_MAJOR_AT_LEAST_${version}")
+  endif()
+endforeach()
+
 is_build_type_optimized("${SWIFT_STDLIB_BUILD_TYPE}" swift_optimized)
 if(swift_optimized)
   set(SWIFT_STDLIB_ASSERTIONS_default FALSE)

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -150,6 +150,12 @@ function(add_swift_compiler_modules_library name)
     list(APPEND swift_compile_options "-Xcc" "-DPURE_BRIDGING_MODE")
   endif()
 
+  # LLVM_VERSION_MAJOR for Swift sources in the compiler, should they ever
+  # need it.
+  foreach(condition ${SWIFT_LLVM_VERSION_MAJOR_SWIFT_COMPILE_DEFINITIONS})
+    list(APPEND swift_compile_options "-D${condition}")
+  endforeach()
+
   if(NOT SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
     list(APPEND swift_compile_options "-Xfrontend" "-disable-legacy-type-info")
   endif()

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -76,6 +76,11 @@ function(_add_host_swift_compile_options name)
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DPURE_BRIDGING_MODE>")
   endif()
 
+  # LLVM_VERSION_MAJOR for Swift sources in the compiler, should they ever
+  # need it.
+  target_compile_definitions(${name} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:${SWIFT_LLVM_VERSION_MAJOR_SWIFT_COMPILE_DEFINITIONS}>")
+
   # The compat56 library is not available in current toolchains. The stage-0
   # compiler will build fine since the builder compiler is not aware of the 56
   # compat library, but the stage-1 and subsequent stage compilers will fail as


### PR DESCRIPTION
`LLVM_VERSION_MAJOR` allows us to target the `main` branch instead of `rebranch` even when code must differ depending on the `llvm-project` branch.

C++ sources get it "for free" by including `llvm/Config/llvm-config.h`, unlike Swift sources. This change is deliberate redundancy. A need for this conditional compilation flag in Swift code has not arisen, yet.
