### PR TITLE
[test] Reproducer: async resume destroys a decoded payload before retaining Strings extracted from it

### DIFF
--- a/test/SILOptimizer/async_destroy_before_retain_resilient_field.swift
+++ b/test/SILOptimizer/async_destroy_before_retain_resilient_field.swift
@@ -1,0 +1,130 @@
+// A miscompilation, not a fix: the CHECK lines below describe the correct
+// ordering, and the optimizer does not currently produce it. See the XFAIL.
+//
+// In an `async` function, extracting `String` fields out of a decoded payload
+// and returning them in a new value emits `destroy_addr` of the payload BEFORE
+// the `strong_retain` of the extracted bridge objects, so the returned `String`s
+// are already released when the function returns. Requires the payload struct to
+// carry a trailing stored property of a resilient type; with a fragile type of
+// the same layout the retains are correctly ordered before the destroy.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build the resilient library separately.
+// RUN: %target-swift-frontend -emit-module -parse-as-library -O \
+// RUN:   -enable-library-evolution -disable-availability-checking \
+// RUN:   -module-name Stamp %t/library.swift \
+// RUN:   -emit-module-path %t/Stamp.swiftmodule
+
+// RUN: %target-swift-frontend -emit-sil -O -I %t \
+// RUN:   -disable-availability-checking \
+// RUN:   -module-name main %t/client.swift | %FileCheck %s
+
+// XFAIL: *
+
+// REQUIRES: concurrency
+
+//--- library.swift
+
+public struct Stamp: Sendable, Hashable {
+    public var v: Double
+    public init(v: Double) { self.v = v }
+}
+
+//--- client.swift
+
+import Stamp
+
+public struct Decoded: Sendable, Hashable {
+    public var nonce: String
+    public var continuation: String
+    // Remove this field, or give it a fragile type such as `Double` or a struct
+    // declared in this module, and the miscompile below disappears.
+    public var expiresAt: Stamp
+    public init(nonce: String, continuation: String, expiresAt: Stamp) {
+        self.nonce = nonce
+        self.continuation = continuation
+        self.expiresAt = expiresAt
+    }
+}
+
+public struct Refusal: Sendable, Hashable {
+    public var reason: String
+    public init(reason: String) { self.reason = reason }
+}
+
+public enum Output: Sendable, Hashable {
+    public struct Ok: Sendable, Hashable {
+        public enum Body: Sendable, Hashable {
+            case json(Decoded)
+            public var json: Decoded {
+                get throws { switch self { case let .json(b): return b } }
+            }
+        }
+        public var body: Body
+        public init(body: Body) { self.body = body }
+    }
+    public struct Unprocessable: Sendable, Hashable {
+        public enum Body: Sendable, Hashable {
+            case json(Refusal)
+            public var json: Refusal {
+                get throws { switch self { case let .json(b): return b } }
+            }
+        }
+        public var body: Body
+        public init(body: Body) { self.body = body }
+    }
+    case ok(Ok)
+    case unprocessable(Unprocessable)
+    case undocumented(statusCode: Int)
+}
+
+public protocol Transport: Sendable {
+    func send(_ p: String) async throws -> Output
+}
+
+public struct Intent: Sendable, Equatable {
+    public let nonce: String
+    public let continuation: String
+    public init(nonce: String, continuation: String) {
+        self.nonce = nonce
+        self.continuation = continuation
+    }
+}
+
+public enum IntentRead: Sendable, Equatable {
+    case ok(Intent)
+    case refused(String?)
+    case unavailable
+}
+
+public struct API: Sendable {
+    let transport: any Transport
+    public init(transport: any Transport) { self.transport = transport }
+
+    // `body` is an owned value and reading `body.nonce` is a copy, so both
+    // extracted `String`s must be retained before the payload is destroyed.
+    //
+    // CHECK-LABEL: sil {{.*}}@$s4main3APIV10makeIntent8providerAA0D4ReadOSS_tYaF :
+    // CHECK-NOT: destroy_addr
+    // CHECK: strong_retain
+    // CHECK-NOT: destroy_addr
+    // CHECK: strong_retain
+    public func makeIntent(provider: String) async -> IntentRead {
+        do {
+            switch try await transport.send(provider) {
+            case .ok(let ok):
+                let body = try ok.body.json
+                guard !body.nonce.isEmpty, !body.continuation.isEmpty else { return .unavailable }
+                return .ok(.init(nonce: body.nonce, continuation: body.continuation))
+            case .unprocessable(let refusal):
+                return .refused(try refusal.body.json.reason)
+            case .undocumented:
+                return .unavailable
+            }
+        } catch {
+            return .unavailable
+        }
+    }
+}


