### PR TITLE
[DebugInfo] SIL: Remove debug_value operand erasure

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1807,20 +1807,6 @@ public:
     return sharedUInt32().InstructionBaseWithTrailingOperands.numOperands;
   }
 
-protected:
-  /// Removes the last operand, shrinking the tail allocated operand list.
-  /// The other, previous, operands, remain fully valid.
-  /// If there are any OtherTrailingTypes, they need to be moved separately by
-  /// the callee.
-  void eraseLastOperandInPlace() {
-    auto operands = getAllOperands();
-    ASSERT(!operands.empty() && "no operand to erase");
-
-    operands.back().~Operand();
-    sharedUInt32().InstructionBaseWithTrailingOperands.numOperands =
-        operands.size() - 1;
-  }
-
 public:
   ArrayRef<Operand> getAllOperands() const {
     return this->template getTrailingObjectsNonStrict<Operand>(
@@ -5792,12 +5778,19 @@ class DebugValueInst final
   using InstructionBaseWithTrailingOperands::numTrailingObjects;
   SIL_DEBUG_VAR_SUPPLEMENT_TRAILING_OBJS_IMPL()
 
-  /// Removes the last operand, shrinking the tail allocated operand list.
-  /// Only the last operand can be removed, to avoid invalidating other
-  /// existing Operand pointers. Pointers to this last operand are invalidated.
-  void eraseLastOperand();
-
 public:
+  /// The maximum number of operands a debug value can have. Every operand has
+  /// to be kept available up to the debug value, so salvaging gives up rather
+  /// than growing the operand list beyond it.
+  static constexpr unsigned MaxOperands = 16;
+
+  /// Replaces this instruction with an equivalent one whose operand list is
+  /// \p operands.
+  /// Returns the new instruction. The reconstruction block must already
+  /// reflect the new operand list.
+  /// This erases this instruction if the change can't be done in place.
+  DebugValueInst *replaceOperands(ArrayRef<SILValue> operands);
+
   /// Returns the single operand, asserting that there is exactly one.
   /// Should only be used in contexts where it is known that there is no
   /// debug reconstruction block.
@@ -5966,16 +5959,15 @@ public:
   /// created and attached to this instruction.
   /// The newly created basic block will be well-formed, returning the SSA
   /// value of this debug_value directly.
-  /// If this debug_value has an undef operand, the reconstruction block
-  /// has no arguments and returns undef directly, and the operand is dropped.
+  /// If this debug_value has an undef operand, the reconstruction block returns
+  /// undef directly, leaving its argument unused.
   SILBasicBlock *getOrCreateDebugReconstructionBlock();
 
   /// Kills the operand from this debug value.
   /// This function must be called by passes whenever the operand of this debug
   /// value is no longer valid and cannot be salvaged.
-  /// Uses inside a debug reconstruction block are replaced with undef. If this
-  /// is the last operand, the operand list is shrunk.
-  /// Any pointers to the killed Operand are invalidated.
+  /// The operand becomes undef, and its uses inside a debug reconstruction
+  /// block are replaced with undef, leaving its argument unused.
   /// If \p operandType is specified, that undef will use that type (in the
   /// appropriate address/object form) instead of the current operand's type.
   void killOperand(unsigned operandIdx, SILType operandType = SILType());

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -598,8 +598,9 @@ SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
     // Clear the op_deref, unless we have an address-only type.
     if (!addressOnly)
       sharedUInt8().DebugValueInst.prependDeref = false;
-    // As the block has no argument, drop the operand.
-    eraseLastOperand();
+    // An unused argument is left behind, as there must be the same amount
+    // of operands and arguments.
+    block->createPhiArgument(operand->getType(), OwnershipKind::None);
   } else if (hasDeref()) {
     SILArgument *arg = block->createPhiArgument(
         operand->getType().getAddressType(), OwnershipKind::None);
@@ -641,23 +642,31 @@ void DebugValueInst::cloneReconstructionBlockFrom(DebugValueInst *src) {
     .cloneDebugReconstructionBlockContent(srcBB, newBB);
 }
 
-void DebugValueInst::eraseLastOperand() {
-  // The variable data is tail allocated after the operands, so shrinking the
-  // operand list moves it by one operand. It is all trivially copyable, so
-  // using memmove is safe. Nothing keeps pointers on the varinfo.
-  size_t varinfoSize = getDebugVarTrailingDataSize(
-      VarInfo.getName(getTrailingObjects<char>()).size(),
-      HasAuxDebugVariableType, hasAuxDebugLocation(), hasAuxDebugScope(),
-      NumDIExprOperands);
-  char *varinfoBegin = reinterpret_cast<char *>(getAllOperands().end());
+DebugValueInst *DebugValueInst::replaceOperands(ArrayRef<SILValue> operands) {
+  ASSERT(operands.size() <= MaxOperands &&
+         "too many operands for a debug value");
+  ASSERT(!ReconstructionBlock ||
+         ReconstructionBlock->getNumArguments() == operands.size());
 
-  eraseLastOperandInPlace();
-  std::memmove(varinfoBegin - sizeof(Operand), varinfoBegin, varinfoSize);
+  // If the operand list is not resized, the change is done in place.
+  if (operands.size() == getAllOperands().size()) {
+    for (auto [operand, value] : llvm::zip(getAllOperands(), operands))
+      operand.set(value);
+    return this;
+  }
+
+  auto *newInst = create(getDebugLocation(), operands, getModule(), *getVarInfo(),
+                         usesMoveableValueDebugInfo(), hasTrace());
+  std::swap(newInst->ReconstructionBlock, this->ReconstructionBlock);
+
+  getParent()->insert(this, newInst);
+  eraseFromParent();
+  return newInst;
 }
 
 void DebugValueInst::killOperand(unsigned operandIdx, SILType operandType) {
   // If there is a debug reconstruction block, the operand doesn't describe the
-  // variable directly, the block does. Drop the operand, keeping the rest of
+  // variable directly, the block does. Poison the operand, keeping the rest of
   // the block, as a part of the variable might be constant and still recoverable.
   if (auto *bb = getDebugReconstructionBlock()) {
     ASSERT(bb->getNumArguments() == getAllOperands().size() &&
@@ -665,16 +674,8 @@ void DebugValueInst::killOperand(unsigned operandIdx, SILType operandType) {
     ASSERT(operandIdx < bb->getNumArguments());
     auto *argument = bb->getArgument(operandIdx);
     argument->replaceAllUsesWithUndef();
-
-    // Only a trailing operand can be removed: erasing one in the middle would
-    // shift the following operands, invalidating existing Operand pointers.
-    if (operandIdx == getAllOperands().size() - 1) {
-      bb->eraseArgument(operandIdx);
-      eraseLastOperand();
-    } else {
-      // Keep an undef operand and its now unused block argument.
-      getAllOperands()[operandIdx].set(SILUndef::get(argument));
-    }
+    // Keep a dead undef operand as operand count cannot be changed in place.
+    getAllOperands()[operandIdx].set(SILUndef::get(argument));
     return;
   }
 

--- a/test/DebugInfo/LoadableByAddress.sil
+++ b/test/DebugInfo/LoadableByAddress.sil
@@ -60,10 +60,10 @@ sil @large_param_closure : $@convention(thin) <T> (@guaranteed X, Int) -> @out T
 // CHECK-LABEL: sil @test_partial_apply_reconstruction_block :
 // CHECK:   [[FN:%[0-9]+]] = function_ref @large_param_closure : $@convention(thin) <τ_0_0> (@in_guaranteed X, Int) -> @out τ_0_0
 // CHECK:   [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [[FN]]<T>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed X, Int) -> @out τ_0_0
-// CHECK:   debug_value (), let, name "closure", transform {
-// CHECK:   bb0:
-// CHECK:     %0 = convert_function undef : $@callee_guaranteed (@guaranteed X) -> @out T to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed X) -> @out τ_0_0 for <T>
-// CHECK:     return %0
+// CHECK:   debug_value undef : {{.*}}, let, name "closure", transform {
+// CHECK:   bb0(%0 :
+// CHECK:     %1 = convert_function undef : $@callee_guaranteed (@guaranteed X) -> @out T to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed X) -> @out τ_0_0 for <T>
+// CHECK:     return %1
 // CHECK:   }
 // CHECK:   debug_value [[PA]] : $@callee_guaranteed (@in_guaranteed X) -> @out T, let, name "plain"
 // CHECK:   debug_value undef : $@callee_guaranteed (@guaranteed X) -> @out T, var, name "pair", type $(@callee_guaranteed (@guaranteed X) -> @out T, Int), expr op_tuple_fragment:$(@callee_guaranteed (@guaranteed X) -> @out T, Int):0
@@ -90,8 +90,8 @@ sil @large_param : $@convention(thin) (@guaranteed X) -> ()
 // A thin function type ref.
 // CHECK-LABEL: sil @test_function_ref :
 // CHECK:   [[FR:%[0-9]+]] = function_ref @large_param : $@convention(thin) (@in_guaranteed X) -> ()
-// CHECK:   debug_value (), let, name "f", transform {
-// CHECK:   bb0:
+// CHECK:   debug_value undef : {{.*}}, let, name "f", transform {
+// CHECK:   bb0(%0 :
 // CHECK:     return undef : $@convention(thin) (@guaranteed X) -> ()
 // CHECK:   }
 // CHECK:   debug_value [[FR]] : $@convention(thin) (@in_guaranteed X) -> (), let, name "plain"
@@ -111,8 +111,8 @@ bb0:
 // Function with a large argument, wrapped in an optional.
 // CHECK-LABEL: sil @test_unchecked_enum_data :
 // CHECK:   [[E:%[0-9]+]] = unchecked_enum_data %0 : $Optional<@callee_guaranteed (@in_guaranteed X) -> ()>, #Optional.some!enumelt
-// CHECK:   debug_value (), let, name "f", transform {
-// CHECK:   bb0:
+// CHECK:   debug_value undef : {{.*}}, let, name "f", transform {
+// CHECK:   bb0(%0 :
 // CHECK:     return undef : $@callee_guaranteed (@guaranteed X) -> ()
 // CHECK:   }
 // CHECK:   debug_value [[E]] : $@callee_guaranteed (@in_guaranteed X) -> (), let, name "plain"
@@ -133,10 +133,10 @@ bb0(%0 : $Optional<@callee_guaranteed (@guaranteed X) -> ()>):
 // A large function type within an alloc_stack.
 // CHECK-LABEL: sil @test_alloc_stack_closure :
 // CHECK:   [[AS:%[0-9]+]] = alloc_stack $@callee_guaranteed (@in_guaranteed X) -> ()
-// CHECK:   debug_value (), let, name "f", transform {
-// CHECK:   bb0:
-// CHECK:     %0 = load undef : $*@callee_guaranteed (@guaranteed X) -> ()
-// CHECK:     return %0
+// CHECK:   debug_value undef : {{.*}}, let, name "f", transform {
+// CHECK:   bb0(%0 :
+// CHECK:     %1 = load undef : $*@callee_guaranteed (@guaranteed X) -> ()
+// CHECK:     return %1
 // CHECK:   }
 // CHECK:   dealloc_stack [[AS]]
 // CHECK-LABEL: } // end sil function 'test_alloc_stack_closure'
@@ -157,8 +157,8 @@ bb0(%0 : $@callee_guaranteed (@guaranteed X) -> ()):
 // A large function type extracted from a tuple.
 // CHECK-LABEL: sil @test_tuple_extract :
 // CHECK:   [[TE:%[0-9]+]] = tuple_extract %0 : $(@callee_guaranteed (@in_guaranteed X) -> (), Int), 0
-// CHECK:   debug_value (), let, name "f", transform {
-// CHECK:   bb0:
+// CHECK:   debug_value undef : {{.*}}, let, name "f", transform {
+// CHECK:   bb0(%0 :
 // CHECK:     return undef : $@callee_guaranteed (@guaranteed X) -> ()
 // CHECK:   }
 // CHECK:   debug_value [[TE]] : $@callee_guaranteed (@in_guaranteed X) -> (), let, name "plain"

--- a/test/DebugInfo/allocbox_to_stack.sil
+++ b/test/DebugInfo/allocbox_to_stack.sil
@@ -14,7 +14,7 @@ enum Nat {
 // CHECK-LABEL: sil [ossa] @box_with_debug_reconstruction_block_indirect_enum
 // CHECK: alloc_stack
 // CHECK-NOT: alloc_box
-// CHECK: debug_value (), var, name "x", type $Nat, transform
+// CHECK: debug_value undef : ${ var Nat }, var, name "x", type $Nat, transform
 sil [ossa] @box_with_debug_reconstruction_block_indirect_enum : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_box ${ var Nat }

--- a/test/DebugInfo/dead-store-elimination.sil
+++ b/test/DebugInfo/dead-store-elimination.sil
@@ -56,8 +56,8 @@ bb0(%0 : $MyStruct):
 // When a debug_value has a reconstruction block with no load (e.g.
 // address_to_pointer), stripDeref cannot salvage and calls killOperand.
 // CHECK-LABEL: @dse_salvage_store_strip_deref_kill
-// CHECK: debug_value (), let, name "ptr", type $Builtin.RawPointer, transform {
-// CHECK:   bb0:
+// CHECK: debug_value undef : $*MyStruct, let, name "ptr", type $Builtin.RawPointer, transform {
+// CHECK:   bb0(%0 : $*MyStruct):
 // CHECK:     address_to_pointer undef : $*MyStruct to $Builtin.RawPointer
 // CHECK:     return
 // CHECK:   }

--- a/test/DebugInfo/salvage_struct_extract_lifetime.sil
+++ b/test/DebugInfo/salvage_struct_extract_lifetime.sil
@@ -20,7 +20,7 @@ struct Job: ~Copyable {
 // CHECK:             return %1 : $Builtin.Int64
 // CHECK:         }
 // CHECK:         release_value %0
-// CHECK:         debug_value (), let, name "after_destroy", {{.*}}transform
+// CHECK:         debug_value undef : $Job, let, name "after_destroy", {{.*}}transform
 // CHECK-LABEL: } // end sil function 'test_destroy_kills_debug_value'
 sil [ossa] @test_destroy_kills_debug_value : $@convention(thin) (@owned Job) -> () {
 bb0(%0 : @owned $Job):

--- a/test/DebugInfo/simplify_alloc_stack.sil
+++ b/test/DebugInfo/simplify_alloc_stack.sil
@@ -132,8 +132,8 @@ bb3:
 // already have a reconstruction block are killed as unsalvageable.
 // CHECK-LABEL: sil [ossa] @kill_transform_operand_of_existential :
 // CHECK:         alloc_stack $T
-// CHECK:         debug_value (), var, name "x", type $Builtin.RawPointer, transform {
-// CHECK-NEXT:    bb0:
+// CHECK:         debug_value undef : $*any P, var, name "x", type $Builtin.RawPointer, transform {
+// CHECK-NEXT:    bb0(%0 : $*any P):
 // CHECK-NEXT:      = address_to_pointer undef
 // CHECK:         }
 // CHECK:       } // end sil function 'kill_transform_operand_of_existential'

--- a/test/DebugInfo/sroa_debug_value.sil
+++ b/test/DebugInfo/sroa_debug_value.sil
@@ -71,8 +71,8 @@ sil_scope 3 { loc "sroa.swift":20:6 parent @sroa_kills_debug_reconstruction_bloc
 // CHECK-SROA-LABEL: sil {{.+}} @sroa_kills_debug_reconstruction_block
 // When a debug_value has a reconstruction block, SROA cannot append fragments.
 // Instead it kills the operand (replaces with undef) and preserves the block.
-// CHECK-SROA: debug_value (), let, name "ptr", type $Builtin.RawPointer, transform {
-// CHECK-SROA:   bb0:
+// CHECK-SROA: debug_value undef : $*MyStruct, let, name "ptr", type $Builtin.RawPointer, transform {
+// CHECK-SROA:   bb0(%0 : $*MyStruct):
 // CHECK-SROA:     address_to_pointer undef : $*MyStruct to $Builtin.RawPointer
 // CHECK-SROA:     return
 // CHECK-SROA:   }


### PR DESCRIPTION
For memory safety, change killOperand back to leave a stray undef operand, rather than erasing the operand. A dead argument is left as well, so the operand and argument count always match.

This makes Operand pointers never be invalidated during a pass.
