### PR TITLE
[stdlib] Work around low-address breadcrumb pointers on Windows

### DIFF
--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -155,7 +155,8 @@ fileprivate struct _CapacityAndFlags {
  For "one crumb" breadcrumbs, the breadcrumbs pointer is replaced with what
  would have been the last breadcrumb itself. This allows .utf16.count to be fast
  without requiring extra storage. This is detected by checking if the breadcrumb
- pointer has a numeric value of less than or equal to Int32.max
+ pointer has a numeric value of less than or equal to Int32.max. This encoding
+ is disabled on Windows, where valid heap pointers can occupy that range.
 
  H                                                                             n
  ├─────────────────────────────────────────────────────────────────────────────┤
@@ -246,7 +247,7 @@ fileprivate func _allocateStringStorage(
   let pointerSize = MemoryLayout<Int>.stride
   let headerSize = Int(_StringObject.nativeBias)
   let codeUnitSize = capacity + 1 /* code units and null */
-#if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64) && !os(Windows)
   let needBreadcrumbs = utf16Len != nil ||
     capacity >= _StringBreadcrumbs.breadcrumbStride
 #else
@@ -366,13 +367,13 @@ extension __StringStorage {
       storage._capacityAndFlags._storage == capAndFlags._storage)
     _internalInvariant(
       storage.unusedCapacity == capAndFlags.capacity - countAndFlags.count)
-#if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64) && !os(Windows)
     _internalInvariant(
        ((utf16Len != nil) && storage.hasBreadcrumbs) || (utf16Len == nil)
     )
 #endif
     
-#if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64) && !os(Windows)
     if let utf16Len, utf16Len <= Int32.max {
       storage._oneCrumb = utf16Len
     } else if storage.hasBreadcrumbs {
@@ -464,9 +465,10 @@ extension __StringStorage {
   internal var hasBreadcrumbs: Bool { _capacityAndFlags.hasBreadcrumbs }
   
   internal var hasOneCrumb: Bool {
-#if _pointerBitWidth(_32) || _pointerBitWidth(_16)
+#if _pointerBitWidth(_32) || _pointerBitWidth(_16) || os(Windows)
     // On 32-bit platforms, Int(Int32.max) == Int.max, so we can't distinguish
-    // a one-crumb integer from a valid pointer. Disable the optimization.
+    // a one-crumb integer from a valid pointer. Windows also permits heap
+    // pointers below Int32.max on 64-bit platforms. Disable the optimization.
     return false
 #else
     if !_capacityAndFlags.hasBreadcrumbs {
@@ -624,7 +626,7 @@ extension __StringStorage {
 #endif
     unsafe self.terminator.pointee = 0
 
-#if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64) && !os(Windows)
     if let utf16Len, hasBreadcrumbs, utf16Len <= Int32.max {
       // `_oneCrumb`'s setter uses a raw `storeBytes`, so an ARC reference in
       // the slot would be leaked. Current callers only pass `utf16Len` on
@@ -930,7 +932,7 @@ extension _StringGuts {
   
   @_effects(releasenone)
   internal func getUTF16Count() -> Int {
-#if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64) && !os(Windows)
     // Read the one-crumb value in a single atomic load to avoid a TOCTOU race
     // with loadUnmanagedBreadcrumbs(), which can CAS the slot to zero or
     // replace it with a real breadcrumbs pointer concurrently.
@@ -939,7 +941,8 @@ extension _StringGuts {
     // (including a breadcrumbs pointer) would pass the range check below,
     // causing a pointer address to be returned as a UTF-16 count. The
     // one-crumb optimization is already disabled on 32-bit (hasOneCrumb
-    // returns false), so skip this fast path entirely.
+    // returns false), so skip this fast path entirely. The same restriction
+    // applies on Windows, where even 64-bit pointers can occupy this range.
     if hasNativeStorage {
       let val = _object.withNativeStorage { storage -> Int in
         guard storage.hasBreadcrumbs else { return -1 }

--- a/test/stdlib/StringBreadcrumbsLowAddress.swift
+++ b/test/stdlib/StringBreadcrumbsLowAddress.swift
@@ -1,0 +1,19 @@
+// RUN: %target-run-simple-swift(-Xlinker /HIGHENTROPYVA:NO -Xlinker /DYNAMICBASE:NO)
+// REQUIRES: executable_test, OS=windows-msvc, CPU=x86_64
+// UNSUPPORTED: use_os_stdlib, back_deployment_runtime
+
+// Without high-entropy address randomization, Windows can allocate breadcrumbs
+// below Int32.max. Such a pointer must not be mistaken for a cached UTF-16 count.
+
+let units = Array(repeating: UInt16(0x00E9), count: 128)
+var value = String(decoding: units, as: UTF16.self)
+precondition(value.utf16.count == units.count)
+
+// An interior UTF-16 offset populates the full breadcrumbs cache.
+let midpoint = value.utf16.index(value.utf16.startIndex, offsetBy: 64)
+precondition(value.utf16[midpoint] == units[64])
+precondition(value.utf16.count == units.count)
+
+value.append("x")
+precondition(value.utf16.count == units.count + 1)
+precondition(Array(value.utf16) == units + [0x0078])


### PR DESCRIPTION
Gate the single-breadcrumb UTF-16 count optimization behind a CMake-defined workaround on Windows so a low-address heap pointer cannot be returned as a string length.

The encoding introduced in #83987 distinguishes an inline UTF-16 count from a `_StringBreadcrumbs` reference by checking whether the stored word is in `1...Int32.max`. Windows permits valid heap allocations in that range even in a 64-bit process. After an interior UTF-16 lookup creates a full breadcrumbs object, `getUTF16Count()` can therefore report its address as the length. The same ambiguity also affects breadcrumb upgrade and lifetime handling.

This is reproducible with ordinary String APIs. Build the following for x86_64 Windows with `-Xlinker /HIGHENTROPYVA:NO -Xlinker /DYNAMICBASE:NO`:

```swift
let units = Array(repeating: UInt16(0x00E9), count: 128)
let value = String(decoding: units, as: UTF16.self)
print(value.utf16.count)
let midpoint = value.utf16.index(value.utf16.startIndex, offsetBy: 64)
print(value.utf16[midpoint])
print(value.utf16.count)
```

The length should remain 128. In the local low-address reproduction it changes to a heap-address-sized integer; the equivalent Foundation version printed `128`, `233`, then `5454112`. The exact wrong length depends on the allocation address. Calls such as `NSString.trimmingCharacters(in:)` subsequently use this bogus length to construct an out-of-bounds range for `getCharacters(_:range:)`.

### Change

Define `WORKAROUND_LOW_ENTROPY_VA_BREADCRUMBS` in the Windows standard-library CMake configuration and use it to select the existing non-single-breadcrumb path for allocation, initialization, mutation, classification, and UTF-16 count lookup. Naming the workaround explicitly keeps it separate from intrinsic platform restrictions and makes it easy to remove when a better encoding is available. The existing fallback for 32-bit targets remains in place. Windows strings decoded from UTF-16 may need to scan or allocate full breadcrumbs to compute their UTF-16 length; preserving the optimization would require an encoding that does not overlap valid pointers.

Add a Windows x86_64 regression test with low-entropy address layout. It verifies that an interior lookup preserves the UTF-16 length and that appending invalidates the cache correctly.

### Validation

- Compiled and ran the added regression against the Windows runtime from the public [20260417.1 toolchain](https://github.com/thebrowsercompany/swift-build/releases/tag/20260417.1): it fails at the length check immediately after the interior lookup.
- The same regression executable built with the default high-entropy address layout passes, including the mutation checks.
- The patched standard library has not been rebuilt locally; validation against the rebuilt runtime remains for CI. Linux and macOS tests have not been run.

