### PR TITLE
Document that FloatingPoint.pi should be rounded-to-nearest.

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -332,13 +332,11 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// 
   /// When measuring an angle in radians, π is equivalent to a half-turn.
   ///
-  /// This value is rounded toward zero to keep user computations with angles
-  /// from inadvertently ending up in the wrong quadrant. A type that conforms
-  /// to the `FloatingPoint` protocol provides the value for `pi` at its best
-  /// possible precision.
+  /// A type that conforms to the `FloatingPoint` protocol provides the
+  /// value for `pi` at its best possible precision.
   ///
   ///     print(Double.pi)
-  ///     // Prints "3.14159265358979"
+  ///     // Prints "3.141592653589793"
   static var pi: Self { get }
 
   // NOTE: Rationale for "ulp" instead of "epsilon":

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -477,12 +477,7 @@ extension ${Self}: BinaryFloatingPoint {
 %if bits == 16:
     return 0x1.92p1
 %elif bits == 32:
-    // Note: this is not the correctly rounded (to nearest) value of pi,
-    // because pi would round *up* in Float precision, which can result
-    // in angles in the wrong quadrant if users aren't careful.  This is
-    // not a problem for Double or Float80, as pi rounds down in both of
-    // those formats.
-    return 0x1.921fb4p1
+    return 0x1.921fb6p1
 %elif bits == 64:
     return 0x1.921fb54442d18p1
 %elif bits == 80:

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -289,7 +289,7 @@ FloatingPoint.test("Float/staticProperties") {
 #endif
   expectBitwiseEqual(bitPattern: 0x7f80_0000, Ty.infinity)
   expectBitwiseEqual(0x1.ffff_fe__p127, Ty.greatestFiniteMagnitude)
-  expectBitwiseEqual(0x1.921f_b4__p1, Ty.pi)
+  expectBitwiseEqual(0x1.921f_b6__p1, Ty.pi)
   expectBitwiseEqual(0x1.0p-23, Ty.ulpOfOne)
   expectBitwiseEqual(0x1.0p-126, Ty.leastNormalMagnitude)
 #if arch(arm)

--- a/test/stdlib/ParseFloat32.swift
+++ b/test/stdlib/ParseFloat32.swift
@@ -203,7 +203,7 @@ tests.test("HexFloats") {
   expectParse("0xab", 171.0)
   expectParse("0x1p+10", 1024.0)
   expectParse("0x1p+0000000000000000000000000010", 1024.0)
-  expectParse("0x1.921fb4p+1", Float32.pi)
+  expectParse("0x1.921fb6p+1", Float32.pi)
 
   // Rationale for the four assertions below:
   // * Float32.greatestFiniteMagnitude has an odd significand

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -605,7 +605,7 @@ PrintTests.test("Printable_Float") {
   // Standard special numbers:
   expectDescription("inf", Float.infinity)
   expectDescription("-inf", -Float.infinity)
-  expectDescription("3.1415925", Float.pi)
+  expectDescription("3.1415927", Float.pi)
   expectDescription("3.4028235e+38", Float.greatestFiniteMagnitude)
 #if !arch(arm)
   expectDescription("1e-45", Float.leastNonzeroMagnitude)


### PR DESCRIPTION
Historically Swift rounded this value toward zero to preserve the range invariant that the rounded result was in [0,π]. The 754 working group has provided some guidance that they think getting the most accurate value is more important than trying to satisfy such invariants, so we will change our guidance to implementors, and the specific value of Float.pi to match.

Pitched to evolution here: https://forums.swift.org/t/pitch-round-to-nearest/89497