### PR TITLE
[AST][cxx-interop] Remove ObjC-interop-disabled short circuit in getReferenceCounting()

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4886,19 +4886,11 @@ ReferenceCounting TypeBase::getReferenceCounting() {
                ? ReferenceCounting::Custom
                : ReferenceCounting::None;
 
-  ReferenceCounting defaultRefCounting = ReferenceCounting::Unknown;
-
-  // In the absence of Objective-C interoperability, almost everything uses
-  // native reference counting or is the builtin BridgeObject.
-  if (!ctx.LangOpts.EnableObjCInterop) {
-    defaultRefCounting = ReferenceCounting::Native;
-
-    // It is still possible for an FRT to be involved in an archetype or
-    // protocol type, so only short-circuit for cases other than those
-    if (!isa<ArchetypeType, ProtocolType, ProtocolCompositionType>(type))
-      return isa<BuiltinBridgeObjectType>(type) ? ReferenceCounting::Bridge
-                                                : ReferenceCounting::Native;
-  }
+  // In the absence of Objective-C interoperability, a class reference uses
+  // native reference counting unless something more specific applies.
+  ReferenceCounting defaultRefCounting =
+      ctx.LangOpts.EnableObjCInterop ? ReferenceCounting::Unknown
+                                     : ReferenceCounting::Native;
 
   switch (type->getKind()) {
 #define SUGARED_TYPE(id, parent) case TypeKind::id:
@@ -4950,7 +4942,7 @@ ReferenceCounting TypeBase::getReferenceCounting() {
   }
 
   case TypeKind::ParameterizedProtocol: {
-    return cast<ParameterizedProtocolType>(this)
+    return cast<ParameterizedProtocolType>(type)
       ->getBaseType()
       ->getReferenceCounting();
   }


### PR DESCRIPTION
With ObjC interop disabled this method used to return Native or Bridge for most types, including cases that delegate to another type and may bottom out at a foreign reference type (which is Custom or None). This can lead to subtle inconsistencies that arise on platforms with ObjC interop off by default. Deleting the ObjC-interop-off short circuit ensures the behavior is consistent across both interop modes.

Also cast `type` rather than `this` in the ParameterizedProtocol case, unreachable today but matching every sibling case.

Follow up from #91431