### PR TITLE
[Sema] Add fix-its for missing dynamic attribute requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1790,6 +1790,10 @@ GROUPED_ERROR(invalid_dynamic_callable_type,DynamicCallable,none,
       "'@dynamicCallable' requires %0 to have either a valid "
       "'dynamicallyCall(withArguments:)' method or "
       "'dynamicallyCall(withKeywordArguments:)' method", (Type))
+NOTE(add_dynamic_callable_method,none,
+     "add 'dynamicallyCall(%select{withArguments:|withKeywordArguments:|"
+     "withKeywordArguments:}0)' method%select{| with 'Dictionary'| with "
+     "'KeyValuePairs'}0", (unsigned))
 GROUPED_ERROR(missing_dynamic_callable_kwargs_method,DynamicCallable,none,
       "'@dynamicCallable' type %0 cannot be applied with keyword arguments; "
       "missing 'dynamicCall(withKeywordArguments:)' method", (Type))
@@ -1798,6 +1802,9 @@ ERROR(invalid_dynamic_member_lookup_type,none,
       "'@dynamicMemberLookup' requires %0 to have a "
       "'subscript(dynamicMember:)' method that accepts either "
       "'ExpressibleByStringLiteral' or a key path", (Type))
+NOTE(add_dynamic_member_lookup_subscript,none,
+     "add 'subscript(dynamicMember:)' method with %select{'String'|a key path}0",
+     (unsigned))
 ERROR(invalid_dynamic_member_subscript_missing_param_label, none,
       "'@dynamicMemberLookup' requires %0 to have an explicit parameter label",
       (ParamDecl *))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2097,6 +2097,76 @@ static bool hasValidDynamicCallableMethod(NominalTypeDecl *decl,
   return true;
 }
 
+enum class DynamicAttributeRequirementKind : unsigned {
+  CallableWithArguments,
+  CallableWithDictionary,
+  CallableWithKeyValuePairs,
+  MemberLookupWithString,
+  MemberLookupWithKeyPath,
+};
+
+static llvm::SmallString<192> generateDynamicAttributeRequirementText(
+    ASTContext &ctx, NominalTypeDecl *parentDecl,
+    DynamicAttributeRequirementKind requirement) {
+  StringRef extraIndent;
+  StringRef currentIndent = Lexer::getIndentationForLine(
+      ctx.SourceMgr, parentDecl->getStartLoc(), &extraIndent);
+  std::string memberIndent = (currentIndent + extraIndent).str();
+
+  llvm::SmallString<192> text;
+  llvm::raw_svector_ostream out(text);
+  ExtraIndentStreamPrinter printer(out, memberIndent);
+
+  printer.printNewline();
+
+  bool isProtocol = isa<ProtocolDecl>(parentDecl);
+  if (!isProtocol) {
+    auto access = parentDecl->getFormalAccess();
+    if (access == AccessLevel::Package)
+      printer << "package ";
+    else if (access >= AccessLevel::Public)
+      printer << "public ";
+  }
+
+  switch (requirement) {
+  case DynamicAttributeRequirementKind::CallableWithArguments:
+    printer << "func dynamicallyCall(withArguments arguments: [Any])";
+    break;
+  case DynamicAttributeRequirementKind::CallableWithDictionary:
+    printer << "func dynamicallyCall(withKeywordArguments arguments: "
+               "[String: Any])";
+    break;
+  case DynamicAttributeRequirementKind::CallableWithKeyValuePairs:
+    printer << "func dynamicallyCall(withKeywordArguments arguments: "
+               "KeyValuePairs<String, Any>)";
+    break;
+  case DynamicAttributeRequirementKind::MemberLookupWithString:
+    printer << "subscript(dynamicMember member: String) -> <#Type#>";
+    break;
+  case DynamicAttributeRequirementKind::MemberLookupWithKeyPath:
+    printer << "subscript(dynamicMember member: KeyPath<<#Base#>, <#Type#>>) "
+               "-> <#Type#>";
+    break;
+  }
+
+  if (isProtocol) {
+    if (requirement ==
+            DynamicAttributeRequirementKind::MemberLookupWithString ||
+        requirement ==
+            DynamicAttributeRequirementKind::MemberLookupWithKeyPath)
+      printer << " { get }";
+    printer.printNewline();
+    return text;
+  }
+
+  printer << " {\n";
+  printer.printIndent();
+  printer << extraIndent << getCodePlaceholder();
+  printer.printNewline();
+  printer << "}\n";
+  return text;
+}
+
 void AttributeChecker::
 visitDynamicCallableAttr(DynamicCallableAttr *attr) {
   // This attribute is only allowed on nominal types.
@@ -2112,6 +2182,20 @@ visitDynamicCallableAttr(DynamicCallableAttr *attr) {
                                   /*hasKeywordArgs*/ true);
   if (!hasValidMethod) {
     diagnose(attr->getLocation(), diag::invalid_dynamic_callable_type, type);
+    auto fixLocation = decl->getBraces().Start;
+    auto addRequirementFixIt = [&](DynamicAttributeRequirementKind kind,
+                                   unsigned choice) {
+      diagnose(decl->getLoc(), diag::add_dynamic_callable_method, choice)
+          .fixItInsertAfter(
+              fixLocation,
+              generateDynamicAttributeRequirementText(Ctx, decl, kind));
+    };
+    addRequirementFixIt(
+        DynamicAttributeRequirementKind::CallableWithArguments, 0);
+    addRequirementFixIt(
+        DynamicAttributeRequirementKind::CallableWithDictionary, 1);
+    addRequirementFixIt(
+        DynamicAttributeRequirementKind::CallableWithKeyValuePairs, 2);
     attr->setInvalid();
   }
 }
