### PR TITLE
[Backtracing] Compare *stripped* frame pointers when backtracing.

### DIFF
--- a/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
+++ b/stdlib/public/RuntimeModule/FramePointerUnwinder.swift
@@ -212,7 +212,8 @@ public struct FramePointerUnwinder<C: Context, M: MemoryReader>: Sequence, Itera
           return nil
         }
 
-        if next <= fp || pc == 0 {
+        let strippedNext = stripPtrAuth(next)
+        if strippedNext <= strippedFp || pc == 0 {
           done = true
           return nil
         }


### PR DESCRIPTION
We were accidentally comparing un-stripped frame pointers when backtracing, which led to backtraces being truncated for arm64e processes.

Fix by stripping `next` and comparing the result against the stripped `fp` value.

rdar://187201710
