### PR TITLE
Deriving values of other non-escapable types from the span family

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -304,6 +304,56 @@ extension MutableRawSpan {
   ) throws(E) -> Result {
     try unsafe body(.init(start: _pointer, count: _count))
   }
+
+  /// Consume this span and call a closure with a pointer to the viewed mutable
+  /// contiguous storage.
+  ///
+  /// Use this method to derive a new non-escapable value with exclusive access to
+  /// the memory represented by this span. It is an alternative to
+  /// `MutableRawSpan`'s `extracting` methods for deriving values of types other
+  /// than `MutableRawSpan`.
+  ///
+  /// The pointer is passed as `inout` so that `body` has a mutating scope to
+  /// construct against: a non-escapable value with a checked exclusive dependence
+  /// (i.e., not `@_lifetime(immortal)`) must be initialized from an `inout`
+  /// argument, and an exclusive access created inside `body` would not outlive
+  /// the closure. On return, that dependency is replaced by this span's own. An
+  /// escapable result has no dependency; hence, return an escapable value only
+  /// if it does not store the pointer.
+  ///
+  /// On return from `body` or throwing, `bytes` must still address the same
+  /// region it was given. Changing its base address or count traps, and any
+  /// pointer `body` derives must also lie within that region. This method can
+  /// verify none of these requirements; therefore, it is an unsafe operation.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage. If `body`
+  ///   has a return value, that value is also used as the return value
+  ///   for the `consumeWithUnsafeMutableBytes(_:)` method.
+  /// - Returns: The return value of the `body` closure parameter.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(copy self)
+  public consuming func consumeWithUnsafeMutableBytes<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: @_lifetime(&bytes) (
+      _ bytes: inout UnsafeMutableRawBufferPointer
+    ) throws(E) -> Result
+  ) throws(E) -> Result {
+    var bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: _pointer, count: _count
+    )
+    let original = unsafe bytes
+    defer {
+      _precondition(
+        original.isTriviallyIdentical(to: bytes),
+        "bytes must address the same region on return from consumeWithUnsafeMutableBytes(_:)"
+      )
+    }
+    return unsafe _overrideLifetime(try unsafe body(&bytes), copying: self)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -540,7 +540,9 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// The buffer pointer passed as an argument to `body` is valid only
   /// during the execution of `withUnsafeMutableBufferPointer(_:)`.
-  /// Do not store or return the pointer for later use.
+  /// Do not store or return the pointer for later use. To derive a value that
+  /// stores the pointer and outlives the call, use
+  /// `consumeWithUnsafeMutableBufferPointer(_:)`.
   ///
   /// - Parameter body: A closure with an `UnsafeMutableBufferPointer`
   ///   parameter that points to the viewed contiguous storage. If `body`
@@ -565,6 +567,55 @@ extension MutableSpan where Element: ~Copyable {
       buffer throws(E) -> Result in
       try unsafe body(buffer)
     }
