### PR TITLE
[SILGen] Avoid recursive vtable thunk for stub initializers

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -122,9 +122,14 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass, SILDeclRef derived,
   // but then in turn be overridden by a derived class in another file in
   // the same module that either doesn't import the ultimate base class's
   // module or else imports it non-publicly in its file.
+  //
+  // Stub initializers do not introduce their own vtable entries, so a thunk
+  // for one must call the synthesized stub directly instead of redispatching.
+  auto *derivedCtor = dyn_cast<ConstructorDecl>(derivedDecl);
   bool baseLessVisibleThanDerived =
     (!usesObjCDynamicDispatch &&
      !derivedDecl->isFinal() &&
+     !(derivedCtor && derivedCtor->hasStubImplementation()) &&
      derivedDecl->isMoreVisibleThan(derivedDecl->getOverriddenDecl()));
 
   // Determine the derived thunk type by lowering the derived type against the

--- a/test/SILGen/package_stub_initializer_vtable.swift
+++ b/test/SILGen/package_stub_initializer_vtable.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -package-name Package -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -package-name Package -emit-sil %s -o /dev/null -verify
+
+public class Base {
+  package init(value: Int) {}
+}
+
+class Subclass: Base {
+  let name: String
+
+  init(name: String) {
+    self.name = name
+    super.init(value: 0)
+  }
+}
+
+// CHECK-LABEL: // vtable thunk for Base.__allocating_init(value:) dispatching to Subclass.__allocating_init(value:)
+// CHECK-NOT: class_method
+// CHECK: function_ref @$s{{.*}}8SubclassC5valueACSi_tcfC


### PR DESCRIPTION
A package-visible designated initializer can cause a same-module subclass to receive a synthesized trapping initializer stub. Because stub initializers do not introduce a distinct vtable entry, redispatching through the derived slot makes the adaptation thunk call itself after devirtualization and produces a spurious infinite-recursion warning.

Make vtable thunks call synthesized initializer stubs directly while preserving redispatch for ordinary visibility thunks. Add a SILGen regression test that checks the direct reference and verifies that mandatory diagnostics remain silent.

Resolves https://github.com/swiftlang/swift/issues/92023

Testing:
- `git diff --check`
- Reproduced the warning with the installed Swift 6.3.3 compiler before this fix
- Added targeted `-emit-silgen` FileCheck and `-emit-sil -verify` coverage