### PR TITLE
[Mandatory inlining] Don't force-inline a function that binds dynamic self

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -426,15 +426,16 @@ private func shouldInline(apply: FullApplySite, callee: Function, alreadyInlined
     return true
   }
 
+  if callee.mayBindDynamicSelf {
+    // We don't support inlining a function that binds dynamic self, e.g. into a
+    // global-init function, because the caller cannot provide the self metadata
+    // for the cloner to rewrite the callee's references to.
+    return false
+  }
+
   if apply is BeginApplyInst {
     // Avoid co-routines because they might allocate (their context).
     return true
-  }
-
-  if callee.mayBindDynamicSelf {
-    // We don't support inlining a function that binds dynamic self into a global-init function
-    // because the global-init function cannot provide the self metadata.
-    return false
   }
 
   if apply.parentFunction.isGlobalInitOnceFunction && (

--- a/test/embedded/coroutine-accessor-dynamic-self.swift
+++ b/test/embedded/coroutine-accessor-dynamic-self.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-emit-sil %s -enable-experimental-feature Embedded -wmo -o /dev/null
+
+// REQUIRES: swift_feature_Embedded
+
+// A coroutine accessor whose body binds dynamic self -- here by referring to
+// `Self` from inside a closure, which gives the accessor a dynamic-self metadata
+// argument -- must not be force-inlined into a caller that has no such metadata
+// to supply.
+
+class G<T> {
+  static var meta: Int { 7 }
+  var value: Int {
+    _read {
+      var x = 3
+      let r = withUnsafePointer(to: &x) { p -> Int in
+        return p.pointee + Self.meta
+      }
+      yield r
+    }
+  }
+}
+
+var g = G<Int>()
+print(g.value)


### PR DESCRIPTION
The "self" metadata won't be around, causing a crash.