+  }
+
+  /// Consume this span and call a closure with a pointer to the viewed mutable
+  /// contiguous storage.
+  ///
+  /// Use this method to derive a new non-escapable value with exclusive access to
+  /// the memory represented by this span. It is an alternative to `MutableSpan`'s
+  /// `extracting` methods for deriving values of types other than `MutableSpan`.
+  ///
+  /// The pointer is passed as `inout` so that `body` has a mutating scope to
+  /// construct against: a non-escapable value with a checked exclusive dependence
+  /// (i.e., not `@_lifetime(immortal)`) must be initialized from an `inout`
+  /// argument, and an exclusive access created inside `body` would not outlive
+  /// the closure. On return, that dependency is replaced by this span's own. An
+  /// escapable result has no dependency; hence, return an escapable value only
+  /// if it does not store the pointer.
+  ///
+  /// On return from `body` or throwing, `buffer` must still address the same
+  /// region it was given. Changing its base address or count traps, and any
+  /// pointer `body` derives must also lie within that region. This method can
+  /// verify none of these requirements; therefore, it is an unsafe operation.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableBufferPointer`
+  ///   parameter that points to the viewed contiguous storage. If `body`
+  ///   has a return value, that value is also used as the return value
+  ///   for the `consumeWithUnsafeMutableBufferPointer(_:)` method.
+  /// - Returns: The return value of the `body` closure parameter.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(copy self)
+  public consuming func consumeWithUnsafeMutableBufferPointer<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: @_lifetime(&buffer) (
+      _ buffer: inout UnsafeMutableBufferPointer<Element>
+    ) throws(E) -> Result
+  ) throws(E) -> Result {
+    var buffer = unsafe UnsafeMutableBufferPointer<Element>(
+      start: _pointer?.assumingMemoryBound(to: Element.self), count: _count
+    )
+    let original = unsafe buffer
+    defer {
+      _precondition(
+        original.isTriviallyIdentical(to: buffer),
+        "buffer must address the same region on return from consumeWithUnsafeMutableBufferPointer(_:)"
+      )
+    }
+    return unsafe _overrideLifetime(try unsafe body(&buffer), copying: self)
   }
 }
 
@@ -622,6 +673,55 @@ extension MutableSpan where Element: BitwiseCopyable {
       start: _pointer, count: _count &* MemoryLayout<Element>.stride
     )
     return try unsafe body(bytes)
+  }
+
+  /// Consume this span and call a closure with a mutable pointer to the
+  /// underlying bytes of the viewed contiguous storage.
+  ///
+  /// Use this method to derive a new non-escapable value with exclusive access to
+  /// the memory represented by this span. It is an alternative to `MutableSpan`'s
+  /// `extracting` methods for deriving values of types other than `MutableSpan`.
+  ///
+  /// The pointer is passed as `inout` so that `body` has a mutating scope to
+  /// construct against: a non-escapable value with a checked exclusive dependence
+  /// (i.e., not `@_lifetime(immortal)`) must be initialized from an `inout`
+  /// argument, and an exclusive access created inside `body` would not outlive
+  /// the closure. On return, that dependency is replaced by this span's own. An
+  /// escapable result has no dependency; hence, return an escapable value only
+  /// if it does not store the pointer.
+  ///
+  /// On return from `body` or throwing, `bytes` must still address the same
+  /// region it was given. Changing its base address or count traps, and any
+  /// pointer `body` derives must also lie within that region. This method can
+  /// verify none of these requirements; therefore, it is an unsafe operation.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage. If `body`
+  ///   has a return value, that value is also used as the return value
+  ///   for the `consumeWithUnsafeMutableBytes(_:)` method.
+  /// - Returns: The return value of the `body` closure parameter.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(copy self)
+  public consuming func consumeWithUnsafeMutableBytes<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: @_lifetime(&bytes) (
+      _ bytes: inout UnsafeMutableRawBufferPointer
+    ) throws(E) -> Result
+  ) throws(E) -> Result {
+    var bytes = unsafe UnsafeMutableRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    let original = unsafe bytes
+    defer {
+      _precondition(
+        original.isTriviallyIdentical(to: bytes),
+        "bytes must address the same region on return from consumeWithUnsafeMutableBytes(_:)"
+      )
+    }
+    return unsafe _overrideLifetime(try unsafe body(&bytes), copying: self)
   }
 }
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -593,6 +593,42 @@ extension RawSpan {
   ) throws(E) -> Result {
     try unsafe body(.init(start: _pointer, count: byteCount))
   }
