### PR TITLE
Build all execution tests with -solver-enable-diagnose-valid-salvage too

### DIFF
--- a/test/Constraints/salvage_preconcurrency.swift
+++ b/test/Constraints/salvage_preconcurrency.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+func testInOut(_ arr: inout [Any]) {}
+func testInOut(_ dict: inout [String: Any]) {}
+
+@preconcurrency var dict: [String : any Sendable] = ["a": 42]
+@preconcurrency var arr: [any Sendable] = [42]
+
+testInOut(&arr)
+// expected-error@-1 {{failed to produce diagnostic for expression}}
+testInOut(&dict)
+// expected-error@-1 {{failed to produce diagnostic for expression}}

--- a/test/Interpreter/sendable_erasure_to_any_in_preconcurrency.swift
+++ b/test/Interpreter/sendable_erasure_to_any_in_preconcurrency.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -solver-disable-diagnose-valid-salvage) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1155,6 +1155,8 @@ elif swift_test_mode == 'with_cxx_interop':
 else:
     lit_config.fatal("Unknown test mode %r" % swift_test_mode)
 
+swift_execution_tests_extra_flags += ' -Xfrontend -solver-enable-diagnose-valid-salvage'
+
 swift_test_subset = lit_config.params.get('swift_test_subset', 'validation')
 if swift_test_subset in ['primary', 'validation', 'only_validation']:
     # No extra flags needed.


### PR DESCRIPTION
This uncovered one more valid-in-salvage expression, which I extracted into its own test case.