### PR TITLE
[AST] Handle extension macros in `getTopLevelDeclsWithAuxiliaryDecls`

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -683,6 +683,16 @@ public:
   /// type-checked yet.
   virtual bool shouldWalkIntoUncheckedMacroDefinitions() { return false; }
 
+  /// Whether to walk the top-level auxiliary decls for a SourceFile, including
+  /// peer and extension macro expansions. Note this does not control the
+  /// walking of expansions for freestanding macros.
+  ///
+  /// FIXME: This ought to just be controlled by
+  /// `shouldWalkMacroArgumentsAndExpansion`, but we currently have a bunch of
+  /// misconfigured walkers that are currently relying on phase ordering to not
+  /// expand macros too early.
+  virtual bool shouldWalkTopLevelAuxiliaryDecls() const { return false; }
+
   /// walkToParameterListPre - This method is called when first visiting a
   /// ParameterList, before walking into its parameters.
   ///

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1174,10 +1174,14 @@ public:
   ///
   /// When \p visitFreestandingExpanded is true (the default), this will also
   /// visit the declarations produced by a freestanding macro expansion.
-  void visitAuxiliaryDecls(
-      AuxiliaryDeclCallback callback,
-      bool visitFreestandingExpanded = true
-  ) const;
+  ///
+  /// When \p visitExtensions is true (currently `false` by default), this
+  /// will also visit the top-level extensions for any expanded extension
+  /// macros. Use this with care since in an ASTWalker it would cause a
+  /// non-source-order walk.
+  void visitAuxiliaryDecls(AuxiliaryDeclCallback callback,
+                           bool visitFreestandingExpanded = true,
+                           bool visitExtensions = false) const;
 
   using MacroCallback = llvm::function_ref<void(CustomAttr *, MacroDecl *)>;
 
@@ -4912,6 +4916,10 @@ public:
   /// Return a collection of the stored member variables of this type, along
   /// with placeholders for unimportable stored properties.
   ArrayRef<Decl *> getStoredPropertiesAndMissingMemberPlaceholders() const;
+
+  /// Visit the auxiliary extensions for the given nominal. This includes both
+  /// those expanded by macros as well as others synthesized by the compiler.
+  void visitAuxiliaryExtensions(llvm::function_ref<void(Decl *)> visit) const;
 
   /// Whether this nominal type qualifies as an actor, meaning that it is
   /// either an actor type or a protocol whose `Self` type conforms to the

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -59,6 +59,12 @@ public:
 
   /// Returns the synthesized file for this source file, creating one and
   /// inserting it into the module if it does not exist.
+  ///
+  /// NOTE: Mutating the AST through the synthesized file should *never* be done
+  /// in Sema -- it breaks lazy type-checking and violates the request
+  /// evaluator. If you need to add a new top-level decl, adjust the logic in
+  /// `getTopLevelItemsWithAuxiliaryDecls`. This only exists to allow code
+  /// synthesis during SILOptimizer passes.
   SynthesizedFileUnit &getOrCreateSynthesizedFile();
 
   /// Look up a (possibly overloaded) value set at top-level scope
@@ -217,13 +223,28 @@ public:
   /// The order of the results is not guaranteed to be meaningful.
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {}
 
+  /// Finds all top-level items in this file with their auxiliary decls such as
+  /// macro expansions.
+  ///
+  /// This does a simple local lookup, not recursively looking through imports.
+  /// The order of the results is not guaranteed to be meaningful.
+  ///
+  /// \p visitFreestanding When \c true (the default), includes any top-level
+  /// freestanding macro expansions.
+  ArrayRef<ASTNode>
+  getTopLevelItemsWithAuxiliaryDecls(SmallVectorImpl<ASTNode> &scratch,
+                                     bool visitFreestanding = true) const;
+
   /// Finds all top-level decls in this file with their auxiliary decls such as
   /// macro expansions.
   ///
   /// This does a simple local lookup, not recursively looking through imports.
   /// The order of the results is not guaranteed to be meaningful.
-  void getTopLevelDeclsWithAuxiliaryDecls(
-      SmallVectorImpl<Decl*> &results) const;
+  ///
+  /// \p visitFreestanding When \c true (the default), includes any top-level
+  /// freestanding macro expansions.
+  void getTopLevelDeclsWithAuxiliaryDecls(SmallVectorImpl<Decl *> &results,
+                                          bool visitFreestanding = true) const;
 
   virtual void
   getExportedPrespecializations(SmallVectorImpl<Decl *> &results) const {}
@@ -275,7 +296,8 @@ public:
   /// This can differ from \c getTopLevelDecls, e.g. it returns decls from a
   /// shadowed clang module.
   virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false) const {
-    getTopLevelDecls(results);
+    // When displaying, we generally want to include auxiliary decls.
+    getTopLevelDeclsWithAuxiliaryDecls(results, /*visitFreestanding*/ false);
   }
 
   /// Looks up which modules are imported by this file.

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1107,8 +1107,11 @@ public:
   void getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const;
 
   /// Finds all top-level decls of this module including auxiliary decls.
-  void
-  getTopLevelDeclsWithAuxiliaryDecls(SmallVectorImpl<Decl *> &Results) const;
+  ///
+  /// \p visitFreestanding When \c true (the default), includes any top-level
+  /// freestanding macro expansions.
+  void getTopLevelDeclsWithAuxiliaryDecls(SmallVectorImpl<Decl *> &Results,
+                                          bool visitFreestanding = true) const;
 
   void getExportedPrespecializations(SmallVectorImpl<Decl *> &results) const;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -544,6 +544,15 @@ void NominalTypeDecl::visitAuxiliaryExtensions(
         visit(ext);
     }
   }