+
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// Use this method to derive a new non-escapable value with shared access to
+  /// the memory represented by this span. It is an alternative to `RawSpan`'s
+  /// `extracting` methods for deriving values of types other than `RawSpan`.
+  ///
+  /// Unlike `withUnsafeBytes(_:)`, a non-escapable result of `body` may outlive
+  /// the call; its lifetime is tied to the source of this span and its dependence
+  /// is a read access. An escapable result has no dependency; hence, return an
+  /// escapable value only if it does not store the pointer. Also, any pointer
+  /// `body` derives must lie within the region it was given. This method can
+  /// verify none of these requirements; therefore, it is an unsafe operation.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also used as the return value
+  ///   for the `borrowWithUnsafeBytes(_:)` method.
+  /// - Returns: The return value of the `body` closure parameter.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(copy self)
+  public func borrowWithUnsafeBytes<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: @_lifetime(borrow bytes) (
+      _ bytes: UnsafeRawBufferPointer
+    ) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeRawBufferPointer(
+      start: _pointer, count: byteCount
+    )
+    return unsafe _overrideLifetime(try unsafe body(bytes), copying: self)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -713,7 +713,9 @@ extension Span where Element: ~Copyable  {
   ///
   /// The buffer pointer passed as an argument to `body` is valid only
   /// during the execution of `withUnsafeBufferPointer(_:)`.
-  /// Do not store or return the pointer for later use.
+  /// Do not store or return the pointer for later use. To derive a value that
+  /// stores the pointer and outlives the call, use
+  /// `borrowWithUnsafeBufferPointer(_:)`.
   ///
   /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
   ///   that points to the viewed contiguous storage. If `body` has
@@ -734,6 +736,42 @@ extension Span where Element: ~Copyable  {
       buffer throws(E) -> Result in
       try unsafe body(buffer)
     }
+  }
+
+  /// Calls the given closure with a pointer to the viewed contiguous storage.
+  ///
+  /// Use this method to derive a new non-escapable value with shared access to
+  /// the memory represented by this span. It is an alternative to `Span`'s
+  /// `extracting` methods for deriving values of types other than `Span`.
+  ///
+  /// Unlike `withUnsafeBufferPointer(_:)`, a non-escapable result of `body` may
+  /// outlive the call; its lifetime is tied to the source of this span and its
+  /// dependence is a read access. An escapable result has no dependency; hence,
+  /// return an escapable value only if it does not store the pointer. Also, any
+  /// pointer `body` derives must lie within the region it was given, and the
+  /// viewed memory must already be bound to `Element`. This method can verify
+  /// none of these requirements; therefore, it is an unsafe operation.
+  ///
+  /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+  ///   that points to the viewed contiguous storage. If `body` has
+  ///   a return value, that value is also used as the return value
+  ///   for the `borrowWithUnsafeBufferPointer(_:)` method.
+  /// - Returns: The return value of the `body` closure parameter.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(copy self)
+  public func borrowWithUnsafeBufferPointer<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: @_lifetime(borrow buffer) (
+      _ buffer: UnsafeBufferPointer<Element>
+    ) throws(E) -> Result
+  ) throws(E) -> Result {
+    let buffer = unsafe UnsafeBufferPointer<Element>(
+      start: _pointer?.assumingMemoryBound(to: Element.self), count: _count
+    )
+    return unsafe _overrideLifetime(try unsafe body(buffer), copying: self)
   }
 }
 
@@ -765,6 +803,42 @@ extension Span where Element: BitwiseCopyable {
       start: _pointer, count: _count &* MemoryLayout<Element>.stride
     )
     return try unsafe body(bytes)