### PR DESCRIPTION
**This is a reproducer, not a fix.** Opening as a draft because the CHECK lines describe the correct ordering, which the optimizer does not currently produce, so the test is marked `XFAIL: *`. Happy to convert this to a plain issue instead if that is the preferred intake — CONTRIBUTING points bugs at the issue tracker, and I have no fix to offer, only a reduced case.

## The problem

In an `async` function, extracting `String` fields out of a decoded payload and returning them in a new value emits `destroy_addr` of the payload **before** the `strong_retain` of the extracted bridge objects. The returned `String`s are already released when the function returns.

From the emitted `-O` SIL of the attached test:

```
bb6:
  %55 = load %54                    // continuation's _countAndFlagsBits
  %57 = load %56                    // continuation's _object  -- borrowed, not retained
  ...
bb9(%71 : $Builtin.Int64):          // Preds: bb8 bb7
  destroy_addr %14                  // *** payload destroyed -- releases both Strings
  cond_br %72, bb11, bb10

bb10:                               // Preds: bb9
  ...
  %87 = struct $Intent (%78, %82)
  %88 = enum $IntentRead, #IntentRead.ok!enumelt, %87
  strong_retain %31                 // *** retain of already-released nonce
  strong_retain %57                 // *** retain of already-released continuation
  br bb16(%88)
```

`bb10`'s only predecessor is `bb9`, so on the path that carries the values out, the destroy strictly precedes both retains.

The source is ordinary: `body` is an owned value, and reading `body.nonce` is a copy. There is no unsafe or unmanaged construct anywhere in it.

```swift
public func makeIntent(provider: String) async -> IntentRead {
    do {
        switch try await transport.send(provider) {
        case .ok(let ok):
            let body = try ok.body.json
            guard !body.nonce.isEmpty, !body.continuation.isEmpty else { return .unavailable }
            return .ok(.init(nonce: body.nonce, continuation: body.continuation))
        case .unprocessable(let refusal):
            return .refused(try refusal.body.json.reason)
        case .undocumented:
            return .unavailable
        }
    } catch {
        return .unavailable
    }
}
```

## Expected

The retain of each extracted `String` — or a copy of the payload that performs it — must precede `destroy_addr` of the enclosing value.

## The condition

Established by bisecting the reproducer. The payload struct must carry a **trailing stored property of a resilient type**:

| Trailing field on the payload struct | Miscompiles? |
| --- | --- |
| a struct from a module built with `-enable-library-evolution` | **yes** |
| `Foundation.Date`, `Foundation.UUID` | **yes** |
| the same struct declared in the client module (fragile, identical layout) | no |
| `Double` / `Int` / `Bool` | no |
| `Foundation.Decimal` | no |
| field removed entirely | no |

Changes that make **no** difference: an extra leading `String` field; `@frozen` on the enums; a payload on the `undocumented` case; the number of similar operation types in the module.

`Date` and `UUID` are the practical way to hit this, since Foundation is resilient — which is how it was originally found, in generated OpenAPI response types carrying an `expiresAt: Date`.

## Where it shows up

- `-O` only. Does not reproduce at `-Onone`.
- Verified on `arm64-apple-macosx` and `x86_64-apple-macosx` (identical SIL), and on `arm64-apple-ios`. Not tested on Linux or Windows, so I have deliberately not added a `REQUIRES:` line — please narrow it if it turns out to be Darwin-specific.
- Present in Apple Swift 6.4 (`swiftlang-6.4.0.34.1`, Xcode 27.0 27A266a) and in the earlier `swiftlang-6.4.0.30.4`.

Downstream this reached a shipped iOS build as a hard-to-attribute crash: the freed string storage is reused, and the first `isa` read after bridging to `NSString` fails pointer authentication on arm64e, trapping far from the miscompiled function. It is invisible to unit tests whose doubles return literal or multiply-referenced strings that never reach refcount 0, and invisible in a Simulator build.

## Test plan

`test/SILOptimizer/async_destroy_before_retain_resilient_field.swift` — builds a resilient module via `split-file`, compiles the client with `-emit-sil -O`, and asserts that no `destroy_addr` appears before the two `strong_retain`s. Currently `XFAIL`; removing the `XFAIL` line is the check that a fix works.

I verified the RUN lines against a released toolchain by running the equivalent `swift-frontend` invocations by hand; I have not built the compiler to run lit itself.