### PR TITLE
IRGen: handle non-pointer typed error result slots

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5516,8 +5516,13 @@ Address IRGenFunction::createErrorResultSlot(SILType errorType, bool isAsync,
 
   // Initialize at the alloca point.
   if (setSwiftErrorFlag) {
-    auto nullError = llvm::ConstantPointerNull::get(
-        cast<llvm::PointerType>(errorStorageType));
+    // errorStorageType is a pointer for the swifterror flag, but on targets
+    // that do not reserve a swifterror register a typed error slot has the
+    // error's concrete (possibly non-pointer aggregate) storage type.
+    // getNullValue produces the correct zero for either case; a
+    // ConstantPointerNull carrying an aggregate type is ill-formed and gets
+    // scalarized into invalid `extractvalue <agg> null` stores downstream.
+    auto *nullError = llvm::Constant::getNullValue(errorStorageType);
     builder.CreateStore(nullError, addr);
   }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4098,10 +4098,37 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     // Zero the error slot to maintain the invariant that it always
     // contains null.  This will frequently become a dead store.
     auto nullError = llvm::Constant::getNullValue(errorValue->getType());
+
+    // On targets that do not reserve a swifterror register, a typed error slot
+    // has the error's concrete storage type, which may be a non-scalar
+    // aggregate.  Such a value cannot be used with icmp/ptrtoint, and storing
+    // its zero-initializer gets scalarized into invalid `extractvalue <agg>
+    // null` sequences that crash instruction selection.  In that case operate
+    // on an integer view of the slot of the same size instead.
+    bool errorIsScalar = errorValue->getType()->isPointerTy() ||
+                         errorValue->getType()->isIntegerTy();
+    llvm::IntegerType *errorIntTy = nullptr;
+    Address errorIntSlot;
+    if (!errorIsScalar) {
+      auto sizeInBits =
+          IGM.DataLayout.getTypeSizeInBits(errorValue->getType());
+      errorIntTy = llvm::IntegerType::get(IGM.getLLVMContext(),
+                                          sizeInBits.getFixedValue());
+      errorIntSlot = Address(calleeErrorSlot.getAddress(), errorIntTy,
+                             calleeErrorSlot.getAlignment());
+    }
+    auto zeroErrorSlot = [&] {
+      if (errorIsScalar)
+        Builder.CreateStore(nullError, calleeErrorSlot);
+      else
+        Builder.CreateStore(llvm::ConstantInt::get(errorIntTy, 0),
+                            errorIntSlot);
+    };
+
     if (!tryApplyInst->getErrorBB()->getSinglePredecessorBlock()) {
       // Only do that here if we can't move the store to the error block.
       // See below.
-      Builder.CreateStore(nullError, calleeErrorSlot);
+      zeroErrorSlot();
     }
     auto hasTypedDirectError =
         substConv.isTypedError() && !substConv.hasIndirectSILErrorResults();
@@ -4111,13 +4138,36 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     }
 
     // If the error value is non-null, branch to the error destination.
-    auto hasError = Builder.CreateICmpNE(errorValue, nullError);
+    llvm::Value *hasError;
+    if (errorIsScalar) {
+      hasError = Builder.CreateICmpNE(errorValue, nullError);
 
-    // Create a dummy use of 'errorValue' in the catch BB to workaround an
-    // LLVM miscompile that ends up taking the wrong branch if there are no
-    // uses of 'errorValue' in the catch block.
-    // FIXME: Remove this when the following radar is fixed: rdar://116636601
-    Builder.CreatePtrToInt(errorValue, IGM.IntPtrTy);
+      // Create a dummy use of 'errorValue' in the catch BB to workaround an
+      // LLVM miscompile that ends up taking the wrong branch if there are no
+      // uses of 'errorValue' in the catch block.
+      // FIXME: Remove this when the following radar is fixed: rdar://116636601
+      Builder.CreatePtrToInt(errorValue, IGM.IntPtrTy);
+    } else {
+      // Compare the raw storage bits against zero through the integer view.
+      auto *errorBits = Builder.CreateLoad(errorIntSlot);
+      hasError = Builder.CreateICmpNE(errorBits,
+                                      llvm::ConstantInt::get(errorIntTy, 0));
+    }
+
+    // Precompute the value fed to the single error-edge PHI (see below) while
+    // we are still in the predecessor block, before the conditional branch.
+    // The PHI is typed with the error's native representation, which may differ
+    // from the slot's storage type; reinterpret the slot through the PHI's type
+    // when they disagree.
+    llvm::Value *errorPHIValue = errorValue;
+    if (!errorIsScalar && !typedErrorLoadBB && errorDest.phis.size() == 1) {
+      auto *phiTy = errorDest.phis[0]->getType();
+      if (errorPHIValue->getType() != phiTy) {
+        Address phiSlot(calleeErrorSlot.getAddress(), phiTy,
+                        calleeErrorSlot.getAlignment());
+        errorPHIValue = Builder.CreateLoad(phiSlot);
+      }
+    }
 
     // Emit profile metadata if available.
     llvm::MDNode *Weights = nullptr;