+  }
+
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// Use this method to derive a new non-escapable value with shared access to
+  /// the memory represented by this span. It is an alternative to `Span`'s
+  /// `extracting` methods for deriving values of types other than `Span`.
+  ///
+  /// Unlike `withUnsafeBytes(_:)`, a non-escapable result of `body` may outlive
+  /// the call; its lifetime is tied to the source of this span and its dependence
+  /// is a read access. An escapable result has no dependency; hence, return an
+  /// escapable value only if it does not store the pointer. Also, any pointer
+  /// `body` derives must lie within the region it was given. This method can
+  /// verify none of these requirements; therefore, it is an unsafe operation.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also used as the return value
+  ///   for the `borrowWithUnsafeBytes(_:)` method.
+  /// - Returns: The return value of the `body` closure parameter.
+  @unsafe
+  @export(implementation)
+  @_transparent
+  @_lifetime(copy self)
+  public func borrowWithUnsafeBytes<
+    E: Error, Result: ~Copyable & ~Escapable
+  >(
+    _ body: @_lifetime(borrow bytes) (
+      _ bytes: UnsafeRawBufferPointer
+    ) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return unsafe _overrideLifetime(try unsafe body(bytes), copying: self)
   }
 }
 

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -13,6 +13,7 @@
 // RUN: %target-run-stdlib-swift
 
 // REQUIRES: executable_test
+// XFAIL: swift_test_mode_optimize_none_with_opaque_values
 
 // Blocked by rdar://181604244 (opaque values borrow accessors)
 // XFAIL: swift_test_mode_optimize_none_with_opaque_values
@@ -41,6 +42,8 @@ suite.test("Basic Initializer")
     expectEqual(b.byteCount, 0)
   }
 }
+
+enum MyTestError: Error { case error }
 
 private struct Padded: BitwiseCopyable {
   var storage: (Int64, Int8)
@@ -164,6 +167,58 @@ suite.test("withUnsafeMutableBytes")
     }
   }
   expectEqual(Int(a[i]), i+1)
+}
+
+suite.test("consumeWithUnsafeMutableBytes to a MutableRef")
+.require(.stdlib_6_5)
+.skip(.custom({
+  if #available(StdlibDeploymentTarget 6.4, *) { false } else { true }
+}, reason: "MutableRef requires Swift stdlib 6.4"))
+.code {
+  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+
+  var array = ContiguousArray<UInt8>(0..<4)
+  array.withUnsafeMutableBytes {
+    var ref = unsafe MutableRawSpan(_unsafeBytes: $0)
+      .consumeWithUnsafeMutableBytes { bytes in
+        unsafe MutableRef(
+          unsafeAddress: bytes.baseAddress!.assumingMemoryBound(to: UInt8.self) + 1,
+          mutating: &bytes
+        )
+      }
+    expectEqual(ref.value, 1)
+    ref.value = 99
+  }
+  expectEqual(array, [0, 99, 2, 3])
+}
+
+suite.test("consumeWithUnsafeMutableBytes traps on buffer region change")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.code {
+  var array = ContiguousArray<UInt8>(0..<4)
+
+  array.withUnsafeMutableBytes {
+    unsafe MutableRawSpan(_unsafeBytes: $0)
+      .consumeWithUnsafeMutableBytes { bytes in
+        let exactRegion = unsafe UnsafeMutableRawBufferPointer(
+          start: bytes.baseAddress, count: bytes.count
+        )
+        bytes = exactRegion
+      }
+
+    expectCrashLater()
+    do throws(MyTestError) {
+      try unsafe MutableRawSpan(_unsafeBytes: $0)
+        .consumeWithUnsafeMutableBytes { bytes throws(MyTestError) in
+          let otherRegion = unsafe UnsafeMutableRawBufferPointer(
+            start: bytes.baseAddress, count: bytes.count - 1
+          )
+          bytes = otherRegion
+          throw MyTestError.error
+        }
+    } catch {}
+  }
 }
 
 suite.test("bytes property")

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -20,6 +20,8 @@ import StdlibUnittest
 var suite = TestSuite("MutableSpan Tests")
 defer { runAllTests() }
 
+enum MyTestError: Error { case error }
+
 suite.test("Initialize with ordinary element")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
@@ -260,6 +262,53 @@ suite.test("withUnsafeMutableBufferPointer")
   expectEqual(a[i], i+1)
 }
 