+  // The synthesized IID property for COM interop is added with an extension.
+  if (ctx.LangOpts.EnableCOMInterop && mutableNTD->isInSwiftSourceFile()) {
+    if (auto *PD = dyn_cast<ProtocolDecl>(mutableNTD)) {
+      auto *IDVar =
+          evaluateOrDefault(eval, SynthesizeCOMInterfaceIDRequest{PD}, nullptr);
+      if (IDVar)
+        visit(IDVar->getDeclContext()->getAsDecl());
+    }
+  }
 }
 
 void Decl::forEachAttachedMacro(MacroRole role,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -470,10 +470,9 @@ void Decl::attachParsedAttrs(DeclAttributes attrs) {
   getAttrs() = attrs;
 }
 
-void Decl::visitAuxiliaryDecls(
-    AuxiliaryDeclCallback callback,
-    bool visitFreestandingExpanded
-) const {
+void Decl::visitAuxiliaryDecls(AuxiliaryDeclCallback callback,
+                               bool visitFreestandingExpanded,
+                               bool visitExtensions) const {
   auto &ctx = getASTContext();
   auto *mutableThis = const_cast<Decl *>(this);
   SourceManager &sourceMgr = ctx.SourceMgr;
@@ -522,7 +521,29 @@ void Decl::visitAuxiliaryDecls(
     }
   }
 
+  if (visitExtensions) {
+    if (auto *NTD = dyn_cast<NominalTypeDecl>(this))
+      NTD->visitAuxiliaryExtensions(callback);
+  }
+
   // FIXME: fold VarDecl::visitAuxiliaryVars into this.
+}
+
+void NominalTypeDecl::visitAuxiliaryExtensions(
+    llvm::function_ref<void(Decl *)> visit) const {
+  auto &ctx = getASTContext();
+  auto &eval = ctx.evaluator;
+  auto *M = getParentModule();
+  auto *mutableNTD = const_cast<NominalTypeDecl *>(this);
+  auto buffers = evaluateOrDefault(eval, ExpandExtensionMacros{mutableNTD}, {});
+  for (auto buffer : buffers) {
+    auto startLoc = ctx.SourceMgr.getLocForBufferStart(buffer);
+    auto *SF = M->getSourceFileContainingLocation(startLoc);
+    for (auto *D : SF->getTopLevelDecls()) {
+      if (auto *ext = dyn_cast<ExtensionDecl>(D))
+        visit(ext);
+    }
+  }
 }
 
 void Decl::forEachAttachedMacro(MacroRole role,

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -336,6 +336,7 @@ private:
                                   const ExtensionDecl *ED = nullptr) {
     allNominals.push_back(NTD);
     potentialMemberHolders.push_back(NTD);
+    // FIXME: Does not handle peer macros.
     findNominalsAndOperatorsInMembers(ED ? ED->getMembers()
                                          : NTD->getMembers());
   }
@@ -417,8 +418,9 @@ void FrontendSourceFileDepGraphFactory::addAllDefinedDecls() {
 
   // Many kinds of Decls become top-level depends.
 
-  DeclFinder declFinder(SF->getTopLevelDecls(),
-                        [this](VisibleDeclConsumer &consumer) {
+  SmallVector<Decl *, 32> TopLevelDecls;
+  SF->getTopLevelDeclsWithAuxiliaryDecls(TopLevelDecls);
+  DeclFinder declFinder(TopLevelDecls, [this](VisibleDeclConsumer &consumer) {
     SF->lookupClassMembers({}, consumer);
   });
 
@@ -603,7 +605,7 @@ void ModuleDepGraphFactory::addAllDefinedDecls() {
   // Many kinds of Decls become top-level depends.
 
   SmallVector<Decl *, 32> TopLevelDecls;
-  Mod->getTopLevelDecls(TopLevelDecls);
+  Mod->getTopLevelDeclsWithAuxiliaryDecls(TopLevelDecls);
   DeclFinder declFinder(TopLevelDecls,
                         [this](VisibleDeclConsumer &consumer) {
                           return Mod->lookupClassMembers({}, consumer);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1277,8 +1277,8 @@ void ModuleDecl::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {
 }
 
 void ModuleDecl::getTopLevelDeclsWithAuxiliaryDecls(
-    SmallVectorImpl<Decl *> &Results) const {
-  FORWARD(getTopLevelDeclsWithAuxiliaryDecls, (Results));
+    SmallVectorImpl<Decl *> &Results, bool visitFreestanding) const {
+  FORWARD(getTopLevelDeclsWithAuxiliaryDecls, (Results, visitFreestanding));
 }
 
 void ModuleDecl::dumpDisplayDecls() const {
@@ -3720,7 +3720,12 @@ void *SourceFile::getExportedSourceFile() const {
 
 bool FileUnit::walk(ASTWalker &walker) {
   SmallVector<Decl *, 64> Decls;
-  getTopLevelDecls(Decls);
+  if (walker.shouldWalkTopLevelAuxiliaryDecls()) {
+    // Ignore freestanding expansions since the ASTWalker visits those.
+    getTopLevelDeclsWithAuxiliaryDecls(Decls, /*visitFreestanding*/ false);
+  } else {
+    getTopLevelDecls(Decls);
+  }
   llvm::SaveAndRestore<ASTWalker::ParentTy> SAR(walker.Parent,
                                                 getParentModule());
 
@@ -3769,7 +3774,13 @@ bool FileUnit::walk(ASTWalker &walker) {
 bool SourceFile::walk(ASTWalker &walker) {
   llvm::SaveAndRestore<ASTWalker::ParentTy> SAR(walker.Parent,
                                                 getParentModule());
-  for (auto Item : getTopLevelItems()) {
+  SmallVector<ASTNode, 64> scratch;
+  // Ignore freestanding expansions since the ASTWalker visits those.
+  auto Items = walker.shouldWalkTopLevelAuxiliaryDecls()
+                   ? getTopLevelItemsWithAuxiliaryDecls(scratch,
+                                                        /*freestanding*/ false)
+                   : getTopLevelItems();
+  for (auto Item : Items) {
     if (auto D = Item.dyn_cast<Decl *>()) {
       if (D->walk(walker))
         return true;
@@ -4092,20 +4103,103 @@ void FileUnit::getTopLevelDeclsWhereAttributesMatch(
   Results.erase(newEnd, Results.end());
 }
 
-void FileUnit::getTopLevelDeclsWithAuxiliaryDecls(
-    SmallVectorImpl<Decl*> &results) const {
+/// Recursively visit all the auxiliary extensions for any top-level and nested
+/// types.
+static void
+visitAllAuxiliaryExtensions(Decl *D,
+                            llvm::function_ref<void(Decl *)> addResult) {
+  // Only needs to be done for source files and Clang decls.
+  // FIXME: Should Clang be handling this in ClangModuleUnit::getTopLevelDecls?
+  if (!D->getDeclContext()->isInSwiftSourceFile() && !D->hasClangNode())
+    return;
 
-  std::function<void(Decl *)> addResult;
-  addResult = [&](Decl *decl) {
-    results.push_back(decl);
-    decl->visitAuxiliaryDecls(addResult);
+  class Visitor final : public DeclVisitor<Visitor> {
+    llvm::function_ref<void(Decl *)> AddResult;
+
+  public:
+    Visitor(llvm::function_ref<void(Decl *)> addResult)
+        : AddResult(addResult) {}
+
+    void visitDecl(Decl *D) {
+      // Make sure to visit any peer macros. See the comment in
+      // `getTopLevelItemsWithAuxiliaryDecls` for why this is done separately.
+      D->visitAuxiliaryDecls([&](Decl *D) { visit(D); });
+    }
+
+    void visitMembers(IterableDeclContext *IDC) {
+      auto *D = const_cast<Decl *>(IDC->getDecl());
+      visitDecl(D);
+
+      // Make sure to expand any member macros. Note we intentionally don't use
+      // `getABIMembers` here since that unnecessarily synthesizes a bunch of
+      // implicit decls that don't have extension macros, causing unnecessary
+      // work for lazy type-checking.
+      auto &eval = D->getASTContext().evaluator;
+      (void)evaluateOrDefault(eval, ExpandSynthesizedMemberMacroRequest{D}, {});
+      for (auto *member : IDC->getMembers())
+        visit(member);
+    }
+
+    void visitExtensionDecl(ExtensionDecl *ED) { visitMembers(ED); }
+
+    void visitNominalTypeDecl(NominalTypeDecl *NTD) {
+      NTD->visitAuxiliaryExtensions([&](Decl *D) {
+        visit(D);
+        AddResult(D);
+      });
+      visitMembers(NTD);
+    }
   };
+  Visitor visitor(addResult);
+  visitor.visit(D);
+}
 
+ArrayRef<ASTNode>
+FileUnit::getTopLevelItemsWithAuxiliaryDecls(SmallVectorImpl<ASTNode> &scratch,
+                                             bool visitFreestanding) const {
+  std::function<void(Decl *)> addDecl;
+  addDecl = [&](Decl *decl) {
+    scratch.push_back(decl);
+    decl->visitAuxiliaryDecls(addDecl, visitFreestanding);
+  };
+  // Currently only SourceFiles have top-level code items.
+  if (auto *SF = dyn_cast<SourceFile>(this)) {
+    for (auto item : SF->getTopLevelItems()) {
+      if (auto *D = dyn_cast<Decl *>(item)) {
+        addDecl(D);
+        // Note this isn't in `addDecl` since when `visitFreestanding` is
+        // `false` we don't want to collect freestanding expansions for the
+        // result, but we *do* still want to walk them to find auxiliary
+        // extensions.
+        visitAllAuxiliaryExtensions(D, addDecl);
+      } else {
+        scratch.push_back(item);
+      }
+    }
+  } else {
+    SmallVector<Decl *, 32> decls;
+    getTopLevelDeclsWithAuxiliaryDecls(decls, visitFreestanding);
+    for (auto *D : decls)
+      scratch.push_back(D);
+  }
+  return scratch;
+}
+
+void FileUnit::getTopLevelDeclsWithAuxiliaryDecls(
+    SmallVectorImpl<Decl *> &results, bool visitFreestanding) const {
+  std::function<void(Decl *)> addDecl;
+  addDecl = [&](Decl *decl) {
+    results.push_back(decl);
+    decl->visitAuxiliaryDecls(addDecl, visitFreestanding);
+  };
   SmallVector<Decl *, 32> nonExpandedDecls;
-  nonExpandedDecls.reserve(results.capacity());
   getTopLevelDecls(nonExpandedDecls);
-  for (auto *decl : nonExpandedDecls) {
-    addResult(decl);
+  for (auto *D : nonExpandedDecls) {
+    addDecl(D);
+    // Note this isn't in `addDecl` since when `visitFreestanding` is `false`
+    // we don't want to collect freestanding expansions for the result, but
+    // we *do* still want to walk them to find auxiliary extensions.
+    visitAllAuxiliaryExtensions(D, addDecl);
   }
 }
 

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -79,7 +79,8 @@ public:
   visitAuxiliaryDecls:
     // Visit peers expanded from macros
     D->visitAuxiliaryDecls([&](Decl *decl) { decl->walk(*this); },
-                           /*visitFreestandingExpanded=*/false);
+                           /*visitFreestandingExpanded=*/false,
+                           /*visitExtensions*/ true);
     return Action::Continue();
   }
 
@@ -702,12 +703,6 @@ gatherConstValuesForModule(const std::unordered_set<std::string> &Protocols,
   NominalTypeConformanceCollector ConformanceCollector(Protocols,
                                                        ConformanceDecls);
   Module->walk(ConformanceCollector);
-  // Visit macro expanded extensions
-  for (auto *FU : Module->getFiles())
-    if (auto *synthesizedSF = FU->getSynthesizedFile())
-      for (auto D : synthesizedSF->getTopLevelDecls())
-        if (isa<ExtensionDecl>(D))
-          D->walk(ConformanceCollector);
 
   for (auto *CD : ConformanceDecls)
     Result.emplace_back(evaluateOrDefault(CD->getASTContext().evaluator,
@@ -724,13 +719,8 @@ gatherConstValuesForPrimary(const std::unordered_set<std::string> &Protocols,
   std::vector<NominalTypeDecl *> ConformanceDecls;
   NominalTypeConformanceCollector ConformanceCollector(Protocols,
                                                        ConformanceDecls);
-  for (auto D : SF->getTopLevelDecls())
-    D->walk(ConformanceCollector);
-  // Visit macro expanded extensions
-  if (auto *synthesizedSF = SF->getSynthesizedFile())
-    for (auto D : synthesizedSF->getTopLevelDecls())
-      if (isa<ExtensionDecl>(D))
-        D->walk(ConformanceCollector);
+  auto *mutableSF = const_cast<SourceFile *>(SF);
+  mutableSF->walk(ConformanceCollector);
 
   for (auto *CD : ConformanceDecls)
     Result.emplace_back(evaluateOrDefault(

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -67,6 +67,11 @@ private:
     return SEWalker.getMacroWalkingBehavior();
   }
 
+  bool shouldWalkTopLevelAuxiliaryDecls() const override {
+    // Walk top-level expansions whenever we're walking expansions.
+    return shouldWalkMacroArgumentsAndExpansion().second;
+  }
+
   QualifiedIdentTypeReprWalkingScheme
   getQualifiedIdentTypeReprWalkingScheme() const override {
     return QualifiedIdentTypeReprWalkingScheme::SourceOrderRecursive;
@@ -244,8 +249,10 @@ ASTWalker::PostWalkAction SemaAnnotator::walkToDeclPost(Decl *D) {
   if (Action.Action == PostWalkAction::Stop)
     return Action;
 
-  // Walk into peer and conformance expansions if walking expansions
-  if (shouldWalkMacroArgumentsAndExpansion().second) {
+  // Walk into peer and conformance expansions if walking expansions. Avoid
+  // doing this for top-level decls since their auxiliary decls are walked
+  // separately by `SourceFile::walk`.
+  if (shouldWalkMacroArgumentsAndExpansion().second && !Parent.getAsModule()) {
     D->visitAuxiliaryDecls([&](Decl *auxDecl) {
       if (Action.Action == PostWalkAction::Stop)
         return;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -477,7 +477,7 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
 
   PrettySourceFileEmission StackEntry(SF);
 
-  // Emit types and other global decls.
+  // Emit types and other global decls. `emitGlobalDecl` handles auxiliary.
   for (auto *decl : SF.getTopLevelDecls())
     emitGlobalDecl(decl);
   for (auto *decl : SF.getHoistedDecls())
@@ -2656,9 +2656,8 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   if (!D->isAvailableDuringLowering())
     return;
 
-  D->visitAuxiliaryDecls([&](Decl *decl) {
-    emitGlobalDecl(decl);
-  });
+  D->visitAuxiliaryDecls([&](Decl *decl) { emitGlobalDecl(decl); },
+                         /*visitFreestanding*/ true, /*visitExtensions*/ true);
 
   switch (D->getKind()) {
   case DeclKind::Extension:
@@ -5975,9 +5974,17 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
     if (!member->isAvailableDuringLowering())
       continue;
 
-    member->visitAuxiliaryDecls([&](Decl *decl) {
-      emitNestedTypeDecls({decl, nullptr});
-    });
+    member->visitAuxiliaryDecls(
+        [&](Decl *decl) {
+          // Nested types can have extension macros, these need to be emitted
+          // as top-level.
+          if (auto *ED = dyn_cast<ExtensionDecl>(decl)) {
+            emitGlobalDecl(ED);
+          } else {
+            emitNestedTypeDecls({decl, nullptr});
+          }
+        },
+        /*visitFreestanding*/ true, /*visitExtensions*/ true);
     switch (member->getKind()) {
     case DeclKind::Import:
     case DeclKind::TopLevelCode:

--- a/lib/IRGen/TypeLayoutDumper.cpp
+++ b/lib/IRGen/TypeLayoutDumper.cpp
@@ -121,9 +121,11 @@ static std::optional<YAMLModuleNode> createYAMLModuleNode(ModuleDecl *Mod,
   std::vector<NominalTypeDecl *> Decls;
   NominalTypeWalker Walker(Decls);
 
-  // Collect all nominal types, including nested types.
+  // Collect all nominal types, including nested types. We don't want
+  // freestanding since ASTWalker handles those.
   SmallVector<Decl *, 16> TopLevelDecls;
-  Mod->getTopLevelDecls(TopLevelDecls);
+  Mod->getTopLevelDeclsWithAuxiliaryDecls(TopLevelDecls,
+                                          /*visitFreestanding*/ false);
 
   for (auto *D : TopLevelDecls)
     D->walk(Walker);
@@ -170,7 +172,10 @@ bool swift::performDumpTypeInfo(const IRGenOptions &Opts, SILModule &SILMod) {
 
   auto *Mod = SILMod.getSwiftModule();
   SmallVector<Decl *, 16> AllDecls;
-  Mod->getTopLevelDecls(AllDecls);
+  // Find all top level declarations. We don't want freestanding since ASTWalker
+  // handles those.
+  Mod->getTopLevelDeclsWithAuxiliaryDecls(AllDecls,
+                                          /*visitFreestanding*/ false);
 
   SmallVector<ModuleDecl *, 4> AllModules;
   for (auto *D : AllDecls) {

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1310,9 +1310,6 @@ void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod) {
     if (!handleSourceOrModuleFile(*SrcFile))
       return;
     walk(*SrcFile);
-    if (auto *synthesizedSF = SrcFile->getSynthesizedFile()) {
-      walk(synthesizedSF);
-    }
   } else {
     IsModuleFile = true;
     isSystemModule = Mod.isNonUserModule();

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4313,7 +4313,7 @@ static void printSILLinearMapTypes(SILPrintContext &Ctx,
   Options.PrintInSILBody = false;
 
   SmallVector<Decl *, 32> topLevelDecls;
-  M->getTopLevelDecls(topLevelDecls);
+  M->getTopLevelDeclsWithAuxiliaryDecls(topLevelDecls);
   for (const Decl *D : topLevelDecls) {
     if (D->getDeclContext() == M)
       continue;
@@ -4478,7 +4478,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
     bool WholeModuleMode = (M == AssociatedDeclContext);
 
     SmallVector<Decl *, 32> topLevelDecls;
-    M->getTopLevelDecls(topLevelDecls);
+    M->getTopLevelDeclsWithAuxiliaryDecls(topLevelDecls);
     for (const Decl *D : topLevelDecls) {
       if (!WholeModuleMode && !(D->getDeclContext() == AssociatedDeclContext))
           continue;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2267,13 +2267,11 @@ void SILGenModule::emitSourceFile(SourceFile *sf) {
     emitEntryPoint(sf);
   }
 
-  for (auto *D : sf->getTopLevelDecls()) {
-    // Emit auxiliary decls.
-    D->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
-      visit(auxiliaryDecl);
-    });
-
-    visit(D);
+  {
+    SmallVector<Decl *, 64> decls;
+    sf->getTopLevelDeclsWithAuxiliaryDecls(decls);
+    for (auto *D : decls)
+      visit(D);
   }
 
   // Visit extensions recorded in the synthesized file separately. The code

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2274,25 +2274,6 @@ void SILGenModule::emitSourceFile(SourceFile *sf) {
       visit(D);
   }
 
-  // Visit extensions recorded in the synthesized file separately. The code
-  // above that visits auxiliary decls of the top-level decls in the source
-  // file does not work for nested types with attached conformance macros:
-  // ```
-  // struct Outer {
-  //   @AddConformance struct Inner {}
-  // }
-  // ```
-  // Because the attached-to decl is not at the top level. Other compiler
-  // features can also add extensions directly to the synthesized file.
-  if (auto *synthesizedFile = sf->getSynthesizedFile()) {
-    for (auto *D : synthesizedFile->getTopLevelDecls()) {
-      if (!isa<ExtensionDecl>(D))
-        continue;
-
-      visit(D);
-    }
-  }
-
   for (Decl *D : sf->getHoistedDecls()) {
     visit(D);
   }

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -388,9 +388,11 @@ SILGenTopLevel::SILGenTopLevel(SILGenFunction &SGF) : SGF(SGF) {}
 
 void SILGenTopLevel::visitSourceFile(SourceFile *SF) {
 
-  for (auto *D : SF->getTopLevelDecls()) {
-    D->visitAuxiliaryDecls([&](Decl *AuxiliaryDecl) { visit(AuxiliaryDecl); });
-    visit(D);
+  {
+    SmallVector<Decl *, 64> decls;
+    SF->getTopLevelDeclsWithAuxiliaryDecls(decls);
+    for (auto *D : decls)
+      visit(D);
   }
 
   if (auto *SynthesizedFile = SF->getSynthesizedFile()) {

--- a/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
@@ -84,8 +84,10 @@ void ProtocolConformanceAnalysis::populateConformanceCacheIfNecessary() {
   // Process all types implementing protocols.
   SmallVector<Decl *, 32> Decls;
 
-  // Find all top level declarations.
-  M->getSwiftModule()->getTopLevelDecls(Decls);
+  // Find all top level declarations. We don't want freestanding since ASTWalker
+  // handles those.
+  M->getSwiftModule()->getTopLevelDeclsWithAuxiliaryDecls(
+      Decls, /*visitFreestanding*/ false);
 
   /// This operation is quadratic and should only be performed
   /// in whole module compilation!

--- a/lib/SILOptimizer/Mandatory/AlwaysEmitConformanceMetadataPreservation.cpp
+++ b/lib/SILOptimizer/Mandatory/AlwaysEmitConformanceMetadataPreservation.cpp
@@ -75,7 +75,8 @@ public:
 
     // Visit peers expanded from macros
     D->visitAuxiliaryDecls([&](Decl *decl) { decl->walk(*this); },
-                           /*visitFreestandingExpanded=*/false);
+                           /*visitFreestandingExpanded=*/false,
+                           /*visitExtensions*/ true);
 
     return Action::Continue();
   }
@@ -94,12 +95,8 @@ class AlwaysEmitConformanceMetadataPreservation : public SILModuleTransform {
         for (const auto File : M.getSwiftModule()->getFiles())
           File->getTopLevelDecls(TopLevelDecls);
       } else {
-        for (const auto Primary : M.getSwiftModule()->getPrimarySourceFiles()) {
+        for (const auto Primary : M.getSwiftModule()->getPrimarySourceFiles())
           Primary->getTopLevelDecls(TopLevelDecls);
-	  // Visit macro expanded extensions
-	  if (auto *synthesizedPrimary = Primary->getSynthesizedFile())
-	    synthesizedPrimary->getTopLevelDecls(TopLevelDecls);
-	}
       }
     }
     for (auto *TLD : TopLevelDecls)

--- a/lib/Sema/TypeCheckCOM.cpp
+++ b/lib/Sema/TypeCheckCOM.cpp
@@ -196,14 +196,6 @@ VarDecl *synthesizeIIDProperty(ProtocolDecl *PD, ASTContext &ASTContext,
   ext->setExtendedNominal(PD);
   PD->addExtension(ext);
 
-  // Route the extension through the synthesized file unit so it is code-gen'd
-  // and serialized: the `IID` accessor must be emitted for the current module
-  // and reachable by name lookup in modules that import it.  Synthesis only
-  // happens for source-file protocols (see SynthesizeCOMInterfaceIDRequest);
-  // imported protocols recover the extension from the deserialized module.
-  if (auto *file = dyn_cast<FileUnit>(PD->getModuleScopeContext()))
-    file->getOrCreateSynthesizedFile().addTopLevelDecl(ext);
-
   VarDecl *property =
       generateIDAccessor(ASTContext, /*DC=*/ext, /*decl=*/PD,
                          /*identifier=*/ASTContext.Id_IID, value,
@@ -271,11 +263,14 @@ const COMAttr *getAttribute(const ClassDecl *CD) {
 
 const COMAttr *getAttribute(const ProtocolDecl *PD) {
   auto *attr = PD->getAttrs().getAttribute<COMAttr>();
-  if (!attr)
+  if (!attr || attr->IID.empty() || attr->CLSID ||
+      !UUID::fromString(attr->IID.str().c_str())) {
+    // Diagnosed by `AttributeChecker::visitCOMAttr`.
+    // FIXME: We should probably be diagnosing in COMDeclInfoRequest itself,
+    // we shouldn't be relying on phase ordering here since it will break lazy
+    // type-checking.
     return nullptr;
-
-  ASSERT(!attr->IID.empty());
-  ASSERT(!attr->CLSID);
+  }
   return attr;
 }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2284,9 +2284,9 @@ public:
     // We don't do this for members of classes because it happens as part of
     // visiting their ABI members.
     if (!isa<ClassDecl>(decl->getDeclContext())) {
-      decl->visitAuxiliaryDecls([&](Decl *auxiliaryDecl) {
-        this->visit(auxiliaryDecl);
-      }, /*visitFreestandingExpanded=*/false);
+      decl->visitAuxiliaryDecls(
+          [&](Decl *auxiliaryDecl) { this->visit(auxiliaryDecl); },
+          /*visitFreestandingExpanded=*/false, /*visitExtensions*/ true);
     }
 
     if (auto *Stats = Ctx.Stats)
@@ -3513,8 +3513,14 @@ public:
     if (CD->isActor())
       TypeChecker::checkConcurrencyAvailability(CD->getLoc(), CD);
 
-    for (Decl *Member : CD->getABIMembers())
+    for (Decl *Member : CD->getABIMembers()) {
+      // Since `visit(Decl *)` skips visiting auxiliary decls for classes, we
+      // need to manually handle extension macros here.
+      if (auto *NTD = dyn_cast<NominalTypeDecl>(Member)) {
+        NTD->visitAuxiliaryExtensions([&](Decl *ext) { visit(ext); });
+      }
       visit(Member);
+    }
 
     // If this class requires all of its stored properties to have
     // in-class initializers, diagnose this now.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -2181,17 +2181,6 @@ std::optional<unsigned> swift::expandExtensions(CustomAttr *attr,
     extension->setExtendedNominal(nominal);
     nominal->addExtension(extension);
 
-    // Most other macro-generated declarations are visited through calling
-    // 'visitAuxiliaryDecls' on the original declaration the macro is attached
-    // to. We don't do this for macro-generated extensions, because the
-    // extension is not a peer of the original declaration. Instead of
-    // requiring all callers of 'visitAuxiliaryDecls' to understand the
-    // hoisting behavior of macro-generated extensions, we make the
-    // extension accessible through 'getTopLevelDecls()'.
-    if (auto file = dyn_cast<FileUnit>(
-            decl->getDeclContext()->getModuleScopeContext()))
-      file->getOrCreateSynthesizedFile().addTopLevelDecl(extension);
-
     // Don't validate documented conformances for the 'conformance' role.
     if (role == MacroRole::Conformance)
       continue;

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1402,10 +1402,10 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   if (role == MacroRole::Peer) {
     dc = attachedTo->getDeclContext();
   } else if (role == MacroRole::Conformance || role == MacroRole::Extension) {
-    // Conformance macros always expand to extensions at file-scope.
+    // Conformance macros always expand to extensions at top-level file-scope.
     dc = attachedTo->getDeclContext();
     if (!isa<ClangModuleUnit>(dc->getModuleScopeContext()))
-      dc = dc->getParentSourceFile();
+      dc = dc->getOutermostParentSourceFile();
     else
       ASSERT(isa<FileUnit>(dc) && !isa<SourceFile>(dc) && "decls imported from Clang should not have a SourceFile");
   } else {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -305,7 +305,8 @@ TypeCheckPrimaryFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     // checking.
     (void)AvailabilityScope::getOrBuildForSourceFile(*SF);
 
-    // Type check the top-level elements of the source file.
+    // Type check the top-level elements of the source file. The DeclChecker
+    // handles auxiliary decls.
     for (auto D : SF->getTopLevelDecls()) {
       if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         TypeChecker::typeCheckTopLevelCodeDecl(TLCD);

--- a/test/ConstExtraction/ExtractFromMacroExpansion.swift
+++ b/test/ConstExtraction/ExtractFromMacroExpansion.swift
@@ -74,6 +74,14 @@ extension MyStruct {
 // CHECK:   "value": "3"
 
 
+// CHECK: "typeName": "ExtractFromMacroExpansion.MacroAddedStruct._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"
+
+
 // CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct",
 // CHECK: "properties": [
 // CHECK:   "label": "macroAddedVar",
@@ -140,6 +148,22 @@ extension MyStruct {
 // CHECK:   "value": "3"
 
 
+// CHECK: "typeName": "ExtractFromMacroExpansion._Peer_MyStruct._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"
+
+
 // CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct.Inner",
 // CHECK: "properties": [
 // CHECK:   "label": "_member_Inner",
@@ -179,29 +203,6 @@ extension MyStruct {
 // CHECK:   "type": "Swift.Int",
 // CHECK:   "valueKind": "RawLiteral",
 // CHECK:   "value": "3"
-
-
-// CHECK: "typeName": "ExtractFromMacroExpansion.MacroAddedStruct._Extension_MyProto",
-// CHECK: "properties": [
-// CHECK:   "label": "nested",
-// CHECK:   "type": "Swift.Int",
-// CHECK:   "valueKind": "RawLiteral",
-// CHECK:   "value": "8"
-
-
-// CHECK: "typeName": "ExtractFromMacroExpansion._Peer_MyStruct._Extension_MyProto",
-// CHECK: "properties": [
-// CHECK:   "label": "nested",
-// CHECK:   "type": "Swift.Int",
-// CHECK:   "valueKind": "RawLiteral",
-// CHECK:   "value": "8"
-
-// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct._Extension_MyProto",
-// CHECK: "properties": [
-// CHECK:   "label": "nested",
-// CHECK:   "type": "Swift.Int",
-// CHECK:   "valueKind": "RawLiteral",
-// CHECK:   "value": "8"
 
 
 // CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct._Peer_Inner._Extension_MyProto",

--- a/test/IRGen/macro_expand_extension.swift
+++ b/test/IRGen/macro_expand_extension.swift
@@ -1,0 +1,155 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: executable_test
+
+// dynamic library with wasm is not supported yet
+// UNSUPPORTED: CPU=wasm32
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t/src
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Make sure we emit extension macros correctly for both single-threaded and multi-threaded WMO, as well
+// as regular single primary mode.
+
+// RUN: %target-swift-frontend -emit-ir -module-name main %t/src/main.swift %t/src/a.swift %t/src/b.swift -load-plugin-library %t/%target-library-name(MacroDefinition) | %FileCheck --check-prefix CHECK-ALL %s
+
+// RUN: %target-swift-frontend -emit-ir -module-name main %t/src/main.swift -o %t/main.ll %t/src/a.swift -o %t/a.ll %t/src/b.swift -o %t/b.ll -num-threads 3 -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %FileCheck -check-prefix CHECK-A %s < %t/a.ll
+// RUN: %FileCheck -check-prefix NOT-IN-A %s < %t/a.ll
+// RUN: %FileCheck -check-prefix CHECK-B %s < %t/b.ll
+// RUN: %FileCheck -check-prefix NOT-IN-B %s < %t/b.ll
+
+// RUN: %target-swift-frontend -emit-ir -module-name main %t/src/main.swift -primary-file %t/src/a.swift -o %t/a1.ll %t/src/b.swift -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %FileCheck -check-prefix CHECK-A %s < %t/a1.ll
+
+// RUN: %target-swift-frontend -emit-ir -module-name main %t/src/main.swift %t/src/a.swift -primary-file %t/src/b.swift -o %t/b1.ll -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %FileCheck -check-prefix CHECK-B %s < %t/b1.ll
+
+// RUN: %target-swift-frontend -c -module-name main %t/src/main.swift -o %t/main.o %t/src/a.swift -o %t/a.o %t/src/b.swift -o %t/b.o -num-threads 3 -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %target-build-swift %t/main.o %t/a.o %t/b.o -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck --check-prefix CHECK-OUT %s
+
+//--- a.swift
+public protocol MyProtocol {}
+
+// Adds `extension <Type>: MyProtocol { func macroAddedFunc(); struct MacroAddedNested {} }`.
+@attached(extension, conformances: MyProtocol,
+          names: named(macroAddedFunc), named(MacroAddedNested))
+macro AddMembersAndConformance() = #externalMacro(module: "MacroDefinition", type: "ExtensionWithMembersMacro")
+
+// Adds `extension <Type> { @AddMyProtocol struct Nested {} }`.
+@attached(extension, names: named(Nested))
+macro AddNested() = #externalMacro(module: "MacroDefinition", type: "NestedConformingExtensionMacro")
+
+// Adds `extension <Type>: MyProtocol {}`
+@attached(extension, conformances: MyProtocol)
+macro AddMyProtocol() = #externalMacro(module: "MacroDefinition", type: "ConformanceViaExtensionMacro")
+
+@AddMembersAndConformance
+public struct TopLevelA {
+  public init() {}
+}
+
+public struct OuterA {
+  @AddMembersAndConformance
+  public struct InnerA {
+    public init() {}
+  }
+}
+
+@AddNested
+public struct ChainedA {
+  public init() {}
+}
+
+// Conformance descriptors and metadata should be in the same translation unit.
+// CHECK-A-DAG: @"$s4main9TopLevelAVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-A-DAG: @"$s4main6OuterAV6InnerAVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-A-DAG: @"$s4main8ChainedAV6NestedVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-A-DAG: @"$s4main9TopLevelAV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-A-DAG: @"$s4main6OuterAV6InnerAV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-A-DAG: @"$s4main9TopLevelAVMn" = {{(dllexport )?}}{{(protected )?}}constant
+
+// No non-`external` definitions from b.swift
+// NOT-IN-A-NOT: $s4main9TopLevelBV{{.*}} = {{[^e]}}
+// NOT-IN-A-NOT: $s4main6OuterBV{{.*}} = {{[^e]}}
+// NOT-IN-A-NOT: $s4main8ChainedBV{{.*}} = {{[^e]}}
+
+// CHECK-ALL-DAG: @"$s4main9TopLevelAVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main6OuterAV6InnerAVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main8ChainedAV6NestedVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main9TopLevelAV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main6OuterAV6InnerAV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main9TopLevelAVMn" = {{(dllexport )?}}{{(protected )?}}constant
+
+//--- b.swift
+
+@AddMembersAndConformance
+public struct TopLevelB {
+  public init() {}
+}
+
+public struct OuterB {
+  @AddMembersAndConformance
+  public struct InnerB {
+    public init() {}
+  }
+}
+
+@AddNested
+public struct ChainedB {
+  public init() {}
+}
+
+// CHECK-B-DAG: @"$s4main9TopLevelBVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-B-DAG: @"$s4main6OuterBV6InnerBVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-B-DAG: @"$s4main8ChainedBV6NestedVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-B-DAG: @"$s4main9TopLevelBV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-B-DAG: @"$s4main6OuterBV6InnerBV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-B-DAG: @"$s4main9TopLevelBVMn" = {{(dllexport )?}}{{(protected )?}}constant
+
+// No non-`external` definitions from a.swift
+// NOT-IN-B-NOT: $s4main9TopLevelAV{{.*}} = {{[^e]}}
+// NOT-IN-B-NOT: $s4main6OuterAV{{.*}} = {{[^e]}}
+// NOT-IN-B-NOT: $s4main8ChainedAV{{.*}} = {{[^e]}}
+
+// CHECK-ALL-DAG: @"$s4main9TopLevelBVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main6OuterBV6InnerBVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main8ChainedBV6NestedVAA10MyProtocolAAMc" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main9TopLevelBV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main6OuterBV6InnerBV16MacroAddedNestedVMn" = {{(dllexport )?}}{{(protected )?}}constant
+// CHECK-ALL-DAG: @"$s4main9TopLevelBVMn" = {{(dllexport )?}}{{(protected )?}}constant
+
+//--- main.swift
+
+@_optimize(none)
+func conformsToMyProtocol(_ value: Any) -> Bool { value is MyProtocol }
+
+TopLevelA().macroAddedFunc()
+TopLevelB().macroAddedFunc()
+OuterA.InnerA().macroAddedFunc()
+OuterB.InnerB().macroAddedFunc()
+
+print(conformsToMyProtocol(TopLevelA()))
+// CHECK-OUT: true
+print(conformsToMyProtocol(TopLevelB()))
+// CHECK-OUT: true
+print(conformsToMyProtocol(OuterA.InnerA()))
+// CHECK-OUT: true
+print(conformsToMyProtocol(OuterB.InnerB()))
+// CHECK-OUT: true
+print(conformsToMyProtocol(ChainedA.Nested()))
+// CHECK-OUT: true
+print(conformsToMyProtocol(ChainedB.Nested()))
+// CHECK-OUT: true
+
+// Types declared inside a macro-expanded extension need their metadata emitted.
+print(TopLevelA.MacroAddedNested.self)
+// CHECK-OUT: MacroAddedNested
+print(TopLevelB.MacroAddedNested.self)
+// CHECK-OUT: MacroAddedNested
+print(OuterA.InnerA.MacroAddedNested.self)
+// CHECK-OUT: MacroAddedNested
+print(OuterB.InnerB.MacroAddedNested.self)
+// CHECK-OUT: MacroAddedNested

--- a/test/IRGen/rdar185645710.swift
+++ b/test/IRGen/rdar185645710.swift
@@ -1,0 +1,63 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: OS=macosx
+// REQUIRES: CODEGENERATOR=X86
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t/src
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name MacroDefinition %t/src/macro.swift -g -no-toolchain-stdlib-rpath
+
+// Similar test to `IRGen/macro_expand_extension.swift`, but triggers the exact
+// LLVM issue when emitting x86.
+
+// RUN: %target-swift-frontend -c -verify -target x86_64-apple-macos13.0 -module-name main -parse-as-library %t/src/a.swift -o %t/a.o %t/src/b.swift -o %t/b.o -num-threads 2 -load-plugin-library %t/%target-library-name(MacroDefinition)
+// RUN: %llvm-nm --defined-only %t/a.o | %FileCheck %s --check-prefix CHECK-A --implicit-check-not Subject
+// RUN: %llvm-nm --defined-only %t/b.o | %FileCheck %s --check-prefix CHECK-B
+
+//--- macro.swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct NestedEnumExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax =
+      """
+      extension \(type.trimmed): P {
+          public enum Kind: Swift.Hashable {
+              case a
+              case b
+          }
+          public var kind: Kind { .a }
+      }
+      """
+    return [ext.cast(ExtensionDeclSyntax.self)]
+  }
+}
+
+//--- a.swift
+protocol P {}
+
+@attached(extension, conformances: P, names: arbitrary)
+macro AddNestedEnum() = #externalMacro(module: "MacroDefinition", type: "NestedEnumExtensionMacro")
+
+// Make sure a.o is non-empty.
+public func dummy() {}
+// CHECK-A: $s4main5dummyyyF
+
+//--- b.swift
+// A separate file from the macro declaration, so the extended type does not
+// belong to the first IRGenModule.
+@AddNestedEnum
+enum E: Sendable {
+  case a(Int)
+  case b(String)
+}
+
+// Make sure we have both the conformance and metadata.
+// CHECK-B-DAG: $s4main1EOAA1PAAMc
+// CHECK-B-DAG: $s4main1EO4KindOMn

--- a/test/Index/index_clang_module_macro_duplicate.swift
+++ b/test/Index/index_clang_module_macro_duplicate.swift
@@ -1,0 +1,25 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print Library -source-filename %t/main.swift -plugin-path %swift-plugin-dir -I %t/Inputs | %FileCheck %s
+
+// FIXME: Both ClangModuleUnit and `getTopLevelDeclsWithAuxiliaryDecls` expand
+// the macro here.
+// CHECK: | function(public)/Swift | readWidgets(_:_:) | c:@F@readWidgets | Def
+// CHECK-COUNT-2: | function(public)/Swift | readWidgets(_:) | {{.*}} | Def
+// CHECK-NOT: | function(public)/Swift | readWidgets(_:) | {{.*}} | Def
+
+//--- Inputs/module.modulemap
+module Library {
+  header "library.h"
+  export *
+}
+
+//--- Inputs/library.h
+__attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(2), count: \"count\"), typeMappings: [\"int * _Nonnull\" : \"UnsafeMutablePointer<CInt>\"])")))
+void readWidgets(int count, int * _Nonnull widgets);
+
+//--- main.swift
+import Library

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -12,6 +12,7 @@
 // Check indexed symbols
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %t/IndexTest.swift -load-plugin-library %t/%target-library-name(IndexMacros) -parse-as-library > %t/index.out
 // RUN: %FileCheck %s --input-file %t/index.out
+// RUN: %FileCheck %s --input-file %t/index.out --check-prefix DUP
 
 //--- IndexTest.swift
 @freestanding(expression)
@@ -21,6 +22,10 @@ macro freestandingExpr<T>(arg: T) = #externalMacro(module: "IndexMacros", type: 
 @freestanding(declaration, names: named(TestFree))
 macro freestandingDecl<T>(arg: T) = #externalMacro(module: "IndexMacros", type: "FreestandingDeclMacro")
 // CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | freestandingDecl(arg:) |  [[DECL_USR:.*]] | Def
+
+@freestanding(declaration, names: named(TestFreeConforming))
+macro freestandingConformingDecl() = #externalMacro(module: "IndexMacros", type: "FreestandingConformingDeclMacro")
+// CHECK: [[@LINE-1]]:7 | macro(internal)/Swift | freestandingConformingDecl() |  [[CONFORMING_DECL_USR:.*]] | Def
 
 @attached(accessor)
 macro Accessor() = #externalMacro(module: "IndexMacros", type: "SomeAccessorMacro")
@@ -123,6 +128,11 @@ struct TestAttached {
 // CHECK: [[@LINE-24]]:39 | function/Swift | peerLog() | [[PEER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
 // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | peerFunc() | [[PEER_FUNC_USR]]
 
+// `Conformance` adds `TestProto` as a conformance on an extension of `TestAttached`
+// CHECK: [[@LINE-28]]:1 | extension/ext-struct/Swift | TestAttached | {{.*}} | Def,Impl
+// CHECK: [[@LINE-29]]:1 | protocol/Swift | TestProto | [[PROTO_USR]] | Ref,Impl,RelBase
+// CHECK-NEXT: RelBase | extension/ext-struct/Swift | TestAttached
+
 // CHECK: [[@LINE+1]]:8 | struct(internal)/Swift | Outer | [[OUTER_USR:.*]] | Def
 struct Outer {
   // CHECK: [[@LINE+1]]:4 | macro/Swift | PeerMember() | [[PEER_MEMBER_USR]] | Ref
@@ -143,18 +153,21 @@ struct Outer {
 // CHECK: [[@LINE-6]]:16 | function/Swift | memberLog() | [[MEMBER_LOG_USR]] | Ref,Call,Impl,RelCall,RelCont
 // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | memberFunc() | [[INNER_FUNC_USR]]
 
-
-// Expanded extensions are visited last
-
-// `Conformance` adds `TestProto` as a conformance on an extension of `TestAttached`
-// CHECK: [[@LINE-51]]:1 | extension/ext-struct/Swift | TestAttached | {{.*}} | Def,Impl
-// CHECK: [[@LINE-52]]:1 | protocol/Swift | TestProto | [[PROTO_USR]] | Ref,Impl,RelBase
-// CHECK-NEXT: RelBase | extension/ext-struct/Swift | TestAttached
-
 // `Conformance` adds `TestProto` as a conformance on an extension of `TestInner`
-// CHECK: [[@LINE-18]]:3 | extension/ext-struct/Swift | TestInner | {{.*}} | Def,Impl
-// CHECK: [[@LINE-19]]:3 | protocol/Swift | TestProto | [[PROTO_USR]] | Ref,Impl,RelBase
+// CHECK: [[@LINE-10]]:3 | extension/ext-struct/Swift | TestInner | {{.*}} | Def,Impl
+// CHECK: [[@LINE-11]]:3 | protocol/Swift | TestProto | [[PROTO_USR]] | Ref,Impl,RelBase
 // CHECK-NEXT: RelBase | extension/ext-struct/Swift | TestInner
+
+// Make sure we pick up an extension macro attached to the expansion of a freestanding macro.
+#freestandingConformingDecl
+// CHECK: [[@LINE-1]]:1 | struct(internal)/Swift | TestFreeConforming | {{.*}} | Def,Impl
+// CHECK: [[@LINE-2]]:1 | extension/ext-struct/Swift | TestFreeConforming | {{.*}} | Def,Impl
+// CHECK: [[@LINE-3]]:1 | protocol/Swift | TestProto | {{.*}} | Ref,Impl,RelBase
+// CHECK-NEXT: RelBase | extension/ext-struct/Swift | TestFreeConforming
+
+// Make sure a freestanding decl expansion only gets reported once.
+// DUP-COUNT-1: | struct(internal)/Swift | TestFree | {{.*}} | Def,Impl
+// DUP-NOT: | struct(internal)/Swift | TestFree | {{.*}} | Def,Impl
 
 //--- IndexMacros.swift
 import SwiftSyntax
@@ -182,6 +195,17 @@ public struct FreestandingDeclMacro: DeclarationMacro {
         }
       }
       """]
+  }
+}
+
+/// Like `FreestandingDeclMacro`, but the expanded type also has an attached
+/// extension macro.
+public struct FreestandingConformingDeclMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["@Conformance struct TestFreeConforming {}"]
   }
 }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -3367,3 +3367,96 @@ public struct MemberAttributeThatAddsPeerMacro: MemberAttributeMacro {
     return ["@PeerThatEmitsCode(\(literal: try verbatimCode(node)))"]
   }
 }
+
+/// Extension macro that declares a nested type with an extension macro
+/// conformance on it.
+public struct NestedConformingExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax = """
+      extension \(type.trimmed) {
+        @AddMyProtocol public struct Nested {}
+      }
+      """
+    return [ext.cast(ExtensionDeclSyntax.self)]
+  }
+}
+
+// Extension macro conformance on a member macro.
+public struct ConformingMemberStructMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["@AddMyProtocol public struct Generated {}"]
+  }
+}
+
+/// Peer macro with nested type.
+public struct PeerStructMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["""
+      public struct MacroPeer {
+        public struct Nested {}
+      }
+      """]
+  }
+}
+
+// Peer macro with conformance on extension macro.
+public struct ConformingPeerStructMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["@AddMyProtocol public struct ConformingPeer {}"]
+  }
+}
+
+/// Extension macro that itself has a peer.
+public struct PeeredExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax = """
+      @AddPeerStruct extension \(type.trimmed) {
+        public func extMember() {}
+      }
+      """
+    return [ext.cast(ExtensionDeclSyntax.self)]
+  }
+}
+
+/// Extension macro that has a conformance and regular members.
+public struct ExtensionWithMembersMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let ext: DeclSyntax = """
+      extension \(type.trimmed): MyProtocol {
+        public func macroAddedFunc() {}
+        public struct MacroAddedNested {}
+      }
+      """
+    return [ext.cast(ExtensionDeclSyntax.self)]
+  }
+}

--- a/test/Macros/macro_expand_auxiliary_swiftdeps.swift
+++ b/test/Macros/macro_expand_auxiliary_swiftdeps.swift
@@ -1,0 +1,35 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Make sure we pick up extension macros and top-level peers in swiftdeps.
+
+// RUN: %target-swift-frontend -typecheck -module-name main -primary-file %s -load-plugin-library %t/%target-library-name(MacroDefinition) -emit-reference-dependencies-path %t/deps.swiftdeps
+// RUN: %{python} %S/../Inputs/process_fine_grained_swiftdeps.py %swift-dependency-tool %t/deps.swiftdeps | %FileCheck %s
+
+public protocol MyProtocol {}
+
+@attached(extension, conformances: MyProtocol,
+          names: named(macroAddedFunc), named(MacroAddedNested))
+macro AddExtensionWithMembers() = #externalMacro(module: "MacroDefinition", type: "ExtensionWithMembersMacro")
+
+@attached(peer, names: named(MacroPeer))
+macro AddPeerStruct() = #externalMacro(module: "MacroDefinition", type: "PeerStructMacro")
+
+@AddExtensionWithMembers
+public struct Outer {}
+
+// CHECK-DAG: member interface 4main5OuterV macroAddedFunc true
+// CHECK-DAG: member interface 4main5OuterV MacroAddedNested true
+// CHECK-DAG: nominal interface 4main5OuterV16MacroAddedNestedV '' true
+// CHECK-DAG: potentialMember interface 4main5OuterV16MacroAddedNestedV '' true
+
+@AddPeerStruct
+public struct Anchor {}
+
+// CHECK-DAG: topLevel interface '' MacroPeer true
+// CHECK-DAG: nominal interface 4main9MacroPeerV '' true
+// CHECK-DAG: potentialMember interface 4main9MacroPeerV '' true
+// CHECK-DAG: nominal interface 4main9MacroPeerV6NestedV '' true
+// CHECK-DAG: potentialMember interface 4main9MacroPeerV6NestedV '' true

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -14,6 +14,21 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
+// Regression test for sourcekit-lsp #2696: lazy typechecking + skip-all-function-bodies
+//
+// The SwiftPM `--experimental-prepare-for-indexing` combo) must not drop
+// macro-synthesized extension conformances from the produced .swiftmodule.
+// RUN: %empty-directory(%t/lazy)
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/lazy/ModuleWithEquatable.swiftmodule %s -DMODULE_EXPORTING_TYPE -module-name ModuleWithEquatable -load-plugin-library %t/%target-library-name(MacroDefinition) -experimental-lazy-typecheck -experimental-skip-all-function-bodies
+// RUN: %target-swift-ide-test -print-module -module-to-print=ModuleWithEquatable -source-filename %s -I %t/lazy -load-plugin-library %t/%target-library-name(MacroDefinition) | %FileCheck -check-prefix CHECK-LAZY %s
+
+// CHECK-LAZY: struct Outer
+// CHECK-LAZY: struct Generated
+// CHECK-LAZY: extension Outer.Generated : MyProtocol
+// CHECK-LAZY: struct PublicEquatable
+// CHECK-LAZY: extension PublicEquatable : Equatable
+// CHECK-LAZY: extension PublicEquatable.Inner : Equatable
+
 #if TEST_DIAGNOSTICS
 @attached(conformance) // expected-error{{conformance macros are replaced by extension macros}}
 macro InvalidEquatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
@@ -31,9 +46,30 @@ public struct PublicEquatable {
   public init() { }
 }
 
+extension PublicEquatable {
+  @Equatable
+  public struct Inner {
+    public init() { }
+  }
+}
+
+public protocol MyProtocol {}
+
+@attached(extension, conformances: MyProtocol)
+macro AddMyProtocol() = #externalMacro(module: "MacroDefinition", type: "ConformanceViaExtensionMacro")
+
+@attached(member, names: named(Generated))
+macro AddGeneratedMember() = #externalMacro(module: "MacroDefinition", type: "ConformingMemberStructMacro")
+
+@AddGeneratedMember
+public struct Outer {
+  public init() {}
+}
+
 // INTERFACE-NOT: @Equatable
 // INTERFACE: public struct PublicEquatable
 // INTERFACE: extension ModuleWithEquatable::PublicEquatable : Swift::Equatable
+// INTERFACE: extension ModuleWithEquatable::PublicEquatable.ModuleWithEquatable::Inner : Swift::Equatable
 
 #else
 import ModuleWithEquatable

--- a/test/Macros/macro_expand_conformances_xref.swift
+++ b/test/Macros/macro_expand_conformances_xref.swift
@@ -18,9 +18,9 @@ protocol P2 {}
 macro ListConformances() = #externalMacro(module: "MacroDefinition", type: "ListConformancesMacro")
 
 
-// CHECK-DUMP: [ "Root": [ "P1", "P2" ] ]
 // CHECK-DUMP: extension Root: P1
 // CHECK-DUMP: extension Root: P2
+// CHECK-DUMP: [ "Root": [ "P1", "P2" ] ]
 @ListConformances
 class Root {
 // CHECK-DUMP: extension OtherRoot: P1
@@ -28,9 +28,9 @@ class Root {
   var other: OtherRoot?
 }
 
-// CHECK-DUMP: [ "P1Root": [ "P2" ] ]
 // CHECK-DUMP-NOT: extension P1Root: P1
 // CHECK-DUMP: extension P1Root: P2
+// CHECK-DUMP: [ "P1Root": [ "P2" ] ]
 @ListConformances
 class P1Root: P1 { }
 

--- a/test/Macros/macro_expand_extension_nested.swift
+++ b/test/Macros/macro_expand_extension_nested.swift
@@ -1,0 +1,78 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -verify -o %t/Library.swiftmodule -module-name Library %s -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-library-evolution -emit-module-interface-path %t/Library.swiftinterface -emit-tbd -emit-tbd-path %t/Library.tbd -tbd-install_name libLibrary.dylib
+
+// Make sure we can serialize a primary file, where the auxiliary extensions
+// are cross-references into their macro expansion buffers.
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -verify -o %t/LibraryPrimary.swiftmodule -module-name Library -primary-file %s -load-plugin-library %t/%target-library-name(MacroDefinition)
+
+// Make sure we don't end up with any duplicate decls in the interface or tbd.
+// RUN: %FileCheck %s --check-prefix NESTED < %t/Library.swiftinterface
+// RUN: %FileCheck %s --check-prefix TOP-LEVEL-PEER < %t/Library.swiftinterface
+// RUN: %FileCheck %s --check-prefix MEMBER-PEER < %t/Library.swiftinterface
+
+// Make sure we correctly include a peer of an extension macro.
+// RUN: %FileCheck %s --check-prefix EXT-PEER < %t/Library.swiftinterface
+
+// Verify the interface compiles.
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/LibraryFromInterface.swiftmodule %t/Library.swiftinterface -module-name Library
+// RUN: %FileCheck %s --check-prefix NESTED-TBD < %t/Library.tbd
+// RUN: %FileCheck %s --check-prefix TOP-LEVEL-PEER-TBD < %t/Library.tbd
+// RUN: %FileCheck %s --check-prefix MEMBER-PEER-TBD < %t/Library.tbd
+
+public protocol MyProtocol {}
+
+@attached(extension, conformances: MyProtocol)
+macro AddMyProtocol() = #externalMacro(module: "MacroDefinition", type: "ConformanceViaExtensionMacro")
+
+@attached(extension, names: named(Nested))
+macro AddNested() = #externalMacro(module: "MacroDefinition", type: "NestedConformingExtensionMacro")
+
+@attached(peer, names: named(ConformingPeer))
+macro AddConformingPeer() = #externalMacro(module: "MacroDefinition", type: "ConformingPeerStructMacro")
+
+@attached(peer, names: named(MacroPeer))
+macro AddPeerStruct() = #externalMacro(module: "MacroDefinition", type: "PeerStructMacro")
+
+// Expands to `@AddPeerStruct extension PeeredOuter { public func extMember() {} }`.
+@attached(extension, names: arbitrary)
+macro AddPeeredExtension() = #externalMacro(module: "MacroDefinition", type: "PeeredExtensionMacro")
+
+@AddNested
+public struct Outer {
+  public init() {}
+}
+
+// NESTED-COUNT-1: extension Library::Outer.Library::Nested : Library::MyProtocol
+// NESTED-NOT: extension Library::Outer.Library::Nested : Library::MyProtocol
+// NESTED-TBD-COUNT-1: $s7Library5OuterV6NestedVAA10MyProtocolAAMc
+// NESTED-TBD-NOT: $s7Library5OuterV6NestedVAA10MyProtocolAAMc
+
+@AddConformingPeer
+public func foo() {}
+
+// TOP-LEVEL-PEER-COUNT-1: extension Library::ConformingPeer : Library::MyProtocol
+// TOP-LEVEL-PEER-NOT: extension Library::ConformingPeer : Library::MyProtocol
+// TOP-LEVEL-PEER-TBD-COUNT-1: $s7Library14ConformingPeerVAA10MyProtocolAAMc
+// TOP-LEVEL-PEER-TBD-NOT: $s7Library14ConformingPeerVAA10MyProtocolAAMc
+
+public struct Outer2 {
+  @AddConformingPeer
+  public func bar() {}
+}
+
+// MEMBER-PEER-COUNT-1: extension Library::Outer2.Library::ConformingPeer : Library::MyProtocol
+// MEMBER-PEER-NOT: extension Library::Outer2.Library::ConformingPeer : Library::MyProtocol
+// MEMBER-PEER-TBD-COUNT-1: $s7Library6Outer2V14ConformingPeerVAA10MyProtocolAAMc
+// MEMBER-PEER-TBD-NOT: $s7Library6Outer2V14ConformingPeerVAA10MyProtocolAAMc
+
+@AddPeeredExtension
+public struct PeeredOuter {
+  public init() {}
+}
+
+// EXT-PEER-DAG: extension Library::PeeredOuter
+// EXT-PEER-DAG: public struct MacroPeer

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -8,7 +8,7 @@
 
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 -I %t
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5 -I %t -verify-ignore-unrelated
 
 // Ensure that we can serialize this file as a module.
 // RUN: %target-swift-frontend -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -emit-module -o %t/MyModule.swiftmodule -enable-testing
@@ -190,6 +190,35 @@ expected-expansion@-2:2 {{
   expected-error@1:11{{cannot find type 'SomeNestedType' in scope}}
 }}
 */
+
+@attached(extension, conformances: Equatable)
+macro EquatableConformance() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
+
+struct NonEquatableValue {}
+
+// Make sure we reject for both struct and class.
+
+struct StructOuter {
+  @EquatableConformance // expected-note 2{{in expansion of macro}}
+  struct Inner {
+    var x = NonEquatableValue() // expected-note {{stored property type 'NonEquatableValue' does not conform to protocol 'Equatable'}}
+  }
+}
+// expected-expansion@-1:2 {{
+//   expected-error@1 {{type 'StructOuter.Inner' does not conform to protocol 'Equatable'}}
+//   expected-note@1 {{add stubs for conformance}}
+// }}
+
+class ClassOuter {
+  @EquatableConformance // expected-note 2{{in expansion of macro}}
+  struct Inner {
+    var x = NonEquatableValue() // expected-note {{stored property type 'NonEquatableValue' does not conform to protocol 'Equatable'}}
+  }
+}
+// expected-expansion@-1:2 {{
+//   expected-error@1 {{type 'ClassOuter.Inner' does not conform to protocol 'Equatable'}}
+//   expected-note@1 {{add stubs for conformance}}
+// }}
 
 #endif
 

--- a/test/SILOptimizer/dead_function_elimination_distributed_resolvable_proxy_adapter.swift
+++ b/test/SILOptimizer/dead_function_elimination_distributed_resolvable_proxy_adapter.swift
@@ -36,25 +36,6 @@ distributed actor GreeterImpl: Greeter {
 }
 
 // ==== -----------------------------------------------------------------------
-// On Impl actor: adapter thunks must survive DFE.
-
-// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$sendAnyGreeter
-// CHECK: sil hidden [distributed_proxy_adapter_thunk]
-// CHECK-SAME: $@convention(method) @async (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned String, @error any Error)
-
-// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$sendSomeGreeter
-// CHECK: sil hidden [distributed_proxy_adapter_thunk]
-// CHECK-SAME: <τ_0_0 where τ_0_0 : Greeter> (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned String, @error any Error)
-
-// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$echoActor
-// CHECK: sil hidden [distributed_proxy_adapter_thunk]
-// CHECK-SAME: $@convention(method) @async (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned $Greeter, @error any Error)
-
-// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$currentSelf
-// CHECK: sil hidden [distributed_proxy_adapter_thunk]
-// CHECK-SAME: $@convention(method) @async (@guaranteed GreeterImpl) -> (@owned $Greeter, @error any Error)
-
-// ==== -----------------------------------------------------------------------
 
 // On the protocol's `_DistributedActorStub` extension:
 // adapter thunks must also survive, because
@@ -75,3 +56,22 @@ distributed actor GreeterImpl: Greeter {
 // CHECK-LABEL: Greeter<>.$distributedProxyAdapter$currentSelf
 // CHECK: sil hidden [distributed_proxy_adapter_thunk]
 // CHECK-SAME: <Self where Self : _DistributedActorStub, Self : Greeter> (@guaranteed Self) -> (@owned $Greeter, @error any Error)
+
+// ==== -----------------------------------------------------------------------
+// On Impl actor: adapter thunks must survive DFE.
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$sendAnyGreeter
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: $@convention(method) @async (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned String, @error any Error)
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$sendSomeGreeter
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: <τ_0_0 where τ_0_0 : Greeter> (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned String, @error any Error)
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$echoActor
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: $@convention(method) @async (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned $Greeter, @error any Error)
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$currentSelf
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: $@convention(method) @async (@guaranteed GreeterImpl) -> (@owned $Greeter, @error any Error)

--- a/test/SymbolGraph/Symbols/Macro.swift
+++ b/test/SymbolGraph/Symbols/Macro.swift
@@ -10,6 +10,11 @@
 // RUN: %FileCheck %s --input-file %t/Macro.symbols.json
 // RUN: %FileCheck %s --input-file %t/Macro.symbols.json --check-prefix MISSING
 
+// Also check for a macro expansion.
+// RUN: %empty-directory(%t/sg)
+// RUN: %target-swift-frontend %s -module-name Macro -emit-module -emit-module-path %t/sg/Macro.swiftmodule -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -emit-symbol-graph -emit-symbol-graph-dir %t/sg
+// RUN: %FileCheck %s --check-prefix EXPANDED --input-file %t/sg/Macro.symbols.json
+
 @freestanding(expression)
 public macro customFileID() -> String = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
 
@@ -23,3 +28,17 @@ macro moduleCustomFileID() -> String = #externalMacro(module: "MacroDefinition",
 // CHECK-DAG: "precise": "s:5Macro12customFileIDSSycfm"
 
 // MISSING-NOT: moduleCustomFileID
+
+public protocol MyProtocol {}
+
+@attached(extension, conformances: MyProtocol)
+public macro AddMyProtocol() = #externalMacro(module: "MacroDefinition", type: "ConformanceViaExtensionMacro")
+
+@attached(extension, names: named(Nested))
+public macro AddNestedType() = #externalMacro(module: "MacroDefinition", type: "NestedConformingExtensionMacro")
+
+@AddNestedType
+public struct Outer {}
+
+// EXPANDED-COUNT-1: "precise":"s:5Macro5OuterV6NestedV"
+// EXPANDED-NOT: "precise":"s:5Macro5OuterV6NestedV"

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -526,7 +526,7 @@ int main(int argc, char **argv) {
       llvm::outs() << "Import successful!\n";
     if (DumpModule) {
       llvm::SmallVector<swift::Decl*, 10> Decls;
-      Module->getTopLevelDecls(Decls);
+      Module->getTopLevelDeclsWithAuxiliaryDecls(Decls);
       for (auto Decl : Decls)
         Decl->dump(llvm::outs());
     }


### PR DESCRIPTION
Rather than placing extension macros in a synthesized file unit, track them separately `getTopLevelDeclsWithAuxiliaryDecls`. This ensures that they are placed in the same `IRGenModule` as the nominal being extended. This requires fixing up some places that weren't previously using `getTopLevelDeclsWithAuxiliaryDecls`. This also required introducing `shouldWalkTopLevelAuxiliaryDecls` to ASTWalker, which is an unfortunate hack due to the fact that many ASTWalkers currently have misconfigured macro-walking preferences.

rdar://185645710
Resolves #90068
Resolves https://github.com/swiftlang/sourcekit-lsp/issues/2696