@@ -4143,7 +4193,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
              (substConv.hasIndirectSILErrorResults() &&
               errorDest.phis.empty()));
       if (errorDest.phis.size() == 1)
-        errorDest.phis[0]->addIncoming(errorValue, Builder.GetInsertBlock());
+        errorDest.phis[0]->addIncoming(errorPHIValue, Builder.GetInsertBlock());
     } else {
       Builder.emitBlock(typedErrorLoadBB);
 
@@ -4192,7 +4242,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
       // that it will become a dead store.
       auto origBB = Builder.GetInsertBlock();
       Builder.SetInsertPoint(errorDest.bb);
-      Builder.CreateStore(nullError, calleeErrorSlot);
+      zeroErrorSlot();
       Builder.SetInsertPoint(origBB);
     }
   }

--- a/test/IRGen/Inputs/typed_throws_cmo_other.swift
+++ b/test/IRGen/Inputs/typed_throws_cmo_other.swift
@@ -1,0 +1,16 @@
+public struct RenderStore {
+  public var data: [UInt8]
+  public init() { data = [] }
+}
+
+public struct ConvertFailure: Error {
+  public init() {}
+}
+
+public final class Server {
+  public init() {}
+  public func convert(_ b: Bool, _ n: Int) async throws -> RenderStore {
+    if b && n > 3 { throw ConvertFailure() }
+    return RenderStore()
+  }
+}

--- a/test/IRGen/typed_throws_cmo_ppc.swift
+++ b/test/IRGen/typed_throws_cmo_ppc.swift
@@ -1,0 +1,41 @@
+// Regression test for a typed-throws IRGen crash on targets without a
+// swifterror register (e.g. PowerPC64). When cross-module optimization
+// specializes a call so that the caller's error-result slot holds a typed
+// error's concrete (non-pointer aggregate) storage type, IRGen used to feed
+// that aggregate to icmp/ptrtoint/PHI and to zero-initialize it with a
+// null-of-aggregate constant, producing invalid IR / an instruction-selection
+// crash. Compiling for PowerPC64 must succeed and emit a scalar has-error test.
+//
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -parse-as-library -O -enable-default-cmo -module-name Other -emit-module-path %t/Other.swiftmodule %S/Inputs/typed_throws_cmo_other.swift
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -O -enable-default-cmo -module-name test -I %t %s | %FileCheck %s
+//
+// REQUIRES: CPU=powerpc64le
+
+import Other
+
+public enum MyErr: Error {
+  case internalError(any Error)
+  case nilStore
+  case cancelled
+}
+
+public struct Catalog {
+  public init() {}
+}
+
+// The function must be emitted (IRGen no longer aborts), and the error slot is
+// tested/zeroed through an integer view rather than as an aggregate.
+// CHECK-LABEL: define {{.*}} @"$s4test5index{{.*}}"
+// CHECK-NOT:   icmp ne %T4test5MyErrO
+// CHECK-NOT:   ptrtoint %T4test5MyErrO
+public func index(_ s: Server, _ b: Bool, _ n: Int) async throws(MyErr) -> Catalog {
+  do {
+    let r = try await s.convert(b, n)
+    _ = r.data.count
+    return Catalog()
+  } catch {
+    let e = error as? MyErr ?? .internalError(error)
+    throw e
+  }
+}


### PR DESCRIPTION
On targets whose Swift calling convention does not reserve a swifterror
register (e.g. ppc64/ppc64le), `ShouldUseSwiftError` is false, so the
error result slot is not forced to pointer type.  When a callee throws a
typed error (`throws(E)`) whose concrete storage type is a non-pointer
aggregate, the error slot then holds that aggregate.  Two places in IRGen
implicitly assume the slot is always a pointer:

1. `IRGenFunction::createErrorResultSlot` initialises the slot with
   `ConstantPointerNull::get(cast<PointerType>(errorStorageType))`.  When
   `errorStorageType` is a non-pointer aggregate the `cast<PointerType>`
   is unchecked in a no-asserts build and fabricates a null constant that
   carries an aggregate type.  Storing it is later scalarised into
   `extractvalue <aggregate> null` sequences, which are ill-formed and
   crash PowerPC instruction selection.

2. `visitFullApplySite` (the `try_apply` lowering) loads the error value
   from the slot and feeds it to `icmp ne`, `ptrtoint` and the error-edge
   PHI, all of which require a scalar/pointer operand.  With an aggregate
   error value the module fails verification ("Invalid operand types for
   ICmp instruction", "PtrToInt source must be pointer", "PHI node
   operands are not the same type as the result").  This is reached when
   cross-module optimisation specialises a call so that its substituted
   error type is concrete while the slot was created from the original
   (`any Error`) convention.

Fix both by operating on a type-correct view of the slot:

* Use `Constant::getNullValue(errorStorageType)`, which yields the right
  zero for either a pointer or an aggregate.
* When the loaded error value is not already a scalar, compute the
  has-error flag by comparing an integer view of the slot against zero,
  and feed the error PHI a value reloaded through the PHI's own type.

These paths are only exercised on targets without a swifterror register,
so behaviour on x86_64/arm64 (where the slot is always a pointer) is
unchanged.
