### PR TITLE
[Diagnostics] Fix incorrect fix-it for static member access on instance for opaque/existential types

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5272,10 +5272,19 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // An implicit 'self' reference base expression means we should
     // prepend with qualification.
     if (baseExpr && !baseExpr->isImplicit()) {
-      Diag->fixItReplace(baseExpr->getSourceRange(),
-                         diag::replace_with_type, baseTy);
+      if (baseTy->hasOpaqueArchetype() || baseTy->isExistentialType()) {
+        Diag->fixItInsert(baseExpr->getSourceRange().Start, "type(of: ");
+        Diag->fixItInsertAfter(baseExpr->getSourceRange().End, ")");
+      } else {
+        Diag->fixItReplace(baseExpr->getSourceRange(),
+                           diag::replace_with_type, baseTy);
+      }
     } else {
-      Diag->fixItInsert(loc, diag::insert_type_qualification, baseTy);
+      if (baseTy->hasOpaqueArchetype() || baseTy->isExistentialType()) {
+        Diag->fixItInsert(loc, "type(of: self).");
+      } else {
+        Diag->fixItInsert(loc, diag::insert_type_qualification, baseTy);
+      }
     }
 
     return true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2221,8 +2221,16 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   }
 
   attr->setInvalid();
-  if (!diagnosed)
-    diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+  if (!diagnosed) {
+    auto diag = diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+    auto braces = decl->getBraces();
+    if (braces.Start.isValid()) {
+      diag.fixItInsertAfter(braces.Start,
+          "\n  subscript(dynamicMember member: String) -> <#Value#> {\n"
+          "    <#code#>\n"
+          "  }");
+    }
+  }
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/test/Constraints/issue85157.swift
+++ b/test/Constraints/issue85157.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  static var x: Int { get }
+}
+func foo(p: some P) -> Int {
+  p.x // expected-error {{static member 'x' cannot be used on instance of type 'some P'}} {{3-3=type(of: }} {{4-4=)}}
+}
+func bar(p: any P) -> Int {
+  p.x // expected-error {{static member 'x' cannot be used on instance of type 'any P'}} {{3-3=type(of: }} {{4-4=)}}
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1382,3 +1382,17 @@ struct InaccessibleAndInvalidCandidate {
   // expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
   // expected-error@-2 {{'@dynamicMemberLookup' requires parameter to have a default value}}
 }
+
+// https://github.com/swiftlang/swift/issues/83344
+// Fix-it to add subscript(dynamicMember:) stub when no subscript exists.
+
+@dynamicMemberLookup struct EmptyStruct_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyStruct_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{48-48=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup class EmptyClass_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyClass_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{46-46=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup enum EmptyEnum_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyEnum_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{44-44=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup struct StructWithUnrelatedMembers_83344 { // expected-error {{'@dynamicMemberLookup' requires 'StructWithUnrelatedMembers_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{63-63=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+  var x: Int = 0
+  func foo() {}
+}


### PR DESCRIPTION
### Summary
Fixes #85157 by providing a correct fix-it for static member accesses on instances of existential or opaque types.

### Motivation
When accessing a static member on an instance of an existential (ny P) or an opaque type (some P), the compiler incorrectly offered a fix-it to replace the base with the type's spelling (e.g. replacing p with ny P or some P). This leads to a fix-it that produces invalid code, like ny P.x or some P.x. 

### Implementation
In CSDiagnostics.cpp, the fix-it logic now checks whether the base type has an opaque archetype or is an existential type. If so, it wraps the base expression in a 	ype(of: ...) call instead of replacing it with the unspellable/invalid static type representation. This applies both to explicit base expressions (inserting 	ype(of:  and )) and implicit self references (inserting 	ype(of: self).).

### Testing
Added tests to 	est/Constraints/issue85157.swift to verify the new fix-its for both some P and ny P.
