### PR TITLE
[SILOptimizer] Fold try_apply with an uninhabited error type

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Declarations.swift
+++ b/SwiftCompilerSources/Sources/AST/Declarations.swift
@@ -134,6 +134,12 @@ public class NominalTypeDecl: GenericTypeDecl {
 final public class EnumDecl: NominalTypeDecl {
   public var rawType: Type? { Type(bridgedOrNil: bridged.Enum_getRawType()) }
 
+  /// True if this enum has cases which cannot be referenced in canonical SIL, but which can still
+  /// exist at runtime. Such an enum must not be treated as exhaustive.
+  public var hasCasesUnavailableDuringLowering: Bool {
+    bridged.Enum_hasCasesUnavailableDuringLowering()
+  }
+
   public static func create(
     declContext: DeclContext, enumKeywordLoc: SourceLoc?, name: String,
     nameLoc: SourceLoc?, genericParamList: GenericParameterList?, inheritedTypes: [Type],

--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -216,6 +216,11 @@ extension TypeProperties {
   /// True if this the nominal type `Swift.Optional`.
   public var isOptional: Bool { rawType.bridged.isOptional() }
 
+  /// True if no value of this type can exist, e.g. `Never`, a case-less enum, or a tuple which
+  /// contains such a type. Note that this doesn't take resilience into account: a case-less enum
+  /// from another module can gain cases in a future version of that module.
+  public var isStructurallyUninhabited: Bool { rawType.bridged.isStructurallyUninhabited() }
+
   /// A non-nil result type implies isUnsafe[Raw][Mutable]Pointer. A raw
   /// pointer has a `void` element type.
   public var unsafePointerElementType: Type? {

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -44,6 +44,9 @@ extension ApplyInst : OnoneSimplifiable, SILCombineSimplifiable {
 
 extension TryApplyInst : OnoneSimplifiable, SILCombineSimplifiable {
   func simplify(_ context: SimplifyContext) {
+    if tryRemoveUninhabitedErrorEdge(of: self, context) {
+      return
+    }
     if context.tryDevirtualize(apply: self, isMandatory: false) != nil {
       return
     }
@@ -195,6 +198,38 @@ private func tryReplaceExistentialArchetype(of apply: ApplyInst, _ context: Simp
     return true
   }
   return false
+}
+
+/// If the callee cannot construct its error - because the error type is uninhabited - the error
+/// branch of a `try_apply` is dead. This happens when a `throws(E)` function is specialized for
+/// `E == Never`.
+///
+///   try_apply %0() : $@convention(thin) () -> (Int, @error Never), normal bb1, error bb2
+/// ->
+///   %1 = apply [nothrow] %0() : $@convention(thin) () -> (Int, @error Never)
+///   br bb1(%1)
+///
+/// Without this, the rethrow in the error block survives to IRGen, which has to emit it as an
+/// unconditional trap - together with the (equally dead) test of the error result which reaches it.
+private func tryRemoveUninhabitedErrorEdge(of tryApply: TryApplyInst, _ context: SimplifyContext) -> Bool {
+  guard tryApply.functionConvention.hasUninhabitedErrorResult(in: tryApply.parentFunction) else {
+    return false
+  }
+
+  let builder = Builder(before: tryApply, context)
+  let apply = builder.createApply(function: tryApply.callee,
+                                  tryApply.substitutionMap,
+                                  arguments: Array(tryApply.arguments),
+                                  isNonThrowing: true,
+                                  isNonAsync: tryApply.isNonAsync,
+                                  specializationInfo: tryApply.specializationInfo,
+                                  argumentLocationsFrom: tryApply)
+  builder.createBranch(to: tryApply.normalBlock, arguments: [apply])
+  context.erase(instruction: tryApply)
+
+  // The error block is now unreachable and gets removed by the dead-block cleanup of the
+  // simplification pass.
+  return true
 }
 
 // The same as the previous function, just for try_apply instructions.

--- a/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
+++ b/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
@@ -55,6 +55,14 @@ extension NominalTypeDecl {
   }
 }
 
+extension EnumDecl {
+  /// True if all cases of this enum are known in `function`, i.e. it cannot gain cases in a future
+  /// version of its module.
+  public func isEffectivelyExhaustive(in function: Function) -> Bool {
+    function.bridged.isEffectivelyExhaustiveEnumDecl(bridged)
+  }
+}
+
 extension ClassDecl {
   public var superClassType: Type? {
     self.superClass?.canonical.silType!

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -56,6 +56,24 @@ public struct FunctionConvention : CustomStringConvertible {
       hasLoweredAddresses: hasLoweredAddresses)
   }
 
+  /// True if there is an error result which can never hold a value, e.g. `Never`, so that the
+  /// function cannot actually throw.
+  public func hasUninhabitedErrorResult(in function: Function) -> Bool {
+    guard let errorResult else {
+      return false
+    }
+    let errorType = errorResult.getReturnValueType(ofFunctionType: functionType, in: function)
+    guard errorType.isStructurallyUninhabited else {
+      return false
+    }
+    if let enumDecl = errorType.nominal as? EnumDecl {
+      // Being case-less today is not enough: a resilient enum can gain cases in a future version of
+      // its module, and cases which are unavailable during lowering can still exist at runtime.
+      return !enumDecl.hasCasesUnavailableDuringLowering && enumDecl.isEffectivelyExhaustive(in: function)
+    }
+    return true
+  }
+
   /// Number of indirect results including the error.
   /// This avoids quadratic lazy iteration on indirectResults.count.
   public var indirectSILResultCount: Int {
@@ -184,8 +202,15 @@ public struct ResultInfo : CustomStringConvertible {
     convention.description + ": " + type.description
   }
 
-  public func getReturnValueType(function: Function) -> CanonicalType {
-    CanonicalType(bridged: self._bridged.getReturnValueType(function.bridged))
+  /// The type of the value returned for this result. Unlike `type`, which is the unsubstituted
+  /// interface type, this has the pattern substitutions of `functionType` applied. For example, for
+  ///   `@substituted <τ_0_0, τ_0_1> () -> (@out τ_0_0, @error_indirect τ_0_1) for <Int, Never>`
+  /// the error result's `type` is `τ_0_1` whereas its return value type is `Never`.
+  ///
+  /// `functionType` must be the function type this result belongs to.
+  public func getReturnValueType(ofFunctionType functionType: CanonicalType,
+                                 in function: Function) -> CanonicalType {
+    CanonicalType(bridged: self._bridged.getReturnValueType(functionType.bridged, function.bridged))
   }
 }
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -367,6 +367,7 @@ struct BridgedDeclObj {
           void (* _Nonnull appendFn)(void * _Nonnull resultArray, BridgedDeclObj protocol)) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj NominalType_getValueTypeDestructor() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType Enum_getRawType() const;
+  BRIDGED_INLINE bool Enum_hasCasesUnavailableDuringLowering() const;
   BRIDGED_INLINE bool Struct_hasUnreferenceableStorage() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType Class_getSuperclass() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj Class_getSuperclassDecl() const;
@@ -3193,6 +3194,7 @@ struct BridgedASTType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getOptionalType() const;
   BRIDGED_INLINE bool isBuiltinFixedWidthInteger(SwiftInt width) const;
   BRIDGED_INLINE bool isOptional() const;
+  BRIDGED_INLINE bool isStructurallyUninhabited() const;
   BRIDGED_INLINE bool isBuiltinType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getAnyPointerElementType() const;
   BRIDGED_INLINE bool isUnsafeBufferPointerType() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -251,6 +251,10 @@ BridgedASTType BridgedDeclObj::Enum_getRawType() const {
   return {nullptr};
 }
 
+bool BridgedDeclObj::Enum_hasCasesUnavailableDuringLowering() const {
+  return getAs<swift::EnumDecl>()->hasCasesUnavailableDuringLowering();
+}
+
 bool BridgedDeclObj::Struct_hasUnreferenceableStorage() const {
   return getAs<swift::StructDecl>()->hasUnreferenceableStorage();
 }
@@ -713,6 +717,10 @@ bool BridgedASTType::isBuiltinFixedWidthInteger(SwiftInt width) const {
 
 bool BridgedASTType::isOptional() const {
   return unbridged()->getCanonicalType()->isOptional();
+}
+
+bool BridgedASTType::isStructurallyUninhabited() const {
+  return unbridged()->isStructurallyUninhabited();
 }
 
 bool BridgedASTType::isUnownedStorageType() const {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -125,7 +125,10 @@ struct BridgedResultInfo {
     : type(type), convention(conv), options(options) {}
   BRIDGED_INLINE swift::SILResultInfo unbridged() const;
 
-  BRIDGED_INLINE BridgedCanType getReturnValueType(BridgedFunction f) const;
+  /// `ofFunctionType` must be the function type this result belongs to; its pattern
+  /// substitutions are applied to the result's interface type.
+  BRIDGED_INLINE BridgedCanType getReturnValueType(BridgedCanType ofFunctionType,
+                                                   BridgedFunction f) const;
 };
 
 struct OptionalBridgedResultInfo {
@@ -612,6 +615,7 @@ struct BridgedFunction {
   BRIDGED_INLINE void setNeedStackProtection(bool needSP) const;
   BRIDGED_INLINE void setIsPerformanceConstraint(bool isPerfConstraint) const;
   BRIDGED_INLINE bool isResilientNominalDecl(BridgedDeclObj decl) const;
+  BRIDGED_INLINE bool isEffectivelyExhaustiveEnumDecl(BridgedDeclObj decl) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getLoweredType(BridgedASTType type, bool maximallyAbstracted) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType
   getLoweredTypeWithAbstractionPattern(BridgedCanType type) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -70,10 +70,13 @@ swift::SILResultInfo BridgedResultInfo::unbridged() const {
                               swift::SILResultInfo::Options(options));
 }
 
-BridgedCanType BridgedResultInfo::getReturnValueType(BridgedFunction f) const {
+BridgedCanType
+BridgedResultInfo::getReturnValueType(BridgedCanType ofFunctionType,
+                                      BridgedFunction f) const {
   const auto function = f.getFunction();
   return BridgedCanType(unbridged().getReturnValueType(
-      function->getModule(), function->getLoweredFunctionType().getPointer(),
+      function->getModule(),
+      ofFunctionType.unbridged()->castTo<swift::SILFunctionType>(),
       function->getTypeExpansionContext()));
 }
 
@@ -1101,6 +1104,12 @@ bool BridgedFunction::isSpecialization() const {
 bool BridgedFunction::isResilientNominalDecl(BridgedDeclObj decl) const {
   return decl.getAs<swift::NominalTypeDecl>()->isResilient(getFunction()->getModule().getSwiftModule(),
                                                            getFunction()->getResilienceExpansion());
+}
+
+bool BridgedFunction::isEffectivelyExhaustiveEnumDecl(BridgedDeclObj decl) const {
+  return decl.getAs<swift::EnumDecl>()->isEffectivelyExhaustive(
+      getFunction()->getModule().getSwiftModule(),
+      getFunction()->getResilienceExpansion());
 }
 
 BridgedType BridgedFunction::getLoweredType(BridgedASTType type, bool maximallyAbstracted) const {

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -98,7 +98,7 @@ public func dontCrash<In, Out>(test: Bool, body: @escaping ((In) -> Out, In) -> 
 // CHECK:  [[FN:%.*]] = function_ref @$s22closure_lifetime_fixup28to_stack_of_convert_function1pySvSg_tFSSSvcfu_ :
 // CHECK:  [[PA:%.*]] = thin_to_thick_function [[FN]]
 // CHECK:  [[MAP:%.*]] = function_ref @$sSq3mapyqd_0_Sgqd_0_xqd__YKXEqd__YKs5ErrorRd__Ri_d_0_r0_lF
-// CHECK:  try_apply [[MAP]]<UnsafeMutableRawPointer, Never, String>({{.*}}, [[PA]], {{.*}})
+// CHECK:  apply [nothrow] [[MAP]]<UnsafeMutableRawPointer, Never, String>({{.*}}, [[PA]], {{.*}})
 public func to_stack_of_convert_function(p: UnsafeMutableRawPointer?) {
   _ = p.map(String.init(describing:))
 }

--- a/test/SILOptimizer/devirt_class_witness_method.sil
+++ b/test/SILOptimizer/devirt_class_witness_method.sil
@@ -3,7 +3,7 @@ sil_stage canonical
 // RUN: %FileCheck -check-prefix=YAML -input-file=%t.opt.yaml %s
 
 import Builtin
-enum Error {}
+enum Error { case failed } // case-less would be uninhabited, so 'caller2' would need no try_apply
 protocol P {
   func f()
   func g() throws

--- a/test/SILOptimizer/simplify_try_apply.sil
+++ b/test/SILOptimizer/simplify_try_apply.sil
@@ -158,3 +158,107 @@ bb3:
   %9 = tuple ()
   return %9
 }
+
+sil @throws_never : $@convention(thin) () -> (Int, @error Never)
+sil @throws_never_indirect : $@convention(thin) (@in_guaranteed Int) -> (@out Int, @error_indirect Never)
+sil @throws_never_substituted : $@convention(thin) @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error_indirect τ_0_1) for <Int, Never>
+sil @throws_substituted_error : $@convention(thin) @substituted <τ_0_0> () -> (Int, @error τ_0_0) for <any Error>
+
+// A `throws(E)` function specialized for `E == Never` cannot take its error branch. Without
+// removing it the rethrow survives to IRGen, which emits it as an unconditional trap.
+
+// CHECK-LABEL: sil @remove_uninhabited_error_edge :
+// CHECK:         [[F:%.*]] = function_ref @throws_never
+// CHECK-NEXT:    [[R:%.*]] = apply [nothrow] [[F]]()
+// CHECK-NEXT:    br bb1([[R]])
+// CHECK-NOT:     throw
+// CHECK:       } // end sil function 'remove_uninhabited_error_edge'
+sil @remove_uninhabited_error_edge : $@convention(thin) () -> (Int, @error Never) {
+bb0:
+  %0 = function_ref @throws_never : $@convention(thin) () -> (Int, @error Never)
+  try_apply %0() : $@convention(thin) () -> (Int, @error Never), normal bb1, error bb2
+
+bb1(%2 : $Int):
+  return %2
+
+bb2(%4 : $Never):
+  throw %4
+}
+
+// CHECK-LABEL: sil @remove_uninhabited_indirect_error_edge :
+// CHECK:         [[F:%.*]] = function_ref @throws_never_indirect
+// CHECK-NEXT:    [[R:%.*]] = apply [nothrow] [[F]](%0, %1, %2)
+// CHECK-NEXT:    br bb1([[R]])
+// CHECK-NOT:     throw_addr
+// CHECK:       } // end sil function 'remove_uninhabited_indirect_error_edge'
+sil @remove_uninhabited_indirect_error_edge : $@convention(thin) (@in_guaranteed Int) -> (@out Int, @error_indirect Never) {
+bb0(%0 : $*Int, %1 : $*Never, %2 : $*Int):
+  %3 = function_ref @throws_never_indirect : $@convention(thin) (@in_guaranteed Int) -> (@out Int, @error_indirect Never)
+  try_apply %3(%0, %1, %2) : $@convention(thin) (@in_guaranteed Int) -> (@out Int, @error_indirect Never), normal bb1, error bb2
+
+bb1(%5 : $()):
+  return %5
+
+bb2:
+  throw_addr
+}
+
+// This is the shape generic specialization actually produces: the error type is `Never` only
+// once the pattern substitutions of the `@substituted` callee type are applied.
+
+// CHECK-LABEL: sil @remove_uninhabited_substituted_error_edge :
+// CHECK:         [[F:%.*]] = function_ref @throws_never_substituted
+// CHECK-NEXT:    [[R:%.*]] = apply [nothrow] [[F]](%0, %1, %2)
+// CHECK-NEXT:    br bb1([[R]])
+// CHECK-NOT:     throw_addr
+// CHECK:       } // end sil function 'remove_uninhabited_substituted_error_edge'
+sil @remove_uninhabited_substituted_error_edge : $@convention(thin) (@in_guaranteed Int) -> (@out Int, @error_indirect Never) {
+bb0(%0 : $*Int, %1 : $*Never, %2 : $*Int):
+  %3 = function_ref @throws_never_substituted : $@convention(thin) @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error_indirect τ_0_1) for <Int, Never>
+  try_apply %3(%0, %1, %2) : $@convention(thin) @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error_indirect τ_0_1) for <Int, Never>, normal bb1, error bb2
+
+bb1(%5 : $()):
+  return %5
+
+bb2:
+  throw_addr
+}
+
+// The error block is removed, so a value which was destroyed on both paths keeps a single
+// destroy on the remaining one.
+
+// CHECK-LABEL: sil [ossa] @remove_uninhabited_error_edge_ossa :
+// CHECK:         apply [nothrow]
+// CHECK:       bb1([[R:%.*]] : $Int):
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    return [[R]]
+// CHECK:       } // end sil function 'remove_uninhabited_error_edge_ossa'
+sil [ossa] @remove_uninhabited_error_edge_ossa : $@convention(thin) (@owned Bar) -> (Int, @error Never) {
+bb0(%0 : @owned $Bar):
+  %1 = function_ref @throws_never : $@convention(thin) () -> (Int, @error Never)
+  try_apply %1() : $@convention(thin) () -> (Int, @error Never), normal bb1, error bb2
+
+bb1(%3 : $Int):
+  destroy_value %0
+  return %3
+
+bb2(%5 : $Never):
+  destroy_value %0
+  throw %5
+}
+
+// CHECK-LABEL: sil @keep_inhabited_substituted_error_edge :
+// CHECK:         try_apply
+// CHECK:         throw
+// CHECK:       } // end sil function 'keep_inhabited_substituted_error_edge'
+sil @keep_inhabited_substituted_error_edge : $@convention(thin) () -> (Int, @error any Error) {
+bb0:
+  %0 = function_ref @throws_substituted_error : $@convention(thin) @substituted <τ_0_0> () -> (Int, @error τ_0_0) for <any Error>
+  try_apply %0() : $@convention(thin) @substituted <τ_0_0> () -> (Int, @error τ_0_0) for <any Error>, normal bb1, error bb2
+
+bb1(%2 : $Int):
+  return %2
+
+bb2(%4 : $any Error):
+  throw %4
+}

--- a/test/SILOptimizer/simplify_try_apply_resilient_error.swift
+++ b/test/SILOptimizer/simplify_try_apply_resilient_error.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Lib built with library evolution: `NoCases` can gain cases in a future version.
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -swift-version 6 \
+// RUN:   -module-name Lib %t/Lib.swift -emit-module-path %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -O -swift-version 6 -I %t -module-name Client \
+// RUN:   %t/Client.swift | %FileCheck %s -check-prefix=RESILIENT
+
+/// The same Lib without library evolution: `NoCases` is exhaustive, so it stays uninhabited.
+// RUN: %target-swift-frontend -emit-module -swift-version 6 \
+// RUN:   -module-name Lib %t/Lib.swift -emit-module-path %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -O -swift-version 6 -I %t -module-name Client \
+// RUN:   %t/Client.swift | %FileCheck %s -check-prefix=EXHAUSTIVE
+
+//--- Lib.swift
+
+public enum NoCases: Error {}
+
+public func mightThrow<R>(_ body: () throws(NoCases) -> R) throws(NoCases) -> R {
+  try body()
+}
+
+//--- Client.swift
+
+import Lib
+
+// RESILIENT-LABEL: sil @$s6Client4callSiy3Lib7NoCasesOYKF :
+// RESILIENT:         try_apply
+// RESILIENT:       } // end sil function '$s6Client4callSiy3Lib7NoCasesOYKF'
+
+// EXHAUSTIVE-LABEL: sil @$s6Client4callSiy3Lib7NoCasesOYKF :
+// EXHAUSTIVE:         apply [nothrow]
+// EXHAUSTIVE-NOT:     try_apply
+// EXHAUSTIVE:       } // end sil function '$s6Client4callSiy3Lib7NoCasesOYKF'
+public func call() throws(NoCases) -> Int {
+  try mightThrow { 42 }
+}

--- a/test/embedded/typed-throws-never.swift
+++ b/test/embedded/typed-throws-never.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend %s -module-name main -parse-as-library -enable-experimental-feature Embedded -Onone -emit-sil -o - | %FileCheck %s
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: OS=macosx
+
+// Embedded Swift specializes generics even at -Onone. Specializing a `throws(E)` function for
+// `E == Never` leaves a rethrow which can never execute, and IRGen has to emit that as an
+// unconditional trap.
+
+public func mapped(_ o: Int?) -> Int? {
+  o.map { $0 &+ 1 }
+}
+
+public func temporary(_ n: Int) -> Int {
+  withUnsafeTemporaryAllocation(of: Int.self, capacity: n) { $0.count }
+}
+
+// CHECK-NOT: {{^ +throw}}


### PR DESCRIPTION
A `try_apply` whose callee's error result is uninhabited can never take its error branch. Turn it into `apply [nothrow]` and let the dead-block cleanup remove the error block.

This mostly shows up in Embedded Swift, which specializes generics at -Onone: a `rethrows`-shaped `throws(E)` function specialized for `E == Never` keeps the rethrow, and IRGen has to emit that as an unconditional trap ("Never can't be initialized") reached by an equally dead test of the error register. Calling `withTemporaryAllocation` or `Optional.map` was enough to get one per call site.

Enums which are resilient from the caller's point of view are excluded, since a case-less non-frozen enum can gain cases in a future version of its module.

`TryApplyInst` is both `OnoneSimplifiable` (so `MandatoryPerformanceOptimizations` gets it, i.e. Embedded `-Onone`) and `SILCombineSimplifiable` (so `-O` gets it without depending on the inliner).

The predicate is `FunctionConvention.hasUninhabitedErrorResult(in:)`, written in Swift over low-level bridges (`TypeProperties.isStructurallyUninhabited`, `EnumDecl.hasCasesUnavailableDuringLowering`, `EnumDecl.isEffectivelyExhaustive`). `ResultInfo.getReturnValueType` now takes the function type the result belongs to; it used to hardcode the enclosing function's lowered type, which is wrong for a result of an apply site's substituted callee type (it had no prior callers).

Two existing tests change behaviour because their error enums are genuinely case-less: closure_lifetime_fixup's `Optional.map<_, Never, _>` call is now an `apply`, and devirt_class_witness_method's local `enum Error` gets a case so that 'caller2' keeps testing a throwing witness call.
