### PR TITLE
[Concurrency] Consider explicit `nonisolated` on a protocol when computing a nominal's isolation under `NoExplicitNonIsolated` with default isolation set to `nonisolated`.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5574,7 +5574,8 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedConcurrent:
       if (inferredIsolation.source.effectivelyExplicit() &&
-          explicitNonisolatedIsSpecial(nominal)) {
+          getDefaultIsolationForContext(nominal) ==
+              DefaultIsolation::Nonisolated) {
         if (!foundIsolation) {
           // We found an explicitly 'nonisolated' protocol.
           foundIsolation = {

--- a/test/Concurrency/nonisolated_protocol_global_actor_cutoff.swift
+++ b/test/Concurrency/nonisolated_protocol_global_actor_cutoff.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature NoExplicitNonIsolated
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_NoExplicitNonIsolated
+
+@MainActor
+func onMain() {}
+
+@MainActor
+protocol IsolatedBase {}
+
+@MainActor
+// expected-note@+1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+class Req {}
+
+protocol IsolatedRequirements: IsolatedBase {
+  var req: Req { get }
+}
+
+nonisolated protocol NonisolatedRequirements: IsolatedBase {
+  var req: Req { get }
+}
+
+nonisolated protocol NonisolatedRefinement: IsolatedBase {}
+
+protocol PlainBase {}
+nonisolated protocol PlainRefinement: PlainBase {}
+
+struct A: NonisolatedRefinement { func f() {} }
+
+struct B: PlainRefinement { func f() {} }
+
+struct C { func f() {} }
+extension C: NonisolatedRefinement {}
+
+protocol IndirectRefinement: NonisolatedRefinement {}
+
+struct D: IndirectRefinement { func f() {} }
+
+nonisolated func probe(a: A, b: B, c: C, d: D) {
+  a.f()
+  b.f()
+  c.f()
+  d.f()
+}
+
+@MainActor protocol IsolatedRefinement: NonisolatedRefinement {}
+
+struct E: IsolatedRefinement {
+  func h() { onMain() }
+}
+
+struct F: NonisolatedRefinement, IsolatedBase {
+  func k() { onMain() }
+}
+
+struct S: IsolatedRequirements {
+  var req = Req()
+}
+
+struct S2: NonisolatedRequirements {
+  // expected-error@+1{{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
+  var req = Req()
+}


### PR DESCRIPTION
Previously, in #91829 a change was made to only collect isolation from explicit protocol conformances. However, that change made the following code no longer compile:

```swift
@MainActor
protocol P { }

@MainActor
struct Test { }

protocol Q: P {
    var test: Test { get }
}

struct S: Q {
    var test = Test() // error
}
```

In the above code, `S` should be `@MainActor` through the implied conformance to `P`. Therefore, the change was reverted. Since the original bug:

```swift
// enable-experimental-feature NoExplicitNonIsolated
@MainActor
protocol IsolatedBase {}

nonisolated protocol NonisolatedRefinement: IsolatedBase {}

struct A: NonisolatedRefinement { func f() {} }

nonisolated func probe() {
  A().f()   //  error
}
```

Only produces an error under `NoExplicitNonIsolated` that stops considering explicit `nonisolated` on protocols so that modules compiled in `default-isolation=MainActor` keep inferring the main actor on such protocols, enable the code-path for cases when the default isolation is set to `nonisolated` to avoid inheriting the main actor from the conformances.

Resolves rdar://187156690.