### PR TITLE
[next] Use llvm::post_order() instead of po_begin/po_end

### DIFF
--- a/include/swift/SIL/PostOrder.h
+++ b/include/swift/SIL/PostOrder.h
@@ -31,7 +31,7 @@ class PostOrderFunctionInfo {
 
 public:
   PostOrderFunctionInfo(SILFunction *F) {
-    for (auto *BB : make_range(po_begin(F), po_end(F))) {
+    for (auto *BB : post_order(F)) {
       BBToPOMap[BB] = PostOrder.size();
       PostOrder.push_back(BB);
     }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -929,8 +929,7 @@ public:
     if (Ctx.sortSIL()) {
       std::vector<SILBasicBlock *> RPOT;
       auto *UnsafeF = const_cast<SILFunction *>(F);
-      std::copy(po_begin(UnsafeF), po_end(UnsafeF),
-                std::back_inserter(RPOT));
+      llvm::copy(post_order(UnsafeF), std::back_inserter(RPOT));
       std::reverse(RPOT.begin(), RPOT.end());
       Ctx.initBlockIDs(RPOT);
       interleave(RPOT,
@@ -5126,7 +5125,7 @@ ID SILPrintContext::getID(const SILBasicBlock *Block) {
     if (sortSIL()) {
       std::vector<SILBasicBlock *> RPOT;
       auto *UnsafeF = const_cast<SILFunction *>(Block->getParent());
-      std::copy(po_begin(UnsafeF), po_end(UnsafeF), std::back_inserter(RPOT));
+      llvm::copy(post_order(UnsafeF), std::back_inserter(RPOT));
       std::reverse(RPOT.begin(), RPOT.end());
       // Initialize IDs so our IDs are in RPOT as well. This is a hack.
       for (unsigned Index : indices(RPOT))


### PR DESCRIPTION
Upstream, LLVM removed the free functions po_begin()/po_end() in favor of post_order(...), an API that already exists on main. Replace the remaining usages of po_{begin,end}() with `post_order(...)`.

By updating to use this newer API, we help next and do not break main.
