### PR TITLE
Optimizer: add OSSA support in the ReleaseDevirtualizer

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -13,6 +13,7 @@ swift_compiler_sources(Optimizer
   AsyncDemotion.swift
   AutoDiffBranchTracingEnumUtilities.swift
   BooleanLiteralFolding.swift
+  ClassDestroyDevirtualizer.swift
   ConstantCapturePropagation.swift
   CleanupDebugSteps.swift
   ClosureSpecialization.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClassDestroyDevirtualizer.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClassDestroyDevirtualizer.swift
@@ -1,8 +1,8 @@
-//===--- ReleaseDevirtualizer.swift - Devirtualizes release-instructions --===//
+//===--- ClassDestroyDevirtualizer.swift ----------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,27 +13,28 @@
 import AST
 import SIL
 
-// TODO: remove the ReleaseDevirtualizer once the ClassDestroyDevirtualizer runs on OSSA
-
-/// Devirtualizes release instructions which are known to destruct the object.
+/// Devirtualizes `destroy_value` instructions which are known to destruct a class object.
 ///
 /// This means, it replaces a sequence of
+/// ```
 ///    %x = alloc_ref [stack] $X
 ///      ...
-///    strong_release %x
+///    destroy_value %x
 ///    dealloc_stack_ref %x
+/// ```
 /// with
+/// ```
 ///    %x = alloc_ref [stack] $X
 ///      ...
-///    set_deallocating %x
+///    %y = begin_dealloc_ref %x
 ///    %d = function_ref @dealloc_of_X
-///    %a = apply %d(%x)
+///    %a = apply %d(%y)
 ///    dealloc_stack_ref %x
+/// ```
 ///
-/// The optimization is only done for stack promoted objects because they are
-/// known to have no associated objects (which are not explicitly released
-/// in the deinit method).
-let releaseDevirtualizerPass = FunctionPass(name: "release-devirtualizer") {
+/// The optimization is only done for stack promoted objects because they are known to have no
+/// associated objects (which are not explicitly released in the deinit method).
+let classDestroyDevirtualizerPass = FunctionPass(name: "class-destroy-devirtualizer") {
   (function: Function, context: FunctionPassContext) in
 
   for inst in function.instructions {
@@ -41,23 +42,21 @@ let releaseDevirtualizerPass = FunctionPass(name: "release-devirtualizer") {
       if !context.continueWithNextSubpassRun(for: dealloc) {
         return
       }
-      tryDevirtualizeRelease(of: dealloc, context)
+      tryDevirtualizeDestroy(of: dealloc, context)
     }
   }
 }
 
-private func tryDevirtualizeRelease(of dealloc: DeallocStackRefInst, _ context: FunctionPassContext) {
-  guard let (lastRelease, pathToRelease) = findLastRelease(of: dealloc, context) else {
-    return
-  }
-
-  if !pathToRelease.isMaterializable {
+private func tryDevirtualizeDestroy(of dealloc: DeallocStackRefInst, _ context: FunctionPassContext) {
+  guard let (lastDestroy, pathToDestroy) = findLastDestroy(of: dealloc, context),
+          pathToDestroy.isMaterializable
+  else {
     return
   }
 
   let allocRef = dealloc.allocRef
   var upWalker = FindAllocationWalker(allocation: allocRef)
-  if upWalker.walkUp(value: lastRelease.operand.value, path: pathToRelease) == .abortWalk {
+  if upWalker.walkUp(value: lastDestroy.destroyedValue, path: pathToDestroy) == .abortWalk {
     return
   }
 
@@ -67,14 +66,14 @@ private func tryDevirtualizeRelease(of dealloc: DeallocStackRefInst, _ context: 
     return
   }
 
-  let builder = Builder(before: lastRelease, location: lastRelease.location, context)
+  let builder = Builder(before: lastDestroy, location: lastDestroy.location, context)
 
-  var object = lastRelease.operand.value.createProjection(path: pathToRelease, builder: builder)
+  var object = lastDestroy.operand.value.createProjection(path: pathToDestroy, builder: builder)
   if object.type != type {
     object = builder.createUncheckedRefCast(from: object, to: type)
   }
 
-  // Do what a release would do before calling the deallocator: set the object
+  // Do what a `destroy_value` would do before calling the deallocator: set the object
   // in deallocating state, which means set the RC_DEALLOCATING_FLAG flag.
   let beginDealloc = builder.createBeginDeallocRef(reference: object, allocation: allocRef)
 
@@ -91,30 +90,26 @@ private func tryDevirtualizeRelease(of dealloc: DeallocStackRefInst, _ context: 
   }
 
   builder.createApply(function: functionRef, substitutionMap, arguments: [beginDealloc])
-  context.erase(instruction: lastRelease)
+  context.erase(instruction: lastDestroy)
 }
 
-private func findLastRelease(
+private func findLastDestroy(
   of dealloc: DeallocStackRefInst,
   _ context: FunctionPassContext
-) -> (lastRelease: RefCountingInst, pathToRelease: SmallProjectionPath)? {
+) -> (lastDestroy: DestroyValueInst, pathToDestroy: SmallProjectionPath)? {
   let allocRef = dealloc.allocRef
 
-  // Search for the final release in the same basic block of the dealloc.
+  // Search for the final `destroy_value` in the same basic block of the dealloc.
   for instruction in ReverseInstructionList(first: dealloc.previous) {
     switch instruction {
-    case let strongRelease as StrongReleaseInst:
-      if let pathToRelease = getPathToRelease(from: allocRef, to: strongRelease) {
-        return (strongRelease, pathToRelease)
-      }
-    case let releaseValue as ReleaseValueInst:
-      if releaseValue.value.type.containsSingleReference(in: dealloc.parentFunction) {
-        if let pathToRelease = getPathToRelease(from: allocRef, to: releaseValue) {
-          return (releaseValue, pathToRelease)
+    case let destroy as DestroyValueInst:
+      if destroy.destroyedValue.type.containsSingleReference(in: dealloc.parentFunction) {
+        if let pathToDestroy = getPathToDestroy(from: allocRef, to: destroy) {
+          return (destroy, pathToDestroy)
         }
       }
     case is BeginDeallocRefInst, is DeallocRefInst:
-      // Check if the last release was already de-virtualized.
+      // Check if the last `destroy_value` was already de-virtualized.
       if allocRef.escapes(to: instruction, context) {
         return nil
       }
@@ -122,36 +117,36 @@ private func findLastRelease(
       break
     }
     if instruction.mayRelease && allocRef.escapes(to: instruction, context) {
-      // This instruction may release the allocRef, which means that any release we find
-      // earlier in the block is not guaranteed to be the final release.
+      // This instruction may release the allocRef, which means that any destroy we find
+      // earlier in the block is not guaranteed to be the final destroy.
       return nil
     }
   }
   return nil
 }
 
-// If the release is a release_value it might release a struct which _contains_ the allocated object.
+// The final destroy might destroy a struct which _contains_ the allocated object.
 // Return a projection path to the contained object in this case.
-private func getPathToRelease(from allocRef: AllocRefInstBase, to release: RefCountingInst) -> SmallProjectionPath? {
-  var downWalker = FindReleaseWalker(release: release)
+private func getPathToDestroy(from allocRef: AllocRefInstBase, to destroy: DestroyValueInst) -> SmallProjectionPath? {
+  var downWalker = FindDestroyWalker(destroy: destroy)
   if downWalker.walkDownUses(ofValue: allocRef, path: SmallProjectionPath()) == .continueWalk {
     return downWalker.result
   }
   return nil
 }
 
-private struct FindReleaseWalker : ValueDefUseWalker {
-  private let release: RefCountingInst
+private struct FindDestroyWalker : ValueDefUseWalker {
+  private let destroy: DestroyValueInst
   private(set) var result: SmallProjectionPath? = nil
 
   var walkDownCache = WalkerCache<SmallProjectionPath>()
 
-  init(release: RefCountingInst) {
-    self.release = release
+  init(destroy: DestroyValueInst) {
+    self.destroy = destroy
   }
 
   mutating func leafUse(value: Operand, path: SmallProjectionPath) -> WalkResult {
-    if value.instruction == release {
+    if value.instruction == destroy {
       if let existingResult = result {
         result = existingResult.merge(with: path)
       } else {
@@ -179,7 +174,7 @@ private struct EscapesToInstructionVisitor : EscapeVisitor {
   }
 }
 
-// Up-walker to find the root of a release instruction.
+// Up-walker to find the root of a `destroy_value` instruction.
 private struct FindAllocationWalker : ValueUseDefWalker {
   private let allocInst: AllocRefInstBase
 

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -95,6 +95,7 @@ private func registerSwiftPasses() {
   registerPass(stackPromotion, { stackPromotion.run($0) })
   registerPass(functionStackProtection, { functionStackProtection.run($0) })
   registerPass(assumeSingleThreadedPass, { assumeSingleThreadedPass.run($0) })
+  registerPass(classDestroyDevirtualizerPass, { classDestroyDevirtualizerPass.run($0) })
   registerPass(releaseDevirtualizerPass, { releaseDevirtualizerPass.run($0) })
   registerPass(simplificationPass, { simplificationPass.run($0) })
   registerPass(ononeSimplificationPass, { ononeSimplificationPass.run($0) })

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -126,6 +126,9 @@ PASS(ObjectOutliner, "object-outliner",
      "Outlining of Global Objects")
 PASS(DeinitDevirtualizer, "deinit-devirtualizer",
      "Devirtualizes destroys of non-copyable values")
+PASS(ClassDestroyDevirtualizer, "class-destroy-devirtualizer",
+     "Devirtualizes final destroys of classes")
+// TODO: remove the ReleaseDevirtualizer once the ClassDestroyDevirtualizer runs on OSSA
 PASS(ReleaseDevirtualizer, "release-devirtualizer",
      "SIL release Devirtualization")
 PASS(LetPropertyLowering, "let-property-lowering",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -825,6 +825,8 @@ static void addLowLevelPassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("LowLevel,Function", true /*isFunctionPassPipeline*/);
 
   // Should be after FunctionSignatureOpts and before the last inliner.
+  P.addClassDestroyDevirtualizer(); // currently a no-op in non-OSSA
+  // TODO: remove the ReleaseDevirtualizer once we have OSSA at this place in the pipeline.
   P.addReleaseDevirtualizer();
 
   addFunctionPasses(P, OptimizationLevelKind::LowLevel);

--- a/test/SILOptimizer/class_destroy_devirtualizer.sil
+++ b/test/SILOptimizer/class_destroy_devirtualizer.sil
@@ -1,0 +1,282 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -class-destroy-devirtualizer -module-name=test | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class B {
+  @_hasStorage var next: B
+}
+
+struct Str {
+  @_hasStorage var b: B
+}
+
+sil @unknown_func : $@convention(thin) () -> ()
+sil @unknown_releaseing_func : $@convention(thin) (@owned B) -> ()
+
+sil [ossa] @$s4test1BCfD : $@convention(method) (@owned B) -> () {
+// Note that the destructor is not destroying, but it must block the optimization.
+[global: ]
+bb0(%0 : @owned $B):
+  dealloc_ref %0
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @devirtualize_object :
+// CHECK:         [[A:%[0-9]+]] = alloc_ref
+// CHECK-NEXT:    [[BD:%.*]] = begin_dealloc_ref [[A]] of [[A]]
+// CHECK-NOT:     destroy_value
+// CHECK:         [[D:%[0-9]+]] = function_ref @$s4test1BCfD
+// CHECK-NEXT:    apply [[D]]([[BD]])
+// CHECK-NEXT:    dealloc_stack_ref [[A]]
+// CHECK:       } // end sil function 'devirtualize_object'
+sil [ossa] @devirtualize_object : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  destroy_value %1
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_heap_allocated :
+// CHECK:         alloc_ref
+// CHECK-NEXT:    destroy_value
+// CHECK:       } // end sil function 'dont_devirtualize_heap_allocated'
+sil [ossa] @dont_devirtualize_heap_allocated : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref $B
+  destroy_value %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_devirtualized
+// CHECK:         alloc_ref
+// CHECK-NEXT:    copy_value
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    begin_dealloc_ref
+// CHECK-NEXT:    dealloc_ref
+// CHECK-NEXT:    dealloc_stack_ref
+// CHECK-NEXT:    tuple
+// CHECK:       } // end sil function 'dont_devirtualize_devirtualized'
+sil [ossa] @dont_devirtualize_devirtualized : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = copy_value %1
+  destroy_value %2
+  %4 = begin_dealloc_ref %1 of %1
+  dealloc_ref %4
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_devirtualized_not_inlined :
+// CHECK:         alloc_ref
+// CHECK-NEXT:    copy_value
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    begin_dealloc_ref
+// CHECK:       } // end sil function 'dont_devirtualize_devirtualized_not_inlined'
+sil [ossa] @dont_devirtualize_devirtualized_not_inlined : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = copy_value %1
+  destroy_value %2
+  %4 = begin_dealloc_ref %1 of %1
+  %5 = function_ref @$s4test1BCfD : $@convention(method) (@owned B) -> ()
+  %6 = apply %5(%4) : $@convention(method) (@owned B) -> ()
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @devirtualize_with_other_destroys_in_between :
+// CHECK:         %1 = alloc_ref [stack] $B
+// CHECK-NOT:     destroy_value
+// CHECK:         apply
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    dealloc_stack_ref %1
+// CHECK:       } // end sil function 'devirtualize_with_other_destroys_in_between'
+sil [ossa] @devirtualize_with_other_destroys_in_between : $@convention(thin) (@owned B) -> () {
+bb0(%0 : @owned $B):
+  %1 = alloc_ref [stack] $B
+  destroy_value %1
+  destroy_value %0
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @devirtualize_with_apply_in_between :
+// CHECK:         alloc_ref
+// CHECK-NEXT:    begin_dealloc_ref
+// CHECK-NOT:     destroy_value
+// CHECK:       } // end sil function 'devirtualize_with_apply_in_between'
+sil [ossa] @devirtualize_with_apply_in_between : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  destroy_value %1 : $B
+  %f = function_ref @unknown_func : $@convention(thin) () -> ()
+  %a = apply %f() : $@convention(thin) () -> ()
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_unknown_destroy :
+// CHECK:         alloc_ref
+// CHECK-NEXT:    copy_value
+// CHECK-NEXT:    destroy_value
+// CHECK:       } // end sil function 'dont_devirtualize_unknown_destroy'
+sil [ossa] @dont_devirtualize_unknown_destroy : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = copy_value %1
+  destroy_value %2
+  %f = function_ref @unknown_releaseing_func : $@convention(thin) (@owned B) -> ()
+  %a = apply %f(%1) : $@convention(thin) (@owned B) -> ()
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_crash_with_missing_destroy
+// CHECK:         [[A:%[0-9]+]] = alloc_ref
+// CHECK-NEXT:    [[BD:%.*]] = begin_dealloc_ref [[A]] of [[A]]
+// CHECK-NOT:     destroy_value
+// CHECK:         [[D:%[0-9]+]] = function_ref @$s4test1BCfD
+// CHECK-NEXT:    apply [[D]]([[BD]])
+// CHECK-NEXT:    dealloc_stack_ref [[A]]
+// CHECK:       } // end sil function 'dont_crash_with_missing_destroy'
+sil [ossa] @dont_crash_with_missing_destroy : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  destroy_value %1 : $B
+  dealloc_stack_ref %1
+  %2 = alloc_ref [stack] $B
+  end_lifetime %2
+  dealloc_stack_ref %2
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @long_chain_from_alloc_to_destroy
+// CHECK:       bb3([[P:%.*]] : @owned $B):
+// CHECK:         [[T:%.*]] = tuple ({{.*}})
+// CHECK:         ([[S:%.*]], {{.*}}) = destructure_tuple [[T]]
+// CHECK:         [[A:%.*]] = destructure_struct [[S]]
+// CHECK:         begin_dealloc_ref [[A]]
+// CHECK-NOT:     destroy_value
+// CHECK:       } // end sil function 'long_chain_from_alloc_to_destroy'
+sil [ossa] @long_chain_from_alloc_to_destroy : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = struct $Str(%1)
+  %3 = destructure_struct %2
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%3)
+
+bb2:
+  br bb3(%3)
+
+bb3(%a : @owned $B):
+  %s = struct $Str (%a)
+  %i = integer_literal $Builtin.Int64, 0
+  %t = tuple (%s, %i)
+  destroy_value %t
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_double_destroy
+// CHECK-NOT:     begin_dealloc_ref
+// CHECK:         destroy_value
+// CHECK:       } // end sil function 'dont_devirtualize_double_destroy'
+sil [ossa] @dont_devirtualize_double_destroy : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = copy_value %1
+  %t = tuple (%1, %2)
+  destroy_value %t : $(B, B)
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_destroy_of_load
+// CHECK:         [[L:%.*]] = load
+// CHECK:         [[D:%[0-9]+]] = function_ref @$s4test1BCfD
+// CHECK-NEXT:    apply [[D]]
+// CHECK-NEXT:    destroy_value [[L]]
+// CHECK:       } // end sil function 'dont_devirtualize_destroy_of_load'
+sil [ossa] @dont_devirtualize_destroy_of_load : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = begin_borrow %1
+  %3 = ref_element_addr %2, #B.next
+  %4 = load [copy] %3
+  end_borrow %2
+  destroy_value %1
+  destroy_value %4
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_devirtualize_destroy_of_different_allocations
+// CHECK-NOT:     begin_dealloc_ref
+// CHECK:       bb3([[P:%.*]] : @owned $B):
+// CHECK:         destroy_value [[P]]
+// CHECK:       } // end sil function 'dont_devirtualize_destroy_of_different_allocations'
+sil [ossa] @dont_devirtualize_destroy_of_different_allocations : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = alloc_ref [stack] $B
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %2
+  br bb3(%1)
+
+bb2:
+  destroy_value %1
+  br bb3(%2)
+
+bb3(%a : @owned $B):
+  destroy_value %a
+  dealloc_stack_ref %2
+  dealloc_stack_ref %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @devirtualize_double_destroy :
+// CHECK-NOT:     destroy_value
+// CHECK:       } // end sil function 'devirtualize_double_destroy'
+sil [ossa] @devirtualize_double_destroy : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref [stack] $B
+  %1 = end_init_let_ref %0
+  %2 = alloc_ref [stack] $B
+  %3 = end_init_let_ref %2
+  destroy_value %1
+  destroy_value %3
+  %4 = function_ref @unknown_func : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  dealloc_stack_ref %2
+  dealloc_stack_ref %0
+  %r = tuple ()
+  return %r
+}
+
+sil_vtable B {
+  #B.deinit!deallocator: @$s4test1BCfD
+}
+


### PR DESCRIPTION
For now, create a new ClassDestroyDevirtualizer pass, which is basically a copy of the old ReleaseDevirtualizer pass, just with support for OSSA. We still don't have OSSA in the pipeline where the pass runs. So we need to keep the old pass around. The new pass is a no-op until we extend OSSA to this part of the pipeline. Then we can delete the old pass.

The new pass is named ClassDestroyDevirtualizer to distinguish the optimization from de-virtualizing value-type deinits.
