### PR TITLE
[Diagnostics] Add fix-it to explicitly capture inout parameters by copy in escaping closures

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -165,6 +165,8 @@ ERROR(escaping_inout_capture,none,
       (unsigned, Identifier))
 NOTE(inout_param_defined_here,none,
      "parameter %0 is declared 'inout'", (Identifier))
+NOTE(escaping_inout_capture_copy_fixit,none,
+     "capture %0 explicitly to copy the value", (Identifier))
 ERROR(escaping_mutable_self_capture,none,
       SELECT_ESCAPING_CLOSURE_KIND
       " captures mutating 'self' parameter", (unsigned))

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/Types.h"
+#include "swift/Parse/Lexer.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/InstructionUtils.h"
@@ -692,6 +693,32 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
                  functionKind, param->getName());
         diagnose(Context, param->getLoc(), diag::inout_param_defined_here,
                  param->getName());
+        if (auto *closure = PAI->getLoc().getAsASTNode<ClosureExpr>()) {
+          auto diag = diagnose(Context, PAI->getLoc(),
+                               diag::escaping_inout_capture_copy_fixit,
+                               param->getName());
+          const auto brackets = closure->getBracketRange();
+          if (brackets.isValid()) {
+            const auto locAfterBracket = brackets.Start.getAdvancedLoc(1);
+            const auto nextAfterBracket =
+                Lexer::getTokenAtLocation(Context.SourceMgr, locAfterBracket,
+                                          CommentRetentionMode::AttachToNextToken);
+            if (nextAfterBracket.getLoc() != brackets.End)
+              diag.fixItInsertAfter(brackets.Start, param->getName().str().str() + ", ");
+            else
+              diag.fixItInsertAfter(brackets.Start, param->getName().str().str());
+          } else {
+            if (closure->getInLoc().isValid()) {
+              diag.fixItInsertAfter(closure->getLoc(), " [" + param->getName().str().str() + "]");
+            } else {
+              const auto nextLoc = closure->getLoc().getAdvancedLoc(1);
+              const auto next = Lexer::getTokenAtLocation(
+                  Context.SourceMgr, nextLoc, CommentRetentionMode::AttachToNextToken);
+              std::string trailing = next.getLoc() == nextLoc ? " " : "";
+              diag.fixItInsertAfter(closure->getLoc(), " [" + param->getName().str().str() + "] in" + trailing);
+            }
+          }
+        }
       }
     }
     if (functionKind != EscapingAutoClosure) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5272,10 +5272,19 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // An implicit 'self' reference base expression means we should
     // prepend with qualification.
     if (baseExpr && !baseExpr->isImplicit()) {
-      Diag->fixItReplace(baseExpr->getSourceRange(),
-                         diag::replace_with_type, baseTy);
+      if (baseTy->hasOpaqueArchetype() || baseTy->isExistentialType()) {
+        Diag->fixItInsert(baseExpr->getSourceRange().Start, "type(of: ");
+        Diag->fixItInsertAfter(baseExpr->getSourceRange().End, ")");
+      } else {
+        Diag->fixItReplace(baseExpr->getSourceRange(),
+                           diag::replace_with_type, baseTy);
+      }
     } else {
-      Diag->fixItInsert(loc, diag::insert_type_qualification, baseTy);
+      if (baseTy->hasOpaqueArchetype() || baseTy->isExistentialType()) {
+        Diag->fixItInsert(loc, "type(of: self).");
+      } else {
+        Diag->fixItInsert(loc, diag::insert_type_qualification, baseTy);
+      }
     }
 
     return true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2221,8 +2221,16 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   }
 
   attr->setInvalid();
-  if (!diagnosed)
-    diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+  if (!diagnosed) {
+    auto diag = diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+    auto braces = decl->getBraces();
+    if (braces.Start.isValid()) {
+      diag.fixItInsertAfter(braces.Start,
+          "\n  subscript(dynamicMember member: String) -> <#Value#> {\n"
+          "    <#code#>\n"
+          "  }");
+    }
+  }
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/test/Constraints/issue85157.swift
+++ b/test/Constraints/issue85157.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  static var x: Int { get }
+}
+func foo(p: some P) -> Int {
+  p.x // expected-error {{static member 'x' cannot be used on instance of type 'some P'}} {{3-3=type(of: }} {{4-4=)}}
+}
+func bar(p: any P) -> Int {
+  p.x // expected-error {{static member 'x' cannot be used on instance of type 'any P'}} {{3-3=type(of: }} {{4-4=)}}
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1382,3 +1382,17 @@ struct InaccessibleAndInvalidCandidate {
   // expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
   // expected-error@-2 {{'@dynamicMemberLookup' requires parameter to have a default value}}
 }
+
+// https://github.com/swiftlang/swift/issues/83344
+// Fix-it to add subscript(dynamicMember:) stub when no subscript exists.
+
+@dynamicMemberLookup struct EmptyStruct_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyStruct_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{48-48=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup class EmptyClass_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyClass_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{46-46=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup enum EmptyEnum_83344 {} // expected-error {{'@dynamicMemberLookup' requires 'EmptyEnum_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{44-44=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+
+@dynamicMemberLookup struct StructWithUnrelatedMembers_83344 { // expected-error {{'@dynamicMemberLookup' requires 'StructWithUnrelatedMembers_83344' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}} {{63-63=\n  subscript(dynamicMember member: String) -> <#Value#> {\n    <#code#>\n  }}}
+  var x: Int = 0
+  func foo() {}
+}


### PR DESCRIPTION
### Summary
Fixes #87830 by adding a fix-it to explicitly capture an inout parameter by copy when it is used in an escaping closure.

### Motivation
When an escaping closure captures an inout parameter, the compiler correctly emits an error indicating that escaping closures cannot capture inout parameters. However, the fix for this is often to explicitly capture a copy of the parameter (e.g. [x] in), but the compiler did not provide a fix-it to do so, leaving users to discover the syntax themselves.

### Implementation
Added a new NOTE escaping_inout_capture_copy_fixit to DiagnosticsSIL.def alongside escaping_inout_capture. In DiagnoseInvalidEscapingCaptures.cpp, we now check if the escaping context is a ClosureExpr. If it is, we use the Lexer to insert a capture list [paramName] (or append to an existing one) directly on the AST node.
