### PR TITLE
[CSApply] Don't use special isolation erasure for global-actor to `@isolated(any)` conversions

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7757,10 +7757,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
     if (ctx.LangOpts.isDynamicActorIsolationCheckingEnabled()) {
       // Passing a synchronous global actor-isolated function value and
-      // parameter that expects a synchronous non-isolated function type could
+      // parameter that expects a synchronous nonisolated function type could
       // require a runtime check to ensure that function is always called in
       // expected context.
-      if (!toEI.getGlobalActor() && fromEI.getGlobalActor() &&
+      if (toEI.getIsolation().isNonIsolated() && fromEI.getGlobalActor() &&
           !toEI.isAsync()) {
         // Runtime check is required when isolation function value
         // is passed to an API that comes from a module that doesn't

--- a/test/Concurrency/dynamic_isolation_checks_for_closures.swift
+++ b/test/Concurrency/dynamic_isolation_checks_for_closures.swift
@@ -22,6 +22,8 @@ public func computeSendable(_: @escaping @Sendable () -> Void) {}
 
 public func computeSending(_: sending @escaping () -> Void) {}
 
+public func computeIsolatedAny(_: @isolated(any) @Sendable () -> Void) {}
+
 //--- Client.swift
 import API
 
@@ -106,3 +108,21 @@ func test_global_actor_sendable_and_sending_closures() {
     forceIsolation(isolation: #isolation)
   }
 }
+
+@MainActor
+func test_isolated_any_and_closures() {
+  // CHECK-LABEL: sil private [ossa] @$s6Client30test_isolated_any_and_closuresyyFyyYbXEfU_
+  // CHECK-NOT: function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
+  // CHECK: } // end sil function '$s6Client30test_isolated_any_and_closuresyyFyyYbXEfU_'
+  computeIsolatedAny {
+  }
+
+  // CHECK-LABEL: sil private [ossa] @$s6Client30test_isolated_any_and_closuresyyFyyYbScMYcXEfU0_
+  // CHECK: [[EXPECTED_EXECUTOR:%.*]] = extract_executor {{.*}} : $MainActor
+  // CHECK: [[CHECK_EXECUTOR_FN:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+  // CHECK: apply [[CHECK_EXECUTOR_FN]]({{.*}}, [[EXPECTED_EXECUTOR]]) : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+  // CHECK: } // end sil function '$s6Client30test_isolated_any_and_closuresyyFyyYbScMYcXEfU0_'
+  computeIsolatedAny { @MainActor in
+  }
+}
+

--- a/validation-test/compiler_crashers_fixed/SILGenFunction-emitActorIsolationErasureThunk-78dcaf.swift
+++ b/validation-test/compiler_crashers_fixed/SILGenFunction-emitActorIsolationErasureThunk-78dcaf.swift
@@ -1,0 +1,22 @@
+// {"signature":"swift::Lowering::SILGenFunction::emitActorIsolationErasureThunk(swift::SILLocation, swift::Lowering::ManagedValue, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::CanTypeWrapper<swift::AnyFunctionType>)","signatureAssert":"Assertion failed: (!expectedType->hasErasedIsolation()), function emitActorIsolationErasureThunk"}
+//
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -emit-module -module-name Lib -emit-module-path %t/Lib.swiftmodule -DLib %s \
+// RUN:   -language-mode 5
+// RUN: %target-swift-emit-silgen -I %t %s \
+// RUN:   -language-mode 6 -verify
+//
+// rdar://171146729
+#if Lib
+  public struct Foo {
+    public func bar(_: @isolated(any) @Sendable (Foo) -> Void) {
+    }
+  }
+#else
+  import Lib
+  func test(foo: Foo) {
+    foo.bar { @MainActor _ in
+    }
+  }
+#endif


### PR DESCRIPTION
Regular `FunctionConversionExpr` handles that correctly and `ActorIsolationErasureExpr` should only be used for cases when the resulting type is `nonisolated`.

Resolves: rdar://171146729
(cherry picked from commit 5097a86b8828dbbb99aecb1f8bca244d1e3911de)
