### PR TITLE
Sema: Always diagnose custom availability domain restrictions for protocols

### DIFF
--- a/include/swift/AST/AvailabilityRestriction.h
+++ b/include/swift/AST/AvailabilityRestriction.h
@@ -260,6 +260,16 @@ enum class AvailabilityRestrictionFlag : uint8_t {
   /// Return restrictions for `@available` attributes indicating deprecation in
   /// a future deployment target.
   IncludeSoftDeprecation = 1 << 3,
+
+  /// Do not return `Unintroduced` restrictions belonging to platform domains.
+  /// This is used when checking the availability of a protocol that a type
+  /// conforms to, since a conformance is allowed to be introduced in a later
+  /// OS version than the conforming type itself.
+  AllowUnintroducedInPlatformDomains = 1 << 4,
+
+  /// Do not return `Unintroduced` restrictions that are satisfied at or below
+  /// the deployment range of the restriction's domain.
+  AllowUnintroducedAtOrBelowDeploymentRange = 1 << 5,
 };
 using AvailabilityRestrictionFlags = OptionSet<AvailabilityRestrictionFlag>;
 

--- a/lib/AST/AvailabilityRestriction.cpp
+++ b/lib/AST/AvailabilityRestriction.cpp
@@ -301,25 +301,6 @@ getSubstituteDomainForRestriction(const AvailabilityRestriction &restriction,
   return std::nullopt;
 }
 
-static bool
-shouldIgnoreRestrictionInContext(const Decl *decl,
-                                 const AvailabilityRestriction &restriction,
-                                 const AvailabilityContext &context,
-                                 const AvailabilityRestrictionFlags flags) {
-  if (!context.isUnavailable())
-    return false;
-
-  if (!canIgnoreRestrictionInUnavailableContexts(decl, restriction, flags))
-    return false;
-
-  auto domain = restriction.getDomain();
-  if (auto substituteDomain =
-          getSubstituteDomainForRestriction(restriction, decl->getASTContext()))
-    domain = *substituteDomain;
-
-  return context.isUnavailableForDomain(domain);
-}
-
 static std::optional<AvailabilityRestriction>
 getDeprecationRestrictionForAttr(const Decl *decl,
                                  const SemanticAvailableAttr &attr,
@@ -357,6 +338,50 @@ getDeprecationRestrictionForAttr(const Decl *decl,
   }
 
   return std::nullopt;
+}
+
+/// Returns true if \p restriction should not be reported for a reference to
+/// \p decl from \p context.
+static bool shouldIgnoreRestriction(const Decl *decl,
+                                    const AvailabilityRestriction &restriction,
+                                    const AvailabilityContext &context,
+                                    const AvailabilityRestrictionFlags flags) {
+  auto &ctx = decl->getASTContext();
+
+  // The caller may have opted out of diagnosing potential unavailability for
+  // some of the domains that the restriction could belong to.
+  if (restriction.getReason() ==
+      AvailabilityRestriction::Reason::Unintroduced) {
+    if (flags.contains(
+            AvailabilityRestrictionFlag::AllowUnintroducedInPlatformDomains) &&
+        restriction.getDomain().isPlatform())
+      return true;
+
+    if (flags.contains(AvailabilityRestrictionFlag::
+                           AllowUnintroducedAtOrBelowDeploymentRange)) {
+      auto domainAndRange = restriction.getDomainAndRange(ctx);
+      if (auto deploymentRange =
+              domainAndRange.getDomain().getDeploymentRange(ctx)) {
+        if (deploymentRange->isContainedIn(domainAndRange.getRange()))
+          return true;
+      }
+    }
+  }
+
+  // The remaining reasons to ignore a restriction all require the context of
+  // the reference to be unavailable.
+  if (!context.isUnavailable())
+    return false;
+
+  if (!canIgnoreRestrictionInUnavailableContexts(decl, restriction, flags))
+    return false;
+
+  auto domain = restriction.getDomain();
+  if (auto substituteDomain =
+          getSubstituteDomainForRestriction(restriction, ctx))
+    domain = *substituteDomain;
+
+  return context.isUnavailableForDomain(domain);
 }
 
 std::optional<AvailabilityRestriction> swift::getAvailabilityRestrictionForAttr(
@@ -405,7 +430,7 @@ std::optional<AvailabilityRestriction> swift::getAvailabilityRestrictionForAttr(
 
   auto restriction = getRestriction();
   if (restriction &&
-      shouldIgnoreRestrictionInContext(decl, *restriction, context, flags))
+      shouldIgnoreRestriction(decl, *restriction, context, flags))
     return std::nullopt;
 
   return restriction;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3039,6 +3039,17 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
   if (ctx.LangOpts.WarnSoftDeprecated)
     restrictionFlags |= AvailabilityRestrictionFlag::IncludeSoftDeprecation;
 
+  if (Flags.contains(
+          DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol) &&
+      isa<ProtocolDecl>(D))
+    restrictionFlags |=
+        AvailabilityRestrictionFlag::AllowUnintroducedInPlatformDomains;
+
+  if (Flags.contains(DeclAvailabilityFlag::
+                         AllowPotentiallyUnavailableAtOrBelowDeploymentTarget))
+    restrictionFlags |=
+        AvailabilityRestrictionFlag::AllowUnintroducedAtOrBelowDeploymentRange;
+
   auto getAvailabilityRestriction = [&](const Decl *decl) {
     return Where.getAvailability().restrictionForDecl(decl, restrictionFlags);
   };
@@ -3073,21 +3084,9 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
     return false;
   }
 
