### PR TITLE
[Sema] Avoid optional debug-description warning for custom interpolations

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6065,6 +6065,10 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
     void diagnoseIfUnintendedInterpolation(CallExpr *segment,
                                            UnintendedInterpolationKind kind) {
+      if (kind == UnintendedInterpolationKind::Optional &&
+          baseInterpolationTypeName(segment) != "DefaultStringInterpolation")
+        return;
+
       if (interpolationWouldBeUnintended(
               segment->getCalledValue(/*skipFunctionConversions=*/true), kind))
         if (auto firstArg =

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -251,12 +251,9 @@ func warnOptionalInStringInterpolationSegment(_ o : Int?) {
   // expected-note@-2 {{provide a default value to avoid this warning}} {{52-52= ?? <#default value#>}}
   // expected-note@-3 {{use 'String(describing:)' to silence this warning}} {{51-51=String(describing: }} {{52-52=)}}
   
-  // Don't provide a `\(_:default:)` fix-it for interpolations that don't resolve
-  // to strings.
+  // Custom interpolations can handle optional values without producing a debug
+  // description.
   let _: CustomInterpolation = "Always some, Always some, Always some: \(o)"
-  // expected-warning@-1 {{string interpolation produces a debug description for an optional value; did you mean to make this explicit?}}
-  // expected-note@-2 {{provide a default value to avoid this warning}} {{75-75= ?? <#default value#>}}
-  // expected-note@-3 {{use 'String(describing:)' to silence this warning}} {{74-74=String(describing: }} {{75-75=)}}
 }
 
 // Make sure we don't double diagnose

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -197,11 +197,15 @@ extension DefaultStringInterpolation {
 }
 
 /// A type that provides a custom `StringInterpolation` type.
+protocol CustomInterpolatable {}
+extension Int: CustomInterpolatable {}
+extension Optional: CustomInterpolatable where Wrapped: CustomInterpolatable {}
+
 struct CustomInterpolation: ExpressibleByStringInterpolation {
     struct StringInterpolation: StringInterpolationProtocol {
         init(literalCapacity: Int, interpolationCount: Int) {}
         mutating func appendLiteral(_ literal: String) {}
-        mutating func appendInterpolation<T>(_ interp: T) {}
+        mutating func appendInterpolation(_ interp: some CustomInterpolatable) {}
     }
     init(stringInterpolation: StringInterpolation) {}
     init(stringLiteral: String) {}


### PR DESCRIPTION
Custom string interpolations can handle optional values directly and do not necessarily produce a debug description. Limit the optional interpolation diagnostic to `DefaultStringInterpolation`, while preserving the existing warning and fix-its for ordinary string interpolation.

The existing custom-interpolation test now mirrors the issue's protocol-constrained overload and verifies that it does not warn.

Resolves https://github.com/swiftlang/swift/issues/92066

Testing:
- `git diff --check`
- Confirmed the reproducer warns with the installed Swift 6.3.3 compiler before this fix