+suite.test("consumeWithUnsafeMutableBufferPointer to a MutableRef")
+.require(.stdlib_6_5)
+.skip(.custom({
+  if #available(StdlibDeploymentTarget 6.4, *) { false } else { true }
+}, reason: "MutableRef requires Swift stdlib 6.4"))
+.code {
+  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+
+  var array = ContiguousArray(0..<4)
+  var ref = unsafe array.mutableSpan
+    .consumeWithUnsafeMutableBufferPointer { buffer in
+      unsafe MutableRef(
+        unsafeAddress: buffer.baseAddress! + 1, mutating: &buffer
+      )
+    }
+  expectEqual(ref.value, 1)
+  ref.value = 99
+  expectEqual(array, [0, 99, 2, 3])
+}
+
+suite.test("consumeWithUnsafeMutableBufferPointer traps on buffer region change")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.code {
+  var array = ContiguousArray(0..<4)
+
+  unsafe array.mutableSpan.consumeWithUnsafeMutableBufferPointer {
+    buffer in
+    let exactRegion = unsafe UnsafeMutableBufferPointer(
+      start: buffer.baseAddress, count: buffer.count
+    )
+    buffer = exactRegion
+  }
+
+  expectCrashLater()
+  do throws(MyTestError) {
+    try unsafe array.mutableSpan.consumeWithUnsafeMutableBufferPointer {
+      buffer throws(MyTestError) in
+      let otherRegion = unsafe UnsafeMutableBufferPointer(
+        start: buffer.baseAddress, count: buffer.count - 1
+      )
+      buffer = otherRegion
+      throw MyTestError.error
+    }
+  } catch {}
+}
+
 suite.test("withUnsafeMutableBytes")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
@@ -285,6 +334,54 @@ suite.test("withUnsafeMutableBytes")
     }
   }
   expectEqual(Int(a[i]), i+1)
+}
+
+suite.test("consumeWithUnsafeMutableBytes to a MutableRef")
+.require(.stdlib_6_5)
+.skip(.custom({
+  if #available(StdlibDeploymentTarget 6.4, *) { false } else { true }
+}, reason: "MutableRef requires Swift stdlib 6.4"))
+.code {
+  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+
+  var array = ContiguousArray(0..<4)
+  var ref = unsafe array.mutableSpan
+    .consumeWithUnsafeMutableBytes { bytes in
+      unsafe MutableRef(
+        unsafeAddress: (bytes.baseAddress! + MemoryLayout<Int>.stride)
+          .assumingMemoryBound(to: Int.self),
+        mutating: &bytes
+      )
+    }
+  expectEqual(ref.value, 1)
+  ref.value = 99
+  expectEqual(array, [0, 99, 2, 3])
+}
+
+suite.test("consumeWithUnsafeMutableBytes traps on buffer region change")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.code {
+  var array = ContiguousArray(0..<4)
+
+  unsafe array.mutableSpan.consumeWithUnsafeMutableBytes { bytes in
+    let exactRegion = unsafe UnsafeMutableRawBufferPointer(
+      start: bytes.baseAddress, count: bytes.count
+    )
+    bytes = exactRegion
+  }
+
+  expectCrashLater()
+  do throws(MyTestError) {
+    try unsafe array.mutableSpan.consumeWithUnsafeMutableBytes {
+      bytes throws(MyTestError) in
+      let otherRegion = unsafe UnsafeMutableRawBufferPointer(
+        start: bytes.baseAddress, count: bytes.count - 1
+      )
+      bytes = otherRegion
+      throw MyTestError.error
+    }
+  } catch {}
 }
 
 private class ID {

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -345,6 +345,40 @@ suite.test("withUnsafeBytes()")
   }
 }
 
