### PR TITLE
Don't always require TargetConditionals.h for Embedded Swift on Apple platforms

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -129,7 +129,9 @@
 #error Masking ISAs are incompatible with opaque ISAs
 #endif
 
-#if defined(__APPLE__) && defined(__LP64__) && __has_include(<malloc_type_private.h>) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
+#if defined(__APPLE__) && defined(__LP64__) &&                                 \
+    __has_include(<malloc_type_private.h>) &&                                  \
+    __has_include(<TargetConditionals.h>) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
 # include <TargetConditionals.h>
 # if TARGET_OS_IOS && !TARGET_OS_SIMULATOR
 #  define SWIFT_STDLIB_HAS_MALLOC_TYPE 1
@@ -574,7 +576,7 @@ swift_auth_code(T value, unsigned extra) {
 }
 
 /// Does this platform support backtrace-on-crash?
-#ifdef __APPLE__
+#if defined(__APPLE__) && __has_include(<TargetConditionals.h>)
 #  include <TargetConditionals.h>
 #  if TARGET_OS_OSX
 #    define SWIFT_BACKTRACE_ON_CRASH_SUPPORTED 1

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -110,7 +110,6 @@ set(SWIFT_RUNTIME_CONCURRENCY_C_SOURCES
   ThreadingError.cpp
   TracingSignpost.cpp
   AsyncStream.cpp
-  linker-support/magic-symbols-for-install-name.c
 )
 
 set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
@@ -193,6 +192,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
 
 set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_C_SOURCES
   ExecutorImpl.cpp
+  linker-support/magic-symbols-for-install-name.c
 )
 
 set(SWIFT_RUNTIME_CONCURRENCY_EXECUTOR_SOURCES)


### PR DESCRIPTION
Embedded Swift really shouldn't care about the OS it's running on, so conditionalize the use of `TargetConditionals.h`: if it's not there, don't include it.

Fixes rdar://187199358