### PR TITLE
[Runtime] Address-diversify the compatibility-override function pointers.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1833,6 +1833,10 @@ namespace SpecialPointerAuthDiscriminators {
   const uint16_t CoroDeallocationFunction = 0x9faf; // = 40879
   const uint16_t CoroFrameAllocationFunction = 0xd251;   // = 53841
   const uint16_t CoroFrameDeallocationFunction = 0x5ba8; // = 23464
+
+  /// The compatibility-override cache in each hooked runtime entry point.
+  /// The slot is address-diversified, so one discriminator covers all of them.
+  const uint16_t CompatibilityOverride = 0xf50b; // = 62731
 }
 
 /// The number of arguments that will be passed directly to a generic

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -573,6 +573,37 @@ swift_auth_code(T value, unsigned extra) {
 #endif
 }
 
+/// Authenticate an address-diversified code pointer stored at `address`, and
+/// return it carrying the default C function pointer schema, so it can be
+/// called or assigned to a function pointer.
+template <typename T>
+SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE static inline T
+swift_auth_code_address(T value, const void *address, unsigned extra) {
+#if SWIFT_PTRAUTH
+  return (T)ptrauth_auth_function(
+      (void *)value, ptrauth_key_process_independent_code,
+      ptrauth_blend_discriminator(address, extra));
+#else
+  return value;
+#endif
+}
+
+/// Re-sign a code pointer for at-rest storage at `address`. The value must
+/// carry the default C function pointer schema, which is what a function
+/// pointer passed through a void * or uintptr_t still has.
+template <typename T>
+SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE static inline T
+swift_sign_code_address(T value, const void *address, unsigned extra) {
+#if SWIFT_PTRAUTH
+  return (T)ptrauth_auth_and_resign(
+      (void *)value, ptrauth_key_function_pointer, 0,
+      ptrauth_key_process_independent_code,
+      ptrauth_blend_discriminator(address, extra));
+#else
+  return value;
+#endif
+}
+
 /// Does this platform support backtrace-on-crash?
 #ifdef __APPLE__
 #  include <TargetConditionals.h>

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
@@ -214,16 +214,24 @@ namespace swift {
       uintptr_t fn, Original_##name defaultImpl) {                             \
     constexpr uintptr_t DEFAULT_IMPL_SENTINEL = 0x1;                           \
     if (SWIFT_UNLIKELY(fn == 0x0)) {                                           \
-      fn = (uintptr_t)getOverride_##name();                                    \
-      if (fn == 0x0) {                                                         \
+      Override_##name overrideFn = getOverride_##name();                       \
+      if (overrideFn == nullptr) {                                             \
         Override.store(DEFAULT_IMPL_SENTINEL,                                  \
                        std::memory_order::memory_order_relaxed);               \
         return defaultImpl COMPATIBILITY_PAREN(namedArgs);                     \
       }                                                                        \
-      Override.store(fn, std::memory_order::memory_order_relaxed);             \
+      Override.store((uintptr_t)swift_sign_code_address(                       \
+                         (void *)overrideFn, &Override,                        \
+                         SpecialPointerAuthDiscriminators::                    \
+                             CompatibilityOverride),                           \
+                     std::memory_order::memory_order_relaxed);                 \
+      return overrideFn(COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs)            \
+                            defaultImpl);                                      \
     }                                                                          \
-    return ((Override_##name)fn)(COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs)   \
-                                     defaultImpl);                             \
+    return ((Override_##name)swift_auth_code_address(                          \
+        (void *)fn, &Override,                                                 \
+        SpecialPointerAuthDiscriminators::CompatibilityOverride))(             \
+        COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs) defaultImpl);              \
   }                                                                            \
   attrs ccAttrs ret namespace swift_##name COMPATIBILITY_PAREN(typedArgs) {    \
     constexpr uintptr_t DEFAULT_IMPL_SENTINEL = 0x1;                           \
@@ -236,8 +244,10 @@ namespace swift {
                                     Override,                                  \
                                 fn, &swift_##name##Impl);                      \
     }                                                                          \
-    return ((Override_##name)fn)(COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs) & \
-                                 swift_##name##Impl);                          \
+    return ((Override_##name)swift_auth_code_address(                          \
+        (void *)fn, &Override,                                                 \
+        SpecialPointerAuthDiscriminators::CompatibilityOverride))(             \
+        COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs) & swift_##name##Impl);     \
   }
 
 #endif // #else SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT


### PR DESCRIPTION
Add a separate discriminator and address diversification to the Override static variables. Add swift_auth_code_address and swift_sign_code_address helpers, necessary because std::atomic doesn't play nicely with address-diversified __ptrauth schemes.

rdar://185745024