### PR TITLE
Cherry pick fixes for xros test failures to 6.4.x

### DIFF
--- a/test/Concurrency/async_task_priority.swift
+++ b/test/Concurrency/async_task_priority.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift %s -parse-as-library -o %t/async_task_priority
+// RUN: %target-build-swift %s -import-objc-header %S/Inputs/has-dispatch-private.h -parse-as-library -o %t/async_task_priority
 // RUN: %target-codesign %t/async_task_priority
 // RUN: %target-run %t/async_task_priority
 
@@ -340,8 +340,10 @@ actor Test {
           await task2.value // Escalate task2 which should be queued behind task1 on the actor
         }
 
-        // This test will only work properly if Dispatch supports lowering the base priority of a thread
-        if #available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *) {
+        // This test will only work properly if Dispatch supports lowering the base priority of a thread rdar://88155873
+        // If we don't have swift_concurrency_private.h then the runtime doesn't have
+        // full priority escalation, so don't try to test it.
+        if #available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *), HasSwiftConcurrencyPrivateHeader() != 0 {
           tests.test("Task escalation doesn't impact qos_class_self") {
             let task = Task(priority: .utility) {
               let initialQos = DispatchQoS(

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -101,7 +101,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 @__swiftmacro_So13bufferPointer15_SwiftifyImportfMp_.swift
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
-@available(visionOS 1.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
+@available(iOS 2.0, visionOS 1.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
 public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
     return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
@@ -110,7 +110,7 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
-@available(visionOS 1.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
+@available(iOS 2.0, visionOS 1.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = p.withUnsafeMutableBufferPointer {

--- a/test/ModuleInterface/synthesized-conformances.swift
+++ b/test/ModuleInterface/synthesized-conformances.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name synthesized -disable-objc-attr-requires-foundation-module -enable-objc-interop
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name synthesized
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name synthesized -application-extension
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftinterface
 
@@ -70,18 +71,22 @@ public struct HasNestedTypesAndAvailability {
   }
 }
 
-// CHECK-LABEL: @available(visionOS, unavailable)
-// CHECK-NEXT: public struct UnavailableOnVisionOS {
-@available(visionOS, unavailable)
-public struct UnavailableOnVisionOS {
-  // CHECK-LABEL: @available(iOS 18, *)
-  // CHECK-NEXT: public enum HasRawValueAndRefinediOSAvailability : Swift::Int {
-  @available(iOS 18, *)
-  public enum HasRawValueAndRefinediOSAvailability: Int {
-    // CHECK-NEXT: case a
-    case a
-  }
-}
+// FIXME: [availability] These declarations produce synthesized conformances with rejected availability
+//@available(visionOS, unavailable)
+//public struct UnavailableOnVisionOS {
+//  @available(iOS 18, *)
+//  public enum HasRawValueAndRefinediOSAvailability: Int {
+//    case a
+//  }
+//}
+
+//@available(macOSApplicationExtension, unavailable)
+//public struct UnavailableInMacOSAppExtensions {
+//  @available(macOS 99, *)
+//  public enum HasRawValueAndRefinedMacOSAvailability: Int {
+//    case a
+//  }
+//}
 
 @objc public enum ObjCEnum: Int32 {
   case a, b = 5, c
@@ -162,16 +167,6 @@ extension NoRawValueWithExplicitHashable : Hashable {
 // CHECK: @available(macOS 14, iOS 17, watchOS 10, tvOS 17, *)
 // CHECK-NEXT: @available(*, deprecated, message: "Use something else")
 // CHECK-NEXT: extension synthesized::HasNestedTypesAndAvailability.synthesized::HasRawValueUniversallyDeprecated : Swift::RawRepresentable {}
-
-// CHECK: @available(iOS 18, *)
-// CHECK-NEXT: @available(visionOS, unavailable)
-// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::Equatable {}
-// CHECK: @available(iOS 18, *)
-// CHECK-NEXT: @available(visionOS, unavailable)
-// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::Hashable {}
-// CHECK: @available(iOS 18, *)
-// CHECK-NEXT: @available(visionOS, unavailable)
-// CHECK-NEXT: extension synthesized::UnavailableOnVisionOS.synthesized::HasRawValueAndRefinediOSAvailability : Swift::RawRepresentable {}
 
 // CHECK: extension synthesized::ObjCEnum : Swift::Equatable {}
 // CHECK: extension synthesized::ObjCEnum : Swift::Hashable {}


### PR DESCRIPTION
- **Explanation**:
Cherry-pick fixes for 3 XROS test failures on release/6.4.x
- **Scope**:
All three cherry-picks are test changes only.
- **Issues**:
n/a
- **Original PRs**:
https://github.com/swiftlang/swift/pull/91925
https://github.com/swiftlang/swift/pull/91337
https://github.com/swiftlang/swift/pull/90627
- **Risk**:
Low. This is test change only.
- **Testing**:
https://ci.swift.org/view/Apple%20Silicon%20(Swift%206.4.x)/job/oss-swift-6.4.x-package-macos-arm64/146/
- **Reviewers**:
@hnrklssn for https://github.com/swiftlang/swift/pull/91337