### PR TITLE
[Demangling] Null-check the argument-type chain in keyPathSourceString.

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3790,6 +3790,8 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
     NodePointer firstChild = root->getChild(0);
     if (firstChild->getKind() == Node::Kind::KeyPathGetterThunkHelper) {
       NodePointer child = firstChild->getChild(0);
+      if (child == nullptr)
+        return invalid;
       switch (child->getKind()) {
       case Node::Kind::Subscript: {
         std::string subscriptText = "subscript(";
@@ -3800,6 +3802,9 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
           return std::string("<unknown>");
         };
         auto getArgumentNodeName = [](NodePointer node) {
+          if (node == nullptr) {
+            return std::string("<unknown>");
+          }
           if (node->getKind() == Node::Kind::Identifier) {
             return std::string(node->getText());
           }
@@ -3833,8 +3838,15 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
             NodePointer argumentType = argList->getChild(idx);
             idx += 1;
             if (argumentType->getKind() == Node::Kind::TupleElement) {
-              argumentType =
-                  argumentType->getChild(0)->getChild(0)->getChild(1);
+              // A tuple element has the type as its last child, but is not
+              // required to have the shape TupleElement -> Type -> <nominal> ->
+              // [Module, Identifier]. For example, an empty-tuple element has a
+              // childless Tuple as the grandchild, so every step here can produce
+              // null.
+              NodePointer typeNode = argumentType->getLastChild();
+              NodePointer nominal =
+                  typeNode ? typeNode->getChild(0) : nullptr;
+              argumentType = nominal ? nominal->getChild(1) : nullptr;
               argumentTypeNames.push_back(getArgumentNodeName(argumentType));
               continue;
             }
@@ -3850,8 +3862,9 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
                          std::make_pair(Node::Kind::Type, 0),
                      });
           if (argList != nullptr) {
+            NodePointer argType = argList->getChild(0);
             argumentTypeNames.push_back(
-                getArgumentNodeName(argList->getChild(0)->getChild(1)));
+                getArgumentNodeName(argType ? argType->getChild(1) : nullptr));
           }
         }
         child = child->getChild(1);

--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -257,6 +257,7 @@
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm \
 // RUN:             -e _ZSt12__str_concatINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEET_PKNS6_10value_typeENS6_9size_typeES9_SA_RKNS6_14allocator_typeE \
 // RUN:             -e _ZNSt7__cxx119to_stringEl \
+// RUN:             -e _ZNSt7__cxx119to_stringEm \
 // RUN:             -e _ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_realloc_appendIJS5_EEEvDpOT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEiEUlPcmE_EEvmT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEjEUlPcmE_EEvmT_ \
@@ -528,6 +529,7 @@
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm \
 // RUN:             -e _ZSt12__str_concatINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEET_PKNS6_10value_typeENS6_9size_typeES9_SA_RKNS6_14allocator_typeE \
 // RUN:             -e _ZNSt7__cxx119to_stringEl \
+// RUN:             -e _ZNSt7__cxx119to_stringEm \
 // RUN:             -e _ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_realloc_appendIJS5_EEEvDpOT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEiEUlPcmE_EEvmT_ \
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE22__resize_and_overwriteIZNS_9to_stringEjEUlPcmE_EEvmT_ \

--- a/unittests/Basic/DemangleTest.cpp
+++ b/unittests/Basic/DemangleTest.cpp
@@ -170,3 +170,21 @@ TEST(Demangle, KeyPathSourceStringNestedLocalDeclName) {
   EXPECT_EQ("subscript(_: foo #1)",
             keyPathSourceString(local, sizeof(local) - 1));
 }
+
+// A subscript argument tuple element is not required to have the shape
+// TupleElement -> Type -> <nominal> -> [Module, Identifier]. For example, an
+// empty-tuple element has a childless Tuple as the grandchild, so walking the
+// chain unchecked dereferenced null.
+TEST(Demangle, KeyPathSourceStringMalformedTupleElement) {
+  static const char variadic[] = "$s1m1SVySbSi_SidtcipACTK";
+  EXPECT_EQ("subscript(_: Int)",
+            keyPathSourceString(variadic, sizeof(variadic) - 1));
+
+  static const char firstVariadic[] = "$s1m1SVySbSid_SitcipACTK";
+  EXPECT_EQ("subscript(_: Int)",
+            keyPathSourceString(firstVariadic, sizeof(firstVariadic) - 1));
+
+  static const char emptyTuple[] = "$s1m1SVySbSi_yttcipACTK";
+  EXPECT_EQ("subscript(_: Int)",
+            keyPathSourceString(emptyTuple, sizeof(emptyTuple) - 1));
+}


### PR DESCRIPTION
The subscript case walked argumentType->getChild(0)->getChild(0)->getChild(1) with no NULL checks, but it's possible for some of those to return NULL. Split them apart and check along the way. Also use getLastChild() for the first step in the chain, as the tuple element type is the last child, not the first.

rdar://185697961

Note: `symbol-visibility-linux.test-sh` gains an entry for `std::__cxx11::to_string(unsigned long)` even though the new code in this PR doesn't use it. There's an existing use, and it seems that we've perturbed the inliner enough that it's now being referenced as a symbol rather than being inlined.