### PR TITLE
[Optimizer] Improve stack-protection optimizations

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -493,7 +493,8 @@ private extension Instruction {
           return nil
         }
         var hasNoStores = NoStores()
-        if hasNoStores.walkDownUses(ofAddress: ia, path: SmallProjectionPath()) == .continueWalk {
+        if hasNoStores.walkDownUses(ofAddress: ia,
+                                    path: SmallProjectionPath(.anything)) == .continueWalk {
           return nil
         }
 
@@ -520,7 +521,9 @@ private struct NoStores : ValueDefUseWalker, AddressDefUseWalker {
   mutating func leafUse(value: Operand, path: SmallProjectionPath) -> WalkResult {
     switch value.instruction {
     case let ptai as PointerToAddressInst:
-      return walkDownUses(ofAddress: ptai, path: path)
+      return walkDownUses(ofAddress: ptai, path: SmallProjectionPath(.anything))
+    case let irp as IndexRawPointerInst:
+      return walkDownUses(ofValue: irp, path: path)
     case let bi as BuiltinInst:
       switch bi.intrinsicID {
       case .memcpy, .memmove:
@@ -528,6 +531,8 @@ private struct NoStores : ValueDefUseWalker, AddressDefUseWalker {
       default:
         return .abortWalk
       }
+    case is DebugValueInst:
+      return .continueWalk
     default:
       return .abortWalk
     }
@@ -535,10 +540,12 @@ private struct NoStores : ValueDefUseWalker, AddressDefUseWalker {
 
   mutating func leafUse(address: Operand, path: SmallProjectionPath) -> WalkResult {
     switch address.instruction {
-    case is LoadInst:
+    case is LoadInst, is DebugValueInst:
       return .continueWalk
     case let cai as CopyAddrInst:
       return address == cai.sourceOperand ? .continueWalk : .abortWalk
+    case let ia as IndexAddrInst:
+      return walkDownUses(ofAddress: ia, path: path)
     default:
       return .abortWalk
     }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -471,6 +471,15 @@ private extension AccessBase {
   }
 }
 
+private extension Value {
+  var lookThroughAddressCast: Value {
+    if let addrCast = self as? UncheckedAddrCastInst {
+      return addrCast.fromAddress.lookThroughAddressCast
+    }
+    return self
+  }
+}
+
 private extension Instruction {
   /// If the instruction needs stack protection, return the relevant access base and scope.
   var accessBaseToProtect: (AccessBase, scope: BeginAccessInst?)? {
@@ -503,7 +512,7 @@ private extension Instruction {
       default:
         return nil
     }
-    let (accessPath, scope) = baseAddr.accessPathWithScope
+    let (accessPath, scope) = baseAddr.lookThroughAddressCast.accessPathWithScope
 
     if case .tail = accessPath.base, self is IndexAddrInst {
       // `index_addr` for tail-allocated elements is the usual case (most likely coming from

--- a/test/SILOptimizer/stack_protection.sil
+++ b/test/SILOptimizer/stack_protection.sil
@@ -410,6 +410,49 @@ bb0(%0 : $Int64):
   return %r : $()
 }
 
+// CHECK-LABEL: sil [stack_protection] @unchecked_addr_cast_base_with_store
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'unchecked_addr_cast_base_with_store'
+sil @unchecked_addr_cast_base_with_store : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $S
+  %2 = unchecked_addr_cast %1 : $*S to $*Int64
+  %3 = address_to_pointer [stack_protection] %2 : $*Int64 to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to $*Int64
+  store %0 to %4 : $*Int64
+  dealloc_stack %1 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @unchecked_addr_cast_base_with_only_loads
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'unchecked_addr_cast_base_with_only_loads'
+sil @unchecked_addr_cast_base_with_only_loads : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = alloc_stack $S
+  %2 = unchecked_addr_cast %1 : $*S to $*Int64
+  %3 = address_to_pointer [stack_protection] %2 : $*Int64 to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to $*Int64
+  %5 = load %4 : $*Int64
+  dealloc_stack %1 : $*S
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: sil [stack_protection] @unchecked_addr_cast_base_of_index_addr
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'unchecked_addr_cast_base_of_index_addr'
+sil @unchecked_addr_cast_base_of_index_addr : $@convention(thin) (Int64, Builtin.Word) -> () {
+bb0(%0 : $Int64, %1 : $Builtin.Word):
+  %2 = alloc_stack $S
+  %3 = unchecked_addr_cast %2 : $*S to $*Int64
+  %4 = index_addr [stack_protection] %3 : $*Int64, %1 : $Builtin.Word
+  store %0 to %4 : $*Int64
+  dealloc_stack %2 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil [stack_protection] @stack_alloc_builtin
 // CHECK-NOT:     copy_addr
 // CHECK:       } // end sil function 'stack_alloc_builtin'

--- a/test/SILOptimizer/stack_protection.sil
+++ b/test/SILOptimizer/stack_protection.sil
@@ -19,6 +19,11 @@ struct S {
   @_hasStorage var b: Int64
 }
 
+struct SpanLike {
+  @_hasStorage var _pointer: Optional<UnsafeRawPointer>
+  @_hasStorage var _count: Int
+}
+
 sil @unknown : $@convention(thin) (Builtin.RawPointer) -> ()
 sil @unknown_addr : $@convention(thin) (@in Int64) -> ()
 
@@ -133,6 +138,276 @@ bb0:
   %4 = load %3 : $*Int64
   dealloc_stack %0 : $*Int64
   return %4 : $Int64
+}
+
+// A store through a sub-object projection of the addressed memory is still a store to that
+// memory, no matter which projection it goes through.
+
+// CHECK-LABEL: sil [stack_protection] @store_to_struct_element_addr
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'store_to_struct_element_addr'
+sil @store_to_struct_element_addr : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $S
+  %2 = address_to_pointer [stack_protection] %1 : $*S to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*S
+  %4 = struct_element_addr %3 : $*S, #S.b
+  store %0 to %4 : $*Int64
+  dealloc_stack %1 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @load_from_struct_element_addr
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'load_from_struct_element_addr'
+sil @load_from_struct_element_addr : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = alloc_stack $S
+  %2 = address_to_pointer [stack_protection] %1 : $*S to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*S
+  %4 = struct_element_addr %3 : $*S, #S.b
+  %5 = load %4 : $*Int64
+  dealloc_stack %1 : $*S
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: sil [stack_protection] @store_to_tuple_element_addr
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'store_to_tuple_element_addr'
+sil @store_to_tuple_element_addr : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $(Int64, Int64)
+  %2 = address_to_pointer [stack_protection] %1 : $*(Int64, Int64) to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*(Int64, Int64)
+  %4 = tuple_element_addr %3 : $*(Int64, Int64), 1
+  store %0 to %4 : $*Int64
+  dealloc_stack %1 : $*(Int64, Int64)
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @projection_index_addr_with_only_loads
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'projection_index_addr_with_only_loads'
+sil @projection_index_addr_with_only_loads : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*Int64
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr [projection] %3 : $*Int64, %4 : $Builtin.Word
+  %6 = load %5 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %6 : $Int64
+}
+
+// CHECK-LABEL: sil [stack_protection] @projection_index_addr_with_store
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'projection_index_addr_with_store'
+sil @projection_index_addr_with_store : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*Int64
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr [projection] %3 : $*Int64, %4 : $Builtin.Word
+  store %0 to %5 : $*Int64
+  dealloc_stack %1 : $*Int64
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [stack_protection] @index_addr_with_store_to_field
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'index_addr_with_store_to_field'
+sil @index_addr_with_store_to_field : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $S
+  %2 = address_to_pointer %1 : $*S to $Builtin.RawPointer
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = index_addr [stack_protection] %1 : $*S, %3 : $Builtin.Word
+  %5 = struct_element_addr %4 : $*S, #S.b
+  store %0 to %5 : $*Int64
+  dealloc_stack %1 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
+// The read-only bailout must not be defeated by debug instructions or by pointer arithmetic,
+// neither of which can store anything by itself.
+
+// CHECK-LABEL: sil @only_loads_with_debug_value_on_pointer
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'only_loads_with_debug_value_on_pointer'
+sil @only_loads_with_debug_value_on_pointer : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  debug_value %2 : $Builtin.RawPointer, let, name "p"
+  %4 = pointer_to_address %2 : $Builtin.RawPointer to $*Int64
+  %5 = load %4 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: sil @only_loads_with_debug_value_on_address
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'only_loads_with_debug_value_on_address'
+sil @only_loads_with_debug_value_on_address : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*Int64
+  debug_value %3 : $*Int64, let, name "a", expr op_deref
+  %5 = load %3 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: sil @span_like_only_loads
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'span_like_only_loads'
+sil @span_like_only_loads : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $Int64
+  store %0 to %1 : $*Int64
+  %3 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %4 = struct $UnsafeRawPointer (%3 : $Builtin.RawPointer)
+  %5 = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, %4 : $UnsafeRawPointer
+  %6 = integer_literal $Builtin.Int64, 8
+  %7 = struct $Int (%6 : $Builtin.Int64)
+  %8 = struct $SpanLike (%5 : $Optional<UnsafeRawPointer>, %7 : $Int)
+  %9 = mark_dependence %8 : $SpanLike on %1 : $*Int64
+  debug_value %9 : $SpanLike, let, name "b"
+  %11 = struct_extract %9 : $SpanLike, #SpanLike._count
+  %12 = struct_extract %9 : $SpanLike, #SpanLike._pointer
+  %13 = unchecked_enum_data %12 : $Optional<UnsafeRawPointer>, #Optional.some!enumelt
+  %14 = struct_extract %13 : $UnsafeRawPointer, #UnsafeRawPointer._rawValue
+  %15 = pointer_to_address %14 : $Builtin.RawPointer to $*Int64
+  %16 = load %15 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %16 : $Int64
+}
+
+// CHECK-LABEL: sil [stack_protection] @span_like_with_store
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'span_like_with_store'
+sil @span_like_with_store : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $Int64
+  store %0 to %1 : $*Int64
+  %3 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %4 = struct $UnsafeRawPointer (%3 : $Builtin.RawPointer)
+  %5 = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt, %4 : $UnsafeRawPointer
+  %6 = integer_literal $Builtin.Int64, 8
+  %7 = struct $Int (%6 : $Builtin.Int64)
+  %8 = struct $SpanLike (%5 : $Optional<UnsafeRawPointer>, %7 : $Int)
+  %9 = mark_dependence %8 : $SpanLike on %1 : $*Int64
+  debug_value %9 : $SpanLike, let, name "b"
+  %11 = struct_extract %9 : $SpanLike, #SpanLike._pointer
+  %12 = unchecked_enum_data %11 : $Optional<UnsafeRawPointer>, #Optional.some!enumelt
+  %13 = struct_extract %12 : $UnsafeRawPointer, #UnsafeRawPointer._rawValue
+  %14 = pointer_to_address %13 : $Builtin.RawPointer to $*Int64
+  store %0 to %14 : $*Int64
+  dealloc_stack %1 : $*Int64
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @index_raw_pointer_with_only_loads
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'index_raw_pointer_with_only_loads'
+sil @index_raw_pointer_with_only_loads : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = index_raw_pointer %2 : $Builtin.RawPointer, %3 : $Builtin.Word
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to $*Int64
+  %6 = load %5 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %6 : $Int64
+}
+
+// CHECK-LABEL: sil [stack_protection] @index_raw_pointer_with_store
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'index_raw_pointer_with_store'
+sil @index_raw_pointer_with_store : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = index_raw_pointer %2 : $Builtin.RawPointer, %3 : $Builtin.Word
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to $*Int64
+  store %0 to %5 : $*Int64
+  dealloc_stack %1 : $*Int64
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [stack_protection] @index_raw_pointer_escapes
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'index_raw_pointer_escapes'
+sil @index_raw_pointer_escapes : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = integer_literal $Builtin.Word, 1
+  %4 = index_raw_pointer %2 : $Builtin.RawPointer, %3 : $Builtin.Word
+  %5 = function_ref @unknown : $@convention(thin) (Builtin.RawPointer) -> ()
+  apply %5(%4) : $@convention(thin) (Builtin.RawPointer) -> ()
+  dealloc_stack %1 : $*Int64
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @non_projection_index_addr_with_only_loads
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'non_projection_index_addr_with_only_loads'
+sil @non_projection_index_addr_with_only_loads : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*Int64
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr %3 : $*Int64, %4 : $Builtin.Word
+  %6 = load %5 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %6 : $Int64
+}
+
+// CHECK-LABEL: sil [stack_protection] @non_projection_index_addr_with_store_to_field
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'non_projection_index_addr_with_store_to_field'
+sil @non_projection_index_addr_with_store_to_field : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $S
+  %2 = address_to_pointer [stack_protection] %1 : $*S to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*S
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr %3 : $*S, %4 : $Builtin.Word
+  %6 = struct_element_addr %5 : $*S, #S.b
+  store %0 to %6 : $*Int64
+  dealloc_stack %1 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [stack_protection] @non_projection_index_addr_with_store
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function 'non_projection_index_addr_with_store'
+sil @non_projection_index_addr_with_store : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack $Int64
+  %2 = address_to_pointer [stack_protection] %1 : $*Int64 to $Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to $*Int64
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = index_addr %3 : $*Int64, %4 : $Builtin.Word
+  store %0 to %5 : $*Int64
+  dealloc_stack %1 : $*Int64
+  %r = tuple ()
+  return %r : $()
 }
 
 // CHECK-LABEL: sil [stack_protection] @stack_alloc_builtin

--- a/test/SILOptimizer/stack_protection.swift
+++ b/test/SILOptimizer/stack_protection.swift
@@ -113,6 +113,29 @@ public func storeToFieldAtOffset(value: Int) -> Int {
   return s.a
 }
 
+// CHECK-LABEL: sil @$s4test24onlyLoadsAtReboundOffset5indexS2i_tF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test24onlyLoadsAtReboundOffset5indexS2i_tF'
+public func onlyLoadsAtReboundOffset(index: Int) -> Int {
+  var t = (1, 2)
+  return withUnsafeMutablePointer(to: &t) {
+    let p = UnsafeMutableRawPointer($0).assumingMemoryBound(to: Int.self)
+    return p[index]
+  }
+}
+
+// CHECK-LABEL: sil [stack_protection] @$s4test20storeAtReboundOffset5value5indexS2i_SitF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test20storeAtReboundOffset5value5indexS2i_SitF'
+public func storeAtReboundOffset(value: Int, index: Int) -> Int {
+  var t = (0, 0)
+  return withUnsafeMutablePointer(to: &t) {
+    let p = UnsafeMutableRawPointer($0).assumingMemoryBound(to: Int.self)
+    p[index] = value
+    return p[0]
+  }
+}
+
 // CHECK-LABEL: sil @$s4test22unprotectedUnsafeBytesyyF
 // CHECK-NOT:     copy_addr
 // CHECK:       } // end sil function '$s4test22unprotectedUnsafeBytesyyF'

--- a/test/SILOptimizer/stack_protection.swift
+++ b/test/SILOptimizer/stack_protection.swift
@@ -53,6 +53,66 @@ public func onlyLoads(value: Int) -> Int {
   }
 }
 
+// CHECK-LABEL: sil @$s4test17onlyLoadsAtOffset5values5UInt8VSi_tF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test17onlyLoadsAtOffset5values5UInt8VSi_tF'
+public func onlyLoadsAtOffset(value: Int) -> UInt8 {
+  withUnsafeBytes(of: value) { $0[1] }
+}
+
+// CHECK-LABEL: sil @$s4test17onlyLoadsAllBytes5values5UInt8VSi_tF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test17onlyLoadsAllBytes5values5UInt8VSi_tF'
+public func onlyLoadsAllBytes(value: Int) -> UInt8 {
+  withUnsafeBytes(of: value) { buf in
+    var sum: UInt8 = 0
+    for i in 0..<buf.count { sum = sum &+ buf[i] }
+    return sum
+  }
+}
+
+// CHECK-LABEL: sil @$s4test18onlyLoadsSomeBytes5values5UInt8VSi_tF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test18onlyLoadsSomeBytes5values5UInt8VSi_tF'
+public func onlyLoadsSomeBytes(value: Int) -> UInt8 {
+  withUnsafeBytes(of: value) { buf in
+    var sum: UInt8 = 0
+    for i in 1..<3 { sum = sum &+ buf[i] }
+    return sum
+  }
+}
+
+// CHECK-LABEL: sil [stack_protection] @$s4test13storeAtOffset5valueS2i_tF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test13storeAtOffset5valueS2i_tF'
+public func storeAtOffset(value: Int) -> Int {
+  var x = value
+  withUnsafeMutableBytes(of: &x) { $0[1] = 42 }
+  return x
+}
+
+struct S {
+  var a: Int
+  var b: Int
+}
+
+// CHECK-LABEL: sil @$s4test17loadFieldAtOffset5valueS2i_tF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test17loadFieldAtOffset5valueS2i_tF'
+public func loadFieldAtOffset(value: Int) -> Int {
+  var s = S(a: value, b: 0)
+  return withUnsafeMutablePointer(to: &s) { $0[1].b }
+}
+
+// CHECK-LABEL: sil [stack_protection] @$s4test20storeToFieldAtOffset5valueS2i_tF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test20storeToFieldAtOffset5valueS2i_tF'
+public func storeToFieldAtOffset(value: Int) -> Int {
+  var s = S(a: 0, b: 0)
+  withUnsafeMutablePointer(to: &s) { $0[1].b = value }
+  return s.a
+}
+
 // CHECK-LABEL: sil @$s4test22unprotectedUnsafeBytesyyF
 // CHECK-NOT:     copy_addr
 // CHECK:       } // end sil function '$s4test22unprotectedUnsafeBytesyyF'


### PR DESCRIPTION
Improve the optimizations for the stack-canaries that come with `Builtin.addressOfBorrow` which is used in lots of `Span` getter implementations as well as `withUnsafe[]Bytes` functions which require to have an addressable pointer to work with, and that can require a stack-canary to capture possible writes over memory that was not supposed to be written over.

**The rows that have had a change are in bold.**

`test/SILOptimizer/stack_protection.sil`:

test | main | this PR
-- | -- | --
**store_to_struct_element_addr** | no canary | **canary**
**store_to_tuple_element_addr** | no canary | **canary**
**projection_index_addr_with_store** | no canary | **canary**
**index_addr_with_store_to_field** | no canary | **canary**
load_from_struct_element_addr | no canary | no canary
projection_index_addr_with_only_loads | no canary | no canary
**only_loads_with_debug_value_on_pointer** | canary | **no canary**
**only_loads_with_debug_value_on_address** | canary | **no canary**
**span_like_only_loads** | canary | **no canary**
**index_raw_pointer_with_only_loads** | canary | **no canary**
**non_projection_index_addr_with_only_loads** | canary | **no canary**
non_projection_index_addr_with_store_to_field | canary | canary
span_like_with_store | canary | canary
index_raw_pointer_with_store | canary | canary
index_raw_pointer_escapes | canary | canary
non_projection_index_addr_with_store | canary | canary
**unchecked_addr_cast_base_with_store** | no canary | **canary**
**unchecked_addr_cast_base_of_index_addr** | no canary | **canary**
unchecked_addr_cast_base_with_only_loads | no canary | no canary

<br class="Apple-interchange-newline">

`test/SILOptimizer/stack_protection.swift`:

test | main | this PR
-- | -- | --
**storeToFieldAtOffset** | no canary | **canary**
**onlyLoadsAtOffset** | canary | **no canary**
**onlyLoadsAllBytes** | canary | **no canary**
**onlyLoadsSomeBytes** | canary | **no canary**
loadFieldAtOffset | no canary | no canary
storeAtOffset | canary | canary
**storeAtReboundOffset** | no canary | **canary**
onlyLoadsAtReboundOffset | no canary | no canary

<br class="Apple-interchange-newline">

### Motivation

I bumped into this when working on [swift-endpoint](https://github.com/swift-dns/swift-endpoint), parts of which are likely going to make it into a new `swift-network-types` package under supervision of the Networking workgroup.
Specifically to [get `span`s out of `IPv[4/6]Address`](https://github.com/swift-dns/swift-endpoint/blob/a65255c36b521930cbe03b2f172b0d54af340eb2/Sources/IPAddress/IPv6Address/IPv6Address.swift#L354) types which would degrade the performance compared to the former `var bytes: (UInt8 tuple of 4/16)` which was changed to now be `var bytes: Span<UInt8>`, even in trivial cases. Subsequently, for now I've introduced a new accessor in each types called `_unprotectedBytes` which is suboptimal as most use-cases shouldn't need it (like with this PR) but I did come to need it to ensure performance does not regress.