@@ -2221,8 +2305,22 @@ void AttributeChecker::visitDynamicMemberLookupAttr(
   }
 
   attr->setInvalid();
-  if (!diagnosed)
+  if (!diagnosed) {
     diagnose(attr->getStartLoc(), diag::invalid_dynamic_member_lookup_type, type);
+    auto fixLocation = decl->getBraces().Start;
+    auto addRequirementFixIt = [&](DynamicAttributeRequirementKind kind,
+                                   unsigned choice) {
+      diagnose(decl->getLoc(), diag::add_dynamic_member_lookup_subscript,
+               choice)
+          .fixItInsertAfter(
+              fixLocation,
+              generateDynamicAttributeRequirementText(ctx, decl, kind));
+    };
+    addRequirementFixIt(
+        DynamicAttributeRequirementKind::MemberLookupWithString, 0);
+    addRequirementFixIt(
+        DynamicAttributeRequirementKind::MemberLookupWithKeyPath, 1);
+  }
 }
 
 /// Get the innermost enclosing declaration for a declaration.

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -100,6 +100,9 @@ func testFunction(a: CallableReturningFunction) {
 // Arguments' type may not be variadic.
 // expected-error @+1 {{'@dynamicCallable' requires 'Invalid1' to have either a valid 'dynamicallyCall(withArguments:)' method or 'dynamicallyCall(withKeywordArguments:)' method}} {{documentation-file=dynamic-callable-requirements}}
 @dynamicCallable
+// expected-note@+1 {{add 'dynamicallyCall(withArguments:)' method}} {{18-18=\n    func dynamicallyCall(withArguments arguments: [Any]) {\n        <#code#>\n    }\n}}
+// expected-note@+1 {{add 'dynamicallyCall(withKeywordArguments:)' method with 'Dictionary'}} {{18-18=\n    func dynamicallyCall(withKeywordArguments arguments: [String: Any]) {\n        <#code#>\n    }\n}}
+// expected-note@+1 {{add 'dynamicallyCall(withKeywordArguments:)' method with 'KeyValuePairs'}} {{18-18=\n    func dynamicallyCall(withKeywordArguments arguments: KeyValuePairs<String, Any>) {\n        <#code#>\n    }\n}}
 struct Invalid1 {
   func dynamicallyCall(withArguments arguments: [Int]...) -> Int {
     return 1
@@ -109,13 +112,20 @@ struct Invalid1 {
 // Keyword arguments' key type must be ExpressibleByStringLiteral.
 // expected-error @+1 {{'@dynamicCallable' requires 'Invalid2' to have either a valid 'dynamicallyCall(withArguments:)' method or 'dynamicallyCall(withKeywordArguments:)' method}} {{documentation-file=dynamic-callable-requirements}}
 @dynamicCallable
-struct Invalid2 {
+struct Invalid2 { // expected-note {{add 'dynamicallyCall(withArguments:)' method}} expected-note {{add 'dynamicallyCall(withKeywordArguments:)' method with 'Dictionary'}} expected-note {{add 'dynamicallyCall(withKeywordArguments:)' method with 'KeyValuePairs'}}
   func dynamicallyCall(
     withKeywordArguments arguments: KeyValuePairs<Int, Int>
   ) -> Int {
     return 1
   }
 }
+
+// expected-error @+1 {{'@dynamicCallable' requires 'InvalidProtocol' to have either a valid 'dynamicallyCall(withArguments:)' method or 'dynamicallyCall(withKeywordArguments:)' method}}
+@dynamicCallable
+// expected-note@+1 {{add 'dynamicallyCall(withArguments:)' method}} {{27-27=\n    func dynamicallyCall(withArguments arguments: [Any])\n}}
+// expected-note@+1 {{add 'dynamicallyCall(withKeywordArguments:)' method with 'Dictionary'}} {{27-27=\n    func dynamicallyCall(withKeywordArguments arguments: [String: Any])\n}}
+// expected-note@+1 {{add 'dynamicallyCall(withKeywordArguments:)' method with 'KeyValuePairs'}} {{27-27=\n    func dynamicallyCall(withKeywordArguments arguments: KeyValuePairs<String, Any>)\n}}
+protocol InvalidProtocol {}
 
 // Dynamic calls with keyword arguments require `dynamicallyCall(withKeywordArguments:)` to be defined.
 @dynamicCallable
@@ -149,7 +159,7 @@ func NotAllowedOnFunc() {}
 
 // expected-error @+1 {{'@dynamicCallable' requires 'InvalidBase' to have either a valid 'dynamicallyCall(withArguments:)' method or 'dynamicallyCall(withKeywordArguments:)' method}}
 @dynamicCallable
-class InvalidBase {}
+class InvalidBase {} // expected-note {{add 'dynamicallyCall(withArguments:)' method}} expected-note {{add 'dynamicallyCall(withKeywordArguments:)' method with 'Dictionary'}} expected-note {{add 'dynamicallyCall(withKeywordArguments:)' method with 'KeyValuePairs'}}
 
 class InvalidDerived : InvalidBase {
   func dynamicallyCall(withArguments arguments: [Int]) -> Int {

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -6,9 +6,17 @@ var global = 42
 
 // expected-error@+1 {{'@dynamicMemberLookup' requires 'S' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
+// expected-note@+1 {{add 'subscript(dynamicMember:)' method with 'String'}} {{11-11=\n    subscript(dynamicMember member: String) -> <#Type#> {\n        <#code#>\n    }\n}}
+// expected-note@+1 {{add 'subscript(dynamicMember:)' method with a key path}} {{11-11=\n    subscript(dynamicMember member: KeyPath<<#Base#>, <#Type#>>) -> <#Type#> {\n        <#code#>\n    }\n}}
 struct S {
   subscript(bogus: Int) -> Void { () }
 }
+
+// expected-error@+1 {{'@dynamicMemberLookup' requires 'PublicLookup' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+@dynamicMemberLookup
+// expected-note@+1 {{add 'subscript(dynamicMember:)' method with 'String'}} {{29-29=\n    public subscript(dynamicMember member: String) -> <#Type#> {\n        <#code#>\n    }\n}}
+// expected-note@+1 {{add 'subscript(dynamicMember:)' method with a key path}} {{29-29=\n    public subscript(dynamicMember member: KeyPath<<#Base#>, <#Type#>>) -> <#Type#> {\n        <#code#>\n    }\n}}
+public struct PublicLookup {}
 
 @dynamicMemberLookup
 struct Gettable {
@@ -413,7 +421,7 @@ func NotAllowedOnFunc() {}
 
 // expected-error @+1 {{'@dynamicMemberLookup' requires 'InvalidBase' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
-class InvalidBase {}
+class InvalidBase {} // expected-note {{add 'subscript(dynamicMember:)' method with 'String'}} expected-note {{add 'subscript(dynamicMember:)' method with a key path}}
 
 class InvalidDerived : InvalidBase { subscript(dynamicMember: String) -> Int { get {}} }
 


### PR DESCRIPTION
`@dynamicCallable` and `@dynamicMemberLookup` diagnostics identify missing requirements, but currently leave the declarations to be written from scratch.

Add fix-it alternatives for positional and keyword dynamic calls, along with string- and key-path-based dynamic member lookup. The generated stubs preserve surrounding indentation, omit bodies for protocol requirements, and match public or package access on concrete types.

Verifier coverage checks the emitted edits for concrete, protocol, and public declarations.

Resolves https://github.com/swiftlang/swift/issues/87837.