+suite.test("RawSpan.borrowWithUnsafeBytes to a Ref")
+.require(.stdlib_6_5)
+.skip(.custom({
+  if #available(StdlibDeploymentTarget 6.4, *) { false } else { true }
+}, reason: "Ref requires Swift stdlib 6.4"))
+.code {
+  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+
+  let array = ContiguousArray<UInt8>(0..<4)
+  array.withUnsafeBytes { ub in
+    let span = unsafe RawSpan(_unsafeBytes: ub)
+
+    let ref = unsafe span.borrowWithUnsafeBytes { bytes in
+      unsafe Ref(
+        unsafeAddress: (bytes.baseAddress! + 1)
+          .assumingMemoryBound(to: UInt8.self),
+        borrowing: bytes
+      )
+    }
+    expectEqual(ref.value, 1)
+    expectEqual(span.byteCount, 4)
+
+    let contemporaryRef = unsafe span.borrowWithUnsafeBytes { bytes in
+      unsafe Ref(
+        unsafeAddress: (bytes.baseAddress! + 2)
+          .assumingMemoryBound(to: UInt8.self),
+        borrowing: bytes
+      )
+    }
+    expectEqual(contemporaryRef.value, 2)
+    expectEqual(ref.value + contemporaryRef.value, 3)
+  }
+}
+
 suite.test("byteOffsets(of:)")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -534,6 +534,66 @@ suite.test("withUnsafeBytes()")
   }
 }
 
+suite.test("borrowWithUnsafeBufferPointer to a Ref")
+.require(.stdlib_6_5)
+.skip(.custom({
+  if #available(StdlibDeploymentTarget 6.4, *) { false } else { true }
+}, reason: "Ref requires Swift stdlib 6.4"))
+.code {
+  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+
+  let array = ContiguousArray(0..<4)
+  array.withUnsafeBufferPointer { ub in
+    let span = unsafe Span(_unsafeElements: ub)
+
+    let ref = unsafe span.borrowWithUnsafeBufferPointer { buffer in
+      unsafe Ref(unsafeAddress: buffer.baseAddress! + 1, borrowing: buffer)
+    }
+    expectEqual(ref.value, 1)
+    expectEqual(span.count, 4)
+
+    let contemporaryRef = unsafe span.borrowWithUnsafeBufferPointer { buffer in
+      unsafe Ref(unsafeAddress: buffer.baseAddress! + 2, borrowing: buffer)
+    }
+    expectEqual(contemporaryRef.value, 2)
+    expectEqual(ref.value + contemporaryRef.value, 3)
+  }
+}
+
+suite.test("borrowWithUnsafeBytes to a Ref")
+.require(.stdlib_6_5)
+.skip(.custom({
+  if #available(StdlibDeploymentTarget 6.4, *) { false } else { true }
+}, reason: "Ref requires Swift stdlib 6.4"))
+.code {
+  guard #available(StdlibDeploymentTarget 6.4, *) else { return }
+
+  let array = ContiguousArray<UInt8>(0..<4)
+  array.withUnsafeBufferPointer { ub in
+    let span = unsafe Span(_unsafeElements: ub)
+
+    let ref = unsafe span.borrowWithUnsafeBytes { bytes in
+      unsafe Ref(
+        unsafeAddress: (bytes.baseAddress! + 1)
+          .assumingMemoryBound(to: UInt8.self),
+        borrowing: bytes
+      )
+    }
+    expectEqual(ref.value, 1)
+    expectEqual(span.count, 4)
+
+    let contemporaryRef = unsafe span.borrowWithUnsafeBytes { bytes in
+      unsafe Ref(
+        unsafeAddress: (bytes.baseAddress! + 2)
+          .assumingMemoryBound(to: UInt8.self),
+        borrowing: bytes
+      )
+    }
+    expectEqual(contemporaryRef.value, 2)
+    expectEqual(ref.value + contemporaryRef.value, 3)
+  }
+}
+
 suite.test("isTriviallyIdentical(to:)")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },


### PR DESCRIPTION
Adds methods for `Span`, `RawSpan`, `MutableSpan` and `MutableRawSpan` to yield their pointer so callers can derive values of other non-escapable types over the same memory, with an exclusive access for the mutable types and a shared access for the read-only types.