### PR TITLE
[wasi] Build Concurrency C++ sources with -fno-exceptions even for non-embedded.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2182,6 +2182,7 @@ function(add_swift_target_library name)
         C_COMPILE_FLAGS_WATCHOS
         C_COMPILE_FLAGS_LINUX
         C_COMPILE_FLAGS_WINDOWS
+        C_COMPILE_FLAGS_WASI
         DEPENDS
         FILE_DEPENDS
         FRAMEWORK_DEPENDS
@@ -2688,6 +2689,9 @@ function(add_swift_target_library name)
       elseif(sdk STREQUAL "WINDOWS")
         list(APPEND swiftlib_c_compile_flags_all
              ${SWIFTLIB_C_COMPILE_FLAGS_WINDOWS})
+      elseif(sdk STREQUAL "WASI")
+        list(APPEND swiftlib_c_compile_flags_all
+             ${SWIFTLIB_C_COMPILE_FLAGS_WASI})
       endif()
 
       # Add flags to prepend framework search paths for the parallel framework

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -278,6 +278,9 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   C_COMPILE_FLAGS
     -Dswift_Concurrency_EXPORTS ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS}
     -I${SWIFT_SOURCE_DIR}/stdlib/include
+  # WASI's libc++abi has no exception runtime, even in non-embedded builds.
+  C_COMPILE_FLAGS_WASI
+    -fno-exceptions
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib


### PR DESCRIPTION
This patch fixes linker errors when building the wasm targets for the non-embedded variant.

The WASI sysroot's libc++/libc++abi are built with -fno-exceptions (see wasisysroot.py), so libc++abi defines no __cxa_throw or __cxa_allocate_exception.

The Concurrency runtime uses C++ STL data structures, which can throw if not compiled with the right flags.

The cmake helper add_swift_target_library_single runs llvm_update_compile_flags, which supplies -fno-exceptions, on the shared target. The -static target is only created later, the static archive never receives those flags.

This bug was masked until
llvm/llvm-project@54faa755bc36 ("[LLVM][CMake][NFC] Use generator expression to separate CXXFLAGS"). The old llvm_update_compile_flags applied COMPILE_FLAGS as directory-scoped *source* properties for targets mixing C and C++ sources, which swift_Concurrency does. The -static target compiles the same sources in the same directory, so it inherited the flags for free. That commit switched to per-target target_compile_options, which does not leak; it is NFC in tree but not for downstream trees that relied on the old behavior.

Pass the flag through C_COMPILE_FLAGS_WASI, which reaches both variants. WASI had no such entry, so add one alongside the existing six.

Fixes around 300 failures in check-swift-wasi-wasm32-custom, which used to fail with:

  wasm-ld: error: libswift_Concurrency.a(Task.cpp.o):
  undefined symbol: __cxa_allocate_exception