-  if (Flags.contains(DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol)
-        && isa<ProtocolDecl>(D))
-    return false;
-
   // Diagnose (and possibly signal) for potential unavailability
   auto domainAndRange = restriction->getDomainAndRange(ctx);
   auto fixItDomainAndRange = restriction->getFixItDomainAndRange(ctx);
-  auto domain = domainAndRange.getDomain();
-  auto requiredRange = domainAndRange.getRange();
-
-  if (Flags.contains(
-          DeclAvailabilityFlag::
-              AllowPotentiallyUnavailableAtOrBelowDeploymentTarget) &&
-      requiresDeploymentTargetOrEarlier(domain, requiredRange, ctx))
-    return false;
 
   if (accessor) {
     bool forInout = Flags.contains(DeclAvailabilityFlag::ForInout);

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -46,7 +46,8 @@ enum class DeclAvailabilityFlag : uint8_t {
   /// We allow a type to conform to a protocol that is less available than the
   /// type itself. This enables a type to retroactively model or directly conform
   /// to a protocol only available on newer OSes and yet still be used on older
-  /// OSes.
+  /// OSes. This exception only applies to platform domains; potential
+  /// unavailability in other domains, like custom domains, is still diagnosed.
   AllowPotentiallyUnavailableProtocol = 1 << 0,
 
   /// Diagnose uses of declarations in versions before they were introduced, but

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -649,33 +649,113 @@ class DerivedUnavailable2: BaseAvailableInEnabledDomain { } // expected-error {{
 @available(DisabledDomain, unavailable)
 class DerivedUnavailable3: BaseAvailableInEnabledDomain { }
 
+@available(EnabledDomain)
+protocol ProtoAvailableInEnabledDomain { }
+
+@available(EnabledDomain, unavailable) // expected-note * {{'ProtoUnavailableInEnabledDomain' has been explicitly marked unavailable here}}
+protocol ProtoUnavailableInEnabledDomain { }
+
+@available(AlwaysEnabledDomain)
+protocol ProtoAvailableInAlwaysEnabledDomain { }
+
+@available(AlwaysEnabledDomain, unavailable) // expected-note * {{'ProtoUnavailableInAlwaysEnabledDomain' has been explicitly marked unavailable here}}
+protocol ProtoUnavailableInAlwaysEnabledDomain { }
+
+struct ConformsMoreAvailable: ProtoAvailableInEnabledDomain { // expected-error {{'ProtoAvailableInEnabledDomain' is only available in EnabledDomain}}
+  // expected-note@-1 {{add '@available' attribute to enclosing struct}}
+}
+
+struct ConformsMoreAvailableInExtension { }
+
+// expected-note@+2 {{add '@available' attribute to enclosing extension}}
+// expected-error@+1 {{'ProtoAvailableInEnabledDomain' is only available in EnabledDomain}}
+extension ConformsMoreAvailableInExtension: ProtoAvailableInEnabledDomain { }
+
+@available(EnabledDomain)
+struct ConformsAsAvailable: ProtoAvailableInEnabledDomain { }
+
+struct ConformsAsAvailableInExtension { }
+
+@available(EnabledDomain)
+extension ConformsAsAvailableInExtension: ProtoAvailableInEnabledDomain { }
+
+@available(DisabledDomain)
+struct ConformsLessAvailable: ProtoAvailableInEnabledDomain { // expected-error {{'ProtoAvailableInEnabledDomain' is only available in EnabledDomain}}
+  // expected-note@-1 {{add '@available' attribute to enclosing struct}}
+}
+
+@available(EnabledDomain, unavailable)
+struct ConformsUnavailable: ProtoAvailableInEnabledDomain { } // expected-error {{'ProtoAvailableInEnabledDomain' is only available in EnabledDomain}}
+
+struct ConformsToUnavailableProto: ProtoUnavailableInEnabledDomain { } // expected-error {{'ProtoUnavailableInEnabledDomain' is unavailable}}
+
+@available(EnabledDomain, unavailable)
+struct ConformsToUnavailableProtoWhenUnavailable: ProtoUnavailableInEnabledDomain { }
+
+struct ConformsToAlwaysEnabledProto: ProtoAvailableInAlwaysEnabledDomain { }
+
+struct ConformsToUnavailableAlwaysEnabledProto: ProtoUnavailableInAlwaysEnabledDomain { } // expected-error {{'ProtoUnavailableInAlwaysEnabledDomain' is unavailable}}
+
+@available(AlwaysEnabledDomain, unavailable)
+struct ConformsToUnavailableAlwaysEnabledProtoWhenUnavailable: ProtoUnavailableInAlwaysEnabledDomain { }
+
+// A conformance is allowed to be introduced in a later OS version than the
+// conforming type, but that exception must not hide a restriction that comes
+// from a custom domain.
+@available(macOS 99, iOS 99, tvOS 99, watchOS 99, visionOS 99, *)
+protocol ProtoAvailableInFutureOS { }
+
+struct ConformsToProtoAvailableInFutureOS: ProtoAvailableInFutureOS { }
+
+@available(macOS 99, iOS 99, tvOS 99, watchOS 99, visionOS 99, *)
+@available(EnabledDomain)
+protocol ProtoAvailableInFutureOSAndEnabledDomain { }
+
+@available(EnabledDomain)
+@available(macOS 99, iOS 99, tvOS 99, watchOS 99, visionOS 99, *)
+protocol ProtoAvailableInEnabledDomainAndFutureOS { }
+
+struct ConformsToProtoAvailableInFutureOSAndEnabledDomain: ProtoAvailableInFutureOSAndEnabledDomain { // expected-error {{'ProtoAvailableInFutureOSAndEnabledDomain' is only available in EnabledDomain}}
+  // expected-note@-1 {{add '@available' attribute to enclosing struct}}
+}
+
+struct ConformsToProtoAvailableInEnabledDomainAndFutureOS: ProtoAvailableInEnabledDomainAndFutureOS { // expected-error {{'ProtoAvailableInEnabledDomainAndFutureOS' is only available in EnabledDomain}}
+  // expected-note@-1 {{add '@available' attribute to enclosing struct}}
+}
+
 
 // Protocol conformance availability.
 protocol P { }
 
-struct MyType1 { }
+struct ConformsToPInEnabledDomain { }
 
 @available(EnabledDomain)
-extension MyType1: P { }
+extension ConformsToPInEnabledDomain: P { }
 
-struct MyType2 { }
+struct ConformsToPInAlwaysEnabledDomain { }
 
 @available(AlwaysEnabledDomain)
-extension MyType2: P { }
+extension ConformsToPInAlwaysEnabledDomain: P { }
 
-struct MyType3 { }
+struct ConformsToPInDisabledDomain { }
 
 @available(DisabledDomain)
-extension MyType3: P { }
+extension ConformsToPInDisabledDomain: P { }
+
+struct ConformsToPUnavailableInEnabledDomain { }
+
+@available(EnabledDomain, unavailable) // expected-note {{conformance of 'ConformsToPUnavailableInEnabledDomain' to 'P' has been explicitly marked unavailable here}}
+extension ConformsToPUnavailableInEnabledDomain: P { }
 
 func acceptP<T: P>(_: T.Type) { }
 
 func testP() { // expected-note 2{{add '@available' attribute to enclosing global function}}
-  acceptP(MyType1.self) // expected-error{{conformance of 'MyType1' to 'P' is only available in EnabledDomain}}
-  // expected-note@-1{{add 'if #available' version check}}
-  acceptP(MyType2.self) // okay
-  acceptP(MyType3.self)  // expected-error{{conformance of 'MyType3' to 'P' is only available in DisabledDomain}}
-  // expected-note@-1{{add 'if #available' version check}}
+  acceptP(ConformsToPInEnabledDomain.self) // expected-error {{conformance of 'ConformsToPInEnabledDomain' to 'P' is only available in EnabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  acceptP(ConformsToPInAlwaysEnabledDomain.self) // okay
+  acceptP(ConformsToPInDisabledDomain.self) // expected-error {{conformance of 'ConformsToPInDisabledDomain' to 'P' is only available in DisabledDomain}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  acceptP(ConformsToPUnavailableInEnabledDomain.self) // expected-error {{conformance of 'ConformsToPUnavailableInEnabledDomain' to 'P' is unavailable}}
 }
 
 enum E {

--- a/test/Availability/availability_swift_runtime.swift
+++ b/test/Availability/availability_swift_runtime.swift
@@ -29,6 +29,18 @@ func availableSwift6() {
   availableInSwift6_0Runtime()
 }
 
+@available(Swift 6.0, *)
+protocol AvailableInSwift6_0Runtime { }
+
+// Unlike a platform domain, the Swift runtime domain does not allow a
+// conformance to be introduced in a later version than the conforming type.
+struct ConformsToAvailableInSwift6_0Runtime: AvailableInSwift6_0Runtime { // expected-error {{'AvailableInSwift6_0Runtime' is only available in Swift 6.0 or newer}}
+  // expected-note@-1 {{add '@available' attribute to enclosing struct}}{{1-1=@available(Swift 6.0)\n}}
+}
+
+@available(Swift 6.0, *)
+struct ConformsToAvailableInSwift6_0RuntimeInSwift6: AvailableInSwift6_0Runtime { }
+
 @available(Swift, introduced: 5.0, obsoleted: 5.1)
 func obsoletedBeforeSwiftRuntime() {}
 // expected-note@-2 3{{'obsoletedBeforeSwiftRuntime()' was obsoleted in Swift 5.1}}


### PR DESCRIPTION
As a concession to source compatibility, protocols may be listed in inheritance clauses even when those protocols are not yet introduced on the target platform in the context of the declaration carrying the inheritance clause:

    @available(macOS 99, *)
    protocol P { }

    struct S: P { } // no error

The conformance itself cannot be used in contexts where the protocol is unavailable, so this exception ends up being sound even though availability restrictions are generally meant to be enforced lexically.

This exception is unsound for protocols that have custom availability domain requirements, though, since a protocol that `@available(SomeDomain)` does not exist at all at link time if `SomeDomain` is disabled. Limit the exception to platform domains.

Resolves rdar://187210815.
